### PR TITLE
feat(client): 09 — Client shells

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -913,6 +913,24 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "devOptional": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -1139,6 +1157,47 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw=="
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz",
+      "integrity": "sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==",
+      "dev": true,
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -1529,6 +1588,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2086,6 +2151,32 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
       "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true
+    },
+    "node_modules/framer-motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "dependencies": {
+        "motion-dom": "^12.42.2",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2712,6 +2803,44 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.42.2.tgz",
+      "integrity": "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==",
+      "dependencies": {
+        "framer-motion": "^12.42.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3043,6 +3172,25 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -3187,6 +3335,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
@@ -3437,9 +3590,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3856,6 +4007,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    },
     "packages/engine": {
       "name": "@table-top-poker/engine",
       "version": "0.0.0",
@@ -3876,7 +4055,20 @@
     },
     "packages/player-client": {
       "name": "@table-top-poker/player-client",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dependencies": {
+        "@use-gesture/react": "^10.3.1",
+        "motion": "^12.42.2",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "zustand": "^5.0.14"
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.4",
+        "vite": "^8.1.5"
+      }
     },
     "packages/protocol": {
       "name": "@table-top-poker/protocol",
@@ -3902,11 +4094,37 @@
     },
     "packages/table-client": {
       "name": "@table-top-poker/table-client",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dependencies": {
+        "@use-gesture/react": "^10.3.1",
+        "motion": "^12.42.2",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "zustand": "^5.0.14"
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.4",
+        "vite": "^8.1.5"
+      }
     },
     "packages/ui-shared": {
       "name": "@table-top-poker/ui-shared",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dependencies": {
+        "@use-gesture/react": "^10.3.1",
+        "motion": "^12.42.2",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "zustand": "^5.0.14"
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.4",
+        "vite": "^8.1.5"
+      }
     }
   }
 }

--- a/packages/player-client/index.html
+++ b/packages/player-client/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
+    <title>Table Top Poker — Player</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/player-client/package.json
+++ b/packages/player-client/package.json
@@ -6,7 +6,24 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --build",
+    "dev": "vite",
+    "build": "tsc --build && vite build",
+    "preview": "vite preview",
     "test": "vitest run"
+  },
+  "dependencies": {
+    "@table-top-poker/protocol": "*",
+    "@table-top-poker/ui-shared": "*",
+    "@use-gesture/react": "^10.3.1",
+    "motion": "^12.42.2",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "zustand": "^5.0.14"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.4",
+    "vite": "^8.1.5"
   }
 }

