### PR TITLE
feat(client): 09 — Client shells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+build/
 coverage/
 *.tsbuildinfo
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -913,6 +913,24 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "devOptional": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -1139,6 +1157,47 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw=="
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz",
+      "integrity": "sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==",
+      "dev": true,
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -1529,6 +1588,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2086,6 +2151,32 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
       "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true
+    },
+    "node_modules/framer-motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
+      "dependencies": {
+        "motion-dom": "^12.42.2",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2712,6 +2803,44 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/motion": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.42.2.tgz",
+      "integrity": "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==",
+      "dependencies": {
+        "framer-motion": "^12.42.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3043,6 +3172,25 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
     },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -3187,6 +3335,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "node_modules/secure-json-parse": {
       "version": "4.1.0",
@@ -3437,9 +3590,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3856,6 +4007,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    },
     "packages/engine": {
       "name": "@table-top-poker/engine",
       "version": "0.0.0",
@@ -3876,7 +4055,22 @@
     },
     "packages/player-client": {
       "name": "@table-top-poker/player-client",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dependencies": {
+        "@table-top-poker/protocol": "*",
+        "@table-top-poker/ui-shared": "*",
+        "@use-gesture/react": "^10.3.1",
+        "motion": "^12.42.2",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "zustand": "^5.0.14"
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.4",
+        "vite": "^8.1.5"
+      }
     },
     "packages/protocol": {
       "name": "@table-top-poker/protocol",
@@ -3902,11 +4096,34 @@
     },
     "packages/table-client": {
       "name": "@table-top-poker/table-client",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dependencies": {
+        "@table-top-poker/protocol": "*",
+        "@table-top-poker/ui-shared": "*",
+        "@use-gesture/react": "^10.3.1",
+        "motion": "^12.42.2",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "zustand": "^5.0.14"
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.4",
+        "vite": "^8.1.5"
+      }
     },
     "packages/ui-shared": {
       "name": "@table-top-poker/ui-shared",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dependencies": {
+        "@table-top-poker/protocol": "*",
+        "react": "^19.2.8"
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.17",
+        "react-dom": "^19.2.8"
+      }
     }
   }
 }

--- a/packages/player-client/index.html
+++ b/packages/player-client/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <title>Table Top Poker — Player</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/player-client/package.json
+++ b/packages/player-client/package.json
@@ -7,6 +7,24 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc --build",
-    "test": "vitest run"
+    "test": "vitest run",
+    "dev": "vite",
+    "build:app": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@table-top-poker/protocol": "*",
+    "@table-top-poker/ui-shared": "*",
+    "@use-gesture/react": "^10.3.1",
+    "motion": "^12.42.2",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "zustand": "^5.0.14"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.4",
+    "vite": "^8.1.5"
   }
 }

--- a/packages/player-client/src/App.test.tsx
+++ b/packages/player-client/src/App.test.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { App } from "./App.js";
+
+describe("App", () => {
+  it("renders the player-client placeholder shell with a connection badge", () => {
+    const html = renderToStaticMarkup(<App />);
+    expect(html).toContain('data-testid="player-client-shell"');
+    expect(html).toContain('data-testid="connection-status"');
+  });
+});

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -1,0 +1,23 @@
+import { Card } from "@table-top-poker/ui-shared";
+import { usePlayerStore } from "./store/store.js";
+import { useWebSocket } from "./ws/useWebSocket.js";
+
+export function App() {
+  useWebSocket();
+  const connectionStatus = usePlayerStore((state) => state.connectionStatus);
+
+  return (
+    <div className="app-shell" data-testid="player-client-shell">
+      <header className="status-bar">
+        <span>Table Top Poker — Player</span>
+        <span data-testid="connection-status" data-status={connectionStatus}>
+          {connectionStatus}
+        </span>
+      </header>
+      <main className="hand">
+        <Card rank="K" suit="hearts" />
+        <Card faceDown />
+      </main>
+    </div>
+  );
+}

--- a/packages/player-client/src/app-shell.css
+++ b/packages/player-client/src/app-shell.css
@@ -1,0 +1,44 @@
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  touch-action: manipulation;
+}
+
+#root {
+  width: 100%;
+  height: 100svh;
+  overflow: hidden;
+}
+
+.app-shell {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: #1e293b;
+  color: #f8fafc;
+  font-family: system-ui, sans-serif;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right)
+    env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+
+.status-bar {
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 16px;
+  font-size: 14px;
+}
+
+.hand {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}

