### PR TITLE
feat(engine): per-seat visibility (view)

### DIFF
--- a/packages/engine/src/apply.ts
+++ b/packages/engine/src/apply.ts
@@ -124,29 +124,46 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
       const hand = asBetting(state);
       return {
         ...state,
-        hand: { status: "complete", seed: hand.seed, button: hand.button },
+        hand: {
+          status: "complete",
+          reason: "folded-out",
+          seed: hand.seed,
+          button: hand.button,
+          winner: event.winner,
+        },
       };
     }
 
-    case "ShowdownReached":
-      return state;
+    case "ShowdownReached": {
+      const hand = asBetting(state);
+      const results = event.results.map((result) => ({
+        ...result,
+        holeCards: must(
+          seatState(hand, result.seatId).holeCards,
+          "a live seat at showdown always has hole cards",
+        ),
+      }));
+      return {
+        ...state,
+        hand: {
+          status: "complete",
+          reason: "showdown",
+          seed: hand.seed,
+          button: hand.button,
+          results,
+          winners: event.winners,
+        },
+      };
+    }
 
     case "HandComplete": {
-      if (state.hand === null) {
-        throw new Error("expected an in-progress hand");
+      if (state.hand?.status !== "complete") {
+        throw new Error("expected the hand to already be complete");
       }
-      const completedHand =
-        state.hand.status === "complete"
-          ? state.hand
-          : {
-              status: "complete" as const,
-              seed: state.hand.seed,
-              button: state.hand.button,
-            };
       return {
         ...state,
         button: nextButtonAfter(state.seats, state.button),
-        hand: completedHand,
+        hand: state.hand,
       };
     }
   }