--- a/packages/player-client/src/App.test.tsx
+++ b/packages/player-client/src/App.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import App from "./App.js";
+import { getWebSocketUrl } from "./hooks/useWebSocket.js";
+import { usePlayerStore } from "./store/index.js";
+
+describe("player-client", () => {
+  it("derives WebSocket URL scheme correctly from location.protocol", () => {
+    const mockHttpsLocation = {
+      protocol: "https:",
+      host: "player.local:8080",
+    } as Location;
+    expect(getWebSocketUrl("/ws", mockHttpsLocation)).toBe(
+      "wss://player.local:8080/ws",
+    );
+
+    const mockHttpLocation = {
+      protocol: "http:",
+      host: "localhost:3000",
+    } as Location;
+    expect(getWebSocketUrl("/ws", mockHttpLocation)).toBe(
+      "ws://localhost:3000/ws",
+    );
+  });
+
+  it("updates Zustand connection slice and player slice independently", () => {
+    const store = usePlayerStore.getState();
+    expect(store.connectionStatus).toBe("disconnected");
+    expect(store.seatId).toBeNull();
+
+    store.setConnectionStatus("connected");
+    expect(usePlayerStore.getState().connectionStatus).toBe("connected");
+    expect(usePlayerStore.getState().seatId).toBeNull();
+
+    store.setSeatId(2);
+    expect(usePlayerStore.getState().seatId).toBe(2);
+    expect(usePlayerStore.getState().connectionStatus).toBe("connected");
+  });
+
+  it("renders player-client app shell, hole cards and action buttons", () => {
+    const html = renderToString(React.createElement(App));
+    expect(html).toContain('data-testid="player-client-shell"');
+    expect(html).toContain('data-testid="connection-status"');
+    expect(html).toContain('data-testid="hole-cards"');
+    expect(html).toContain('data-testid="action-buttons"');
+    expect(html).toContain("Table Top Poker — Player");
+  });
+});

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -1,0 +1,51 @@
+import { Card } from "@table-top-poker/ui-shared";
+import React from "react";
+import { useWebSocket } from "./hooks/useWebSocket.js";
+import { usePlayerStore } from "./store/index.js";
+
+export const App: React.FC = () => {
+  useWebSocket();
+
+  const connectionStatus = usePlayerStore((state) => state.connectionStatus);
+
+  return (
+    <div className="app-shell" data-testid="player-client-shell">
+      <header className="header-bar">
+        <h1 style={{ margin: 0, fontSize: "16px", fontWeight: 600 }}>
+          Table Top Poker — Player
+        </h1>
+        <div className="status-badge" data-testid="connection-status">
+          <span className={`status-dot ${connectionStatus}`} />
+          <span style={{ textTransform: "capitalize" }}>
+            {connectionStatus}
+          </span>
+        </div>
+      </header>
+
+      <main className="player-main">
+        <div style={{ textAlign: "center" }}>
+          <h2 style={{ margin: 0, fontSize: "20px", color: "#38bdf8" }}>
+            Your Cards
+          </h2>
+          <p style={{ color: "#94a3b8", fontSize: "13px", marginTop: "4px" }}>
+            Placeholder hand
+          </p>
+        </div>
+
+        <div className="cards-container" data-testid="hole-cards">
+          <Card rank="A" suit="spades" />
+          <Card rank="K" suit="spades" />
+        </div>
+      </main>
+
+      <footer className="actions-panel" data-testid="action-buttons">
+        <button className="action-btn fold">Fold</button>
+        <button className="action-btn check">Check</button>
+        <button className="action-btn call">Call</button>
+        <button className="action-btn raise">Raise</button>
+      </footer>
+    </div>
+  );
+};
+
+export default App;

--- a/packages/player-client/src/hooks/useWebSocket.ts
+++ b/packages/player-client/src/hooks/useWebSocket.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+import { usePlayerStore } from "../store/index.js";
+
+export function getWebSocketUrl(path = "/ws", locationObj?: Location): string {
+  const loc =
+    locationObj ??
+    (typeof window !== "undefined" ? window.location : undefined);
+  if (!loc) return "ws://localhost:3000/ws";
+  const protocol = loc.protocol === "https:" ? "wss:" : "ws:";
+  return `${protocol}//${loc.host}${path}`;
+}
+
+export function useWebSocket(urlOverride?: string): void {
+  const setConnectionStatus = usePlayerStore(
+    (state) => state.setConnectionStatus,
+  );
+  const socketRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    const url = urlOverride ?? getWebSocketUrl();
+    setConnectionStatus("connecting");
+
+    try {
+      const socket = new WebSocket(url);
+      socketRef.current = socket;
+
+      socket.onopen = () => {
+        setConnectionStatus("connected");
+      };
+
+      socket.onclose = () => {
+        setConnectionStatus("disconnected");
+      };
+
+      socket.onerror = () => {
+        setConnectionStatus("disconnected");
+      };
+    } catch {
+      setConnectionStatus("disconnected");
+    }
+
+    return () => {
+      if (socketRef.current) {
+        socketRef.current.close();
+        socketRef.current = null;
+      }
+    };
+  }, [setConnectionStatus, urlOverride]);
+}