--- a/packages/player-client/src/index.ts
+++ b/packages/player-client/src/index.ts
@@ -1,1 +1,2 @@
-export {};
+export { App } from "./App.js";
+export { usePlayerStore } from "./store/store.js";

--- a/packages/player-client/src/main.tsx
+++ b/packages/player-client/src/main.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { App } from "./App.js";
+import "./app-shell.css";
+
+const rootEl = document.getElementById("root");
+if (!rootEl) {
+  throw new Error("#root element not found");
+}
+
+ReactDOM.createRoot(rootEl).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/packages/player-client/src/store/connectionSlice.ts
+++ b/packages/player-client/src/store/connectionSlice.ts
@@ -1,0 +1,15 @@
+import type { StateCreator } from "zustand";
+
+export type ConnectionStatus = "disconnected" | "connecting" | "connected";
+
+export interface ConnectionSlice {
+  readonly connectionStatus: ConnectionStatus;
+  readonly setConnectionStatus: (status: ConnectionStatus) => void;
+}
+
+export const createConnectionSlice: StateCreator<ConnectionSlice> = (set) => ({
+  connectionStatus: "disconnected",
+  setConnectionStatus: (connectionStatus) => {
+    set({ connectionStatus });
+  },
+});

--- a/packages/player-client/src/store/seatSlice.ts
+++ b/packages/player-client/src/store/seatSlice.ts
@@ -1,0 +1,15 @@
+import type { SeatId } from "@table-top-poker/protocol";
+import type { StateCreator } from "zustand";
+
+export interface SeatSlice {
+  readonly seatId: SeatId | null;
+  readonly setSeatId: (seatId: SeatId | null) => void;
+}
+
+/** Placeholder slice — replaced by the real seat-claim flow once ticket 13 lands. */
+export const createSeatSlice: StateCreator<SeatSlice> = (set) => ({
+  seatId: null,
+  setSeatId: (seatId) => {
+    set({ seatId });
+  },
+});