--- a/packages/engine/src/complete-hand-state.test.ts
+++ b/packages/engine/src/complete-hand-state.test.ts
@@ -22,9 +22,7 @@ describe("CompleteHandState carries how the hand ended", () => {
 
   it("tags a showdown completion with reason 'showdown' plus results and winners", () => {
     let state = createInitialState([0, 1]);
-    state = playAll(state, [
-      { type: "startHand", playerId: 0, seed: "s0" },
-    ]);
+    state = playAll(state, [{ type: "startHand", playerId: 0, seed: "s0" }]);
     state = playAll(state, [
       { type: "call", playerId: 0 },
       { type: "check", playerId: 1 },

--- a/packages/engine/src/complete-hand-state.test.ts
+++ b/packages/engine/src/complete-hand-state.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { createInitialState } from "./room.js";
+import { playAll } from "./test-utils.js";
+
+describe("CompleteHandState carries how the hand ended", () => {
+  it("tags a fold-out completion with reason 'folded-out' and the winner", () => {
+    let state = createInitialState([0, 1, 2]);
+    state = playAll(state, [
+      { type: "startHand", playerId: 0, seed: "foldout" },
+    ]);
+    state = playAll(state, [
+      { type: "fold", playerId: 1 },
+      { type: "fold", playerId: 2 },
+    ]);
+
+    if (state.hand?.status !== "complete") throw new Error("expected complete");
+    expect(state.hand.reason).toBe("folded-out");
+    if (state.hand.reason === "folded-out") {
+      expect(state.hand.winner).toBe(0);
+    }
+  });
+
+  it("tags a showdown completion with reason 'showdown' plus results and winners", () => {
+    let state = createInitialState([0, 1]);
+    state = playAll(state, [
+      { type: "startHand", playerId: 0, seed: "s0" },
+    ]);
+    state = playAll(state, [
+      { type: "call", playerId: 0 },
+      { type: "check", playerId: 1 },
+      { type: "check", playerId: 1 },
+      { type: "check", playerId: 0 },
+      { type: "check", playerId: 1 },
+      { type: "check", playerId: 0 },
+      { type: "check", playerId: 1 },
+      { type: "check", playerId: 0 },
+    ]);
+
+    if (state.hand?.status !== "complete") throw new Error("expected complete");
+    expect(state.hand.reason).toBe("showdown");
+    if (state.hand.reason === "showdown") {
+      expect(state.hand.results).toHaveLength(2);
+      expect(state.hand.winners.length).toBeGreaterThan(0);
+      for (const result of state.hand.results) {
+        expect(result.holeCards).toHaveLength(2);
+      }
+    }
+  });
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -11,13 +11,20 @@ export type {
   Command,
   CompleteHandState,
   EngineState,
+  FoldedOutCompleteHandState,
   HandEvent,
   HandRank,
   HandState,
   Rank,
   Rejection,
   RejectionReason,
+  RevealedResult,
+  SeatHandState,
   SeatId,
+  ShowdownCompleteHandState,
+  ShowdownResult,
   Street,
   Suit,
 } from "./types.js";
+export { view } from "./view.js";
+export type { PlayerView, TableView } from "./view.js";

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -66,7 +66,7 @@ export interface Rejection {
   readonly command: Command;
 }
 
-interface SeatHandState {
+export interface SeatHandState {
   readonly holeCards: readonly [Card, Card] | null;
   readonly folded: boolean;
 }
@@ -90,11 +90,44 @@ export interface BettingHandState {
   readonly raiseOccurred: boolean;
 }
 
-export interface CompleteHandState {
+export interface ShowdownResult {
+  readonly seatId: SeatId;
+  readonly rank: HandRank;
+  readonly bestHand: readonly [Card, Card, Card, Card, Card];
+  readonly description: string;
+}
+
+/**
+ * A live seat's showdown result with its hole cards attached — the only
+ * place another seat's hole cards are structurally reachable, and only
+ * ever for a seat that actually reached showdown live (see
+ * docs/phase-1-spec.md §4, Visibility). Built once, in `apply`, from the
+ * betting hand's players map; nothing downstream needs that map again.
+ */
+export interface RevealedResult extends ShowdownResult {
+  readonly holeCards: readonly [Card, Card];
+}
+
+export interface FoldedOutCompleteHandState {
   readonly status: "complete";
+  readonly reason: "folded-out";
   readonly seed: string;
   readonly button: SeatId;
+  readonly winner: SeatId;
 }
+
+export interface ShowdownCompleteHandState {
+  readonly status: "complete";
+  readonly reason: "showdown";
+  readonly seed: string;
+  readonly button: SeatId;
+  readonly results: readonly RevealedResult[];
+  readonly winners: readonly SeatId[];
+}
+
+export type CompleteHandState =
+  | FoldedOutCompleteHandState
+  | ShowdownCompleteHandState;
 
 export type HandState = BettingHandState | CompleteHandState;
 

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -126,8 +126,7 @@ export interface ShowdownCompleteHandState {
 }
 
 export type CompleteHandState =
-  | FoldedOutCompleteHandState
-  | ShowdownCompleteHandState;
+  FoldedOutCompleteHandState | ShowdownCompleteHandState;
 
 export type HandState = BettingHandState | CompleteHandState;
 

--- a/packages/engine/src/view.test.ts
+++ b/packages/engine/src/view.test.ts
@@ -1,0 +1,280 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { apply } from "./apply.js";
+import { decide } from "./decide.js";
+import { createInitialState } from "./room.js";
+import { facingBet } from "./table.js";
+import { playAll } from "./test-utils.js";
+import type { Card, EngineState, SeatId } from "./types.js";
+import { must } from "./util.js";
+import { view } from "./view.js";
+
+function headsUpToRiver(seed: string): EngineState {
+  let state = createInitialState([0, 1]);
+  state = playAll(state, [{ type: "startHand", playerId: 0, seed }]);
+  state = playAll(state, [
+    { type: "call", playerId: 0 },
+    { type: "check", playerId: 1 },
+    { type: "check", playerId: 1 },
+    { type: "check", playerId: 0 },
+    { type: "check", playerId: 1 },
+    { type: "check", playerId: 0 },
+    { type: "check", playerId: 1 },
+    { type: "check", playerId: 0 },
+  ]);
+  return state;
+}
+
+/** Three-way, preflop action closed and the flop dealt — a non-trivial board. */
+function onTheFlopThreeWay(): EngineState {
+  let state = createInitialState([0, 1, 2]);
+  state = playAll(state, [{ type: "startHand", playerId: 0, seed: "mid" }]);
+  // ring (button 0) = [1, 2, 0], BB = seat 2. Only the BB can check preflop
+  // absent a raise; everyone else calls. No raise, so the BB also gets its
+  // one-time option turn after the lap closes back around.
+  state = playAll(state, [
+    { type: "call", playerId: 1 },
+    { type: "check", playerId: 2 },
+    { type: "call", playerId: 0 },
+    { type: "check", playerId: 2 },
+  ]);
+  if (state.hand?.status !== "betting" || state.hand.street !== "flop") {
+    throw new Error("expected to reach the flop");
+  }
+  return state;
+}
+
+describe("view: own hole cards mid-hand", () => {
+  it("a seat sees its own hole cards", () => {
+    const state = onTheFlopThreeWay();
+    const mine = view(state, 0);
+    if (mine.phase !== "betting") throw new Error("expected betting phase");
+    expect(mine.yourHoleCards).not.toBeNull();
+    expect(mine.yourHoleCards).toHaveLength(2);
+  });
+});
+
+describe("view: other seats' hole cards mid-hand", () => {
+  it("a seat does not see another live seat's hole cards", () => {
+    const state = onTheFlopThreeWay();
+    if (state.hand?.status !== "betting") throw new Error("expected betting");
+    const otherHoleCards = must(must(state.hand.players.get(1)).holeCards);
+
+    const mine = view(state, 0);
+    if (mine.phase !== "betting") throw new Error("expected betting phase");
+    expect(mine.yourSeatId).toBe(0);
+    for (const card of otherHoleCards) {
+      expect(JSON.stringify(mine)).not.toContain(JSON.stringify(card));
+    }
+    for (const seat of mine.seats) {
+      expect(seat).not.toHaveProperty("holeCards");
+    }
+  });
+});
+
+describe("view: folded seats", () => {
+  it("a folded seat no longer sees its own hole cards", () => {
+    let state = onTheFlopThreeWay();
+    state = playAll(state, [{ type: "fold", playerId: 1 }]);
+
+    const mine = view(state, 1);
+    if (mine.phase !== "betting") throw new Error("expected betting phase");
+    expect(mine.yourHoleCards).toBeNull();
+  });
+});
+
+describe("view: table view", () => {
+  it("sees no hole card pre-showdown, even with a board dealt", () => {
+    const state = onTheFlopThreeWay();
+    if (state.hand?.status !== "betting") throw new Error("expected betting");
+    expect(state.hand.board.length).toBeGreaterThan(0);
+
+    const table = view(state, "table");
+    expect(table).not.toHaveProperty("results");
+
+    for (const seatState of state.hand.players.values()) {
+      if (!seatState.holeCards) continue;
+      for (const card of seatState.holeCards) {
+        expect(JSON.stringify(table)).not.toContain(JSON.stringify(card));
+      }
+    }
+  });
+});
+
+describe("view: post-showdown", () => {
+  it("all live seats' cards are visible to every viewer, including the table", () => {
+    const state = headsUpToRiver("s0");
+    if (
+      state.hand?.status !== "complete" ||
+      state.hand.reason !== "showdown"
+    ) {
+      throw new Error("expected a showdown completion");
+    }
+    const expectedSeats = state.hand.results.map((r) => r.seatId).sort();
+
+    for (const v of [view(state, 0), view(state, 1), view(state, "table")]) {
+      if (v.phase !== "showdown") throw new Error("expected showdown phase");
+      expect(v.results.map((r) => r.seatId).sort()).toEqual(expectedSeats);
+      for (const result of v.results) {
+        expect(result.holeCards).toHaveLength(2);
+      }
+    }
+  });
+
+  it("never reveals a folded seat, even at a normal showdown", () => {
+    let state = createInitialState([0, 1, 2]);
+    state = playAll(state, [
+      { type: "startHand", playerId: 0, seed: "seed-1" },
+    ]);
+    state = playAll(state, [
+      { type: "call", playerId: 1 },
+      { type: "raise", playerId: 2 },
+      { type: "call", playerId: 0 },
+      { type: "call", playerId: 1 },
+      { type: "check", playerId: 1 },
+      { type: "check", playerId: 2 },
+      { type: "check", playerId: 0 },
+      { type: "fold", playerId: 1 },
+      { type: "check", playerId: 2 },
+      { type: "check", playerId: 0 },
+      { type: "check", playerId: 2 },
+      { type: "raise", playerId: 0 },
+      { type: "call", playerId: 2 },
+    ]);
+    if (
+      state.hand?.status !== "complete" ||
+      state.hand.reason !== "showdown"
+    ) {
+      throw new Error("expected a showdown completion");
+    }
+
+    const table = view(state, "table");
+    if (table.phase !== "showdown") throw new Error("expected showdown phase");
+    expect(table.results.some((r) => r.seatId === 1)).toBe(false);
+  });
+});
+
+const seatsArb = fc
+  .array(fc.integer({ min: 0, max: 7 }), { minLength: 2, maxLength: 8 })
+  .map((raw) => [...new Set(raw)])
+  .filter((seats) => seats.length >= 2);
+
+function collectAllCards(value: unknown, into: Card[]): void {
+  if (value === null || typeof value !== "object") return;
+  if (
+    "rank" in (value as Record<string, unknown>) &&
+    "suit" in (value as Record<string, unknown>)
+  ) {
+    into.push(value as Card);
+    return;
+  }
+  for (const child of Object.values(value)) collectAllCards(child, into);
+}
+
+const actionArb = fc.constantFrom<"fold" | "check" | "call" | "raise">(
+  "fold",
+  "check",
+  "call",
+  "raise",
+);
+
+/**
+ * Asserts the leak-freeness property against the state as it stands right
+ * now: every seat's dealt cards are visible to every viewer (including the
+ * table) exactly when that viewer is entitled to them — the owner while
+ * still live, or anyone once the seat is revealed at showdown — and never
+ * otherwise. Called after the deal, after every action, and at the end, so
+ * every intermediate street and every partial-fold configuration gets
+ * checked, not just whatever state a hand happens to finish in.
+ */
+function assertNoLeak(
+  state: EngineState,
+  dealtCards: ReadonlyMap<SeatId, readonly [Card, Card]>,
+  seats: readonly SeatId[],
+): void {
+  const revealed = new Set<SeatId>();
+  if (state.hand?.status === "complete" && state.hand.reason === "showdown") {
+    for (const result of state.hand.results) revealed.add(result.seatId);
+  }
+
+  const viewers: (SeatId | "table")[] = [...seats, "table"];
+  for (const v of viewers) {
+    const rendered = v === "table" ? view(state, "table") : view(state, v);
+    const cardsInView: Card[] = [];
+    collectAllCards(rendered, cardsInView);
+    const cardKeys = new Set(cardsInView.map((c) => `${c.rank}${c.suit}`));
+
+    for (const [seatId, cards] of dealtCards) {
+      const isRevealed = revealed.has(seatId);
+      const isLiveOwner =
+        v === seatId &&
+        state.hand?.status === "betting" &&
+        !must(state.hand.players.get(seatId)).folded;
+
+      for (const card of cards) {
+        const present = cardKeys.has(`${card.rank}${card.suit}`);
+        if (isRevealed) {
+          // Post-showdown, every viewer — including the table — sees
+          // every live seat's cards, not just the owner.
+          expect(present).toBe(true);
+        } else if (!isLiveOwner) {
+          expect(present).toBe(false);
+        }
+      }
+    }
+  }
+}
+
+describe("property: view never leaks a hole card it isn't entitled to", () => {
+  it("holds at every step of arbitrary hands, for every seat and the table", () => {
+    fc.assert(
+      fc.property(
+        seatsArb,
+        fc.string({ minLength: 1, maxLength: 10 }),
+        fc.array(actionArb, { minLength: 0, maxLength: 40 }),
+        (seats, seed, actions) => {
+          let state: EngineState = createInitialState(seats);
+          const firstPlayer = must(seats[0]);
+          const startEvents = decide(state, {
+            type: "startHand",
+            playerId: firstPlayer,
+            seed,
+          });
+          if (!Array.isArray(startEvents)) {
+            throw new Error("unexpected rejection starting the hand");
+          }
+          for (const event of startEvents) state = apply(state, event);
+
+          const dealt = startEvents.find((e) => e.type === "HoleCardsDealt");
+          if (dealt?.type !== "HoleCardsDealt") {
+            throw new Error("expected a deal");
+          }
+          const dealtCards = new Map<SeatId, readonly [Card, Card]>(
+            dealt.deals.map((d) => [d.seatId, d.cards]),
+          );
+
+          assertNoLeak(state, dealtCards, seats);
+
+          for (const action of actions) {
+            if (state.hand?.status !== "betting") break;
+            const hand = state.hand;
+            const actor = must(hand.toAct[0]);
+            const legal = facingBet(hand, actor)
+              ? action === "check"
+                ? "call"
+                : action
+              : action === "call"
+                ? "check"
+                : action;
+            const result = decide(state, { type: legal, playerId: actor });
+            if (!Array.isArray(result)) continue;
+            for (const event of result) state = apply(state, event);
+            assertNoLeak(state, dealtCards, seats);
+          }
+
+          assertNoLeak(state, dealtCards, seats);
+        },
+      ),
+    );
+  });
+});

--- a/packages/engine/src/view.test.ts
+++ b/packages/engine/src/view.test.ts
@@ -44,6 +44,18 @@ function onTheFlopThreeWay(): EngineState {
   return state;
 }
 
+describe("view: unknown seat", () => {
+  it("rejects a seat id that isn't seated at the table", () => {
+    const state = onTheFlopThreeWay();
+    expect(() => view(state, 999)).toThrow(/unknown seat/);
+  });
+
+  it("rejects an unknown seat id even before any hand has started", () => {
+    const state = createInitialState([0, 1, 2]);
+    expect(() => view(state, 999)).toThrow(/unknown seat/);
+  });
+});
+
 describe("view: own hole cards mid-hand", () => {
   it("a seat sees its own hole cards", () => {
     const state = onTheFlopThreeWay();
@@ -211,7 +223,9 @@ function assertNoLeak(
           // Post-showdown, every viewer — including the table — sees
           // every live seat's cards, not just the owner.
           expect(present).toBe(true);
-        } else if (!isLiveOwner) {
+        } else if (isLiveOwner) {
+          expect(present).toBe(true);
+        } else {
           expect(present).toBe(false);
         }
       }

--- a/packages/engine/src/view.test.ts
+++ b/packages/engine/src/view.test.ts
@@ -104,10 +104,7 @@ describe("view: table view", () => {
 describe("view: post-showdown", () => {
   it("all live seats' cards are visible to every viewer, including the table", () => {
     const state = headsUpToRiver("s0");
-    if (
-      state.hand?.status !== "complete" ||
-      state.hand.reason !== "showdown"
-    ) {
+    if (state.hand?.status !== "complete" || state.hand.reason !== "showdown") {
       throw new Error("expected a showdown completion");
     }
     const expectedSeats = state.hand.results.map((r) => r.seatId).sort();
@@ -141,10 +138,7 @@ describe("view: post-showdown", () => {
       { type: "raise", playerId: 0 },
       { type: "call", playerId: 2 },
     ]);
-    if (
-      state.hand?.status !== "complete" ||
-      state.hand.reason !== "showdown"
-    ) {
+    if (state.hand?.status !== "complete" || state.hand.reason !== "showdown") {
       throw new Error("expected a showdown completion");
     }
 

--- a/packages/engine/src/view.ts
+++ b/packages/engine/src/view.ts
@@ -1,0 +1,119 @@
+import type {
+  Card,
+  EngineState,
+  RevealedResult,
+  SeatId,
+  Street,
+} from "./types.js";
+
+export interface SeatSnapshot {
+  readonly seatId: SeatId;
+  readonly folded: boolean;
+}
+
+interface NoHandView {
+  readonly phase: "no-hand";
+  readonly button: SeatId;
+}
+
+interface FoldedOutView {
+  readonly phase: "folded-out";
+  readonly button: SeatId;
+  readonly winner: SeatId;
+}
+
+interface ShowdownView {
+  readonly phase: "showdown";
+  readonly button: SeatId;
+  readonly results: readonly RevealedResult[];
+  readonly winners: readonly SeatId[];
+}
+
+export interface PlayerViewBetting {
+  readonly phase: "betting";
+  readonly button: SeatId;
+  readonly street: Street;
+  readonly board: readonly Card[];
+  readonly toAct: readonly SeatId[];
+  readonly seats: readonly SeatSnapshot[];
+  readonly yourSeatId: SeatId;
+  readonly yourHoleCards: readonly [Card, Card] | null;
+}
+
+export interface TableViewBetting {
+  readonly phase: "betting";
+  readonly button: SeatId;
+  readonly street: Street;
+  readonly board: readonly Card[];
+  readonly toAct: readonly SeatId[];
+  readonly seats: readonly SeatSnapshot[];
+}
+
+export type PlayerView =
+  | NoHandView
+  | PlayerViewBetting
+  | FoldedOutView
+  | ShowdownView;
+
+export type TableView =
+  | NoHandView
+  | TableViewBetting
+  | FoldedOutView
+  | ShowdownView;
+
+/**
+ * Builds the restricted view for one seat, or the table device via the
+ * `"table"` sentinel. Both are derived from the same authoritative state so
+ * the table is never privileged over a player — see docs/phase-1-spec.md §4.
+ */
+export function view(state: EngineState, seatId: SeatId): PlayerView;
+export function view(state: EngineState, seatId: "table"): TableView;
+export function view(
+  state: EngineState,
+  seatId: SeatId | "table",
+): PlayerView | TableView {
+  const hand = state.hand;
+
+  if (hand === null) {
+    return { phase: "no-hand", button: state.button };
+  }
+
+  if (hand.status === "complete" && hand.reason === "folded-out") {
+    return { phase: "folded-out", button: hand.button, winner: hand.winner };
+  }
+
+  if (hand.status === "complete" && hand.reason === "showdown") {
+    return {
+      phase: "showdown",
+      button: hand.button,
+      winners: hand.winners,
+      results: hand.results,
+    };
+  }
+
+  const seats: SeatSnapshot[] = [...hand.players].map(
+    ([seat, seatState]) => ({ seatId: seat, folded: seatState.folded }),
+  );
+
+  const tableView: TableViewBetting = {
+    phase: "betting",
+    button: hand.button,
+    street: hand.street,
+    board: hand.board,
+    toAct: hand.toAct,
+    seats,
+  };
+
+  if (seatId === "table") return tableView;
+
+  const yourState = hand.players.get(seatId);
+  const yourHoleCards =
+    yourState && !yourState.folded ? yourState.holeCards : null;
+
+  const playerView: PlayerViewBetting = {
+    ...tableView,
+    yourSeatId: seatId,
+    yourHoleCards,
+  };
+  return playerView;
+}

--- a/packages/engine/src/view.ts
+++ b/packages/engine/src/view.ts
@@ -50,16 +50,10 @@ export interface TableViewBetting {
 }
 
 export type PlayerView =
-  | NoHandView
-  | PlayerViewBetting
-  | FoldedOutView
-  | ShowdownView;
+  NoHandView | PlayerViewBetting | FoldedOutView | ShowdownView;
 
 export type TableView =
-  | NoHandView
-  | TableViewBetting
-  | FoldedOutView
-  | ShowdownView;
+  NoHandView | TableViewBetting | FoldedOutView | ShowdownView;
 
 /**
  * Builds the restricted view for one seat, or the table device via the
@@ -82,7 +76,7 @@ export function view(
     return { phase: "folded-out", button: hand.button, winner: hand.winner };
   }
 
-  if (hand.status === "complete" && hand.reason === "showdown") {
+  if (hand.status === "complete") {
     return {
       phase: "showdown",
       button: hand.button,
@@ -91,9 +85,10 @@ export function view(
     };
   }
 
-  const seats: SeatSnapshot[] = [...hand.players].map(
-    ([seat, seatState]) => ({ seatId: seat, folded: seatState.folded }),
-  );
+  const seats: SeatSnapshot[] = [...hand.players].map(([seat, seatState]) => ({
+    seatId: seat,
+    folded: seatState.folded,
+  }));
 
   const tableView: TableViewBetting = {
     phase: "betting",

--- a/packages/engine/src/view.ts
+++ b/packages/engine/src/view.ts
@@ -66,6 +66,10 @@ export function view(
   state: EngineState,
   seatId: SeatId | "table",
 ): PlayerView | TableView {
+  if (seatId !== "table" && !state.seats.includes(seatId)) {
+    throw new Error(`unknown seat ${String(seatId)}`);
+  }
+
   const hand = state.hand;
 
   if (hand === null) {


### PR DESCRIPTION
## Summary

Implements `view(state, seatId)` per issue #24 — a leak-free, per-seat/table restricted projection of `EngineState`, provable by construction and by test.

- `view(state, seatId)` and `view(state, "table")` live in `packages/engine/src/view.ts`, not the API layer.
- `PlayerView`/`TableView` are distinct discriminated unions. Their `betting`-phase variants have no field capable of holding another seat's `Card` — only `yourHoleCards` (single seat) and the public `board` touch `Card` at all. Cross-seat hole cards are only reachable through the `showdown`-phase variant's `RevealedResult`, which only exists once a hand actually completes at showdown.
- Folding withdraws a seat's own hole cards from its view mid-hand (burn-pile), not just from others' views.
- Folded seats are never revealed, even at a real showdown (already true of `ShowdownReached`; `view` doesn't re-expose them either, since results are read straight from the stored showdown result).
- The remaining deck order was never reachable from state or `view` to begin with.

### Behavioral change of note

`CompleteHandState` is now a discriminated union (`FoldedOutCompleteHandState` | `ShowdownCompleteHandState`) instead of a flat `{ seed, button }`. A showdown completion carries each live seat's result with its hole cards attached — built once in `apply`'s `ShowdownReached` handler from the betting hand's players map, so nothing downstream needs that map again. `apply`'s `HandComplete` case now requires the hand to already be `"complete"` (set by a prior `HandFoldedOut`/`ShowdownReached`) rather than reconstructing one defensively — this branch was previously unreachable dead code since `decide` never emits `HandComplete` any other way. Verified no consumers outside `packages/engine` touch these fields; full workspace typecheck and test suite pass.

## Acceptance criteria

- [x] Fast-check property test asserts `view` never contains a `Card` belonging to another seat unless that seat appears in a completed `ShowdownReached` — checked at *every* step of arbitrary hands (after the deal, after each action, and at the end), not just the final state.
- [x] Unit test: a seat sees its own hole cards mid-hand.
- [x] Unit test: a seat does not see another live seat's hole cards mid-hand.
- [x] Unit test: a folded seat no longer sees its own hole cards.
- [x] Unit test: `view(state, "table")` sees no hole card pre-showdown (including with a non-empty board).
- [x] Unit test: all live seats' cards are visible to every viewer (both players and the table) post-showdown.
- [x] `PlayerView`/`TableView` type definitions make cross-seat hole-card storage structurally impossible.

## Test plan

- [x] `npx vitest run` — full workspace, 104/104 passing
- [x] `npx tsc --build --force` — clean across all packages
- [x] `npm run lint` — eslint + prettier clean
- [x] TDD red/green commit pairs for both the `CompleteHandState` reason tagging and `view` itself, with red states manually verified

https://claude.ai/code/session_01GnUQEcqRgot6ViuRJtidyf