### PR TITLE
feat(harness): persist commands and events as append-as-you-go JSONL

### DIFF
--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -1,6 +1,7 @@
 export { apply } from "./apply.js";
 export { decide } from "./decide.js";
 export { createInitialState } from "./room.js";
+export { ENGINE_LOG_VERSION } from "./version.js";
 export type {
   ActionType,
   BettingHandState,

--- a/packages/engine/src/version.test.ts
+++ b/packages/engine/src/version.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+import { ENGINE_LOG_VERSION } from "./version.js";
+
+describe("ENGINE_LOG_VERSION", () => {
+  it("is a positive integer", () => {
+    expect(Number.isInteger(ENGINE_LOG_VERSION)).toBe(true);
+    expect(ENGINE_LOG_VERSION).toBeGreaterThan(0);
+  });
+});

--- a/packages/engine/src/version.ts
+++ b/packages/engine/src/version.ts
@@ -1,0 +1,6 @@
+/**
+ * Schema version tag for persisted command/event log records — bumped
+ * whenever a change to `HandEvent`/`Command` shapes or the shuffle would
+ * break bit-identical replay. See docs/phase-1-spec.md §5.
+ */
+export const ENGINE_LOG_VERSION = 1;

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -65,6 +65,38 @@ cat commands.jsonl | npx harness > run2.jsonl
 diff run1.jsonl run2.jsonl && echo "identical"
 ```
 
+## Persistence
+
+Pass `--log-dir` to have the harness write both the command stream (ground
+truth for replay) and the event stream (audit trail) to disk as it plays,
+append-as-you-go — see `docs/phase-1-spec.md` §5:
+
+```sh
+cat commands.jsonl | npx harness --log-dir ./logs --game-id friday-game
+```
+
+This produces, per hand, `./logs/friday-game/hand-0001.commands.jsonl` and
+`./logs/friday-game/hand-0001.events.jsonl`, plus a `game.jsonl` manifest
+recording the seating once. `--game-id` defaults to a sortable UTC
+timestamp if omitted, and must be a safe path segment
+(`[A-Za-z0-9._-]+`). Every record is wrapped with the schema version tag
+(`ENGINE_LOG_VERSION` from `@table-top-poker/engine`), so old logs stay
+interpretable against the build they were written by even after a later
+schema change.
+
+A persisted `*.commands.jsonl` file re-pipes through the harness exactly
+like a plain command file — the versioned wrapper is transparently
+unwrapped on read — so the replay procedure above works unmodified on a
+logged file:
+
+```sh
+cat logs/friday-game/hand-0001.commands.jsonl | npx harness --seats 0,1,2
+```
+
+Seating isn't recorded in the command stream itself (it's fixed for a
+game's whole life, set by `--seats` at startup) — replaying a logged game
+requires passing the same `--seats` it was originally run with.
+
 ## Failure modes
 
 The harness fails fast on malformed input rather than risk writing a

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -79,15 +79,16 @@ This produces, per hand, `./logs/friday-game/hand-0001.commands.jsonl` and
 `./logs/friday-game/hand-0001.events.jsonl`, plus a `game.jsonl` manifest
 recording the seating once. `--game-id` defaults to a sortable UTC
 timestamp if omitted, and must be a safe path segment
-(`[A-Za-z0-9._-]+`). Every record is wrapped with the schema version tag
-(`ENGINE_LOG_VERSION` from `@table-top-poker/engine`), so old logs stay
-interpretable against the build they were written by even after a later
-schema change.
+(`[A-Za-z0-9._-]+`).
 
-A persisted `*.commands.jsonl` file re-pipes through the harness exactly
-like a plain command file — the versioned wrapper is transparently
-unwrapped on read — so the replay procedure above works unmodified on a
-logged file:
+Each logged line is exactly the `Command`/`HandEvent`/`Rejection` JSON the
+harness reads or writes on stdin/stdout, plus one extra field: `v`, the
+schema version tag (`ENGINE_LOG_VERSION` from `@table-top-poker/engine`).
+Old logs stay interpretable against the build they were written by even
+after a later schema change bumps the tag for new ones. Because the extra
+field is additive, a persisted `*.commands.jsonl` file re-pipes through
+the harness exactly like a plain command file — the replay procedure
+above works unmodified on a logged file:
 
 ```sh
 cat logs/friday-game/hand-0001.commands.jsonl | npx harness --seats 0,1,2
@@ -95,7 +96,9 @@ cat logs/friday-game/hand-0001.commands.jsonl | npx harness --seats 0,1,2
 
 Seating isn't recorded in the command stream itself (it's fixed for a
 game's whole life, set by `--seats` at startup) — replaying a logged game
-requires passing the same `--seats` it was originally run with.
+requires passing the same `--seats` it was originally run with. The
+`game.jsonl` manifest records the seating for a human or later replay
+tooling to read back; the harness CLI itself doesn't consume it.
 
 ## Failure modes
 

--- a/packages/harness/src/cli-args.test.ts
+++ b/packages/harness/src/cli-args.test.ts
@@ -11,7 +11,9 @@ describe("parseSeats", () => {
   });
 
   it("rejects a non-integer seat", () => {
-    expect(() => parseSeats(["--seats", "0,x"])).toThrow(/not a non-negative integer/);
+    expect(() => parseSeats(["--seats", "0,x"])).toThrow(
+      /not a non-negative integer/,
+    );
   });
 });
 
@@ -27,11 +29,18 @@ describe("parseLogOptions", () => {
   it("defaults --game-id to a sortable timestamp when omitted", () => {
     const options = parseLogOptions(["--log-dir", "/tmp/logs"]);
     expect(options?.logDir).toBe("/tmp/logs");
-    expect(options?.gameId).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/);
+    expect(options?.gameId).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/,
+    );
   });
 
   it("uses an explicit --game-id when given", () => {
-    const options = parseLogOptions(["--log-dir", "/tmp/logs", "--game-id", "friday-game"]);
+    const options = parseLogOptions([
+      "--log-dir",
+      "/tmp/logs",
+      "--game-id",
+      "friday-game",
+    ]);
     expect(options).toEqual({ logDir: "/tmp/logs", gameId: "friday-game" });
   });
 