--- a/packages/player-client/src/store/store.test.ts
+++ b/packages/player-client/src/store/store.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { usePlayerStore } from "./store.js";
 
 describe("usePlayerStore", () => {
+  beforeEach(() => {
+    usePlayerStore.setState(usePlayerStore.getInitialState());
+  });
+
   it("starts disconnected with no seat claimed", () => {
     const state = usePlayerStore.getState();
     expect(state.connectionStatus).toBe("disconnected");

--- a/packages/player-client/src/store/store.test.ts
+++ b/packages/player-client/src/store/store.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { usePlayerStore } from "./store.js";
+
+describe("usePlayerStore", () => {
+  it("starts disconnected with no seat claimed", () => {
+    const state = usePlayerStore.getState();
+    expect(state.connectionStatus).toBe("disconnected");
+    expect(state.seatId).toBeNull();
+  });
+
+  it("updates the connection slice independently of the seat slice", () => {
+    usePlayerStore.getState().setConnectionStatus("connected");
+    expect(usePlayerStore.getState().connectionStatus).toBe("connected");
+    expect(usePlayerStore.getState().seatId).toBeNull();
+  });
+
+  it("updates the seat slice independently of the connection slice", () => {
+    usePlayerStore.getState().setConnectionStatus("connected");
+    usePlayerStore.getState().setSeatId(3);
+    expect(usePlayerStore.getState().seatId).toBe(3);
+    expect(usePlayerStore.getState().connectionStatus).toBe("connected");
+  });
+});

--- a/packages/player-client/src/store/store.ts
+++ b/packages/player-client/src/store/store.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+import {
+  type ConnectionSlice,
+  createConnectionSlice,
+} from "./connectionSlice.js";
+import { createSeatSlice, type SeatSlice } from "./seatSlice.js";
+
+export type PlayerStore = ConnectionSlice & SeatSlice;
+
+export const usePlayerStore = create<PlayerStore>()((...args) => ({
+  ...createConnectionSlice(...args),
+  ...createSeatSlice(...args),
+}));

--- a/packages/player-client/src/ws/getWebSocketUrl.test.ts
+++ b/packages/player-client/src/ws/getWebSocketUrl.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getWebSocketUrl } from "./getWebSocketUrl.js";
+
+describe("getWebSocketUrl", () => {
+  it("derives wss:// from an https: location", () => {
+    expect(
+      getWebSocketUrl({ protocol: "https:", host: "poker.local:8080" }),
+    ).toBe("wss://poker.local:8080/ws");
+  });
+
+  it("derives ws:// from an http: location", () => {
+    expect(getWebSocketUrl({ protocol: "http:", host: "localhost:3000" })).toBe(
+      "ws://localhost:3000/ws",
+    );
+  });
+});

--- a/packages/player-client/src/ws/getWebSocketUrl.ts
+++ b/packages/player-client/src/ws/getWebSocketUrl.ts
@@ -1,0 +1,10 @@
+export interface WsLocation {
+  readonly protocol: string;
+  readonly host: string;
+}
+
+/** Derives the WebSocket scheme from `location.protocol` — never hard-coded. */
+export function getWebSocketUrl(location: WsLocation): string {
+  const scheme = location.protocol === "https:" ? "wss:" : "ws:";
+  return `${scheme}//${location.host}/ws`;
+}

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { usePlayerStore } from "../store/store.js";
+import { getWebSocketUrl } from "./getWebSocketUrl.js";
+
+/**
+ * Opens a WebSocket connection on mount and reflects its lifecycle into the
+ * connection slice. No reconnection logic yet — that's ticket 15.
+ */
+export function useWebSocket(): void {
+  const setConnectionStatus = usePlayerStore(
+    (state) => state.setConnectionStatus,
+  );
+
+  useEffect(() => {
+    let active = true;
+    setConnectionStatus("connecting");
+    const socket = new WebSocket(getWebSocketUrl(window.location));
+
+    socket.addEventListener("open", () => {
+      if (active) setConnectionStatus("connected");
+    });
+    socket.addEventListener("close", () => {
+      if (active) setConnectionStatus("disconnected");
+    });
+
+    return () => {
+      active = false;
+      socket.close();
+    };
+  }, [setConnectionStatus]);
+}

--- a/packages/player-client/tsconfig.json
+++ b/packages/player-client/tsconfig.json
@@ -2,8 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx"
   },
   "include": ["src"],
-  "references": []
+  "references": [{ "path": "../ui-shared" }, { "path": "../protocol" }]
 }

--- a/packages/player-client/vite.config.ts
+++ b/packages/player-client/vite.config.ts
@@ -1,0 +1,18 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: "build",
+  },
+  server: {
+    port: 5174,
+    proxy: {
+      "/ws": {
+        target: "ws://localhost:3000",
+        ws: true,
+      },
+    },
+  },
+});

--- a/packages/table-client/index.html
+++ b/packages/table-client/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <title>Table Top Poker — Table</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/table-client/package.json
+++ b/packages/table-client/package.json
@@ -7,6 +7,24 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc --build",
-    "test": "vitest run"
+    "test": "vitest run",
+    "dev": "vite",
+    "build:app": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@table-top-poker/protocol": "*",
+    "@table-top-poker/ui-shared": "*",
+    "@use-gesture/react": "^10.3.1",
+    "motion": "^12.42.2",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
+    "zustand": "^5.0.14"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.4",
+    "vite": "^8.1.5"
   }
 }

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { App } from "./App.js";
+
+describe("App", () => {
+  it("renders the table-client placeholder shell with a connection badge", () => {
+    const html = renderToStaticMarkup(<App />);
+    expect(html).toContain('data-testid="table-client-shell"');
+    expect(html).toContain('data-testid="connection-status"');
+  });
+});

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -1,0 +1,23 @@
+import { Card } from "@table-top-poker/ui-shared";
+import { useTableStore } from "./store/store.js";
+import { useWebSocket } from "./ws/useWebSocket.js";
+
+export function App() {
+  useWebSocket();
+  const connectionStatus = useTableStore((state) => state.connectionStatus);
+
+  return (
+    <div className="app-shell" data-testid="table-client-shell">
+      <header className="status-bar">
+        <span>Table Top Poker — Table</span>
+        <span data-testid="connection-status" data-status={connectionStatus}>
+          {connectionStatus}
+        </span>
+      </header>
+      <main className="felt">
+        <Card rank="A" suit="spades" />
+        <Card faceDown />
+      </main>
+    </div>
+  );
+}