--- a/packages/player-client/src/index.css
+++ b/packages/player-client/src/index.css
@@ -1,0 +1,152 @@
+:root {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    sans-serif;
+  color-scheme: dark;
+  --bg-dark: #090d16;
+  --panel-bg: #131b2e;
+  --text-main: #f8fafc;
+  --text-muted: #94a3b8;
+  --accent-blue: #38bdf8;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  padding: 0;
+  width: 100vw;
+  height: 100svh;
+  max-height: 100svh;
+  overflow: hidden;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  touch-action: manipulation;
+  user-select: none;
+  -webkit-user-select: none;
+  background-color: var(--bg-dark);
+  color: var(--text-main);
+  box-sizing: border-box;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right)
+    env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+
+.app-shell {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: hidden;
+  position: relative;
+}
+
+.header-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  background: rgba(19, 27, 46, 0.9);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.status-badge {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+
+.status-dot.connected {
+  background-color: #22c55e;
+  box-shadow: 0 0 6px #22c55e;
+}
+
+.status-dot.connecting {
+  background-color: #eab308;
+  box-shadow: 0 0 6px #eab308;
+}
+
+.status-dot.disconnected {
+  background-color: #ef4444;
+  box-shadow: 0 0 6px #ef4444;
+}
+
+.player-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  gap: 20px;
+}
+
+.cards-container {
+  display: flex;
+  gap: 12px;
+}
+
+.actions-panel {
+  width: 100%;
+  padding: 16px;
+  box-sizing: border-box;
+  display: flex;
+  gap: 10px;
+  background: var(--panel-bg);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.action-btn {
+  flex: 1;
+  padding: 14px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: #1e293b;
+  color: #f8fafc;
+  font-weight: 600;
+  font-size: 15px;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.action-btn.fold {
+  background: #7f1d1d;
+  border-color: #991b1b;
+}
+
+.action-btn.check {
+  background: #1e3a8a;
+  border-color: #1d4ed8;
+}
+
+.action-btn.call {
+  background: #14532d;
+  border-color: #15803d;
+}
+
+.action-btn.raise {
+  background: #78350f;
+  border-color: #b45309;
+}

--- a/packages/player-client/src/index.ts
+++ b/packages/player-client/src/index.ts
@@ -1,1 +1,3 @@
-export {};
+export { App } from "./App.js";
+export { getWebSocketUrl } from "./hooks/useWebSocket.js";
+export { usePlayerStore } from "./store/index.js";

--- a/packages/player-client/src/main.tsx
+++ b/packages/player-client/src/main.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.js";
+import "./index.css";
+
+const rootEl = document.getElementById("root");
+if (rootEl) {
+  ReactDOM.createRoot(rootEl).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+}

--- a/packages/player-client/src/store/index.ts
+++ b/packages/player-client/src/store/index.ts
@@ -1,0 +1,52 @@
+import type { SeatId } from "@table-top-poker/protocol";
+import type { StateCreator } from "zustand";
+import { create } from "zustand";
+
+export type ConnectionStatus = "disconnected" | "connecting" | "connected";
+
+export interface ConnectionSlice {
+  readonly connectionStatus: ConnectionStatus;
+  readonly setConnectionStatus: (status: ConnectionStatus) => void;
+}
+
+export interface PlayerSlice {
+  readonly seatId: SeatId | null;
+  readonly setSeatId: (seatId: SeatId | null) => void;
+  readonly placeholderCount: number;
+  readonly incrementPlaceholder: () => void;
+}
+
+export type PlayerStore = ConnectionSlice & PlayerSlice;
+
+export const createConnectionSlice: StateCreator<
+  PlayerStore,
+  [],
+  [],
+  ConnectionSlice
+> = (set) => ({
+  connectionStatus: "disconnected",
+  setConnectionStatus: (connectionStatus) => {
+    set({ connectionStatus });
+  },
+});
+
+export const createPlayerSlice: StateCreator<
+  PlayerStore,
+  [],
+  [],
+  PlayerSlice
+> = (set) => ({
+  seatId: null,
+  setSeatId: (seatId) => {
+    set({ seatId });
+  },
+  placeholderCount: 0,
+  incrementPlaceholder: () => {
+    set((state) => ({ placeholderCount: state.placeholderCount + 1 }));
+  },
+});
+
+export const usePlayerStore = create<PlayerStore>()((...a) => ({
+  ...createConnectionSlice(...a),
+  ...createPlayerSlice(...a),
+}));

--- a/packages/player-client/tsconfig.json
+++ b/packages/player-client/tsconfig.json
@@ -2,8 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx"
   },
   "include": ["src"],
-  "references": []
+  "references": [{ "path": "../protocol" }, { "path": "../ui-shared" }]
 }