--- a/packages/harness/src/cli-args.test.ts
+++ b/packages/harness/src/cli-args.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { parseLogOptions, parseSeats } from "./cli-args.js";
+
+describe("parseSeats", () => {
+  it("defaults to seats 0, 1, 2", () => {
+    expect(parseSeats([])).toEqual([0, 1, 2]);
+  });
+
+  it("parses a comma-separated --seats value", () => {
+    expect(parseSeats(["--seats", "0,1,2,3"])).toEqual([0, 1, 2, 3]);
+  });
+
+  it("rejects a non-integer seat", () => {
+    expect(() => parseSeats(["--seats", "0,x"])).toThrow(/not a non-negative integer/);
+  });
+});
+
+describe("parseLogOptions", () => {
+  it("returns null when --log-dir is absent", () => {
+    expect(parseLogOptions(["--seats", "0,1"])).toBeNull();
+  });
+
+  it("requires a value after --log-dir", () => {
+    expect(() => parseLogOptions(["--log-dir"])).toThrow(/--log-dir requires/);
+  });
+
+  it("defaults --game-id to a sortable timestamp when omitted", () => {
+    const options = parseLogOptions(["--log-dir", "/tmp/logs"]);
+    expect(options?.logDir).toBe("/tmp/logs");
+    expect(options?.gameId).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z$/);
+  });
+
+  it("uses an explicit --game-id when given", () => {
+    const options = parseLogOptions(["--log-dir", "/tmp/logs", "--game-id", "friday-game"]);
+    expect(options).toEqual({ logDir: "/tmp/logs", gameId: "friday-game" });
+  });
+
+  it("rejects a --game-id that isn't a safe path segment", () => {
+    expect(() =>
+      parseLogOptions(["--log-dir", "/tmp/logs", "--game-id", "../escape"]),
+    ).toThrow(/game-id/);
+  });
+
+  it("requires a value after --game-id", () => {
+    expect(() =>
+      parseLogOptions(["--log-dir", "/tmp/logs", "--game-id"]),
+    ).toThrow(/--game-id requires/);
+  });
+});

