### PR TITLE
docs: correct room-code alphabet arithmetic in phase-1-spec

### DIFF
--- a/docs/phase-1-spec.md
+++ b/docs/phase-1-spec.md
@@ -286,8 +286,9 @@ network round trip.
 ([Rooms, identity, seat claiming and reconnection](https://github.com/ewanhardingham/table-top-poker/issues/13))
 
 - **Room codes**: 4 characters, confusable-excluded alphabet (digits +
-  uppercase, excluding `0/O`, `1/I/L`, `2/Z`, `5/S`, `8/B`) — 32⁴ ≈ 1M
-  combinations, re-rolled on collision against live in-memory rooms. No
+  uppercase, excluding `0/O`, `1/I/L`, `2/Z`, `5/S`, `8/B`) — 25 characters,
+  25⁴ ≈ 390K combinations, re-rolled on collision against live in-memory
+  rooms. No
   independent expiry; a code lives as long as its room.
 - **Joining**: by QR code generated live from the current address, plus the
   room code as fallback for anyone who can't scan.


### PR DESCRIPTION
## Summary
- §7's room-code combinations math said "32⁴ ≈ 1M" but the exclusion list itself (`0/O`, `1/I/L`, `2/Z`, `5/S`, `8/B`) removes 11 characters from 36 alphanumerics, leaving **25**, not 32 — 25⁴ ≈ 390K.
- No reading of the exclusion list gets to 32; the closest 32-symbol scheme is Crockford's Base32 (excludes only `I,L,O,U`), which isn't what this list describes.
- The room-code implementation in #26/PR #42 already follows the literal exclusion list (25 chars); this just brings the spec's arithmetic in line with its own stated rule.

## Test plan
- [x] `npx prettier --check docs/phase-1-spec.md`
- Doc-only change, no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjvG7VqCfZkfA3xYrBYMwo