--- a/packages/table-client/src/app-shell.css
+++ b/packages/table-client/src/app-shell.css
@@ -1,0 +1,44 @@
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  touch-action: manipulation;
+}
+
+#root {
+  width: 100%;
+  height: 100svh;
+  overflow: hidden;
+}
+
+.app-shell {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: #0f172a;
+  color: #f8fafc;
+  font-family: system-ui, sans-serif;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right)
+    env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+
+.status-bar {
+  display: flex;
+  justify-content: space-between;
+  padding: 12px 16px;
+  font-size: 14px;
+}
+
+.felt {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}

--- a/packages/table-client/src/index.ts
+++ b/packages/table-client/src/index.ts
@@ -1,1 +1,2 @@
-export {};
+export { App } from "./App.js";
+export { useTableStore } from "./store/store.js";

--- a/packages/table-client/src/main.tsx
+++ b/packages/table-client/src/main.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { App } from "./App.js";
+import "./app-shell.css";
+
+const rootEl = document.getElementById("root");
+if (!rootEl) {
+  throw new Error("#root element not found");
+}
+
+ReactDOM.createRoot(rootEl).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/packages/table-client/src/store/connectionSlice.ts
+++ b/packages/table-client/src/store/connectionSlice.ts
@@ -1,0 +1,15 @@
+import type { StateCreator } from "zustand";
+
+export type ConnectionStatus = "disconnected" | "connecting" | "connected";
+
+export interface ConnectionSlice {
+  readonly connectionStatus: ConnectionStatus;
+  readonly setConnectionStatus: (status: ConnectionStatus) => void;
+}
+
+export const createConnectionSlice: StateCreator<ConnectionSlice> = (set) => ({
+  connectionStatus: "disconnected",
+  setConnectionStatus: (connectionStatus) => {
+    set({ connectionStatus });
+  },
+});

--- a/packages/table-client/src/store/roomSlice.ts
+++ b/packages/table-client/src/store/roomSlice.ts
@@ -1,0 +1,14 @@
+import type { StateCreator } from "zustand";
+
+export interface RoomSlice {
+  readonly roomCode: string | null;
+  readonly setRoomCode: (roomCode: string | null) => void;
+}
+
+/** Placeholder slice — replaced by the real room `view` snapshot once ticket 13 lands. */
+export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
+  roomCode: null,
+  setRoomCode: (roomCode) => {
+    set({ roomCode });
+  },
+});

--- a/packages/table-client/src/store/store.test.ts
+++ b/packages/table-client/src/store/store.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { useTableStore } from "./store.js";
+
+describe("useTableStore", () => {
+  it("starts disconnected with no room code", () => {
+    const state = useTableStore.getState();
+    expect(state.connectionStatus).toBe("disconnected");
+    expect(state.roomCode).toBeNull();
+  });
+
+  it("updates the connection slice independently of the room slice", () => {
+    useTableStore.getState().setConnectionStatus("connected");
+    expect(useTableStore.getState().connectionStatus).toBe("connected");
+    expect(useTableStore.getState().roomCode).toBeNull();
+  });
+
+  it("updates the room slice independently of the connection slice", () => {
+    useTableStore.getState().setConnectionStatus("connected");
+    useTableStore.getState().setRoomCode("ABCD");
+    expect(useTableStore.getState().roomCode).toBe("ABCD");
+    expect(useTableStore.getState().connectionStatus).toBe("connected");
+  });
+});