--- a/packages/player-client/vite.config.ts
+++ b/packages/player-client/vite.config.ts
@@ -1,0 +1,9 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3002,
+  },
+});

--- a/packages/table-client/index.html
+++ b/packages/table-client/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
+    <title>Table Top Poker — Table</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/table-client/package.json
+++ b/packages/table-client/package.json
@@ -6,7 +6,24 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc --build",
+    "dev": "vite",
+    "build": "tsc --build && vite build",
+    "preview": "vite preview",
     "test": "vitest run"
+  },
+  "dependencies": {
+    "@table-top-poker/protocol": "*",
+    "@table-top-poker/ui-shared": "*",
+    "@use-gesture/react": "^10.3.1",
+    "motion": "^12.42.2",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "zustand": "^5.0.14"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.4",
+    "vite": "^8.1.5"
   }
 }

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import App from "./App.js";
+import { getWebSocketUrl } from "./hooks/useWebSocket.js";
+import { useTableStore } from "./store/index.js";
+
+describe("table-client", () => {
+  it("derives WebSocket URL scheme correctly from location.protocol", () => {
+    const mockHttpsLocation = {
+      protocol: "https:",
+      host: "poker.local:8080",
+    } as Location;
+    expect(getWebSocketUrl("/ws", mockHttpsLocation)).toBe(
+      "wss://poker.local:8080/ws",
+    );
+
+    const mockHttpLocation = {
+      protocol: "http:",
+      host: "localhost:3000",
+    } as Location;
+    expect(getWebSocketUrl("/ws", mockHttpLocation)).toBe(
+      "ws://localhost:3000/ws",
+    );
+  });
+
+  it("updates Zustand connection slice and table slice independently", () => {
+    const store = useTableStore.getState();
+    expect(store.connectionStatus).toBe("disconnected");
+    expect(store.roomCode).toBeNull();
+
+    store.setConnectionStatus("connected");
+    expect(useTableStore.getState().connectionStatus).toBe("connected");
+    expect(useTableStore.getState().roomCode).toBeNull();
+
+    store.setRoomCode("TEST");
+    expect(useTableStore.getState().roomCode).toBe("TEST");
+    expect(useTableStore.getState().connectionStatus).toBe("connected");
+  });
+
+  it("renders table-client app shell and placeholder components", () => {
+    const html = renderToString(React.createElement(App));
+    expect(html).toContain('data-testid="table-client-shell"');
+    expect(html).toContain('data-testid="connection-status"');
+    expect(html).toContain('data-testid="community-cards"');
+    expect(html).toContain("Table Top Poker — Table Device");
+  });
+});

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -1,0 +1,45 @@
+import { Card } from "@table-top-poker/ui-shared";
+import React from "react";
+import { useWebSocket } from "./hooks/useWebSocket.js";
+import { useTableStore } from "./store/index.js";
+
+export const App: React.FC = () => {
+  useWebSocket();
+
+  const connectionStatus = useTableStore((state) => state.connectionStatus);
+
+  return (
+    <div className="app-shell" data-testid="table-client-shell">
+      <header className="header-bar">
+        <h1 style={{ margin: 0, fontSize: "18px", fontWeight: 600 }}>
+          Table Top Poker — Table Device
+        </h1>
+        <div className="status-badge" data-testid="connection-status">
+          <span className={`status-dot ${connectionStatus}`} />
+          <span style={{ textTransform: "capitalize" }}>
+            {connectionStatus}
+          </span>
+        </div>
+      </header>
+
+      <main className="table-felt">
+        <h2 style={{ margin: 0, fontSize: "24px", color: "#f59e0b" }}>
+          Poker Table Shell
+        </h2>
+        <p style={{ color: "#94a3b8", fontSize: "14px", marginTop: "8px" }}>
+          Waiting for room initialization...
+        </p>
+
+        <div className="cards-container" data-testid="community-cards">
+          <Card rank="A" suit="spades" />
+          <Card rank="K" suit="hearts" />
+          <Card rank="10" suit="diamonds" />
+          <Card faceDown />
+          <Card faceDown />
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default App;

--- a/packages/table-client/src/hooks/useWebSocket.ts
+++ b/packages/table-client/src/hooks/useWebSocket.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+import { useTableStore } from "../store/index.js";
+
+export function getWebSocketUrl(path = "/ws", locationObj?: Location): string {
+  const loc =
+    locationObj ??
+    (typeof window !== "undefined" ? window.location : undefined);
+  if (!loc) return "ws://localhost:3000/ws";
+  const protocol = loc.protocol === "https:" ? "wss:" : "ws:";
+  return `${protocol}//${loc.host}${path}`;
+}
+
+export function useWebSocket(urlOverride?: string): void {
+  const setConnectionStatus = useTableStore(
+    (state) => state.setConnectionStatus,
+  );
+  const socketRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    const url = urlOverride ?? getWebSocketUrl();
+    setConnectionStatus("connecting");
+
+    try {
+      const socket = new WebSocket(url);
+      socketRef.current = socket;
+
+      socket.onopen = () => {
+        setConnectionStatus("connected");
+      };
+
+      socket.onclose = () => {
+        setConnectionStatus("disconnected");
+      };
+
+      socket.onerror = () => {
+        setConnectionStatus("disconnected");
+      };
+    } catch {
+      setConnectionStatus("disconnected");
+    }
+
+    return () => {
+      if (socketRef.current) {
+        socketRef.current.close();
+        socketRef.current = null;
+      }
+    };
+  }, [setConnectionStatus, urlOverride]);
+}

