### PR TITLE
feat(engine): exhaustive seven-card hand evaluator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2074,6 +2074,12 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true
     },
+    "node_modules/phe": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/phe/-/phe-0.6.0.tgz",
+      "integrity": "sha512-OUhqPZdGeqcu6AZ38WTW+pVPcb4hzaoZweliBAlgIsmSNPTkMKsTGly5+aiwPlCiwz2e3n5K9WBHgKbMSx/KFw==",
+      "dev": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2618,7 +2624,8 @@
       "name": "@table-top-poker/engine",
       "version": "0.0.0",
       "devDependencies": {
-        "fast-check": "^4.9.0"
+        "fast-check": "^4.9.0",
+        "phe": "^0.6.0"
       }
     },
     "packages/harness": {

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "fast-check": "^4.9.0"
+    "fast-check": "^4.9.0",
+    "phe": "^0.6.0"
   }
 }

--- a/packages/engine/src/evaluate.split.test.ts
+++ b/packages/engine/src/evaluate.split.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { evaluate } from "./evaluate.js";
+import type { Card } from "./types.js";
+
+function cards(spec: string): Card[] {
+  const suitMap = {
+    s: "spades",
+    h: "hearts",
+    d: "diamonds",
+    c: "clubs",
+  } as const;
+  return spec.split(" ").map((token) => {
+    const suitChar = token.at(-1) as keyof typeof suitMap;
+    const rank = token.slice(0, -1) as Card["rank"];
+    return { rank, suit: suitMap[suitChar] };
+  });
+}
+
+describe("evaluate: split and tie cases", () => {
+  it("splits when the board itself plays the best five (kickers dead)", () => {
+    const board = "Ac Kd Qh Jc 10s";
+    const seatA = evaluate(cards(`${board} 2h 3d`));
+    const seatB = evaluate(cards(`${board} 4h 5d`));
+    expect(seatA.rank).toBe(seatB.rank);
+  });
+
+  it("does not split when kickers differ within the same category and rank", () => {
+    // Both have aces and kings two pair, but one has a queen kicker, the other a jack.
+    const seatA = evaluate(cards("Ac Ah Kd Kh Qc 2s 3d"));
+    const seatB = evaluate(cards("As Ad Ks Kc Jc 2s 3d"));
+    expect(seatA.rank).toBeGreaterThan(seatB.rank);
+  });
+
+  it("splits on the same straight made from different suits", () => {
+    const seatA = evaluate(cards("5c 6d 7h 8s 9c Ah 2d"));
+    const seatB = evaluate(cards("5d 6c 7s 8h 9d Ac 2h"));
+    expect(seatA.rank).toBe(seatB.rank);
+    expect(seatA.description).toBe("Straight, nine high");
+  });
+
+  it("the wheel beats a made pair of kings", () => {
+    const wheel = evaluate(cards("Ac 2h 3d 4c 5s Kh Kd"));
+    const kings = evaluate(cards("Kc Kh 9d Jc 8s 2h 3d"));
+    expect(wheel.rank).toBeGreaterThan(kings.rank);
+    expect(wheel.description).toBe("Straight, five high");
+  });
+
+  it("returns exactly five cards for a hand with six flush-suited cards available", () => {
+    const result = evaluate(cards("5c 8c 9c Kc Ac 7c 3d"));
+    expect(result.bestHand).toHaveLength(5);
+    expect(result.description).toBe("Flush, ace high");
+  });
+
+  it("three-way splits a royal flush on the board", () => {
+    const board = "10s Js Qs Ks As";
+    const seatA = evaluate(cards(`${board} 2h 3d`));
+    const seatB = evaluate(cards(`${board} 4h 5d`));
+    const seatC = evaluate(cards(`${board} 6h 7d`));
+    expect(seatA.rank).toBe(seatB.rank);
+    expect(seatB.rank).toBe(seatC.rank);
+    expect(seatA.description).toBe("Royal flush");
+  });
+});

--- a/packages/engine/src/evaluate.test.ts
+++ b/packages/engine/src/evaluate.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { evaluate } from "./evaluate.js";
+import type { Card } from "./types.js";
+
+function cards(spec: string): Card[] {
+  const suitMap = {
+    s: "spades",
+    h: "hearts",
+    d: "diamonds",
+    c: "clubs",
+  } as const;
+  return spec.split(" ").map((token) => {
+    const suitChar = token.at(-1) as keyof typeof suitMap;
+    const rank = token.slice(0, -1) as Card["rank"];
+    return { rank, suit: suitMap[suitChar] };
+  });
+}
+
+describe("evaluate", () => {
+  it("returns a rank, the winning five cards, and a description for seven cards", () => {
+    const result = evaluate(cards("2c 2h 9d Jc As 3h 4d"));
+    expect(result.description).toBe("Pair of twos");
+    expect(result.bestHand).toHaveLength(5);
+    expect(typeof result.rank).toBe("number");
+  });
+
+  it("ranks a stronger hand above a weaker one", () => {
+    const flush = evaluate(cards("2c 5c 9c Jc Ac 3h 4d"));
+    const pair = evaluate(cards("2c 2h 9d Jc As 3h 4d"));
+    expect(flush.rank).toBeGreaterThan(pair.rank);
+  });
+
+  it("gives equal rank to two different hands of the same strength (a split)", () => {
+    const boardPlaysA = evaluate(cards("Ac Kd Qh Jc 10s 2h 3d"));
+    const boardPlaysB = evaluate(cards("Ac Kd Qh Jc 10s 4h 5d"));
+    expect(boardPlaysA.rank).toBe(boardPlaysB.rank);
+    expect(boardPlaysA.description).toBe(boardPlaysB.description);
+  });
+});