--- a/packages/harness/src/cli-args.ts
+++ b/packages/harness/src/cli-args.ts
@@ -1,0 +1,53 @@
+import type { SeatId } from "@table-top-poker/engine";
+import { assertValidGameId } from "./persistence.js";
+
+export function parseSeats(argv: readonly string[]): SeatId[] {
+  const flagIndex = argv.indexOf("--seats");
+  if (flagIndex === -1) return [0, 1, 2];
+
+  const value = argv[flagIndex + 1];
+  if (value === undefined) {
+    throw new Error("--seats requires a comma-separated list of seat ids");
+  }
+  return value.split(",").map((seat) => {
+    const trimmed = seat.trim();
+    if (!/^\d+$/.test(trimmed)) {
+      throw new Error(`--seats: "${seat}" is not a non-negative integer`);
+    }
+    return Number.parseInt(trimmed, 10);
+  });
+}
+
+export interface LogOptions {
+  readonly logDir: string;
+  readonly gameId: string;
+}
+
+function defaultGameId(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+export function parseLogOptions(argv: readonly string[]): LogOptions | null {
+  const dirIndex = argv.indexOf("--log-dir");
+  if (dirIndex === -1) return null;
+
+  const logDir = argv[dirIndex + 1];
+  if (logDir === undefined) {
+    throw new Error("--log-dir requires a directory path");
+  }
+
+  const gameIdIndex = argv.indexOf("--game-id");
+  let gameId: string;
+  if (gameIdIndex === -1) {
+    gameId = defaultGameId();
+  } else {
+    const value = argv[gameIdIndex + 1];
+    if (value === undefined) {
+      throw new Error("--game-id requires a value");
+    }
+    gameId = value;
+  }
+
+  assertValidGameId(gameId);
+  return { logDir, gameId };
+}

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -1,24 +1,8 @@
 #!/usr/bin/env node
 import { createInitialState } from "@table-top-poker/engine";
-import type { SeatId } from "@table-top-poker/engine";
+import { parseLogOptions, parseSeats } from "./cli-args.js";
 import { runHarness } from "./harness.js";
-
-function parseSeats(argv: readonly string[]): SeatId[] {
-  const flagIndex = argv.indexOf("--seats");
-  if (flagIndex === -1) return [0, 1, 2];
-
-  const value = argv[flagIndex + 1];
-  if (value === undefined) {
-    throw new Error("--seats requires a comma-separated list of seat ids");
-  }
-  return value.split(",").map((seat) => {
-    const trimmed = seat.trim();
-    if (!/^\d+$/.test(trimmed)) {
-      throw new Error(`--seats: "${seat}" is not a non-negative integer`);
-    }
-    return Number.parseInt(trimmed, 10);
-  });
-}
+import { HandLog } from "./persistence.js";
 
 // A downstream reader (`| head`, `| less`) closing early is normal Unix
 // pipeline usage, not a harness failure — exit quietly instead of crashing
@@ -29,10 +13,17 @@ process.stdout.on("error", (error: NodeJS.ErrnoException) => {
 });
 
 try {
+  const argv = process.argv.slice(2);
+  const seats = parseSeats(argv);
+  const logOptions = parseLogOptions(argv);
+
   await runHarness({
-    state: createInitialState(parseSeats(process.argv.slice(2))),
+    state: createInitialState(seats),
     input: process.stdin,
     output: process.stdout,
+    ...(logOptions
+      ? { log: new HandLog(logOptions.logDir, logOptions.gameId, seats) }
+      : {}),
   });
 } catch (error) {
   console.error(error instanceof Error ? error.message : error);

--- a/packages/harness/src/harness.test.ts
+++ b/packages/harness/src/harness.test.ts
@@ -136,11 +136,13 @@ describe("runHarness", () => {
     ).rejects.toThrow(/unrecognized command/);
   });
 
-  it("accepts a versioned-command line ({v, command}) the same as a bare command", async () => {
+  it("accepts a logged command line (bare Command plus an extra v field) the same as a plain command", async () => {
     const input = Readable.from([
       JSON.stringify({
+        type: "startHand",
+        playerId: 0,
+        seed: "seed-1",
         v: ENGINE_LOG_VERSION,
-        command: { type: "startHand", playerId: 0, seed: "seed-1" },
       }) + "\n",
     ]);
     const { writable, lines } = collectingWritable();
@@ -194,27 +196,31 @@ describe("runHarness", () => {
       })
         .trim()
         .split("\n")
-        .map((line) => JSON.parse(line) as { command: { type: string } });
-      expect(loggedCommands.map((r) => r.command.type)).toEqual([
-        "startHand",
-        "call",
-      ]);
+        .map((line) => JSON.parse(line) as { type: string; v: number });
+      expect(loggedCommands.map((r) => r.type)).toEqual(["startHand", "call"]);
+      expect(loggedCommands.every((r) => r.v === ENGINE_LOG_VERSION)).toBe(
+        true,
+      );
 
       const loggedEvents = readFileSync(hand1.eventsPath, { encoding: "utf8" })
         .trim()
         .split("\n")
-        .map((line) => JSON.parse(line) as { event: { type: string } });
-      expect(loggedEvents.map((r) => r.event.type)).toEqual(
+        .map((line) => JSON.parse(line) as { type: string; v: number });
+      expect(loggedEvents.map((r) => r.type)).toEqual(
         lines().map((line) => (JSON.parse(line) as { type: string }).type),
       );
+      expect(loggedEvents.every((r) => r.v === ENGINE_LOG_VERSION)).toBe(true);
     });
 
-    it("logs a Rejection to the event log too", async () => {
+    it("logs a Rejection raised mid-hand to that hand's event log", async () => {
       const logDir = tempLogDir();
       const log = new HandLog(logDir, "game-1", [0, 1, 2]);
-      const input = Readable.from([
-        JSON.stringify({ type: "call", playerId: 1 }) + "\n",
-      ]);
+      const input = Readable.from(
+        [
+          { type: "startHand", playerId: 0, seed: "seed-1" },
+          { type: "check", playerId: 1 },
+        ].map((command) => JSON.stringify(command) + "\n"),
+      );
       const { writable } = collectingWritable();
 
       await runHarness({
@@ -224,17 +230,14 @@ describe("runHarness", () => {
         log,
       });
 
-      const hand0 = handLogPaths(path.join(logDir, "game-1"), 0);
-      const loggedEvents = readFileSync(hand0.eventsPath, { encoding: "utf8" })
+      const hand1 = handLogPaths(path.join(logDir, "game-1"), 1);
+      const loggedEvents = readFileSync(hand1.eventsPath, { encoding: "utf8" })
         .trim()
         .split("\n")
-        .map(
-          (line) =>
-            JSON.parse(line) as { event: { type: string; reason?: string } },
-        );
-      expect(loggedEvents).toHaveLength(1);
-      expect(loggedEvents[0]?.event.type).toBe("Rejection");
-      expect(loggedEvents[0]?.event.reason).toBe("hand-not-in-progress");
+        .map((line) => JSON.parse(line) as { type: string; reason?: string });
+      const rejection = loggedEvents.at(-1);
+      expect(rejection?.type).toBe("Rejection");
+      expect(rejection?.reason).toBe("action-not-legal");
     });
   });
 });

--- a/packages/harness/src/harness.test.ts
+++ b/packages/harness/src/harness.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { Readable, Writable } from "node:stream";
 import { afterEach, describe, expect, it } from "vitest";
-import { createInitialState, ENGINE_LOG_VERSION } from "@table-top-poker/engine";
+import {
+  createInitialState,
+  ENGINE_LOG_VERSION,
+} from "@table-top-poker/engine";
 import { runHarness } from "./harness.js";
 import { HandLog, handLogPaths } from "./persistence.js";
 
@@ -148,7 +151,9 @@ describe("runHarness", () => {
       output: writable,
     });
 
-    const events = lines().map((line: string) => JSON.parse(line) as { type: string });
+    const events = lines().map(
+      (line: string) => JSON.parse(line) as { type: string },
+    );
     expect(events[0]?.type).toBe("HandStarted");
   });
 
@@ -162,7 +167,8 @@ describe("runHarness", () => {
     }
 
     afterEach(() => {
-      for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+      for (const dir of dirs.splice(0))
+        rmSync(dir, { recursive: true, force: true });
     });
 
     it("writes every command and event to the log without changing stdout", async () => {
@@ -183,11 +189,16 @@ describe("runHarness", () => {
       });
 
       const hand1 = handLogPaths(path.join(logDir, "game-1"), 1);
-      const loggedCommands = readFileSync(hand1.commandsPath, { encoding: "utf8" })
+      const loggedCommands = readFileSync(hand1.commandsPath, {
+        encoding: "utf8",
+      })
         .trim()
         .split("\n")
         .map((line) => JSON.parse(line) as { command: { type: string } });
-      expect(loggedCommands.map((r) => r.command.type)).toEqual(["startHand", "call"]);
+      expect(loggedCommands.map((r) => r.command.type)).toEqual([
+        "startHand",
+        "call",
+      ]);
 
       const loggedEvents = readFileSync(hand1.eventsPath, { encoding: "utf8" })
         .trim()
@@ -217,7 +228,10 @@ describe("runHarness", () => {
       const loggedEvents = readFileSync(hand0.eventsPath, { encoding: "utf8" })
         .trim()
         .split("\n")
-        .map((line) => JSON.parse(line) as { event: { type: string; reason?: string } });
+        .map(
+          (line) =>
+            JSON.parse(line) as { event: { type: string; reason?: string } },
+        );
       expect(loggedEvents).toHaveLength(1);
       expect(loggedEvents[0]?.event.type).toBe("Rejection");
       expect(loggedEvents[0]?.event.reason).toBe("hand-not-in-progress");

--- a/packages/harness/src/harness.test.ts
+++ b/packages/harness/src/harness.test.ts
@@ -1,7 +1,11 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { Readable, Writable } from "node:stream";
-import { describe, expect, it } from "vitest";
-import { createInitialState } from "@table-top-poker/engine";
+import { afterEach, describe, expect, it } from "vitest";
+import { createInitialState, ENGINE_LOG_VERSION } from "@table-top-poker/engine";
 import { runHarness } from "./harness.js";
+import { HandLog, handLogPaths } from "./persistence.js";
 
 function collectingWritable(): { writable: Writable; lines: () => string[] } {
   const chunks: string[] = [];
@@ -127,5 +131,96 @@ describe("runHarness", () => {
         output: writable,
       }),
     ).rejects.toThrow(/unrecognized command/);
+  });
+
+  it("accepts a versioned-command line ({v, command}) the same as a bare command", async () => {
+    const input = Readable.from([
+      JSON.stringify({
+        v: ENGINE_LOG_VERSION,
+        command: { type: "startHand", playerId: 0, seed: "seed-1" },
+      }) + "\n",
+    ]);
+    const { writable, lines } = collectingWritable();
+
+    await runHarness({
+      state: createInitialState([0, 1, 2]),
+      input,
+      output: writable,
+    });
+
+    const events = lines().map((line: string) => JSON.parse(line) as { type: string });
+    expect(events[0]?.type).toBe("HandStarted");
+  });
+
+  describe("with logging enabled", () => {
+    const dirs: string[] = [];
+
+    function tempLogDir(): string {
+      const dir = mkdtempSync(path.join(tmpdir(), "harness-log-"));
+      dirs.push(dir);
+      return dir;
+    }
+
+    afterEach(() => {
+      for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("writes every command and event to the log without changing stdout", async () => {
+      const logDir = tempLogDir();
+      const log = new HandLog(logDir, "game-1", [0, 1, 2]);
+      const commandLines = [
+        JSON.stringify({ type: "startHand", playerId: 0, seed: "seed-1" }),
+        JSON.stringify({ type: "call", playerId: 1 }),
+      ];
+      const input = Readable.from(commandLines.map((line) => line + "\n"));
+      const { writable, lines } = collectingWritable();
+
+      await runHarness({
+        state: createInitialState([0, 1, 2]),
+        input,
+        output: writable,
+        log,
+      });
+
+      const hand1 = handLogPaths(path.join(logDir, "game-1"), 1);
+      const loggedCommands = readFileSync(hand1.commandsPath, { encoding: "utf8" })
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { command: { type: string } });
+      expect(loggedCommands.map((r) => r.command.type)).toEqual(["startHand", "call"]);
+
+      const loggedEvents = readFileSync(hand1.eventsPath, { encoding: "utf8" })
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { event: { type: string } });
+      expect(loggedEvents.map((r) => r.event.type)).toEqual(
+        lines().map((line) => (JSON.parse(line) as { type: string }).type),
+      );
+    });
+
+    it("logs a Rejection to the event log too", async () => {
+      const logDir = tempLogDir();
+      const log = new HandLog(logDir, "game-1", [0, 1, 2]);
+      const input = Readable.from([
+        JSON.stringify({ type: "call", playerId: 1 }) + "\n",
+      ]);
+      const { writable } = collectingWritable();
+
+      await runHarness({
+        state: createInitialState([0, 1, 2]),
+        input,
+        output: writable,
+        log,
+      });
+
+      const hand0 = handLogPaths(path.join(logDir, "game-1"), 0);
+      const loggedEvents = readFileSync(hand0.eventsPath, { encoding: "utf8" })
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as { event: { type: string; reason?: string } });
+      expect(loggedEvents).toHaveLength(1);
+      expect(loggedEvents[0]?.event.type).toBe("Rejection");
+      expect(loggedEvents[0]?.event.reason).toBe("hand-not-in-progress");
+    });
   });
 });

--- a/packages/harness/src/harness.ts
+++ b/packages/harness/src/harness.ts
@@ -7,7 +7,7 @@ import type {
   HandEvent,
   Rejection,
 } from "@table-top-poker/engine";
-import type { HandLog, VersionedCommand } from "./persistence.js";
+import type { HandLog } from "./persistence.js";
 
 export interface RunHarnessOptions {
   readonly state: EngineState;
@@ -17,30 +17,16 @@ export interface RunHarnessOptions {
   readonly log?: HandLog;
 }
 
-function isVersionedCommand(value: object): value is VersionedCommand {
-  return "v" in value && "command" in value;
-}
-
-/**
- * Accepts a bare `Command` line (normal harness input) or a `{v, command}`
- * line as persisted by `HandLog` — so re-piping a persisted command log
- * through the harness (the replay guarantee) needs no separate unwrapping.
- */
+// A logged command line carries an extra `v` field (see persistence.ts's
+// `LoggedCommand`) but is otherwise a bare `Command` — decide() only reads
+// the fields it knows about, so the extra field is silently ignored and a
+// persisted command log re-pipes through the harness unmodified.
 function parseCommand(line: string): Command {
-  let parsed: unknown;
   try {
-    parsed = JSON.parse(line);
+    return JSON.parse(line) as Command;
   } catch (cause) {
     throw new Error(`invalid JSON on harness input: ${line}`, { cause });
   }
-  if (
-    parsed !== null &&
-    typeof parsed === "object" &&
-    isVersionedCommand(parsed)
-  ) {
-    return parsed.command;
-  }
-  return parsed as Command;
 }
 
 /**

--- a/packages/harness/src/harness.ts
+++ b/packages/harness/src/harness.ts
@@ -7,19 +7,36 @@ import type {
   HandEvent,
   Rejection,
 } from "@table-top-poker/engine";
+import type { HandLog, VersionedCommand } from "./persistence.js";
 
 export interface RunHarnessOptions {
   readonly state: EngineState;
   readonly input: Readable;
   readonly output: Writable;
+  /** Optional append-as-you-go persistence — see docs/phase-1-spec.md §5. */
+  readonly log?: HandLog;
 }
 
+function isVersionedCommand(value: object): value is VersionedCommand {
+  return "v" in value && "command" in value;
+}
+
+/**
+ * Accepts a bare `Command` line (normal harness input) or a `{v, command}`
+ * line as persisted by `HandLog` — so re-piping a persisted command log
+ * through the harness (the replay guarantee) needs no separate unwrapping.
+ */
 function parseCommand(line: string): Command {
+  let parsed: unknown;
   try {
-    return JSON.parse(line) as Command;
+    parsed = JSON.parse(line);
   } catch (cause) {
     throw new Error(`invalid JSON on harness input: ${line}`, { cause });
   }
+  if (parsed !== null && typeof parsed === "object" && isVersionedCommand(parsed)) {
+    return parsed.command;
+  }
+  return parsed as Command;
 }
 
 /**
@@ -44,6 +61,7 @@ export async function runHarness(options: RunHarnessOptions): Promise<void> {
     if (line.trim() === "") continue;
 
     const command = parseCommand(line);
+    options.log?.logCommand(command);
     // decide()'s Command union is exhaustive only at compile time; this
     // input is untrusted JSON, so an unrecognized `type` falls off the
     // engine's switch at runtime and returns undefined, not a type error.
@@ -54,12 +72,14 @@ export async function runHarness(options: RunHarnessOptions): Promise<void> {
     }
 
     if (!Array.isArray(result)) {
+      options.log?.logEvent(result);
       options.output.write(JSON.stringify(result) + "\n");
       continue;
     }
 
     for (const event of result) {
       state = apply(state, event);
+      options.log?.logEvent(event);
       options.output.write(JSON.stringify(event) + "\n");
     }
   }

--- a/packages/harness/src/harness.ts
+++ b/packages/harness/src/harness.ts
@@ -33,7 +33,11 @@ function parseCommand(line: string): Command {
   } catch (cause) {
     throw new Error(`invalid JSON on harness input: ${line}`, { cause });
   }
-  if (parsed !== null && typeof parsed === "object" && isVersionedCommand(parsed)) {
+  if (
+    parsed !== null &&
+    typeof parsed === "object" &&
+    isVersionedCommand(parsed)
+  ) {
     return parsed.command;
   }
   return parsed as Command;

--- a/packages/harness/src/persistence.durability.test.ts
+++ b/packages/harness/src/persistence.durability.test.ts
@@ -1,0 +1,122 @@
+import { execSync, spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const cliPath = path.join(repoRoot, "packages/harness/dist/cli.js");
+
+const commands = [
+  { type: "startHand", playerId: 0, seed: "durability-seed" },
+  { type: "call", playerId: 1 },
+  { type: "raise", playerId: 2 },
+  { type: "call", playerId: 0 },
+];
+
+function readJsonLines(filePath: string): unknown[] {
+  const text = readFileSync(filePath, { encoding: "utf8" });
+  const lines = text.split("\n").filter((line) => line !== "");
+  return lines.map((line) => JSON.parse(line) as unknown);
+}
+
+describe("HandLog crash durability", () => {
+  const dirs: string[] = [];
+
+  beforeAll(() => {
+    execSync(
+      "npm run build -w @table-top-poker/engine -w @table-top-poker/harness",
+      {
+        cwd: repoRoot,
+        stdio: "pipe",
+      },
+    );
+  }, 60_000);
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0))
+      rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("SIGKILL mid-hand leaves a partial but line-by-line-parseable log, with no completed write lost", async () => {
+    const logDir = mkdtempSync(path.join(tmpdir(), "durability-"));
+    dirs.push(logDir);
+
+    const child = spawn(
+      process.execPath,
+      [
+        cliPath,
+        "--seats",
+        "0,1,2",
+        "--log-dir",
+        logDir,
+        "--game-id",
+        "crash-test",
+      ],
+      { stdio: ["pipe", "pipe", "pipe"] },
+    );
+
+    let stdout = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+
+    // Send commands one at a time, waiting for at least one new stdout line
+    // after each — proof the harness (and therefore the logger, which
+    // writes synchronously before `decide` runs) has processed it.
+    for (const command of commands) {
+      const before = stdout.length;
+      child.stdin.write(JSON.stringify(command) + "\n");
+      await new Promise<void>((resolve) => {
+        const check = (): void => {
+          if (stdout.length > before) {
+            child.stdout.off("data", check);
+            resolve();
+          }
+        };
+        child.stdout.on("data", check);
+      });
+    }
+
+    const exited = new Promise<void>((resolve) => {
+      child.once("exit", () => {
+        resolve();
+      });
+    });
+    child.kill("SIGKILL");
+    await exited;
+
+    const commandsPath = path.join(
+      logDir,
+      "crash-test",
+      "hand-0001.commands.jsonl",
+    );
+    const eventsPath = path.join(
+      logDir,
+      "crash-test",
+      "hand-0001.events.jsonl",
+    );
+
+    // Every line that made it to disk must be a complete, parseable record —
+    // no torn write from the kill landing mid-append.
+    const loggedCommands = readJsonLines(commandsPath) as {
+      v: number;
+      command: { type: string };
+    }[];
+    const loggedEvents = readJsonLines(eventsPath) as {
+      v: number;
+      event: { type: string };
+    }[];
+
+    expect(loggedCommands.length).toBeGreaterThan(0);
+    expect(loggedEvents.length).toBeGreaterThan(0);
+
+    // The logged commands are a prefix of what was actually sent — nothing
+    // sent-and-acknowledged is missing, and nothing beyond what was sent
+    // could have leaked in.
+    expect(loggedCommands.map((r) => r.command.type)).toEqual(
+      commands.slice(0, loggedCommands.length).map((c) => c.type),
+    );
+  }, 20_000);
+});

--- a/packages/harness/src/persistence.durability.test.ts
+++ b/packages/harness/src/persistence.durability.test.ts
@@ -102,11 +102,11 @@ describe("HandLog crash durability", () => {
     // no torn write from the kill landing mid-append.
     const loggedCommands = readJsonLines(commandsPath) as {
       v: number;
-      command: { type: string };
+      type: string;
     }[];
     const loggedEvents = readJsonLines(eventsPath) as {
       v: number;
-      event: { type: string };
+      type: string;
     }[];
 
     expect(loggedCommands.length).toBeGreaterThan(0);
@@ -115,7 +115,7 @@ describe("HandLog crash durability", () => {
     // The logged commands are a prefix of what was actually sent — nothing
     // sent-and-acknowledged is missing, and nothing beyond what was sent
     // could have leaked in.
-    expect(loggedCommands.map((r) => r.command.type)).toEqual(
+    expect(loggedCommands.map((r) => r.type)).toEqual(
       commands.slice(0, loggedCommands.length).map((c) => c.type),
     );
   }, 20_000);

--- a/packages/harness/src/persistence.test.ts
+++ b/packages/harness/src/persistence.test.ts
@@ -25,7 +25,9 @@ describe("HandLog", () => {
 
   afterEach(async () => {
     const { rm } = await import("node:fs/promises");
-    await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+    await Promise.all(
+      dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+    );
   });
 
   it("writes a game manifest carrying the seats and version tag, once", () => {
@@ -44,12 +46,20 @@ describe("HandLog", () => {
 
     const startHand1: Command = { type: "startHand", playerId: 0, seed: "s1" };
     log.logCommand(startHand1);
-    const handStarted1: HandEvent = { type: "HandStarted", seed: "s1", button: 0 };
+    const handStarted1: HandEvent = {
+      type: "HandStarted",
+      seed: "s1",
+      button: 0,
+    };
     log.logEvent(handStarted1);
 
     const nextHand: Command = { type: "nextHand", playerId: 1, seed: "s2" };
     log.logCommand(nextHand);
-    const handStarted2: HandEvent = { type: "HandStarted", seed: "s2", button: 1 };
+    const handStarted2: HandEvent = {
+      type: "HandStarted",
+      seed: "s2",
+      button: 1,
+    };
     log.logEvent(handStarted2);
 
     const hand1 = handLogPaths(path.join(logDir, "game-1"), 1);

--- a/packages/harness/src/persistence.test.ts
+++ b/packages/harness/src/persistence.test.ts
@@ -1,0 +1,90 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ENGINE_LOG_VERSION } from "@table-top-poker/engine";
+import type { Command, HandEvent } from "@table-top-poker/engine";
+import { HandLog, handLogPaths } from "./persistence.js";
+
+function readLines(filePath: string): unknown[] {
+  return readFileSync(filePath, { encoding: "utf8" })
+    .split("\n")
+    .filter((line) => line !== "")
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+describe("HandLog", () => {
+  const dirs: string[] = [];
+
+  function tempLogDir(): string {
+    const dir = mkdtempSync(path.join(tmpdir(), "handlog-"));
+    dirs.push(dir);
+    return dir;
+  }
+
+  afterEach(async () => {
+    const { rm } = await import("node:fs/promises");
+    await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+  });
+
+  it("writes a game manifest carrying the seats and version tag, once", () => {
+    const logDir = tempLogDir();
+    new HandLog(logDir, "game-1", [0, 1, 2]);
+    new HandLog(logDir, "game-1", [0, 1, 2]);
+
+    const manifestPath = path.join(logDir, "game-1", "game.jsonl");
+    const lines = readLines(manifestPath);
+    expect(lines).toEqual([{ v: ENGINE_LOG_VERSION, seats: [0, 1, 2] }]);
+  });
+
+  it("partitions commands and events into a fresh file pair each time a hand starts", () => {
+    const logDir = tempLogDir();
+    const log = new HandLog(logDir, "game-1", [0, 1, 2]);
+
+    const startHand1: Command = { type: "startHand", playerId: 0, seed: "s1" };
+    log.logCommand(startHand1);
+    const handStarted1: HandEvent = { type: "HandStarted", seed: "s1", button: 0 };
+    log.logEvent(handStarted1);
+
+    const nextHand: Command = { type: "nextHand", playerId: 1, seed: "s2" };
+    log.logCommand(nextHand);
+    const handStarted2: HandEvent = { type: "HandStarted", seed: "s2", button: 1 };
+    log.logEvent(handStarted2);
+
+    const hand1 = handLogPaths(path.join(logDir, "game-1"), 1);
+    const hand2 = handLogPaths(path.join(logDir, "game-1"), 2);
+
+    expect(readLines(hand1.commandsPath)).toEqual([
+      { v: ENGINE_LOG_VERSION, command: startHand1 },
+    ]);
+    expect(readLines(hand1.eventsPath)).toEqual([
+      { v: ENGINE_LOG_VERSION, event: handStarted1 },
+    ]);
+    expect(readLines(hand2.commandsPath)).toEqual([
+      { v: ENGINE_LOG_VERSION, command: nextHand },
+    ]);
+    expect(readLines(hand2.eventsPath)).toEqual([
+      { v: ENGINE_LOG_VERSION, event: handStarted2 },
+    ]);
+  });
+
+  it("appends rather than overwriting across multiple commands in the same hand", async () => {
+    const logDir = tempLogDir();
+    const log = new HandLog(logDir, "game-1", [0, 1, 2]);
+
+    log.logCommand({ type: "startHand", playerId: 0, seed: "s1" });
+    log.logCommand({ type: "call", playerId: 1 });
+    log.logCommand({ type: "raise", playerId: 2 });
+
+    const hand1 = handLogPaths(path.join(logDir, "game-1"), 1);
+    const text = await readFile(hand1.commandsPath, { encoding: "utf8" });
+    expect(text.trim().split("\n")).toHaveLength(3);
+  });
+
+  it("rejects a game id that isn't a safe path segment", () => {
+    const logDir = tempLogDir();
+    expect(() => new HandLog(logDir, "../escape", [0, 1])).toThrow(/game-id/);
+    expect(() => new HandLog(logDir, "has spaces", [0, 1])).toThrow(/game-id/);
+  });
+});

--- a/packages/harness/src/persistence.test.ts
+++ b/packages/harness/src/persistence.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -66,17 +66,27 @@ describe("HandLog", () => {
     const hand2 = handLogPaths(path.join(logDir, "game-1"), 2);
 
     expect(readLines(hand1.commandsPath)).toEqual([
-      { v: ENGINE_LOG_VERSION, command: startHand1 },
+      { ...startHand1, v: ENGINE_LOG_VERSION },
     ]);
     expect(readLines(hand1.eventsPath)).toEqual([
-      { v: ENGINE_LOG_VERSION, event: handStarted1 },
+      { ...handStarted1, v: ENGINE_LOG_VERSION },
     ]);
     expect(readLines(hand2.commandsPath)).toEqual([
-      { v: ENGINE_LOG_VERSION, command: nextHand },
+      { ...nextHand, v: ENGINE_LOG_VERSION },
     ]);
     expect(readLines(hand2.eventsPath)).toEqual([
-      { v: ENGINE_LOG_VERSION, event: handStarted2 },
+      { ...handStarted2, v: ENGINE_LOG_VERSION },
     ]);
+  });
+
+  it("does not log a command received before any hand has started — there's no hand to partition it into", () => {
+    const logDir = tempLogDir();
+    const log = new HandLog(logDir, "game-1", [0, 1, 2]);
+
+    log.logCommand({ type: "call", playerId: 1 });
+
+    const hand0 = handLogPaths(path.join(logDir, "game-1"), 0);
+    expect(existsSync(hand0.commandsPath)).toBe(false);
   });
 
   it("appends rather than overwriting across multiple commands in the same hand", async () => {

--- a/packages/harness/src/persistence.ts
+++ b/packages/harness/src/persistence.ts
@@ -1,0 +1,87 @@
+import { appendFileSync, existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { ENGINE_LOG_VERSION } from "@table-top-poker/engine";
+import type { Command, HandEvent, Rejection, SeatId } from "@table-top-poker/engine";
+
+const GAME_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+export function assertValidGameId(gameId: string): void {
+  if (!GAME_ID_PATTERN.test(gameId)) {
+    throw new Error(
+      `--game-id: "${gameId}" must match ${GAME_ID_PATTERN} (it becomes a directory name)`,
+    );
+  }
+}
+
+export interface VersionedCommand {
+  readonly v: number;
+  readonly command: Command;
+}
+
+export interface VersionedEvent {
+  readonly v: number;
+  readonly event: HandEvent | Rejection;
+}
+
+export interface GameManifest {
+  readonly v: number;
+  readonly seats: readonly SeatId[];
+}
+
+export interface HandLogPaths {
+  readonly commandsPath: string;
+  readonly eventsPath: string;
+}
+
+function handBase(handIndex: number): string {
+  return `hand-${String(handIndex).padStart(4, "0")}`;
+}
+
+/** `handIndex` 0 is the pre-game bucket for anything received before the first `startHand`/`nextHand`. */
+export function handLogPaths(gameDir: string, handIndex: number): HandLogPaths {
+  const base = handBase(handIndex);
+  return {
+    commandsPath: path.join(gameDir, `${base}.commands.jsonl`),
+    eventsPath: path.join(gameDir, `${base}.events.jsonl`),
+  };
+}
+
+/**
+ * Append-as-you-go JSONL logger for one game: a seats manifest written once,
+ * plus a command/event log file pair per hand, partitioned by game and by
+ * hand as required by docs/phase-1-spec.md §5. Every write is a single
+ * synchronous fs call — no in-process buffering — so a killed process loses
+ * at most the record it was mid-write on, never a batch of completed ones.
+ */
+export class HandLog {
+  readonly gameDir: string;
+  #handIndex = 0;
+  #paths: HandLogPaths;
+
+  constructor(logDir: string, gameId: string, seats: readonly SeatId[]) {
+    assertValidGameId(gameId);
+    this.gameDir = path.join(logDir, gameId);
+    mkdirSync(this.gameDir, { recursive: true });
+    this.#paths = handLogPaths(this.gameDir, this.#handIndex);
+
+    const manifestPath = path.join(this.gameDir, "game.jsonl");
+    if (!existsSync(manifestPath)) {
+      const manifest: GameManifest = { v: ENGINE_LOG_VERSION, seats };
+      appendFileSync(manifestPath, JSON.stringify(manifest) + "\n");
+    }
+  }
+
+  logCommand(command: Command): void {
+    if (command.type === "startHand" || command.type === "nextHand") {
+      this.#handIndex += 1;
+      this.#paths = handLogPaths(this.gameDir, this.#handIndex);
+    }
+    const record: VersionedCommand = { v: ENGINE_LOG_VERSION, command };
+    appendFileSync(this.#paths.commandsPath, JSON.stringify(record) + "\n");
+  }
+
+  logEvent(event: HandEvent | Rejection): void {
+    const record: VersionedEvent = { v: ENGINE_LOG_VERSION, event };
+    appendFileSync(this.#paths.eventsPath, JSON.stringify(record) + "\n");
+  }
+}

--- a/packages/harness/src/persistence.ts
+++ b/packages/harness/src/persistence.ts
@@ -18,15 +18,11 @@ export function assertValidGameId(gameId: string): void {
   }
 }
 
-export interface VersionedCommand {
-  readonly v: number;
-  readonly command: Command;
-}
+/** A logged command line is the bare `Command` plus a version tag — the exact shape the harness reads on stdin, so a logged file re-pipes through it unmodified. */
+export type LoggedCommand = Command & { readonly v: number };
 
-export interface VersionedEvent {
-  readonly v: number;
-  readonly event: HandEvent | Rejection;
-}
+/** A logged event line is the bare `HandEvent`/`Rejection` plus a version tag — the exact shape the harness writes on stdout. */
+export type LoggedEvent = (HandEvent | Rejection) & { readonly v: number };
 
 export interface GameManifest {
   readonly v: number;
@@ -42,7 +38,6 @@ function handBase(handIndex: number): string {
   return `hand-${String(handIndex).padStart(4, "0")}`;
 }
 
-/** `handIndex` 0 is the pre-game bucket for anything received before the first `startHand`/`nextHand`. */
 export function handLogPaths(gameDir: string, handIndex: number): HandLogPaths {
   const base = handBase(handIndex);
   return {
@@ -57,17 +52,20 @@ export function handLogPaths(gameDir: string, handIndex: number): HandLogPaths {
  * hand as required by docs/phase-1-spec.md §5. Every write is a single
  * synchronous fs call — no in-process buffering — so a killed process loses
  * at most the record it was mid-write on, never a batch of completed ones.
+ *
+ * A command/event received before the first `startHand`/`nextHand` belongs
+ * to no hand yet, so it isn't logged — there's nothing to partition it
+ * into.
  */
 export class HandLog {
   readonly gameDir: string;
   #handIndex = 0;
-  #paths: HandLogPaths;
+  #paths: HandLogPaths | null = null;
 
   constructor(logDir: string, gameId: string, seats: readonly SeatId[]) {
     assertValidGameId(gameId);
     this.gameDir = path.join(logDir, gameId);
     mkdirSync(this.gameDir, { recursive: true });
-    this.#paths = handLogPaths(this.gameDir, this.#handIndex);
 
     const manifestPath = path.join(this.gameDir, "game.jsonl");
     if (!existsSync(manifestPath)) {
@@ -81,12 +79,16 @@ export class HandLog {
       this.#handIndex += 1;
       this.#paths = handLogPaths(this.gameDir, this.#handIndex);
     }
-    const record: VersionedCommand = { v: ENGINE_LOG_VERSION, command };
+    if (this.#paths === null) return;
+
+    const record: LoggedCommand = { ...command, v: ENGINE_LOG_VERSION };
     appendFileSync(this.#paths.commandsPath, JSON.stringify(record) + "\n");
   }
 
   logEvent(event: HandEvent | Rejection): void {
-    const record: VersionedEvent = { v: ENGINE_LOG_VERSION, event };
+    if (this.#paths === null) return;
+
+    const record: LoggedEvent = { ...event, v: ENGINE_LOG_VERSION };
     appendFileSync(this.#paths.eventsPath, JSON.stringify(record) + "\n");
   }
 }

--- a/packages/harness/src/persistence.ts
+++ b/packages/harness/src/persistence.ts
@@ -1,14 +1,19 @@
 import { appendFileSync, existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { ENGINE_LOG_VERSION } from "@table-top-poker/engine";
-import type { Command, HandEvent, Rejection, SeatId } from "@table-top-poker/engine";
+import type {
+  Command,
+  HandEvent,
+  Rejection,
+  SeatId,
+} from "@table-top-poker/engine";
 
 const GAME_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
 
 export function assertValidGameId(gameId: string): void {
   if (!GAME_ID_PATTERN.test(gameId)) {
     throw new Error(
-      `--game-id: "${gameId}" must match ${GAME_ID_PATTERN} (it becomes a directory name)`,
+      `--game-id: "${gameId}" must match ${GAME_ID_PATTERN.source} (it becomes a directory name)`,
     );
   }
 }

--- a/packages/harness/src/replay.test.ts
+++ b/packages/harness/src/replay.test.ts
@@ -1,0 +1,90 @@
+import { createReadStream, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Readable, Writable } from "node:stream";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createInitialState,
+  ENGINE_LOG_VERSION,
+} from "@table-top-poker/engine";
+import type { HandEvent, Rejection } from "@table-top-poker/engine";
+import { runHarness } from "./harness.js";
+import { handLogPaths, HandLog } from "./persistence.js";
+
+function collectingWritable(): { writable: Writable; lines: () => string[] } {
+  const chunks: string[] = [];
+  const writable = new Writable({
+    write(chunk: Buffer, _encoding, callback) {
+      chunks.push(chunk.toString("utf8"));
+      callback();
+    },
+  });
+  return { writable, lines: () => chunks.join("").split("\n").slice(0, -1) };
+}
+
+function readJsonLines(filePath: string): unknown[] {
+  return readFileSync(filePath, { encoding: "utf8" })
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+describe("replay guarantee", () => {
+  const dirs: string[] = [];
+
+  function tempLogDir(): string {
+    const dir = mkdtempSync(path.join(tmpdir(), "replay-"));
+    dirs.push(dir);
+    return dir;
+  }
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0))
+      rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("re-piping a persisted command log through the harness reproduces the persisted event log exactly", async () => {
+    const logDir = tempLogDir();
+    const seats = [0, 1, 2] as const;
+    const log = new HandLog(logDir, "game-1", seats);
+
+    const commands = [
+      { type: "startHand", playerId: 0, seed: "replay-seed" },
+      { type: "call", playerId: 1 },
+      { type: "raise", playerId: 2 },
+      { type: "call", playerId: 0 },
+      { type: "call", playerId: 1 },
+    ];
+    const original = collectingWritable();
+    await runHarness({
+      state: createInitialState([...seats]),
+      input: Readable.from(commands.map((c) => JSON.stringify(c) + "\n")),
+      output: original.writable,
+      log,
+    });
+
+    const hand1 = handLogPaths(path.join(logDir, "game-1"), 1);
+
+    // Re-pipe the persisted command log (the file on disk, unmodified) through
+    // a fresh harness instance with no logging attached.
+    const replayed = collectingWritable();
+    await runHarness({
+      state: createInitialState([...seats]),
+      input: createReadStream(hand1.commandsPath),
+      output: replayed.writable,
+    });
+
+    const replayedEvents = replayed
+      .lines()
+      .map((line) => JSON.parse(line) as HandEvent | Rejection);
+
+    const persisted = readJsonLines(hand1.eventsPath) as {
+      v: number;
+      event: HandEvent | Rejection;
+    }[];
+
+    expect(persisted.every((r) => r.v === ENGINE_LOG_VERSION)).toBe(true);
+    expect(replayedEvents).toEqual(persisted.map((r) => r.event));
+    expect(replayed.lines()).toEqual(original.lines());
+  });
+});

--- a/packages/harness/src/replay.test.ts
+++ b/packages/harness/src/replay.test.ts
@@ -29,6 +29,12 @@ function readJsonLines(filePath: string): unknown[] {
     .map((line) => JSON.parse(line) as unknown);
 }
 
+function withoutVersion<T extends { v: number }>(record: T): Omit<T, "v"> {
+  const { v, ...rest } = record;
+  void v;
+  return rest;
+}
+
 describe("replay guarantee", () => {
   const dirs: string[] = [];
 
@@ -78,13 +84,12 @@ describe("replay guarantee", () => {
       .lines()
       .map((line) => JSON.parse(line) as HandEvent | Rejection);
 
-    const persisted = readJsonLines(hand1.eventsPath) as {
-      v: number;
-      event: HandEvent | Rejection;
-    }[];
+    const persisted = readJsonLines(hand1.eventsPath) as ((
+      HandEvent | Rejection
+    ) & { v: number })[];
 
     expect(persisted.every((r) => r.v === ENGINE_LOG_VERSION)).toBe(true);
-    expect(replayedEvents).toEqual(persisted.map((r) => r.event));
+    expect(replayedEvents).toEqual(persisted.map(withoutVersion));
     expect(replayed.lines()).toEqual(original.lines());
   });
 });


### PR DESCRIPTION
## Summary

- Adds `HandLog`, an append-as-you-go JSONL logger in `packages/harness/src/persistence.ts`: a `game.jsonl` manifest (seats, version) written once per game, plus a `hand-NNNN.commands.jsonl`/`hand-NNNN.events.jsonl` file pair per hand, partitioned by game and by hand.
- Every write is a single synchronous `fs.appendFileSync` — no in-process buffering — so a killed process loses at most the record it was mid-write on, never a batch of completed lines.
- Each logged line is the bare `Command`/`HandEvent`/`Rejection` plus one extra `v` field (`ENGINE_LOG_VERSION`, exported from `@table-top-poker/engine`) — matching the harness's existing stream shape rather than wrapping it, so a persisted commands log re-pipes through the harness unmodified (the replay guarantee) with no special-case parsing needed.
- New `--log-dir`/`--game-id` CLI flags wire logging into the harness; `--game-id` defaults to a sortable UTC timestamp and is validated as a safe path segment.
- Documents the feature in `packages/harness/README.md`, including the known limitation that seating (fixed by `--seats`) isn't recoverable from the command log itself — the `game.jsonl` manifest records it for a human or later replay tooling, but the CLI doesn't consume it back (out of scope here; replay tooling proper is issue #35).

Closes #25.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 48 passing, including:
  - `persistence.test.ts` — `HandLog` manifest/partitioning/append behavior
  - `harness.test.ts` — logging wired into `runHarness`, logged-command lines accepted as input
  - `replay.test.ts` — re-piping a persisted command log through the harness reproduces the persisted event log exactly
  - `persistence.durability.test.ts` — spawns the built CLI, sends commands one at a time waiting for each to be acknowledged on stdout, `SIGKILL`s mid-hand, and asserts every line on disk is parseable and a prefix of what was sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SUPVv7dguUQJUDY9kMMx3A