--- a/packages/table-client/src/index.css
+++ b/packages/table-client/src/index.css
@@ -1,0 +1,115 @@
+:root {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    Oxygen,
+    Ubuntu,
+    Cantarell,
+    sans-serif;
+  color-scheme: dark;
+  --felt-green: #0d47a1;
+  --bg-dark: #0a0f1d;
+  --text-main: #f8fafc;
+  --text-muted: #94a3b8;
+  --accent-gold: #f59e0b;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  padding: 0;
+  width: 100vw;
+  height: 100svh;
+  max-height: 100svh;
+  overflow: hidden;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  touch-action: manipulation;
+  user-select: none;
+  -webkit-user-select: none;
+  background-color: var(--bg-dark);
+  color: var(--text-main);
+  box-sizing: border-box;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right)
+    env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+
+.app-shell {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+
+.header-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 20px;
+  background: rgba(15, 23, 42, 0.8);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.status-badge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.status-dot.connected {
+  background-color: #22c55e;
+  box-shadow: 0 0 8px #22c55e;
+}
+
+.status-dot.connecting {
+  background-color: #eab308;
+  box-shadow: 0 0 8px #eab308;
+}
+
+.status-dot.disconnected {
+  background-color: #ef4444;
+  box-shadow: 0 0 8px #ef4444;
+}
+
+.table-felt {
+  flex: 1;
+  margin: 16px;
+  border-radius: 120px;
+  background: radial-gradient(circle at center, #1b4332 0%, #081c15 100%);
+  border: 12px solid #2d1810;
+  box-shadow:
+    inset 0 0 40px rgba(0, 0, 0, 0.8),
+    0 10px 25px rgba(0, 0, 0, 0.5);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.cards-container {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}

--- a/packages/table-client/src/index.ts
+++ b/packages/table-client/src/index.ts
@@ -1,1 +1,3 @@
-export {};
+export { App } from "./App.js";
+export { getWebSocketUrl } from "./hooks/useWebSocket.js";
+export { useTableStore } from "./store/index.js";

--- a/packages/table-client/src/main.tsx
+++ b/packages/table-client/src/main.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.js";
+import "./index.css";
+
+const rootEl = document.getElementById("root");
+if (rootEl) {
+  ReactDOM.createRoot(rootEl).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+}

--- a/packages/table-client/src/store/index.ts
+++ b/packages/table-client/src/store/index.ts
@@ -1,0 +1,48 @@
+import type { StateCreator } from "zustand";
+import { create } from "zustand";
+
+export type ConnectionStatus = "disconnected" | "connecting" | "connected";
+
+export interface ConnectionSlice {
+  readonly connectionStatus: ConnectionStatus;
+  readonly setConnectionStatus: (status: ConnectionStatus) => void;
+}
+
+export interface TableSlice {
+  readonly roomCode: string | null;
+  readonly setRoomCode: (code: string | null) => void;
+  readonly placeholderCount: number;
+  readonly incrementPlaceholder: () => void;
+}
+
+export type TableStore = ConnectionSlice & TableSlice;
+
+export const createConnectionSlice: StateCreator<
+  TableStore,
+  [],
+  [],
+  ConnectionSlice
+> = (set) => ({
+  connectionStatus: "disconnected",
+  setConnectionStatus: (connectionStatus) => {
+    set({ connectionStatus });
+  },
+});
+
+export const createTableSlice: StateCreator<TableStore, [], [], TableSlice> = (
+  set,
+) => ({
+  roomCode: null,
+  setRoomCode: (roomCode) => {
+    set({ roomCode });
+  },
+  placeholderCount: 0,
+  incrementPlaceholder: () => {
+    set((state) => ({ placeholderCount: state.placeholderCount + 1 }));
+  },
+});
+
+export const useTableStore = create<TableStore>()((...a) => ({
+  ...createConnectionSlice(...a),
+  ...createTableSlice(...a),
+}));

--- a/packages/table-client/tsconfig.json
+++ b/packages/table-client/tsconfig.json
@@ -2,8 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx"
   },
   "include": ["src"],
-  "references": []
+  "references": [{ "path": "../protocol" }, { "path": "../ui-shared" }]
 }

--- a/packages/table-client/vite.config.ts
+++ b/packages/table-client/vite.config.ts
@@ -1,0 +1,9 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3001,
+  },
+});