--- a/packages/table-client/src/store/store.test.ts
+++ b/packages/table-client/src/store/store.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { useTableStore } from "./store.js";
 
 describe("useTableStore", () => {
+  beforeEach(() => {
+    useTableStore.setState(useTableStore.getInitialState());
+  });
+
   it("starts disconnected with no room code", () => {
     const state = useTableStore.getState();
     expect(state.connectionStatus).toBe("disconnected");

--- a/packages/table-client/src/store/store.ts
+++ b/packages/table-client/src/store/store.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand";
+import {
+  type ConnectionSlice,
+  createConnectionSlice,
+} from "./connectionSlice.js";
+import { createRoomSlice, type RoomSlice } from "./roomSlice.js";
+
+export type TableStore = ConnectionSlice & RoomSlice;
+
+export const useTableStore = create<TableStore>()((...args) => ({
+  ...createConnectionSlice(...args),
+  ...createRoomSlice(...args),
+}));

--- a/packages/table-client/src/ws/getWebSocketUrl.test.ts
+++ b/packages/table-client/src/ws/getWebSocketUrl.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { getWebSocketUrl } from "./getWebSocketUrl.js";
+
+describe("getWebSocketUrl", () => {
+  it("derives wss:// from an https: location", () => {
+    expect(
+      getWebSocketUrl({ protocol: "https:", host: "poker.local:8080" }),
+    ).toBe("wss://poker.local:8080/ws");
+  });
+
+  it("derives ws:// from an http: location", () => {
+    expect(getWebSocketUrl({ protocol: "http:", host: "localhost:3000" })).toBe(
+      "ws://localhost:3000/ws",
+    );
+  });
+});

--- a/packages/table-client/src/ws/getWebSocketUrl.ts
+++ b/packages/table-client/src/ws/getWebSocketUrl.ts
@@ -1,0 +1,10 @@
+export interface WsLocation {
+  readonly protocol: string;
+  readonly host: string;
+}
+
+/** Derives the WebSocket scheme from `location.protocol` — never hard-coded. */
+export function getWebSocketUrl(location: WsLocation): string {
+  const scheme = location.protocol === "https:" ? "wss:" : "ws:";
+  return `${scheme}//${location.host}/ws`;
+}

--- a/packages/table-client/src/ws/useWebSocket.ts
+++ b/packages/table-client/src/ws/useWebSocket.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { useTableStore } from "../store/store.js";
+import { getWebSocketUrl } from "./getWebSocketUrl.js";
+
+/**
+ * Opens a WebSocket connection on mount and reflects its lifecycle into the
+ * connection slice. No reconnection logic yet — that's ticket 15.
+ */
+export function useWebSocket(): void {
+  const setConnectionStatus = useTableStore(
+    (state) => state.setConnectionStatus,
+  );
+
+  useEffect(() => {
+    let active = true;
+    setConnectionStatus("connecting");
+    const socket = new WebSocket(getWebSocketUrl(window.location));
+
+    socket.addEventListener("open", () => {
+      if (active) setConnectionStatus("connected");
+    });
+    socket.addEventListener("close", () => {
+      if (active) setConnectionStatus("disconnected");
+    });
+
+    return () => {
+      active = false;
+      socket.close();
+    };
+  }, [setConnectionStatus]);
+}

--- a/packages/table-client/tsconfig.json
+++ b/packages/table-client/tsconfig.json
@@ -2,8 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx"
   },
   "include": ["src"],
-  "references": []
+  "references": [{ "path": "../ui-shared" }, { "path": "../protocol" }]
 }

--- a/packages/table-client/vite.config.ts
+++ b/packages/table-client/vite.config.ts
@@ -1,0 +1,18 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: "build",
+  },
+  server: {
+    port: 5173,
+    proxy: {
+      "/ws": {
+        target: "ws://localhost:3000",
+        ws: true,
+      },
+    },
+  },
+});

--- a/packages/ui-shared/package.json
+++ b/packages/ui-shared/package.json
@@ -8,5 +8,13 @@
   "scripts": {
     "build": "tsc --build",
     "test": "vitest run"
+  },
+  "dependencies": {
+    "@table-top-poker/protocol": "*",
+    "react": "^19.2.8"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "react-dom": "^19.2.8"
   }
 }

--- a/packages/ui-shared/src/Card.test.tsx
+++ b/packages/ui-shared/src/Card.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { Card } from "./Card.js";
+
+describe("Card", () => {
+  it("renders a face-up card's rank and suit as data attributes", () => {
+    const html = renderToStaticMarkup(<Card rank="A" suit="spades" />);
+    expect(html).toContain('data-rank="A"');
+    expect(html).toContain('data-suit="spades"');
+    expect(html).toContain('data-face-down="false"');
+  });
+
+  it("renders face-down without exposing rank or suit in the markup", () => {
+    const html = renderToStaticMarkup(<Card faceDown />);
+    expect(html).not.toContain("data-rank");
+    expect(html).not.toContain("data-suit");
+    expect(html).toContain('data-face-down="true"');
+  });
+
+  it("never renders an <img> element, for either face", () => {
+    const faceUp = renderToStaticMarkup(<Card rank="K" suit="hearts" />);
+    const faceDown = renderToStaticMarkup(<Card faceDown />);
+    expect(faceUp).not.toContain("<img");
+    expect(faceDown).not.toContain("<img");
+  });
+});