--- a/packages/engine/src/evaluate.ts
+++ b/packages/engine/src/evaluate.ts
@@ -1,0 +1,24 @@
+import { categorize } from "./poker/categorize.js";
+import { describe } from "./poker/describe.js";
+import { scoreOf } from "./poker/score.js";
+import type { Card, HandRank } from "./types.js";
+
+export interface HandEvaluation {
+  readonly rank: HandRank;
+  readonly bestHand: readonly [Card, Card, Card, Card, Card];
+  readonly description: string;
+}
+
+/**
+ * Evaluates 5-7 cards (a hold'em showdown always passes 7: two hole cards
+ * plus a five-card board) and returns a comparable rank, the winning five
+ * cards, and a human-readable description of the made hand.
+ */
+export function evaluate(cards: readonly Card[]): HandEvaluation {
+  const { category, tiebreak, bestHand } = categorize(cards);
+  return {
+    rank: scoreOf(category, tiebreak),
+    bestHand,
+    description: describe(category, tiebreak),
+  };
+}

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,5 +1,7 @@
 export { apply } from "./apply.js";
 export { decide } from "./decide.js";
+export { evaluate } from "./evaluate.js";
+export type { HandEvaluation } from "./evaluate.js";
 export { createInitialState } from "./room.js";
 export type {
   ActionType,

--- a/packages/engine/src/poker/categorize.test.ts
+++ b/packages/engine/src/poker/categorize.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { categorize } from "./categorize.js";
+import type { Card } from "../types.js";
+
+function cards(spec: string): Card[] {
+  const suitMap = {
+    s: "spades",
+    h: "hearts",
+    d: "diamonds",
+    c: "clubs",
+  } as const;
+  return spec.split(" ").map((token) => {
+    const suitChar = token.at(-1) as keyof typeof suitMap;
+    const rank = token.slice(0, -1) as Card["rank"];
+    return { rank, suit: suitMap[suitChar] };
+  });
+}
+
+describe("categorize", () => {
+  it("recognizes a high card hand", () => {
+    const result = categorize(cards("2c 5h 9d Jc As"));
+    expect(result.category).toBe("high-card");
+    expect(result.tiebreak).toEqual([14, 11, 9, 5, 2]);
+  });
+
+  it("recognizes one pair", () => {
+    const result = categorize(cards("2c 2h 9d Jc As"));
+    expect(result.category).toBe("pair");
+    expect(result.tiebreak).toEqual([2, 14, 11, 9]);
+  });
+
+  it("recognizes two pair", () => {
+    const result = categorize(cards("2c 2h 9d 9c As"));
+    expect(result.category).toBe("two-pair");
+    expect(result.tiebreak).toEqual([9, 2, 14]);
+  });
+
+  it("recognizes three of a kind", () => {
+    const result = categorize(cards("2c 2h 2d 9c As"));
+    expect(result.category).toBe("three-of-a-kind");
+    expect(result.tiebreak).toEqual([2, 14, 9]);
+  });
+
+  it("recognizes a straight", () => {
+    const result = categorize(cards("5c 6h 7d 8c 9s"));
+    expect(result.category).toBe("straight");
+    expect(result.tiebreak).toEqual([9]);
+  });
+
+  it("recognizes the wheel (ace-low straight) as five high", () => {
+    const result = categorize(cards("Ac 2h 3d 4c 5s"));
+    expect(result.category).toBe("straight");
+    expect(result.tiebreak).toEqual([5]);
+  });
+
+  it("does not treat A-K-Q-J-10 wraparound (K-Q-J-10-A... low) as a straight", () => {
+    // Q,K,A,2,3 is not a straight in either direction.
+    const result = categorize(cards("Qc Kh Ad 2c 3s"));
+    expect(result.category).toBe("high-card");
+  });
+
+  it("recognizes a flush", () => {
+    const result = categorize(cards("2c 5c 9c Jc Ac"));
+    expect(result.category).toBe("flush");
+    expect(result.tiebreak).toEqual([14, 11, 9, 5, 2]);
+  });
+
+  it("recognizes a full house", () => {
+    const result = categorize(cards("2c 2h 2d 9c 9s"));
+    expect(result.category).toBe("full-house");
+    expect(result.tiebreak).toEqual([2, 9]);
+  });
+
+  it("recognizes four of a kind", () => {
+    const result = categorize(cards("2c 2h 2d 2s 9s"));
+    expect(result.category).toBe("four-of-a-kind");
+    expect(result.tiebreak).toEqual([2, 9]);
+  });
+
+  it("recognizes a straight flush", () => {
+    const result = categorize(cards("5c 6c 7c 8c 9c"));
+    expect(result.category).toBe("straight-flush");
+    expect(result.tiebreak).toEqual([9]);
+  });
+
+  it("recognizes a royal flush as an ace-high straight flush", () => {
+    const result = categorize(cards("10c Jc Qc Kc Ac"));
+    expect(result.category).toBe("straight-flush");
+    expect(result.tiebreak).toEqual([14]);
+  });
+
+  it("picks the best five-card hand out of seven cards", () => {
+    const result = categorize(cards("2c 2h 9d Jc As 3h 4d"));
+    expect(result.category).toBe("pair");
+    expect(result.bestHand).toHaveLength(5);
+  });
+
+  it("prefers a flush over a straight when seven cards offer both", () => {
+    // Diamonds 4-5-6-9-10 make a flush (not a straight); 6-7-8-9-10 across
+    // suits makes a straight. Flush must win.
+    const result = categorize(cards("4d 5d 6d 7h 8h 9d 10d"));
+    expect(result.category).toBe("flush");
+  });
+
+  it("returns the best five cards for a flush, not six", () => {
+    const result = categorize(cards("2c 5c 9c Jc Ac 7c 3d"));
+    expect(result.category).toBe("flush");
+    expect(result.bestHand).toHaveLength(5);
+    expect(result.tiebreak).toEqual([14, 11, 9, 7, 5]);
+  });
+
+  it("resolves a full house from seven cards using the best trips and best pair", () => {
+    // trips of 9s, trips of 2s -> full house should be 9s full of 2s (best trip + best remaining pair-or-trip)
+    const result = categorize(cards("9c 9h 9d 2c 2h 2d Kc"));
+    expect(result.category).toBe("full-house");
+    expect(result.tiebreak).toEqual([9, 2]);
+  });
+});

--- a/packages/engine/src/poker/categorize.ts
+++ b/packages/engine/src/poker/categorize.ts
@@ -1,0 +1,256 @@
+import type { Card } from "../types.js";
+import { must } from "../util.js";
+import {
+  HIGHEST_RANK_VALUE,
+  LOWEST_RANK_VALUE,
+  RANK_VALUE,
+} from "./rank-values.js";
+
+export type HandCategory =
+  | "high-card"
+  | "pair"
+  | "two-pair"
+  | "three-of-a-kind"
+  | "straight"
+  | "flush"
+  | "full-house"
+  | "four-of-a-kind"
+  | "straight-flush";
+
+export interface Categorized {
+  readonly category: HandCategory;
+  /**
+   * Tiebreak ranks in significance order (highest first), enough to compare
+   * any two hands of the same category. Length varies by category.
+   */
+  readonly tiebreak: readonly number[];
+  readonly bestHand: readonly [Card, Card, Card, Card, Card];
+}
+
+/** Highest 5-in-a-row rank present, wheel-aware (A-2-3-4-5 plays as five-high); 0 if none. */
+function highestStraight(present: readonly boolean[]): number {
+  const wheel =
+    present[HIGHEST_RANK_VALUE] &&
+    present[2] &&
+    present[3] &&
+    present[4] &&
+    present[5];
+  for (let high = HIGHEST_RANK_VALUE; high >= LOWEST_RANK_VALUE + 4; high--) {
+    if (
+      present[high] &&
+      present[high - 1] &&
+      present[high - 2] &&
+      present[high - 3] &&
+      present[high - 4]
+    ) {
+      return high;
+    }
+  }
+  return wheel ? 5 : 0;
+}
+
+/** Cards of the given ranks (highest rank first), each appearing once, from `pool`. */
+function pickByRank(pool: readonly Card[], ranks: readonly number[]): Card[] {
+  const remaining = [...pool];
+  const picked: Card[] = [];
+  for (const rank of ranks) {
+    const index = remaining.findIndex((c) => RANK_VALUE[c.rank] === rank);
+    const [card] = remaining.splice(index, 1);
+    if (card) picked.push(card);
+  }
+  return picked;
+}
+
+function highCardsExcluding(
+  byRank: ReadonlyMap<number, Card[]>,
+  exclude: ReadonlySet<number>,
+  count: number,
+): number[] {
+  const ranks: number[] = [];
+  for (
+    let rank = HIGHEST_RANK_VALUE;
+    rank >= LOWEST_RANK_VALUE && ranks.length < count;
+    rank--
+  ) {
+    if (!exclude.has(rank) && byRank.has(rank)) ranks.push(rank);
+  }
+  return ranks;
+}
+
+/**
+ * Scores every card of a straight of the given high rank, wheel-aware (ace
+ * plays low in a five-high straight).
+ */
+function straightRanks(high: number): number[] {
+  if (high === 5) return [5, 4, 3, 2, HIGHEST_RANK_VALUE];
+  return [high, high - 1, high - 2, high - 3, high - 4];
+}
+
+/** Best 5-card poker hand out of 5-7 cards: category, tiebreak ranks, and the winning cards. */
+export function categorize(cards: readonly Card[]): Categorized {
+  const byRank = new Map<number, Card[]>();
+  const bySuit = new Map<Card["suit"], Card[]>();
+  const present = new Array<boolean>(HIGHEST_RANK_VALUE + 1).fill(false);
+
+  for (const card of cards) {
+    const rankValue = RANK_VALUE[card.rank];
+    present[rankValue] = true;
+    const rankGroup = byRank.get(rankValue) ?? [];
+    rankGroup.push(card);
+    byRank.set(rankValue, rankGroup);
+    const suitGroup = bySuit.get(card.suit) ?? [];
+    suitGroup.push(card);
+    bySuit.set(card.suit, suitGroup);
+  }
+
+  const flushCards = [...bySuit.values()].find((group) => group.length >= 5);
+
+  if (flushCards) {
+    const flushPresent = new Array<boolean>(HIGHEST_RANK_VALUE + 1).fill(false);
+    for (const card of flushCards) flushPresent[RANK_VALUE[card.rank]] = true;
+    const straightFlushHigh = highestStraight(flushPresent);
+    if (straightFlushHigh) {
+      const ranks = straightRanks(straightFlushHigh);
+      return {
+        category: "straight-flush",
+        tiebreak: [straightFlushHigh],
+        bestHand: pickByRank(flushCards, ranks) as [
+          Card,
+          Card,
+          Card,
+          Card,
+          Card,
+        ],
+      };
+    }
+  }
+
+  const ranksByCount = new Map<number, number[]>();
+  for (const [rank, group] of byRank) {
+    const list = ranksByCount.get(group.length) ?? [];
+    list.push(rank);
+    ranksByCount.set(group.length, list);
+  }
+  for (const list of ranksByCount.values()) list.sort((a, b) => b - a);
+
+  const quads = ranksByCount.get(4) ?? [];
+  const trips = ranksByCount.get(3) ?? [];
+  const pairs = ranksByCount.get(2) ?? [];
+
+  if (quads.length > 0) {
+    const quadRank = must(quads[0], "quads group must have a rank");
+    const kicker = must(
+      highCardsExcluding(byRank, new Set([quadRank]), 1)[0],
+      "quads always leave a kicker in a 5+ card hand",
+    );
+    return {
+      category: "four-of-a-kind",
+      tiebreak: [quadRank, kicker],
+      bestHand: pickByRank(cards, [
+        quadRank,
+        quadRank,
+        quadRank,
+        quadRank,
+        kicker,
+      ]) as [Card, Card, Card, Card, Card],
+    };
+  }
+
+  if (trips.length > 0) {
+    const bestTrip = must(trips[0], "trips group must have a rank");
+    const pairRank = trips[1] ?? pairs[0];
+    if (pairRank !== undefined) {
+      return {
+        category: "full-house",
+        tiebreak: [bestTrip, pairRank],
+        bestHand: pickByRank(cards, [
+          bestTrip,
+          bestTrip,
+          bestTrip,
+          pairRank,
+          pairRank,
+        ]) as [Card, Card, Card, Card, Card],
+      };
+    }
+  }
+
+  if (flushCards) {
+    const ranks = [...flushCards]
+      .map((c) => RANK_VALUE[c.rank])
+      .sort((a, b) => b - a)
+      .slice(0, 5);
+    return {
+      category: "flush",
+      tiebreak: ranks,
+      bestHand: pickByRank(flushCards, ranks) as [Card, Card, Card, Card, Card],
+    };
+  }
+
+  const straightHigh = highestStraight(present);
+  if (straightHigh) {
+    const ranks = straightRanks(straightHigh);
+    return {
+      category: "straight",
+      tiebreak: [straightHigh],
+      bestHand: pickByRank(cards, ranks) as [Card, Card, Card, Card, Card],
+    };
+  }
+
+  if (trips.length > 0) {
+    const bestTrip = must(trips[0], "trips group must have a rank");
+    const kickers = highCardsExcluding(byRank, new Set([bestTrip]), 2);
+    return {
+      category: "three-of-a-kind",
+      tiebreak: [bestTrip, ...kickers],
+      bestHand: pickByRank(cards, [
+        bestTrip,
+        bestTrip,
+        bestTrip,
+        ...kickers,
+      ]) as [Card, Card, Card, Card, Card],
+    };
+  }
+
+  if (pairs.length >= 2) {
+    const highPair = must(pairs[0], "pairs group must have a rank");
+    const lowPair = must(pairs[1], "two-pair requires a second pair");
+    const kicker = must(
+      highCardsExcluding(byRank, new Set([highPair, lowPair]), 1)[0],
+      "two pair always leaves a kicker in a 5+ card hand",
+    );
+    return {
+      category: "two-pair",
+      tiebreak: [highPair, lowPair, kicker],
+      bestHand: pickByRank(cards, [
+        highPair,
+        highPair,
+        lowPair,
+        lowPair,
+        kicker,
+      ]) as [Card, Card, Card, Card, Card],
+    };
+  }
+
+  if (pairs.length === 1) {
+    const pairRank = must(pairs[0], "pairs group must have a rank");
+    const kickers = highCardsExcluding(byRank, new Set([pairRank]), 3);
+    return {
+      category: "pair",
+      tiebreak: [pairRank, ...kickers],
+      bestHand: pickByRank(cards, [pairRank, pairRank, ...kickers]) as [
+        Card,
+        Card,
+        Card,
+        Card,
+        Card,
+      ],
+    };
+  }
+
+  const highs = highCardsExcluding(byRank, new Set(), 5);
+  return {
+    category: "high-card",
+    tiebreak: highs,
+    bestHand: pickByRank(cards, highs) as [Card, Card, Card, Card, Card],
+  };
+}

--- a/packages/engine/src/poker/describe.test.ts
+++ b/packages/engine/src/poker/describe.test.ts
@@ -1,0 +1,52 @@
+import { describe as vitestDescribe, expect, it } from "vitest";
+import { describe } from "./describe.js";
+
+vitestDescribe("describe", () => {
+  it("describes a high card hand by its top card", () => {
+    expect(describe("high-card", [14, 11, 9, 5, 2])).toBe("Ace high");
+  });
+
+  it("describes one pair by its rank", () => {
+    expect(describe("pair", [9, 14, 11, 8])).toBe("Pair of nines");
+  });
+
+  it("describes two pair by both ranks", () => {
+    expect(describe("two-pair", [14, 13, 9])).toBe("Two pair, aces and kings");
+  });
+
+  it("describes three of a kind by its rank", () => {
+    expect(describe("three-of-a-kind", [7, 14, 9])).toBe(
+      "Three of a kind, sevens",
+    );
+  });
+
+  it("describes a straight by its high card", () => {
+    expect(describe("straight", [9])).toBe("Straight, nine high");
+  });
+
+  it("describes the wheel as a five-high straight", () => {
+    expect(describe("straight", [5])).toBe("Straight, five high");
+  });
+
+  it("describes a flush by its top card", () => {
+    expect(describe("flush", [14, 11, 9, 5, 2])).toBe("Flush, ace high");
+  });
+
+  it("describes a full house as trips full of the pair", () => {
+    expect(describe("full-house", [9, 2])).toBe(
+      "Full house, nines full of twos",
+    );
+  });
+
+  it("describes four of a kind by its rank", () => {
+    expect(describe("four-of-a-kind", [2, 9])).toBe("Four of a kind, twos");
+  });
+
+  it("describes a straight flush by its high card", () => {
+    expect(describe("straight-flush", [9])).toBe("Straight flush, nine high");
+  });
+
+  it("names a royal flush specially", () => {
+    expect(describe("straight-flush", [14])).toBe("Royal flush");
+  });
+});

--- a/packages/engine/src/poker/describe.ts
+++ b/packages/engine/src/poker/describe.ts
@@ -1,0 +1,83 @@
+import { must } from "../util.js";
+import type { HandCategory } from "./categorize.js";
+
+const SINGULAR: Record<number, string> = {
+  2: "two",
+  3: "three",
+  4: "four",
+  5: "five",
+  6: "six",
+  7: "seven",
+  8: "eight",
+  9: "nine",
+  10: "ten",
+  11: "jack",
+  12: "queen",
+  13: "king",
+  14: "ace",
+};
+
+const PLURAL: Record<number, string> = {
+  2: "twos",
+  3: "threes",
+  4: "fours",
+  5: "fives",
+  6: "sixes",
+  7: "sevens",
+  8: "eights",
+  9: "nines",
+  10: "tens",
+  11: "jacks",
+  12: "queens",
+  13: "kings",
+  14: "aces",
+};
+
+function capitalize(text: string): string {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function singular(rank: number): string {
+  return must(SINGULAR[rank], `no singular name for rank ${String(rank)}`);
+}
+
+function plural(rank: number): string {
+  return must(PLURAL[rank], `no plural name for rank ${String(rank)}`);
+}
+
+/** A human-readable name for a category + tiebreak, e.g. "Full house, nines full of twos". */
+export function describe(
+  category: HandCategory,
+  tiebreak: readonly number[],
+): string {
+  const first = must(
+    tiebreak[0],
+    "every category has at least one tiebreak rank",
+  );
+  switch (category) {
+    case "high-card":
+      return `${capitalize(singular(first))} high`;
+    case "pair":
+      return `Pair of ${plural(first)}`;
+    case "two-pair": {
+      const second = must(tiebreak[1], "two pair has a second rank");
+      return `Two pair, ${plural(first)} and ${plural(second)}`;
+    }
+    case "three-of-a-kind":
+      return `Three of a kind, ${plural(first)}`;
+    case "straight":
+      return `Straight, ${singular(first)} high`;
+    case "flush":
+      return `Flush, ${singular(first)} high`;
+    case "full-house": {
+      const second = must(tiebreak[1], "full house has a pair rank");
+      return `Full house, ${plural(first)} full of ${plural(second)}`;
+    }
+    case "four-of-a-kind":
+      return `Four of a kind, ${plural(first)}`;
+    case "straight-flush":
+      return first === 14
+        ? "Royal flush"
+        : `Straight flush, ${singular(first)} high`;
+  }
+}

--- a/packages/engine/src/poker/exhaustive-5card.test.ts
+++ b/packages/engine/src/poker/exhaustive-5card.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import phe from "phe";
+import { categorize } from "./categorize.js";
+import { scoreOf } from "./score.js";
+import type { Card, Rank, Suit } from "../types.js";
+import { must } from "../util.js";
+
+const RANK_TO_PHE: Record<Rank, string> = {
+  "2": "2",
+  "3": "3",
+  "4": "4",
+  "5": "5",
+  "6": "6",
+  "7": "7",
+  "8": "8",
+  "9": "9",
+  "10": "T",
+  J: "J",
+  Q: "Q",
+  K: "K",
+  A: "A",
+};
+
+const SUIT_TO_PHE: Record<Suit, string> = {
+  clubs: "c",
+  diamonds: "d",
+  hearts: "h",
+  spades: "s",
+};
+
+const SUITS: readonly Suit[] = ["clubs", "diamonds", "hearts", "spades"];
+const RANKS: readonly Rank[] = [
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "10",
+  "J",
+  "Q",
+  "K",
+  "A",
+];
+
+const deck: Card[] = [];
+const pheCode: number[] = [];
+for (const suit of SUITS) {
+  for (const rank of RANKS) {
+    deck.push({ rank, suit });
+    pheCode.push(phe.cardCode(RANK_TO_PHE[rank], SUIT_TO_PHE[suit]));
+  }
+}
+
+// Canonical 5-card category frequencies over all C(52,5) = 2,598,960 hands —
+// settled combinatorics, independent of any evaluator implementation.
+const CANONICAL_5CARD_FREQUENCIES: Record<string, number> = {
+  "straight-flush": 40,
+  "four-of-a-kind": 624,
+  "full-house": 3744,
+  flush: 5108,
+  straight: 10200,
+  "three-of-a-kind": 54912,
+  "two-pair": 123552,
+  pair: 1098240,
+  "high-card": 1302540,
+};
+
+describe("exhaustive 5-card enumeration vs phe", () => {
+  it("agrees with phe on every one of the 2,598,960 five-card hands, and matches the canonical category frequencies", () => {
+    const pheToOurScore = new Map<number, number>();
+    const ourScoreToPhe = new Map<number, number>();
+    const categoryFrequencies: Record<string, number> = {};
+
+    const hand = new Array<Card>(5);
+    const codes = new Array<number>(5);
+    const n = deck.length;
+    let total = 0;
+
+    for (let a = 0; a < n; a++) {
+      hand[0] = must(deck[a], "index in range");
+      codes[0] = must(pheCode[a], "index in range");
+      for (let b = a + 1; b < n; b++) {
+        hand[1] = must(deck[b], "index in range");
+        codes[1] = must(pheCode[b], "index in range");
+        for (let c = b + 1; c < n; c++) {
+          hand[2] = must(deck[c], "index in range");
+          codes[2] = must(pheCode[c], "index in range");
+          for (let d = c + 1; d < n; d++) {
+            hand[3] = must(deck[d], "index in range");
+            codes[3] = must(pheCode[d], "index in range");
+            for (let e = d + 1; e < n; e++) {
+              hand[4] = must(deck[e], "index in range");
+              codes[4] = must(pheCode[e], "index in range");
+
+              total++;
+              const { category, tiebreak } = categorize(hand);
+              const ourScore = scoreOf(category, tiebreak);
+              const pheValue = phe.evaluateCardCodes(codes);
+
+              categoryFrequencies[category] =
+                (categoryFrequencies[category] ?? 0) + 1;
+
+              const mappedOurScore = pheToOurScore.get(pheValue);
+              if (mappedOurScore === undefined) {
+                pheToOurScore.set(pheValue, ourScore);
+              } else if (mappedOurScore !== ourScore) {
+                throw new Error(
+                  `phe value ${String(pheValue)} maps to two different scores: ${String(mappedOurScore)} and ${String(ourScore)}`,
+                );
+              }
+
+              const mappedPheValue = ourScoreToPhe.get(ourScore);
+              if (mappedPheValue === undefined) {
+                ourScoreToPhe.set(ourScore, pheValue);
+              } else if (mappedPheValue !== pheValue) {
+                throw new Error(
+                  `our score ${String(ourScore)} maps to two different phe values: ${String(mappedPheValue)} and ${String(pheValue)}`,
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(total).toBe(2_598_960);
+    expect(categoryFrequencies).toEqual(CANONICAL_5CARD_FREQUENCIES);
+    expect(pheToOurScore.size).toBe(7462);
+    expect(ourScoreToPhe.size).toBe(7462);
+
+    // Ordering must agree: as phe's strength value increases (weaker),
+    // our score must strictly decrease (also weaker).
+    const orderedByPhe = [...pheToOurScore.entries()].sort(
+      (x, y) => x[0] - y[0],
+    );
+    for (let i = 1; i < orderedByPhe.length; i++) {
+      const previous = must(orderedByPhe[i - 1], "index in range");
+      const current = must(orderedByPhe[i], "index in range");
+      expect(current[1]).toBeLessThan(previous[1]);
+    }
+  }, 120_000);
+});

--- a/packages/engine/src/poker/exhaustive-7card.test.ts
+++ b/packages/engine/src/poker/exhaustive-7card.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import phe from "phe";
+import { categorize } from "./categorize.js";
+import { scoreOf } from "./score.js";
+import type { Card, Rank, Suit } from "../types.js";
+import { must } from "../util.js";
+
+const RANK_TO_PHE: Record<Rank, string> = {
+  "2": "2",
+  "3": "3",
+  "4": "4",
+  "5": "5",
+  "6": "6",
+  "7": "7",
+  "8": "8",
+  "9": "9",
+  "10": "T",
+  J: "J",
+  Q: "Q",
+  K: "K",
+  A: "A",
+};
+
+const SUIT_TO_PHE: Record<Suit, string> = {
+  clubs: "c",
+  diamonds: "d",
+  hearts: "h",
+  spades: "s",
+};
+
+const SUITS: readonly Suit[] = ["clubs", "diamonds", "hearts", "spades"];
+const RANKS: readonly Rank[] = [
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "10",
+  "J",
+  "Q",
+  "K",
+  "A",
+];
+
+const deck: Card[] = [];
+const pheCode: number[] = [];
+for (const suit of SUITS) {
+  for (const rank of RANKS) {
+    deck.push({ rank, suit });
+    pheCode.push(phe.cardCode(RANK_TO_PHE[rank], SUIT_TO_PHE[suit]));
+  }
+}
+
+// Canonical 7-card category frequencies over all C(52,7) = 133,784,560 hands
+// — settled combinatorics (only 4,824 of the 7,462 5-card classes are
+// reachable from seven cards), independent of any evaluator implementation.
+const CANONICAL_7CARD_FREQUENCIES: Record<string, number> = {
+  "straight-flush": 41584,
+  "four-of-a-kind": 224848,
+  "full-house": 3473184,
+  flush: 4047644,
+  straight: 6180020,
+  "three-of-a-kind": 6461620,
+  "two-pair": 31433400,
+  pair: 58627800,
+  "high-card": 23294460,
+};
+
+describe("exhaustive 7-card enumeration vs phe", () => {
+  it("agrees with phe on every one of the 133,784,560 seven-card hands, and matches the canonical category frequencies", () => {
+    const pheToOurScore = new Map<number, number>();
+    const categoryFrequencies: Record<string, number> = {};
+
+    const hand = new Array<Card>(7);
+    const codes = new Array<number>(7);
+    const n = deck.length;
+    let total = 0;
+
+    for (let a = 0; a < n; a++) {
+      hand[0] = must(deck[a], "index in range");
+      codes[0] = must(pheCode[a], "index in range");
+      for (let b = a + 1; b < n; b++) {
+        hand[1] = must(deck[b], "index in range");
+        codes[1] = must(pheCode[b], "index in range");
+        for (let c = b + 1; c < n; c++) {
+          hand[2] = must(deck[c], "index in range");
+          codes[2] = must(pheCode[c], "index in range");
+          for (let d = c + 1; d < n; d++) {
+            hand[3] = must(deck[d], "index in range");
+            codes[3] = must(pheCode[d], "index in range");
+            for (let e = d + 1; e < n; e++) {
+              hand[4] = must(deck[e], "index in range");
+              codes[4] = must(pheCode[e], "index in range");
+              for (let f = e + 1; f < n; f++) {
+                hand[5] = must(deck[f], "index in range");
+                codes[5] = must(pheCode[f], "index in range");
+                for (let g = f + 1; g < n; g++) {
+                  hand[6] = must(deck[g], "index in range");
+                  codes[6] = must(pheCode[g], "index in range");
+
+                  total++;
+                  const { category, tiebreak } = categorize(hand);
+                  const ourScore = scoreOf(category, tiebreak);
+                  const pheValue = phe.evaluateCardCodes(codes);
+
+                  categoryFrequencies[category] =
+                    (categoryFrequencies[category] ?? 0) + 1;
+
+                  const mappedOurScore = pheToOurScore.get(pheValue);
+                  if (mappedOurScore === undefined) {
+                    pheToOurScore.set(pheValue, ourScore);
+                  } else if (mappedOurScore !== ourScore) {
+                    throw new Error(
+                      `phe value ${String(pheValue)} maps to two different scores: ${String(mappedOurScore)} and ${String(ourScore)}`,
+                    );
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(total).toBe(133_784_560);
+    expect(categoryFrequencies).toEqual(CANONICAL_7CARD_FREQUENCIES);
+    expect(pheToOurScore.size).toBe(4824);
+
+    // Ordering must agree: as phe's strength value increases (weaker),
+    // our score must strictly decrease (also weaker).
+    const orderedByPhe = [...pheToOurScore.entries()].sort(
+      (x, y) => x[0] - y[0],
+    );
+    for (let i = 1; i < orderedByPhe.length; i++) {
+      const previous = must(orderedByPhe[i - 1], "index in range");
+      const current = must(orderedByPhe[i], "index in range");
+      expect(current[1]).toBeLessThan(previous[1]);
+    }
+  }, 600_000);
+});

--- a/packages/engine/src/poker/phe.d.ts
+++ b/packages/engine/src/poker/phe.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Minimal ambient typing for the `phe` dev-only test oracle (issue #22).
+ * `phe` ships no TypeScript types; only the members these tests use are
+ * declared. Never imported from runtime code.
+ */
+declare module "phe" {
+  const phe: {
+    cardCode(rank: string, suit: string): number;
+    evaluateCardCodes(codes: readonly number[]): number;
+  };
+  export default phe;
+}

--- a/packages/engine/src/poker/rank-values.ts
+++ b/packages/engine/src/poker/rank-values.ts
@@ -1,0 +1,21 @@
+import type { Rank } from "../types.js";
+
+/** Numeric rank value, ace high (14). Straight detection separately treats ace as low for the wheel. */
+export const RANK_VALUE: Record<Rank, number> = {
+  "2": 2,
+  "3": 3,
+  "4": 4,
+  "5": 5,
+  "6": 6,
+  "7": 7,
+  "8": 8,
+  "9": 9,
+  "10": 10,
+  J: 11,
+  Q: 12,
+  K: 13,
+  A: 14,
+};
+
+export const LOWEST_RANK_VALUE = 2;
+export const HIGHEST_RANK_VALUE = 14;

--- a/packages/engine/src/poker/score.test.ts
+++ b/packages/engine/src/poker/score.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { scoreOf } from "./score.js";
+
+describe("scoreOf", () => {
+  it("ranks a higher category above any lower category regardless of tiebreak", () => {
+    const weakStraightFlush = scoreOf("straight-flush", [5]);
+    const strongQuads = scoreOf("four-of-a-kind", [14, 13]);
+    expect(weakStraightFlush).toBeGreaterThan(strongQuads);
+  });
+
+  it("breaks ties within a category by the tiebreak ranks, most significant first", () => {
+    const acesUp = scoreOf("two-pair", [14, 13, 12]);
+    const kingsUp = scoreOf("two-pair", [13, 12, 11]);
+    expect(acesUp).toBeGreaterThan(kingsUp);
+  });
+
+  it("is equal for identical category and tiebreak, which is how splits are detected", () => {
+    const a = scoreOf("flush", [14, 11, 9, 5, 2]);
+    const b = scoreOf("flush", [14, 11, 9, 5, 2]);
+    expect(a).toBe(b);
+  });
+
+  it("resolves a kicker further down the tiebreak when earlier ranks match", () => {
+    const higherKicker = scoreOf("pair", [10, 14, 9, 8]);
+    const lowerKicker = scoreOf("pair", [10, 14, 9, 7]);
+    expect(higherKicker).toBeGreaterThan(lowerKicker);
+  });
+});

--- a/packages/engine/src/poker/score.ts
+++ b/packages/engine/src/poker/score.ts
@@ -1,0 +1,35 @@
+import type { HandRank } from "../types.js";
+import type { HandCategory } from "./categorize.js";
+import { HIGHEST_RANK_VALUE } from "./rank-values.js";
+
+/** Worst to best; index doubles as the category's weight in the score. */
+const CATEGORY_ORDER: readonly HandCategory[] = [
+  "high-card",
+  "pair",
+  "two-pair",
+  "three-of-a-kind",
+  "straight",
+  "flush",
+  "full-house",
+  "four-of-a-kind",
+  "straight-flush",
+];
+
+const TIEBREAK_SLOTS = 5;
+const RADIX = HIGHEST_RANK_VALUE + 1;
+
+/**
+ * A single comparable integer: higher is a stronger hand. Category is the
+ * most significant digit; tiebreak ranks fill in descending significance
+ * after it, padded so every category compares on equal footing.
+ */
+export function scoreOf(
+  category: HandCategory,
+  tiebreak: readonly number[],
+): HandRank {
+  let score = CATEGORY_ORDER.indexOf(category);
+  for (let slot = 0; slot < TIEBREAK_SLOTS; slot++) {
+    score = score * RADIX + (tiebreak[slot] ?? 0);
+  }
+  return score;
+}


### PR DESCRIPTION
## Summary

- Implements issue #22: `evaluate(cards: Card[])` returns a comparable `HandRank`, the winning five cards, and a human-readable description, built with zero runtime dependencies.
- `phe` is added as a devDependency-only test oracle, never imported from runtime code (`packages/engine/package.json`).
- Correctness is proven by exhaustive enumeration: every one of the 2,598,960 five-card hands and all 133,784,560 seven-card hands are checked against `phe`, matching the canonical category frequency tables and phe's induced ordering exactly (~3.5 min for the 7-card test).

## Design

- `poker/categorize.ts` — single-pass rank/suit counting (no lookup tables, no bitmasks) that scores any 5-7 card hand into one of the nine hold'em categories plus tiebreak ranks and the winning five cards.
- `poker/score.ts` — encodes category + tiebreak into one comparable integer (higher = stronger; equal score = split).
- `poker/describe.ts` — formats the human-readable description (e.g. "Full house, nines full of twos", "Royal flush").
- `evaluate.ts` — composes the above into the public API, exported from `index.ts`.

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm test` — 63 tests across 14 files, including both exhaustive enumeration tests
- [x] Split/tie, kicker, and wheel edge cases exercised in `evaluate.split.test.ts`

Closes #22

https://claude.ai/code/session_01PCyHrvRr3fV6EdXdJLPsLS