--- a/packages/ui-shared/package.json
+++ b/packages/ui-shared/package.json
@@ -8,5 +8,19 @@
   "scripts": {
     "build": "tsc --build",
     "test": "vitest run"
+  },
+  "dependencies": {
+    "@table-top-poker/protocol": "*",
+    "@use-gesture/react": "^10.3.1",
+    "motion": "^12.42.2",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "zustand": "^5.0.14"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.4",
+    "vite": "^8.1.5"
   }
 }

--- a/packages/ui-shared/src/Card.test.tsx
+++ b/packages/ui-shared/src/Card.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { Card } from "./Card.js";
+
+describe("Card", () => {
+  it("renders face-down card when faceDown prop is true", () => {
+    const html = renderToString(React.createElement(Card, { faceDown: true }));
+    expect(html).toContain('data-testid="card-back"');
+  });
+
+  it("renders face-down card when rank or suit is missing", () => {
+    const html = renderToString(React.createElement(Card, {}));
+    expect(html).toContain('data-testid="card-back"');
+  });
+
+  it("renders face-up card with rank and suit when faceDown is false", () => {
+    const html = renderToString(
+      React.createElement(Card, { rank: "A", suit: "spades", faceDown: false }),
+    );
+    expect(html).toContain('data-testid="card-face"');
+    expect(html).toContain('data-rank="A"');
+    expect(html).toContain('data-suit="spades"');
+    expect(html).toContain("♠");
+  });
+});