--- a/packages/ui-shared/src/Card.tsx
+++ b/packages/ui-shared/src/Card.tsx
@@ -1,0 +1,64 @@
+import type { Rank, Suit } from "@table-top-poker/protocol";
+import type { CSSProperties } from "react";
+
+export type CardProps =
+  | { readonly faceDown: true }
+  | { readonly faceDown?: false; readonly rank: Rank; readonly suit: Suit };
+
+const suitSymbols: Record<Suit, string> = {
+  clubs: "♣",
+  diamonds: "♦",
+  hearts: "♥",
+  spades: "♠",
+};
+
+const redSuits: ReadonlySet<Suit> = new Set(["diamonds", "hearts"]);
+
+const baseStyle: CSSProperties = {
+  width: "3.5em",
+  height: "5em",
+  borderRadius: "0.3em",
+  border: "1px solid #94a3b8",
+  boxSizing: "border-box",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  alignItems: "center",
+  fontFamily: "system-ui, sans-serif",
+  userSelect: "none",
+};
+
+/**
+ * Renders a card as DOM elements, branching on `faceDown` rather than
+ * swapping an `<img>` src — required so Phase 3's flip animation can
+ * cross-fade between the two branches instead of a network image swap.
+ */
+export function Card(props: CardProps) {
+  if (props.faceDown) {
+    return (
+      <div
+        className="card card-back"
+        data-face-down="true"
+        style={{ ...baseStyle, background: "#334155" }}
+      />
+    );
+  }
+
+  const { rank, suit } = props;
+  return (
+    <div
+      className="card card-face"
+      data-face-down="false"
+      data-rank={rank}
+      data-suit={suit}
+      style={{
+        ...baseStyle,
+        background: "#f8fafc",
+        color: redSuits.has(suit) ? "#dc2626" : "#0f172a",
+      }}
+    >
+      <span className="card-rank">{rank}</span>
+      <span className="card-suit">{suitSymbols[suit]}</span>
+    </div>
+  );
+}

--- a/packages/ui-shared/src/index.ts
+++ b/packages/ui-shared/src/index.ts
@@ -1,1 +1,2 @@
-export {};
+export { Card } from "./Card.js";
+export type { CardProps } from "./Card.js";

--- a/packages/ui-shared/tsconfig.json
+++ b/packages/ui-shared/tsconfig.json
@@ -2,8 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx"
   },
   "include": ["src"],
-  "references": []
+  "references": [{ "path": "../protocol" }]
 }


### PR DESCRIPTION
## Summary
- Boots `table-client` and `player-client` as separate Vite SPAs, each rendering a static placeholder screen and holding an open WebSocket connection to the server (`/ws`, scheme derived from `location.protocol`).
- Adds `<Card>` to `ui-shared` with a `rank`/`suit`/`faceDown` discriminated-union prop contract — never an `<img>` src-swap.
- Wires a Zustand store per client (connection slice + a placeholder room/seat slice) so a future server push only re-renders the relevant slice.
- App shell is non-scrolling and fixed, sized in `svh`, with `viewport-fit=cover` and `touch-action: manipulation`.
- React, Motion (`motion/react`), and `@use-gesture/react` are wired in as dependencies per §9, unused until Phase 3.

## Test plan
- [x] `npm run build` (cross-package `tsc --build`) passes
- [x] `npx eslint .` and `npx prettier --check .` pass
- [x] `vitest run` passes for `table-client`, `player-client`, `ui-shared`, `server`, `harness`, `protocol` (the pre-existing `engine` exhaustive-enumeration test is unrelated and unaffected)
- [x] `vite build` succeeds independently for both clients (separate `build/` output dir, doesn't collide with `tsc`'s `dist/`)
- [x] Manually booted the Fastify server + both Vite dev servers and confirmed each dev-server's `/ws` proxy reaches the server's WS route end-to-end

Closes #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSEgncPysXFzSu6EQEMhAx