--- a/packages/ui-shared/src/Card.tsx
+++ b/packages/ui-shared/src/Card.tsx
@@ -1,0 +1,157 @@
+import type { Rank, Suit } from "@table-top-poker/protocol";
+import React from "react";
+
+export interface CardProps {
+  readonly rank?: Rank;
+  readonly suit?: Suit;
+  readonly faceDown?: boolean;
+  readonly className?: string;
+  readonly style?: React.CSSProperties;
+}
+
+const suitSymbols: Record<Suit, string> = {
+  clubs: "♣",
+  diamonds: "♦",
+  hearts: "♥",
+  spades: "♠",
+};
+
+const suitColors: Record<Suit, string> = {
+  clubs: "#1e293b",
+  diamonds: "#dc2626",
+  hearts: "#dc2626",
+  spades: "#1e293b",
+};
+
+export const Card: React.FC<CardProps> = ({
+  rank,
+  suit,
+  faceDown = false,
+  className = "",
+  style,
+}) => {
+  const isFaceDown = faceDown || !rank || !suit;
+
+  if (isFaceDown) {
+    return (
+      <div
+        data-testid="card-back"
+        className={`card card-back ${className}`}
+        style={{
+          width: "70px",
+          height: "98px",
+          borderRadius: "8px",
+          backgroundColor: "#1e293b",
+          border: "2px solid #334155",
+          boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.3)",
+          position: "relative",
+          boxSizing: "border-box",
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          overflow: "hidden",
+          userSelect: "none",
+          ...style,
+        }}
+      >
+        {/* Decorative CSS grid card-back pattern */}
+        <div
+          style={{
+            position: "absolute",
+            inset: "4px",
+            borderRadius: "4px",
+            border: "1px solid #475569",
+            backgroundImage:
+              "radial-gradient(#38bdf8 1px, transparent 1px), radial-gradient(#38bdf8 1px, #0f172a 1px)",
+            backgroundSize: "8px 8px",
+            backgroundPosition: "0 0, 4px 4px",
+            opacity: 0.8,
+          }}
+        />
+        <div
+          style={{
+            position: "relative",
+            zIndex: 1,
+            color: "#38bdf8",
+            fontSize: "20px",
+            fontWeight: "bold",
+          }}
+        >
+          ♠
+        </div>
+      </div>
+    );
+  }
+
+  const symbol = suitSymbols[suit];
+  const color = suitColors[suit];
+
+  return (
+    <div
+      data-testid="card-face"
+      data-rank={rank}
+      data-suit={suit}
+      className={`card card-face card-${suit} ${className}`}
+      style={{
+        width: "70px",
+        height: "98px",
+        borderRadius: "8px",
+        backgroundColor: "#ffffff",
+        border: "1px solid #cbd5e1",
+        boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.2)",
+        position: "relative",
+        boxSizing: "border-box",
+        padding: "4px 6px",
+        display: "inline-flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        color,
+        fontFamily: "system-ui, -apple-system, sans-serif",
+        userSelect: "none",
+        overflow: "hidden",
+        ...style,
+      }}
+    >
+      {/* Top Left Rank & Suit */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-start",
+          lineHeight: "1",
+        }}
+      >
+        <span style={{ fontSize: "15px", fontWeight: "bold" }}>{rank}</span>
+        <span style={{ fontSize: "14px" }}>{symbol}</span>
+      </div>
+
+      {/* Center Suit Symbol */}
+      <div
+        style={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          fontSize: "28px",
+          opacity: 0.9,
+        }}
+      >
+        {symbol}
+      </div>
+
+      {/* Bottom Right Rank & Suit (Inverted) */}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-end",
+          lineHeight: "1",
+          transform: "rotate(180deg)",
+        }}
+      >
+        <span style={{ fontSize: "15px", fontWeight: "bold" }}>{rank}</span>
+        <span style={{ fontSize: "14px" }}>{symbol}</span>
+      </div>
+    </div>
+  );
+};

--- a/packages/ui-shared/src/index.ts
+++ b/packages/ui-shared/src/index.ts
@@ -1,1 +1,1 @@
-export {};
+export { Card, type CardProps } from "./Card.js";

--- a/packages/ui-shared/tsconfig.json
+++ b/packages/ui-shared/tsconfig.json
@@ -2,8 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx"
   },
   "include": ["src"],
-  "references": []
+  "references": [{ "path": "../protocol" }]
 }


### PR DESCRIPTION
## Summary
Implements **Issue #27 (09 — Client shells)**.

- **`ui-shared`**: Added `<Card>` component supporting `rank`, `suit`, and `faceDown` props using pure CSS/DOM markup (no `<img>` src-swapping).
- **`table-client`**: Booting Vite SPA with non-scrolling app shell sized in `svh`, `touch-action: manipulation`, sliced Zustand store, and WebSocket connection deriving scheme dynamically from `location.protocol`.
- **`player-client`**: Booting Vite SPA with non-scrolling app shell sized in `svh`, `touch-action: manipulation`, sliced Zustand store, hole cards display, action buttons placeholder, and WebSocket connection deriving scheme dynamically from `location.protocol`.

Closes #27