### PR TITLE
10 — Room join tracer bullet: QR to seat claim

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4085,6 +4085,7 @@
       "dependencies": {
         "@fastify/static": "^10.1.2",
         "@fastify/websocket": "^11.3.0",
+        "@table-top-poker/protocol": "*",
         "fastify": "^5.10.0",
         "qrcode": "^1.5.4"
       },

--- a/packages/player-client/src/App.test.tsx
+++ b/packages/player-client/src/App.test.tsx
@@ -4,9 +4,16 @@ import { describe, expect, it } from "vitest";
 import { App } from "./App.js";
 
 describe("App", () => {
-  it("renders the player-client placeholder shell with a connection badge", () => {
+  it("renders the player-client shell with a connection badge", () => {
     const html = renderToStaticMarkup(<App />);
     expect(html).toContain('data-testid="player-client-shell"');
     expect(html).toContain('data-testid="connection-status"');
+  });
+
+  it("shows the join form before a room is joined", () => {
+    const html = renderToStaticMarkup(<App />);
+    expect(html).toContain('data-testid="join-form"');
+    expect(html).not.toContain('data-testid="seat-picker"');
+    expect(html).not.toContain('data-testid="seat-panel"');
   });
 });

--- a/packages/player-client/src/App.test.tsx
+++ b/packages/player-client/src/App.test.tsx
@@ -4,16 +4,16 @@ import { describe, expect, it } from "vitest";
 import { App } from "./App.js";
 
 describe("App", () => {
-  it("renders the player-client shell with a connection badge", () => {
+  it("renders the player-client shell", () => {
     const html = renderToStaticMarkup(<App />);
     expect(html).toContain('data-testid="player-client-shell"');
-    expect(html).toContain('data-testid="connection-status"');
   });
 
-  it("shows the join form before a room is joined", () => {
+  it("shows the join form and hides the connection badge before a room is joined", () => {
     const html = renderToStaticMarkup(<App />);
     expect(html).toContain('data-testid="join-form"');
     expect(html).not.toContain('data-testid="seat-picker"');
     expect(html).not.toContain('data-testid="seat-panel"');
+    expect(html).not.toContain('data-testid="connection-status"');
   });
 });

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -4,6 +4,7 @@ import { JoinForm } from "./JoinForm.js";
 import { parseRoomCodeFromPath } from "./join/parseRoomCodeFromPath.js";
 import { SeatPanel } from "./SeatPanel.js";
 import { SeatPicker } from "./SeatPicker.js";
+import { StatusBar } from "./StatusBar.js";
 import { saveSeatToken } from "./storage/seatToken.js";
 import { usePlayerStore } from "./store/store.js";
 import { useWebSocket } from "./ws/useWebSocket.js";
@@ -87,12 +88,10 @@ export function App() {
 
   return (
     <div className="app-shell" data-testid="player-client-shell">
-      <header className="status-bar">
-        <span>Table Top Poker — Player</span>
-        <span data-testid="connection-status" data-status={connectionStatus}>
-          {connectionStatus}
-        </span>
-      </header>
+      <StatusBar
+        showBadge={wsParams !== null}
+        connectionStatus={connectionStatus}
+      />
       <main className="hand">{content}</main>
     </div>
   );

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -1,10 +1,89 @@
-import { Card } from "@table-top-poker/ui-shared";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { claimSeat, joinRoom } from "./api/rooms.js";
+import { JoinForm } from "./JoinForm.js";
+import { parseRoomCodeFromPath } from "./join/parseRoomCodeFromPath.js";
+import { SeatPanel } from "./SeatPanel.js";
+import { SeatPicker } from "./SeatPicker.js";
+import { saveSeatToken } from "./storage/seatToken.js";
 import { usePlayerStore } from "./store/store.js";
 import { useWebSocket } from "./ws/useWebSocket.js";
 
 export function App() {
-  useWebSocket();
+  const roomCode = usePlayerStore((state) => state.roomCode);
+  const seats = usePlayerStore((state) => state.seats);
+  const joinError = usePlayerStore((state) => state.joinError);
+  const seatId = usePlayerStore((state) => state.seatId);
+  const sittingOut = usePlayerStore((state) => state.sittingOut);
   const connectionStatus = usePlayerStore((state) => state.connectionStatus);
+  const setRoomView = usePlayerStore((state) => state.setRoomView);
+  const setJoinError = usePlayerStore((state) => state.setJoinError);
+  const setSeat = usePlayerStore((state) => state.setSeat);
+
+  const [defaultRoomCode, setDefaultRoomCode] = useState("");
+  const [claimError, setClaimError] = useState<string | null>(null);
+  const [seatToken, setSeatToken] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fromPath = parseRoomCodeFromPath(window.location.pathname);
+    if (fromPath) setDefaultRoomCode(fromPath);
+  }, []);
+
+  const wsParams = useMemo(() => {
+    if (roomCode === null || seatId === null || seatToken === null) {
+      return null;
+    }
+    return { roomCode, seatId, token: seatToken };
+  }, [roomCode, seatId, seatToken]);
+  useWebSocket(wsParams);
+
+  const handleJoin = useCallback(
+    (code: string) => {
+      joinRoom(code)
+        .then(setRoomView)
+        .catch(() => {
+          setJoinError("room-not-found");
+        });
+    },
+    [setRoomView, setJoinError],
+  );
+
+  const handleClaim = useCallback(
+    (seat: number) => {
+      if (roomCode === null) return;
+      claimSeat(roomCode, seat)
+        .then((claim) => {
+          setClaimError(null);
+          setSeat({ seatId: claim.seatId, sittingOut: claim.sittingOut });
+          setSeatToken(claim.token);
+          saveSeatToken(window.localStorage, {
+            roomCode,
+            seatId: claim.seatId,
+            token: claim.token,
+          });
+        })
+        .catch(() => {
+          setClaimError("seat-already-claimed");
+        });
+    },
+    [roomCode, setSeat],
+  );
+
+  let content;
+  if (roomCode === null) {
+    content = (
+      <JoinForm
+        defaultRoomCode={defaultRoomCode}
+        error={joinError}
+        onSubmit={handleJoin}
+      />
+    );
+  } else if (seatId === null) {
+    content = (
+      <SeatPicker seats={seats} error={claimError} onClaim={handleClaim} />
+    );
+  } else {
+    content = <SeatPanel seatId={seatId} sittingOut={sittingOut} />;
+  }
 
   return (
     <div className="app-shell" data-testid="player-client-shell">
@@ -14,10 +93,7 @@ export function App() {
           {connectionStatus}
         </span>
       </header>
-      <main className="hand">
-        <Card rank="K" suit="hearts" />
-        <Card faceDown />
-      </main>
+      <main className="hand">{content}</main>
     </div>
   );
 }

--- a/packages/player-client/src/JoinForm.test.tsx
+++ b/packages/player-client/src/JoinForm.test.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { JoinForm } from "./JoinForm.js";
+
+describe("JoinForm", () => {
+  it("prefills the room code input", () => {
+    const html = renderToStaticMarkup(
+      <JoinForm
+        defaultRoomCode="ABCD"
+        error={null}
+        onSubmit={() => undefined}
+      />,
+    );
+    expect(html).toContain('data-testid="room-code-input"');
+    expect(html).toContain('value="ABCD"');
+  });
+
+  it("shows a join error when present", () => {
+    const html = renderToStaticMarkup(
+      <JoinForm
+        defaultRoomCode=""
+        error="room-not-found"
+        onSubmit={() => undefined}
+      />,
+    );
+    expect(html).toContain('data-testid="join-error"');
+    expect(html).toContain("room-not-found");
+  });
+
+  it("omits the error element when there is none", () => {
+    const html = renderToStaticMarkup(
+      <JoinForm defaultRoomCode="" error={null} onSubmit={() => undefined} />,
+    );
+    expect(html).not.toContain('data-testid="join-error"');
+  });
+});

--- a/packages/player-client/src/JoinForm.tsx
+++ b/packages/player-client/src/JoinForm.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+
+export interface JoinFormProps {
+  readonly defaultRoomCode: string;
+  readonly error: string | null;
+  readonly onSubmit: (roomCode: string) => void;
+}
+
+export function JoinForm({ defaultRoomCode, error, onSubmit }: JoinFormProps) {
+  const [roomCode, setRoomCode] = useState(defaultRoomCode);
+
+  return (
+    <form
+      data-testid="join-form"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit(roomCode.trim().toUpperCase());
+      }}
+    >
+      <input
+        data-testid="room-code-input"
+        value={roomCode}
+        maxLength={4}
+        onChange={(event) => {
+          setRoomCode(event.target.value);
+        }}
+      />
+      <button type="submit" data-testid="join-room-button">
+        Join room
+      </button>
+      {error && <div data-testid="join-error">{error}</div>}
+    </form>
+  );
+}

--- a/packages/player-client/src/SeatPanel.test.tsx
+++ b/packages/player-client/src/SeatPanel.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { SeatPanel } from "./SeatPanel.js";
+
+describe("SeatPanel", () => {
+  it("shows the claimed seat", () => {
+    const html = renderToStaticMarkup(
+      <SeatPanel seatId={2} sittingOut={false} />,
+    );
+    expect(html).toContain('data-testid="claimed-seat"');
+    expect(html).toContain("Seat 3");
+    expect(html).not.toContain('data-testid="sitting-out-badge"');
+  });
+
+  it("shows a sitting-out badge when joined mid-hand", () => {
+    const html = renderToStaticMarkup(
+      <SeatPanel seatId={2} sittingOut={true} />,
+    );
+    expect(html).toContain('data-testid="sitting-out-badge"');
+  });
+});

--- a/packages/player-client/src/SeatPanel.tsx
+++ b/packages/player-client/src/SeatPanel.tsx
@@ -1,0 +1,13 @@
+export interface SeatPanelProps {
+  readonly seatId: number;
+  readonly sittingOut: boolean;
+}
+
+export function SeatPanel({ seatId, sittingOut }: SeatPanelProps) {
+  return (
+    <div data-testid="seat-panel">
+      <div data-testid="claimed-seat">Seat {seatId + 1}</div>
+      {sittingOut && <div data-testid="sitting-out-badge">Sitting out</div>}
+    </div>
+  );
+}

--- a/packages/player-client/src/SeatPicker.test.tsx
+++ b/packages/player-client/src/SeatPicker.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { SeatPicker } from "./SeatPicker.js";
+
+describe("SeatPicker", () => {
+  it("offers a claim button for each free seat and marks taken seats", () => {
+    const html = renderToStaticMarkup(
+      <SeatPicker
+        error={null}
+        onClaim={() => undefined}
+        seats={[
+          { id: 0, claimed: false, sittingOut: false },
+          { id: 1, claimed: true, sittingOut: false },
+        ]}
+      />,
+    );
+
+    expect(html).toContain('data-testid="claim-seat-0"');
+    expect(html).not.toContain('data-testid="claim-seat-1"');
+    expect(html).toContain("taken");
+  });
+
+  it("shows a claim error when present", () => {
+    const html = renderToStaticMarkup(
+      <SeatPicker
+        error="seat-already-claimed"
+        onClaim={() => undefined}
+        seats={[]}
+      />,
+    );
+    expect(html).toContain('data-testid="claim-error"');
+    expect(html).toContain("seat-already-claimed");
+  });
+});

--- a/packages/player-client/src/SeatPicker.tsx
+++ b/packages/player-client/src/SeatPicker.tsx
@@ -1,0 +1,35 @@
+import type { SeatView } from "@table-top-poker/protocol";
+
+export interface SeatPickerProps {
+  readonly seats: readonly SeatView[];
+  readonly error: string | null;
+  readonly onClaim: (seatId: number) => void;
+}
+
+export function SeatPicker({ seats, error, onClaim }: SeatPickerProps) {
+  return (
+    <div data-testid="seat-picker">
+      <ul>
+        {seats.map((seat) => (
+          <li key={seat.id} data-testid={`seat-option-${String(seat.id)}`}>
+            Seat {seat.id + 1}
+            {seat.claimed ? (
+              " — taken"
+            ) : (
+              <button
+                type="button"
+                data-testid={`claim-seat-${String(seat.id)}`}
+                onClick={() => {
+                  onClaim(seat.id);
+                }}
+              >
+                Sit here
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+      {error && <div data-testid="claim-error">{error}</div>}
+    </div>
+  );
+}

--- a/packages/player-client/src/StatusBar.test.tsx
+++ b/packages/player-client/src/StatusBar.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { StatusBar } from "./StatusBar.js";
+
+describe("StatusBar", () => {
+  it("hides the connection badge before a seat is claimed", () => {
+    const html = renderToStaticMarkup(
+      <StatusBar showBadge={false} connectionStatus="disconnected" />,
+    );
+    expect(html).not.toContain('data-testid="connection-status"');
+  });
+
+  it("shows the connection badge once connecting begins", () => {
+    const html = renderToStaticMarkup(
+      <StatusBar showBadge={true} connectionStatus="connected" />,
+    );
+    expect(html).toContain('data-testid="connection-status"');
+    expect(html).toContain("connected");
+  });
+});

--- a/packages/player-client/src/StatusBar.tsx
+++ b/packages/player-client/src/StatusBar.tsx
@@ -1,0 +1,20 @@
+import type { ConnectionStatus } from "./store/connectionSlice.js";
+
+export interface StatusBarProps {
+  readonly showBadge: boolean;
+  readonly connectionStatus: ConnectionStatus;
+}
+
+/** No connection badge before a seat is claimed — there's nothing to connect to yet. */
+export function StatusBar({ showBadge, connectionStatus }: StatusBarProps) {
+  return (
+    <header className="status-bar">
+      <span>Table Top Poker — Player</span>
+      {showBadge && (
+        <span data-testid="connection-status" data-status={connectionStatus}>
+          {connectionStatus}
+        </span>
+      )}
+    </header>
+  );
+}

--- a/packages/player-client/src/api/rooms.test.ts
+++ b/packages/player-client/src/api/rooms.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { claimSeat, joinRoom } from "./rooms.js";
+
+describe("joinRoom", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts to /rooms/:code/join and returns the room view", async () => {
+    const body = { code: "ABCD", seats: [] };
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify(body), { status: 200 }),
+    );
+
+    const view = await joinRoom("ABCD");
+
+    expect(fetch).toHaveBeenCalledWith("/rooms/ABCD/join", { method: "POST" });
+    expect(view).toEqual(body);
+  });
+
+  it("throws when the room doesn't exist", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 404 }));
+    await expect(joinRoom("ZZZZ")).rejects.toThrow("failed to join room: 404");
+  });
+});
+
+describe("claimSeat", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts to /rooms/:code/seats/:seatId/claim and returns the claim", async () => {
+    const body = { seatId: 2, token: "tok", sittingOut: false };
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify(body), { status: 200 }),
+    );
+
+    const claim = await claimSeat("ABCD", 2);
+
+    expect(fetch).toHaveBeenCalledWith("/rooms/ABCD/seats/2/claim", {
+      method: "POST",
+    });
+    expect(claim).toEqual(body);
+  });
+
+  it("throws when the seat is already claimed", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 409 }));
+    await expect(claimSeat("ABCD", 2)).rejects.toThrow(
+      "failed to claim seat: 409",
+    );
+  });
+});

--- a/packages/player-client/src/api/rooms.ts
+++ b/packages/player-client/src/api/rooms.ts
@@ -1,0 +1,28 @@
+import type { RoomView } from "@table-top-poker/protocol";
+
+export async function joinRoom(code: string): Promise<RoomView> {
+  const response = await fetch(`/rooms/${code}/join`, { method: "POST" });
+  if (!response.ok) {
+    throw new Error(`failed to join room: ${String(response.status)}`);
+  }
+  return (await response.json()) as RoomView;
+}
+
+export interface SeatClaim {
+  readonly seatId: number;
+  readonly token: string;
+  readonly sittingOut: boolean;
+}
+
+export async function claimSeat(
+  code: string,
+  seatId: number,
+): Promise<SeatClaim> {
+  const response = await fetch(`/rooms/${code}/seats/${String(seatId)}/claim`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    throw new Error(`failed to claim seat: ${String(response.status)}`);
+  }
+  return (await response.json()) as SeatClaim;
+}

--- a/packages/player-client/src/join/parseRoomCodeFromPath.test.ts
+++ b/packages/player-client/src/join/parseRoomCodeFromPath.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { parseRoomCodeFromPath } from "./parseRoomCodeFromPath.js";
+
+describe("parseRoomCodeFromPath", () => {
+  it("extracts and upper-cases a room code from a /join/:code path", () => {
+    expect(parseRoomCodeFromPath("/join/ab3d")).toBe("AB3D");
+  });
+
+  it("returns null for the root path", () => {
+    expect(parseRoomCodeFromPath("/")).toBeNull();
+  });
+
+  it("returns null for a code of the wrong length", () => {
+    expect(parseRoomCodeFromPath("/join/abc")).toBeNull();
+  });
+});

--- a/packages/player-client/src/join/parseRoomCodeFromPath.ts
+++ b/packages/player-client/src/join/parseRoomCodeFromPath.ts
@@ -1,0 +1,7 @@
+const JOIN_PATH = /^\/join\/([A-Za-z0-9]{4})$/;
+
+/** Prefills the room-code field from a QR-scanned `/join/:code` URL. */
+export function parseRoomCodeFromPath(pathname: string): string | null {
+  const code = JOIN_PATH.exec(pathname)?.[1];
+  return code ? code.toUpperCase() : null;
+}

--- a/packages/player-client/src/storage/seatToken.test.ts
+++ b/packages/player-client/src/storage/seatToken.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import { saveSeatToken } from "./seatToken.js";
+
+function fakeStorage(setItem: (key: string, value: string) => void): Storage {
+  const data = new Map<string, string>();
+  return {
+    getItem: (key) => data.get(key) ?? null,
+    setItem: (key, value) => {
+      data.set(key, value);
+      setItem(key, value);
+    },
+    removeItem: (key) => {
+      data.delete(key);
+    },
+    clear: () => {
+      data.clear();
+    },
+    key: () => null,
+    length: 0,
+  };
+}
+
+describe("saveSeatToken", () => {
+  it("stores the seat token as JSON under a namespaced key", () => {
+    const setItem = vi.fn();
+    const storage = fakeStorage(setItem);
+
+    saveSeatToken(storage, { roomCode: "ABCD", seatId: 3, token: "tok-1" });
+
+    expect(setItem).toHaveBeenCalledWith(
+      "ttp:seat-token",
+      JSON.stringify({ roomCode: "ABCD", seatId: 3, token: "tok-1" }),
+    );
+  });
+});

--- a/packages/player-client/src/storage/seatToken.ts
+++ b/packages/player-client/src/storage/seatToken.ts
@@ -1,0 +1,19 @@
+const KEY = "ttp:seat-token";
+
+export interface StoredSeatToken {
+  readonly roomCode: string;
+  readonly seatId: number;
+  readonly token: string;
+}
+
+/**
+ * Persists a claimed seat's token for reconnect (ticket 33 reads it back).
+ * Takes an injected `Storage` so callers can pass `window.localStorage` or a
+ * test double without reaching for a global.
+ */
+export function saveSeatToken(
+  storage: Storage,
+  seatToken: StoredSeatToken,
+): void {
+  storage.setItem(KEY, JSON.stringify(seatToken));
+}

--- a/packages/player-client/src/store/roomSlice.ts
+++ b/packages/player-client/src/store/roomSlice.ts
@@ -1,0 +1,26 @@
+import type { RoomView, SeatView } from "@table-top-poker/protocol";
+import type { StateCreator } from "zustand";
+
+export interface RoomSlice {
+  readonly roomCode: string | null;
+  readonly seats: readonly SeatView[];
+  readonly joinError: string | null;
+  readonly setRoomView: (view: RoomView) => void;
+  readonly setJoinError: (message: string | null) => void;
+  readonly clearRoom: () => void;
+}
+
+export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
+  roomCode: null,
+  seats: [],
+  joinError: null,
+  setRoomView: (view) => {
+    set({ roomCode: view.code, seats: view.seats, joinError: null });
+  },
+  setJoinError: (message) => {
+    set({ joinError: message });
+  },
+  clearRoom: () => {
+    set({ roomCode: null, seats: [], joinError: null });
+  },
+});

--- a/packages/player-client/src/store/seatSlice.ts
+++ b/packages/player-client/src/store/seatSlice.ts
@@ -3,13 +3,18 @@ import type { StateCreator } from "zustand";
 
 export interface SeatSlice {
   readonly seatId: SeatId | null;
-  readonly setSeatId: (seatId: SeatId | null) => void;
+  readonly sittingOut: boolean;
+  readonly setSeat: (seat: { seatId: SeatId; sittingOut: boolean }) => void;
+  readonly clearSeat: () => void;
 }
 
-/** Placeholder slice — replaced by the real seat-claim flow once ticket 13 lands. */
 export const createSeatSlice: StateCreator<SeatSlice> = (set) => ({
   seatId: null,
-  setSeatId: (seatId) => {
-    set({ seatId });
+  sittingOut: false,
+  setSeat: ({ seatId, sittingOut }) => {
+    set({ seatId, sittingOut });
+  },
+  clearSeat: () => {
+    set({ seatId: null, sittingOut: false });
   },
 });

--- a/packages/player-client/src/store/store.test.ts
+++ b/packages/player-client/src/store/store.test.ts
@@ -6,22 +6,65 @@ describe("usePlayerStore", () => {
     usePlayerStore.setState(usePlayerStore.getInitialState());
   });
 
-  it("starts disconnected with no seat claimed", () => {
+  it("starts disconnected with no room joined and no seat claimed", () => {
     const state = usePlayerStore.getState();
     expect(state.connectionStatus).toBe("disconnected");
+    expect(state.roomCode).toBeNull();
     expect(state.seatId).toBeNull();
   });
 
   it("updates the connection slice independently of the seat slice", () => {
     usePlayerStore.getState().setConnectionStatus("connected");
+    usePlayerStore.getState().setSeat({ seatId: 3, sittingOut: false });
     expect(usePlayerStore.getState().connectionStatus).toBe("connected");
-    expect(usePlayerStore.getState().seatId).toBeNull();
+    expect(usePlayerStore.getState().seatId).toBe(3);
   });
 
   it("updates the seat slice independently of the connection slice", () => {
     usePlayerStore.getState().setConnectionStatus("connected");
-    usePlayerStore.getState().setSeatId(3);
+    usePlayerStore.getState().setSeat({ seatId: 3, sittingOut: true });
     expect(usePlayerStore.getState().seatId).toBe(3);
+    expect(usePlayerStore.getState().sittingOut).toBe(true);
     expect(usePlayerStore.getState().connectionStatus).toBe("connected");
+  });
+
+  it("clears the seat slice independently of the room slice", () => {
+    usePlayerStore.getState().setRoomView({
+      code: "ABCD",
+      seats: [{ id: 0, claimed: true, sittingOut: false }],
+    });
+    usePlayerStore.getState().setSeat({ seatId: 0, sittingOut: false });
+
+    usePlayerStore.getState().clearSeat();
+
+    expect(usePlayerStore.getState().seatId).toBeNull();
+    expect(usePlayerStore.getState().roomCode).toBe("ABCD");
+  });
+
+  it("replaces the seat list from a room-view snapshot", () => {
+    usePlayerStore.getState().setRoomView({
+      code: "ABCD",
+      seats: [{ id: 0, claimed: true, sittingOut: false }],
+    });
+    expect(usePlayerStore.getState().roomCode).toBe("ABCD");
+    expect(usePlayerStore.getState().seats).toEqual([
+      { id: 0, claimed: true, sittingOut: false },
+    ]);
+  });
+
+  it("tracks a join error independently of the room slice", () => {
+    usePlayerStore.getState().setJoinError("room-not-found");
+    expect(usePlayerStore.getState().joinError).toBe("room-not-found");
+    expect(usePlayerStore.getState().roomCode).toBeNull();
+  });
+
+  it("clears the room slice back to its initial state", () => {
+    usePlayerStore.getState().setRoomView({
+      code: "ABCD",
+      seats: [{ id: 0, claimed: true, sittingOut: false }],
+    });
+    usePlayerStore.getState().clearRoom();
+    expect(usePlayerStore.getState().roomCode).toBeNull();
+    expect(usePlayerStore.getState().seats).toEqual([]);
   });
 });

--- a/packages/player-client/src/store/store.ts
+++ b/packages/player-client/src/store/store.ts
@@ -3,11 +3,13 @@ import {
   type ConnectionSlice,
   createConnectionSlice,
 } from "./connectionSlice.js";
+import { createRoomSlice, type RoomSlice } from "./roomSlice.js";
 import { createSeatSlice, type SeatSlice } from "./seatSlice.js";
 
-export type PlayerStore = ConnectionSlice & SeatSlice;
+export type PlayerStore = ConnectionSlice & RoomSlice & SeatSlice;
 
 export const usePlayerStore = create<PlayerStore>()((...args) => ({
   ...createConnectionSlice(...args),
+  ...createRoomSlice(...args),
   ...createSeatSlice(...args),
 }));

--- a/packages/player-client/src/ws/getWebSocketUrl.test.ts
+++ b/packages/player-client/src/ws/getWebSocketUrl.test.ts
@@ -13,4 +13,13 @@ describe("getWebSocketUrl", () => {
       "ws://localhost:3000/ws",
     );
   });
+
+  it("appends query params for a seat-scoped connection", () => {
+    expect(
+      getWebSocketUrl(
+        { protocol: "http:", host: "localhost:3000" },
+        { room: "ABCD", seat: "2", token: "tok" },
+      ),
+    ).toBe("ws://localhost:3000/ws?room=ABCD&seat=2&token=tok");
+  });
 });

--- a/packages/player-client/src/ws/getWebSocketUrl.ts
+++ b/packages/player-client/src/ws/getWebSocketUrl.ts
@@ -4,7 +4,11 @@ export interface WsLocation {
 }
 
 /** Derives the WebSocket scheme from `location.protocol` — never hard-coded. */
-export function getWebSocketUrl(location: WsLocation): string {
+export function getWebSocketUrl(
+  location: WsLocation,
+  params: Record<string, string> = {},
+): string {
   const scheme = location.protocol === "https:" ? "wss:" : "ws:";
-  return `${scheme}//${location.host}/ws`;
+  const query = new URLSearchParams(params).toString();
+  return `${scheme}//${location.host}/ws${query ? `?${query}` : ""}`;
 }

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -1,20 +1,40 @@
+import type { ServerMessage } from "@table-top-poker/protocol";
 import { useEffect } from "react";
 import { usePlayerStore } from "../store/store.js";
 import { getWebSocketUrl } from "./getWebSocketUrl.js";
 
+export interface SeatConnectionParams {
+  readonly roomCode: string;
+  readonly seatId: number;
+  readonly token: string;
+}
+
 /**
- * Opens a WebSocket connection on mount and reflects its lifecycle into the
- * connection slice. No reconnection logic yet — that's ticket 15.
+ * Opens a seat-scoped WebSocket connection once a seat is claimed and
+ * reflects its lifecycle into the connection slice. Every `room-view` push
+ * replaces the seat list. No reconnection logic yet — that's ticket 33.
  */
-export function useWebSocket(): void {
+export function useWebSocket(params: SeatConnectionParams | null): void {
   const setConnectionStatus = usePlayerStore(
     (state) => state.setConnectionStatus,
   );
+  const setRoomView = usePlayerStore((state) => state.setRoomView);
 
   useEffect(() => {
+    if (params === null) {
+      setConnectionStatus("disconnected");
+      return;
+    }
+
     let active = true;
     setConnectionStatus("connecting");
-    const socket = new WebSocket(getWebSocketUrl(window.location));
+    const socket = new WebSocket(
+      getWebSocketUrl(window.location, {
+        room: params.roomCode,
+        seat: String(params.seatId),
+        token: params.token,
+      }),
+    );
 
     socket.addEventListener("open", () => {
       if (active) setConnectionStatus("connected");
@@ -22,10 +42,15 @@ export function useWebSocket(): void {
     socket.addEventListener("close", () => {
       if (active) setConnectionStatus("disconnected");
     });
+    socket.addEventListener("message", (event: MessageEvent<string>) => {
+      if (!active) return;
+      const message: ServerMessage = JSON.parse(event.data) as ServerMessage;
+      setRoomView(message.view);
+    });
 
     return () => {
       active = false;
       socket.close();
     };
-  }, [setConnectionStatus]);
+  }, [params, setConnectionStatus, setRoomView]);
 }

--- a/packages/player-client/vite.config.ts
+++ b/packages/player-client/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
         target: "ws://localhost:3000",
         ws: true,
       },
+      "/rooms": "http://localhost:3000",
     },
   },
 });

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,1 +1,2 @@
 export * from "@table-top-poker/engine";
+export * from "./room.js";

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -1,0 +1,19 @@
+import type { SeatId } from "@table-top-poker/engine";
+
+/** A seat's public state — never carries its claim token. */
+export interface SeatView {
+  readonly id: SeatId;
+  readonly claimed: boolean;
+  readonly sittingOut: boolean;
+}
+
+export interface RoomView {
+  readonly code: string;
+  readonly seats: readonly SeatView[];
+}
+
+/** Pushed over the room's WebSocket whenever seat state changes. */
+export interface ServerMessage {
+  readonly type: "room-view";
+  readonly view: RoomView;
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@fastify/static": "^10.1.2",
     "@fastify/websocket": "^11.3.0",
+    "@table-top-poker/protocol": "*",
     "fastify": "^5.10.0",
     "qrcode": "^1.5.4"
   },

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -1,11 +1,9 @@
+import type { RoomView, ServerMessage } from "@table-top-poker/protocol";
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import WebSocket from "ws";
 import { buildApp } from "./app.js";
-
-interface RoomCodeBody {
-  readonly code: string;
-}
+import { RoomStore, SEAT_COUNT } from "./rooms.js";
 
 interface RoomCreatedBody {
   readonly code: string;
@@ -16,6 +14,20 @@ interface RoomCreatedBody {
 interface RoomQrBody {
   readonly url: string;
   readonly dataUrl: string;
+}
+
+interface SeatClaimBody {
+  readonly seatId: number;
+  readonly token: string;
+  readonly sittingOut: boolean;
+}
+
+function unclaimedSeats(): RoomView["seats"] {
+  return Array.from({ length: SEAT_COUNT }, (_, id) => ({
+    id,
+    claimed: false,
+    sittingOut: false,
+  }));
 }
 
 describe("rooms HTTP routes", () => {
@@ -42,16 +54,19 @@ describe("rooms HTTP routes", () => {
     expect(body.qrCodeDataUrl).toMatch(/^data:image\/png;base64,/);
   });
 
-  it("joining a known room code succeeds", async () => {
+  it("joining a known room code returns its room view", async () => {
     const created = await app.inject({ method: "POST", url: "/rooms" });
-    const { code } = created.json<RoomCodeBody>();
+    const { code } = created.json<RoomCreatedBody>();
 
     const joined = await app.inject({
       method: "POST",
       url: `/rooms/${code}/join`,
     });
     expect(joined.statusCode).toBe(200);
-    expect(joined.json<RoomCodeBody>()).toEqual({ code });
+    expect(joined.json<RoomView>()).toEqual({
+      code,
+      seats: unclaimedSeats(),
+    });
   });
 
   it("joining an unknown room code is rejected", async () => {
@@ -64,7 +79,7 @@ describe("rooms HTTP routes", () => {
 
   it("produces a QR code for a created room, derived from the request host", async () => {
     const created = await app.inject({ method: "POST", url: "/rooms" });
-    const { code } = created.json<RoomCodeBody>();
+    const { code } = created.json<RoomCreatedBody>();
 
     const response = await app.inject({
       method: "GET",
@@ -80,7 +95,7 @@ describe("rooms HTTP routes", () => {
 
   it("ending a session discards the room's in-memory state", async () => {
     const created = await app.inject({ method: "POST", url: "/rooms" });
-    const { code } = created.json<RoomCodeBody>();
+    const { code } = created.json<RoomCreatedBody>();
 
     const ended = await app.inject({
       method: "POST",
@@ -96,12 +111,155 @@ describe("rooms HTTP routes", () => {
   });
 });
 
+describe("GET /join/:code", () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    await app.close();
+    delete process.env.PLAYER_CLIENT_ORIGIN;
+  });
+
+  it("404s for an unknown room code", async () => {
+    app = await buildApp();
+    const response = await app.inject({ method: "GET", url: "/join/ZZZZ" });
+    expect(response.statusCode).toBe(404);
+  });
+
+  it("serves the same-origin placeholder when no player origin is configured", async () => {
+    app = await buildApp();
+    const created = await app.inject({ method: "POST", url: "/rooms" });
+    const { code } = created.json<RoomCreatedBody>();
+
+    const response = await app.inject({ method: "GET", url: `/join/${code}` });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["content-type"]).toMatch(/^text\/html/);
+  });
+
+  it("redirects to PLAYER_CLIENT_ORIGIN when configured", async () => {
+    process.env.PLAYER_CLIENT_ORIGIN = "http://192.168.1.50:5174";
+    app = await buildApp();
+    const created = await app.inject({ method: "POST", url: "/rooms" });
+    const { code } = created.json<RoomCreatedBody>();
+
+    const response = await app.inject({ method: "GET", url: `/join/${code}` });
+
+    expect(response.statusCode).toBe(302);
+    expect(response.headers.location).toBe(
+      `http://192.168.1.50:5174/join/${code}`,
+    );
+  });
+});
+
+describe("seat claim/clear routes", () => {
+  let app: FastifyInstance;
+  let rooms: RoomStore;
+
+  beforeEach(async () => {
+    rooms = new RoomStore();
+    app = await buildApp({ rooms });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  async function createRoom(): Promise<string> {
+    const created = await app.inject({ method: "POST", url: "/rooms" });
+    return created.json<RoomCreatedBody>().code;
+  }
+
+  it("claims a free seat, issuing a token", async () => {
+    const code = await createRoom();
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/claim`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json<SeatClaimBody>();
+    expect(typeof body.token).toBe("string");
+    expect(body).toMatchObject({ seatId: 0, sittingOut: false });
+  });
+
+  it("rejects claiming an already-claimed seat", async () => {
+    const code = await createRoom();
+    await app.inject({ method: "POST", url: `/rooms/${code}/seats/0/claim` });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/claim`,
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({ error: "seat-already-claimed" });
+  });
+
+  it("rejects claiming a seat in an unknown room", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/rooms/ZZZZ/seats/0/claim",
+    });
+    expect(response.statusCode).toBe(404);
+  });
+
+  it("rejects an out-of-range seat id", async () => {
+    const code = await createRoom();
+    const response = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/${String(SEAT_COUNT)}/claim`,
+    });
+    expect(response.statusCode).toBe(404);
+  });
+
+  it("rejects a malformed seat id", async () => {
+    const code = await createRoom();
+    const response = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/not-a-number/claim`,
+    });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("marks a seat claimed mid-hand as sitting out", async () => {
+    const code = await createRoom();
+    rooms.markHandInProgress(code, true);
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/claim`,
+    });
+
+    expect(response.json<SeatClaimBody>().sittingOut).toBe(true);
+  });
+
+  it("force-clears a seat so it can be reclaimed", async () => {
+    const code = await createRoom();
+    await app.inject({ method: "POST", url: `/rooms/${code}/seats/0/claim` });
+
+    const cleared = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/clear`,
+    });
+    expect(cleared.statusCode).toBe(204);
+
+    const reclaimed = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/claim`,
+    });
+    expect(reclaimed.statusCode).toBe(200);
+  });
+});
+
 describe("WebSocket upgrade", () => {
   let app: FastifyInstance;
+  let rooms: RoomStore;
   let port: number;
 
   beforeEach(async () => {
-    app = await buildApp();
+    rooms = new RoomStore();
+    app = await buildApp({ rooms });
     await app.listen({ port: 0, host: "127.0.0.1" });
     const address = app.server.address();
     if (address === null || typeof address === "string") {
@@ -114,8 +272,104 @@ describe("WebSocket upgrade", () => {
     await app.close();
   });
 
-  it("accepts a bare WebSocket connection on the same port as HTTP", async () => {
+  it("rejects a connection with no room param", async () => {
     const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/ws`);
+    const closeCode = await new Promise<number>((resolve) => {
+      socket.on("unexpected-response", (_req, res) => {
+        resolve(res.statusCode ?? 0);
+      });
+      socket.on("close", (code) => {
+        resolve(code);
+      });
+    });
+    expect(closeCode).toBe(400);
+  });
+
+  it("rejects a connection for an unknown room", async () => {
+    const socket = new WebSocket(
+      `ws://127.0.0.1:${String(port)}/ws?room=ZZZZ&role=table`,
+    );
+    const closeCode = await new Promise<number>((resolve) => {
+      socket.on("unexpected-response", (_req, res) => {
+        resolve(res.statusCode ?? 0);
+      });
+    });
+    expect(closeCode).toBe(404);
+  });
+
+  it("accepts a table-device connection scoped to a live room", async () => {
+    const room = rooms.create();
+    const socket = new WebSocket(
+      `ws://127.0.0.1:${String(port)}/ws?room=${room.code}&role=table`,
+    );
+    await new Promise<void>((resolve, reject) => {
+      socket.on("open", resolve);
+      socket.on("error", reject);
+    });
+    expect(socket.readyState).toBe(WebSocket.OPEN);
+    socket.close();
+  });
+
+  it("pushes a fresh room view on connect and on every seat claim", async () => {
+    const room = rooms.create();
+    const socket = new WebSocket(
+      `ws://127.0.0.1:${String(port)}/ws?room=${room.code}&role=table`,
+    );
+
+    const messages: ServerMessage[] = [];
+    socket.on("message", (data: Buffer) => {
+      messages.push(JSON.parse(data.toString()) as ServerMessage);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      socket.on("open", resolve);
+      socket.on("error", reject);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toEqual({
+      type: "room-view",
+      view: { code: room.code, seats: unclaimedSeats() },
+    });
+
+    await app.inject({
+      method: "POST",
+      url: `/rooms/${room.code}/seats/0/claim`,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(messages).toHaveLength(2);
+    expect(messages[1]?.type).toBe("room-view");
+    expect((messages[1] as { view: RoomView }).view.seats[0]).toEqual({
+      id: 0,
+      claimed: true,
+      sittingOut: false,
+    });
+
+    socket.close();
+  });
+
+  it("rejects a player connection with an unknown seat token", async () => {
+    const room = rooms.create();
+    const socket = new WebSocket(
+      `ws://127.0.0.1:${String(port)}/ws?room=${room.code}&seat=0&token=bogus`,
+    );
+    const closeCode = await new Promise<number>((resolve) => {
+      socket.on("unexpected-response", (_req, res) => {
+        resolve(res.statusCode ?? 0);
+      });
+    });
+    expect(closeCode).toBe(403);
+  });
+
+  it("accepts a player connection with a valid seat token", async () => {
+    const room = rooms.create();
+    const claim = rooms.claimSeat(room.code, 0);
+    if (!("seat" in claim)) throw new Error("expected a claimed seat");
+
+    const socket = new WebSocket(
+      `ws://127.0.0.1:${String(port)}/ws?room=${room.code}&seat=0&token=${claim.seat.token ?? ""}`,
+    );
     await new Promise<void>((resolve, reject) => {
       socket.on("open", resolve);
       socket.on("error", reject);

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -61,7 +61,7 @@ function findRoomOrReject(
 
 /** Seat ids arrive as route/query strings — reject anything that isn't a bare integer. */
 function parseSeatId(raw: string): number | undefined {
-  return /^-?\d+$/.test(raw) ? Number(raw) : undefined;
+  return /^\d+$/.test(raw) ? Number(raw) : undefined;
 }
 
 export async function buildApp(
@@ -195,6 +195,7 @@ export async function buildApp(
             seatObj.token !== token
           ) {
             await reply.code(403).send({ error: "invalid-seat-token" });
+            return;
           }
         },
       },

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,11 +1,22 @@
 import fastifyStatic from "@fastify/static";
 import fastifyWebsocket from "@fastify/websocket";
+import type { ServerMessage } from "@table-top-poker/protocol";
 import Fastify, { type FastifyInstance, type FastifyReply } from "fastify";
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import type { WebSocket } from "ws";
 import { joinUrl, roomQrCodeDataUrl } from "./qr.js";
-import { type Room, RoomStore } from "./rooms.js";
+import {
+  type ClaimSeatError,
+  type Room,
+  RoomStore,
+  toRoomView,
+} from "./rooms.js";
 
 const publicDir = fileURLToPath(new URL("../public", import.meta.url));
+const publicIndexPath = fileURLToPath(
+  new URL("../public/index.html", import.meta.url),
+);
 
 export interface BuildAppOptions {
   readonly rooms?: RoomStore;
@@ -14,6 +25,25 @@ export interface BuildAppOptions {
 interface RoomCodeRoute {
   Params: { code: string };
 }
+
+interface RoomSeatRoute {
+  Params: { code: string; seatId: string };
+}
+
+interface WsRoute {
+  Querystring: {
+    room?: string;
+    role?: string;
+    seat?: string;
+    token?: string;
+  };
+}
+
+const CLAIM_ERROR_STATUS: Record<ClaimSeatError, number> = {
+  "room-not-found": 404,
+  "seat-not-found": 404,
+  "seat-already-claimed": 409,
+};
 
 /** Looks up a room, replying 404 and returning undefined when it's not live. */
 function findRoomOrReject(
@@ -29,11 +59,31 @@ function findRoomOrReject(
   return room;
 }
 
+/** Seat ids arrive as route/query strings — reject anything that isn't a bare integer. */
+function parseSeatId(raw: string): number | undefined {
+  return /^-?\d+$/.test(raw) ? Number(raw) : undefined;
+}
+
 export async function buildApp(
   options: BuildAppOptions = {},
 ): Promise<FastifyInstance> {
   const rooms = options.rooms ?? new RoomStore();
+  const roomSockets = new Map<string, Set<WebSocket>>();
   const app = Fastify();
+
+  function broadcastRoomView(code: string): void {
+    const room = rooms.get(code);
+    const sockets = roomSockets.get(code);
+    if (!room || !sockets) return;
+    const message: ServerMessage = {
+      type: "room-view",
+      view: toRoomView(room),
+    };
+    const payload = JSON.stringify(message);
+    for (const socket of sockets) {
+      socket.send(payload);
+    }
+  }
 
   await app.register(fastifyStatic, { root: publicDir });
   await app.register(fastifyWebsocket);
@@ -48,7 +98,7 @@ export async function buildApp(
   app.post<RoomCodeRoute>("/rooms/:code/join", (request, reply) => {
     const room = findRoomOrReject(rooms, request.params.code, reply);
     if (!room) return;
-    return { code: room.code };
+    return toRoomView(room);
   });
 
   app.get<RoomCodeRoute>("/rooms/:code/qr", async (request, reply) => {
@@ -66,12 +116,113 @@ export async function buildApp(
     return reply.code(204).send();
   });
 
+  /**
+   * Where the QR code's join URL lands. `PLAYER_CLIENT_ORIGIN` points dev at
+   * the player-client's own Vite server; unset, it serves the (currently
+   * placeholder) same-origin index — ticket 34 bundles the real app there.
+   */
+  app.get<RoomCodeRoute>("/join/:code", (request, reply) => {
+    const room = findRoomOrReject(rooms, request.params.code, reply);
+    if (!room) return;
+    const playerOrigin = process.env.PLAYER_CLIENT_ORIGIN;
+    if (playerOrigin) {
+      return reply.redirect(`${playerOrigin}/join/${room.code}`);
+    }
+    return reply.type("text/html").send(readFileSync(publicIndexPath));
+  });
+
+  app.post<RoomSeatRoute>(
+    "/rooms/:code/seats/:seatId/claim",
+    (request, reply) => {
+      const seatId = parseSeatId(request.params.seatId);
+      if (seatId === undefined) {
+        return reply.code(400).send({ error: "invalid-seat-id" });
+      }
+      const result = rooms.claimSeat(request.params.code, seatId);
+      if ("error" in result) {
+        return reply
+          .code(CLAIM_ERROR_STATUS[result.error])
+          .send({ error: result.error });
+      }
+      broadcastRoomView(request.params.code);
+      return {
+        seatId: result.seat.id,
+        token: result.seat.token,
+        sittingOut: result.seat.sittingOut,
+      };
+    },
+  );
+
+  app.post<RoomSeatRoute>(
+    "/rooms/:code/seats/:seatId/clear",
+    (request, reply) => {
+      const seatId = parseSeatId(request.params.seatId);
+      if (seatId === undefined) {
+        return reply.code(400).send({ error: "invalid-seat-id" });
+      }
+      const room = findRoomOrReject(rooms, request.params.code, reply);
+      if (!room) return;
+      rooms.clearSeat(request.params.code, seatId);
+      broadcastRoomView(request.params.code);
+      return reply.code(204).send();
+    },
+  );
+
   app.register((wsApp, _opts, done) => {
-    wsApp.get("/ws", { websocket: true }, (socket) => {
-      socket.on("message", () => {
-        // No payload logic yet — the connection is the whole contract for this slice.
-      });
-    });
+    wsApp.get<WsRoute>(
+      "/ws",
+      {
+        websocket: true,
+        preValidation: async (request, reply) => {
+          const { room: code, role, seat, token } = request.query;
+          if (!code) {
+            await reply.code(400).send({ error: "room-required" });
+            return;
+          }
+          const room = rooms.get(code);
+          if (!room) {
+            await reply.code(404).send({ error: "room-not-found" });
+            return;
+          }
+          if (role === "table") return;
+
+          const seatId = seat === undefined ? undefined : parseSeatId(seat);
+          const seatObj = seatId === undefined ? undefined : room.seats[seatId];
+          if (
+            !seatObj ||
+            !seatObj.claimed ||
+            token === undefined ||
+            seatObj.token !== token
+          ) {
+            await reply.code(403).send({ error: "invalid-seat-token" });
+          }
+        },
+      },
+      (socket, request) => {
+        const code = request.query.room;
+        if (code === undefined) return;
+
+        let sockets = roomSockets.get(code);
+        if (!sockets) {
+          sockets = new Set();
+          roomSockets.set(code, sockets);
+        }
+        sockets.add(socket);
+
+        const room = rooms.get(code);
+        if (room) {
+          const message: ServerMessage = {
+            type: "room-view",
+            view: toRoomView(room),
+          };
+          socket.send(JSON.stringify(message));
+        }
+
+        socket.on("close", () => {
+          sockets.delete(socket);
+        });
+      },
+    );
     done();
   });
 

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { RoomStore } from "./rooms.js";
+import { RoomStore, SEAT_COUNT, toRoomView } from "./rooms.js";
 
 describe("RoomStore", () => {
   it("creates a room with a fresh code", () => {
@@ -7,6 +7,17 @@ describe("RoomStore", () => {
     const room = store.create();
     expect(room.code).toHaveLength(4);
     expect(store.get(room.code)).toBe(room);
+  });
+
+  it("creates a room with 8 unclaimed seats", () => {
+    const store = new RoomStore();
+    const room = store.create();
+    expect(room.seats).toHaveLength(SEAT_COUNT);
+    for (const seat of room.seats) {
+      expect(seat.claimed).toBe(false);
+      expect(seat.token).toBeNull();
+      expect(seat.sittingOut).toBe(false);
+    }
   });
 
   it("re-rolls the code on collision against live rooms", () => {
@@ -39,5 +50,131 @@ describe("RoomStore", () => {
     expect(() => {
       store.end("ZZZZ");
     }).not.toThrow();
+  });
+
+  describe("seat claiming", () => {
+    it("claims a free seat, issuing an opaque token", () => {
+      let calls = 0;
+      const store = new RoomStore(
+        Math.random,
+        () => `token-${String(calls++)}`,
+      );
+      const room = store.create();
+
+      const result = store.claimSeat(room.code, 0);
+
+      expect(result).toEqual({
+        seat: { id: 0, claimed: true, token: "token-0", sittingOut: false },
+      });
+      expect(room.seats[0]).toEqual({
+        id: 0,
+        claimed: true,
+        token: "token-0",
+        sittingOut: false,
+      });
+    });
+
+    it("rejects claiming an already-claimed seat", () => {
+      const store = new RoomStore();
+      const room = store.create();
+      store.claimSeat(room.code, 0);
+
+      const result = store.claimSeat(room.code, 0);
+
+      expect(result).toEqual({ error: "seat-already-claimed" });
+    });
+
+    it("rejects claiming a seat in an unknown room", () => {
+      const store = new RoomStore();
+      expect(store.claimSeat("ZZZZ", 0)).toEqual({ error: "room-not-found" });
+    });
+
+    it("rejects claiming an out-of-range seat", () => {
+      const store = new RoomStore();
+      const room = store.create();
+      expect(store.claimSeat(room.code, SEAT_COUNT)).toEqual({
+        error: "seat-not-found",
+      });
+      expect(store.claimSeat(room.code, -1)).toEqual({
+        error: "seat-not-found",
+      });
+    });
+
+    it("marks a seat claimed while a hand is in progress as sitting out", () => {
+      const store = new RoomStore();
+      const room = store.create();
+      store.markHandInProgress(room.code, true);
+
+      const result = store.claimSeat(room.code, 0);
+
+      if (!("seat" in result)) throw new Error("expected a claimed seat");
+      expect(typeof result.seat.token).toBe("string");
+      expect(result.seat).toMatchObject({
+        id: 0,
+        claimed: true,
+        sittingOut: true,
+      });
+    });
+
+    it("force-clears a claimed seat so it can be reclaimed", () => {
+      const store = new RoomStore();
+      const room = store.create();
+      store.claimSeat(room.code, 0);
+
+      store.clearSeat(room.code, 0);
+
+      expect(room.seats[0]).toEqual({
+        id: 0,
+        claimed: false,
+        token: null,
+        sittingOut: false,
+      });
+      const reclaimed = store.claimSeat(room.code, 0);
+      if (!("seat" in reclaimed)) throw new Error("expected a claimed seat");
+      expect(typeof reclaimed.seat.token).toBe("string");
+      expect(reclaimed.seat).toMatchObject({
+        id: 0,
+        claimed: true,
+        sittingOut: false,
+      });
+    });
+
+    it("clearing a seat in an unknown room is a no-op", () => {
+      const store = new RoomStore();
+      expect(() => {
+        store.clearSeat("ZZZZ", 0);
+      }).not.toThrow();
+    });
+  });
+
+  describe("hand-in-progress flag", () => {
+    it("toggling an unknown room is a no-op", () => {
+      const store = new RoomStore();
+      expect(() => {
+        store.markHandInProgress("ZZZZ", true);
+      }).not.toThrow();
+    });
+  });
+});
+
+describe("toRoomView", () => {
+  it("projects seats without their tokens", () => {
+    const store = new RoomStore();
+    const room = store.create();
+    store.claimSeat(room.code, 0);
+
+    const view = toRoomView(room);
+
+    expect(view).toEqual({
+      code: room.code,
+      seats: [
+        { id: 0, claimed: true, sittingOut: false },
+        ...Array.from({ length: SEAT_COUNT - 1 }, (_, i) => ({
+          id: i + 1,
+          claimed: false,
+          sittingOut: false,
+        })),
+      ],
+    });
   });
 });

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -1,21 +1,63 @@
+import { randomUUID } from "node:crypto";
+import type { RoomView, SeatId } from "@table-top-poker/protocol";
 import { generateRoomCode } from "./room-code.js";
+
+export const SEAT_COUNT = 8;
+
+/**
+ * `Seat` and `Room` are `RoomStore`'s internal mutable aggregate state, not
+ * wire DTOs — mutated in place by the store rather than replaced, unlike
+ * the `readonly` view/slice types elsewhere that cross a render or wire
+ * boundary. `toRoomView` is the seam that turns them into an immutable
+ * snapshot for broadcast.
+ */
+export interface Seat {
+  readonly id: SeatId;
+  claimed: boolean;
+  token: string | null;
+  sittingOut: boolean;
+}
 
 export interface Room {
   readonly code: string;
+  readonly seats: Seat[];
+  handInProgress: boolean;
 }
 
-/** In-memory room registry. No engine attached yet — rooms are just codes. */
+export type ClaimSeatError =
+  "room-not-found" | "seat-not-found" | "seat-already-claimed";
+
+export type ClaimSeatResult = { seat: Seat } | { error: ClaimSeatError };
+
+function makeSeats(): Seat[] {
+  return Array.from({ length: SEAT_COUNT }, (_, id) => ({
+    id,
+    claimed: false,
+    token: null,
+    sittingOut: false,
+  }));
+}
+
+/**
+ * In-memory room registry. Seats are structural only — no engine attached
+ * yet (ticket 29 wires the engine and takes over `sittingOut` on deal-in).
+ */
 export class RoomStore {
   readonly #rooms = new Map<string, Room>();
   readonly #random: () => number;
+  readonly #generateToken: () => string;
 
-  constructor(random: () => number = Math.random) {
+  constructor(
+    random: () => number = Math.random,
+    generateToken: () => string = randomUUID,
+  ) {
     this.#random = random;
+    this.#generateToken = generateToken;
   }
 
   create(): Room {
     const code = generateRoomCode((c) => this.#rooms.has(c), this.#random);
-    const room: Room = { code };
+    const room: Room = { code, seats: makeSeats(), handInProgress: false };
     this.#rooms.set(code, room);
     return room;
   }
@@ -27,4 +69,48 @@ export class RoomStore {
   end(code: string): void {
     this.#rooms.delete(code);
   }
+
+  claimSeat(code: string, seatId: SeatId): ClaimSeatResult {
+    const room = this.#rooms.get(code);
+    if (!room) return { error: "room-not-found" };
+
+    const seat = room.seats[seatId];
+    if (!seat) return { error: "seat-not-found" };
+    if (seat.claimed) return { error: "seat-already-claimed" };
+
+    seat.claimed = true;
+    seat.token = this.#generateToken();
+    seat.sittingOut = room.handInProgress;
+    return { seat };
+  }
+
+  /** Force-clears a claimed seat. Stand-in for real disconnect handling (ticket 33). */
+  clearSeat(code: string, seatId: SeatId): void {
+    const room = this.#rooms.get(code);
+    const seat = room?.seats[seatId];
+    if (!seat) return;
+
+    seat.claimed = false;
+    seat.token = null;
+    seat.sittingOut = false;
+  }
+
+  /** Stand-in for the engine-driven flag ticket 29 will maintain. */
+  markHandInProgress(code: string, inProgress: boolean): void {
+    const room = this.#rooms.get(code);
+    if (!room) return;
+    room.handInProgress = inProgress;
+  }
+}
+
+/** Public seat/room projection — never carries a seat's claim token. */
+export function toRoomView(room: Room): RoomView {
+  return {
+    code: room.code,
+    seats: room.seats.map((seat) => ({
+      id: seat.id,
+      claimed: seat.claimed,
+      sittingOut: seat.sittingOut,
+    })),
+  };
 }

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "references": []
+  "references": [{ "path": "../protocol" }]
 }

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -4,9 +4,15 @@ import { describe, expect, it } from "vitest";
 import { App } from "./App.js";
 
 describe("App", () => {
-  it("renders the table-client placeholder shell with a connection badge", () => {
+  it("renders the table-client shell with a connection badge", () => {
     const html = renderToStaticMarkup(<App />);
     expect(html).toContain('data-testid="table-client-shell"');
     expect(html).toContain('data-testid="connection-status"');
+  });
+
+  it("shows a Create room button before a room exists", () => {
+    const html = renderToStaticMarkup(<App />);
+    expect(html).toContain('data-testid="create-room-button"');
+    expect(html).not.toContain('data-testid="room-panel"');
   });
 });

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -4,15 +4,15 @@ import { describe, expect, it } from "vitest";
 import { App } from "./App.js";
 
 describe("App", () => {
-  it("renders the table-client shell with a connection badge", () => {
+  it("renders the table-client shell", () => {
     const html = renderToStaticMarkup(<App />);
     expect(html).toContain('data-testid="table-client-shell"');
-    expect(html).toContain('data-testid="connection-status"');
   });
 
-  it("shows a Create room button before a room exists", () => {
+  it("shows a Create room button and hides the connection badge before a room exists", () => {
     const html = renderToStaticMarkup(<App />);
     expect(html).toContain('data-testid="create-room-button"');
     expect(html).not.toContain('data-testid="room-panel"');
+    expect(html).not.toContain('data-testid="connection-status"');
   });
 });

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -1,10 +1,36 @@
-import { Card } from "@table-top-poker/ui-shared";
+import { useCallback } from "react";
+import { createRoom, endSession } from "./api/rooms.js";
+import { RoomPanel } from "./RoomPanel.js";
 import { useTableStore } from "./store/store.js";
 import { useWebSocket } from "./ws/useWebSocket.js";
 
 export function App() {
-  useWebSocket();
+  const roomCode = useTableStore((state) => state.roomCode);
+  const joinUrl = useTableStore((state) => state.joinUrl);
+  const qrCodeDataUrl = useTableStore((state) => state.qrCodeDataUrl);
+  const seats = useTableStore((state) => state.seats);
   const connectionStatus = useTableStore((state) => state.connectionStatus);
+  const setRoomCreated = useTableStore((state) => state.setRoomCreated);
+  const clearRoom = useTableStore((state) => state.clearRoom);
+
+  useWebSocket(roomCode);
+
+  const handleCreateRoom = useCallback(() => {
+    createRoom()
+      .then(setRoomCreated)
+      .catch((error: unknown) => {
+        console.error(error);
+      });
+  }, [setRoomCreated]);
+
+  const handleEndSession = useCallback(() => {
+    if (!roomCode) return;
+    endSession(roomCode)
+      .then(clearRoom)
+      .catch((error: unknown) => {
+        console.error(error);
+      });
+  }, [roomCode, clearRoom]);
 
   return (
     <div className="app-shell" data-testid="table-client-shell">
@@ -15,8 +41,23 @@ export function App() {
         </span>
       </header>
       <main className="felt">
-        <Card rank="A" suit="spades" />
-        <Card faceDown />
+        {roomCode === null ? (
+          <button
+            type="button"
+            data-testid="create-room-button"
+            onClick={handleCreateRoom}
+          >
+            Create room
+          </button>
+        ) : (
+          <RoomPanel
+            roomCode={roomCode}
+            joinUrl={joinUrl}
+            qrCodeDataUrl={qrCodeDataUrl}
+            seats={seats}
+            onEndSession={handleEndSession}
+          />
+        )}
       </main>
     </div>
   );

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { createRoom, endSession } from "./api/rooms.js";
 import { RoomPanel } from "./RoomPanel.js";
+import { StatusBar } from "./StatusBar.js";
 import { useTableStore } from "./store/store.js";
 import { useWebSocket } from "./ws/useWebSocket.js";
 
@@ -34,12 +35,7 @@ export function App() {
 
   return (
     <div className="app-shell" data-testid="table-client-shell">
-      <header className="status-bar">
-        <span>Table Top Poker — Table</span>
-        <span data-testid="connection-status" data-status={connectionStatus}>
-          {connectionStatus}
-        </span>
-      </header>
+      <StatusBar roomCode={roomCode} connectionStatus={connectionStatus} />
       <main className="felt">
         {roomCode === null ? (
           <button

--- a/packages/table-client/src/RoomPanel.test.tsx
+++ b/packages/table-client/src/RoomPanel.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { RoomPanel } from "./RoomPanel.js";
+
+describe("RoomPanel", () => {
+  it("shows the room code, QR and live seat list", () => {
+    const html = renderToStaticMarkup(
+      <RoomPanel
+        roomCode="ABCD"
+        joinUrl="http://localhost:3000/join/ABCD"
+        qrCodeDataUrl="data:image/png;base64,xyz"
+        seats={[
+          { id: 0, claimed: true, sittingOut: false },
+          { id: 1, claimed: true, sittingOut: true },
+          { id: 2, claimed: false, sittingOut: false },
+        ]}
+        onEndSession={() => {
+          /* unused in this test */
+        }}
+      />,
+    );
+
+    expect(html).toContain('data-testid="room-panel"');
+    expect(html).toContain("ABCD");
+    expect(html).toContain('data-testid="room-qr"');
+    expect(html).toMatch(/data-testid="seat-0"[^>]*data-claimed="true"/);
+    expect(html).toMatch(/data-testid="seat-1"[^>]*data-sitting-out="true"/);
+    expect(html).toMatch(/data-testid="seat-2"[^>]*data-claimed="false"/);
+  });
+
+  it("omits the QR image when none is available", () => {
+    const html = renderToStaticMarkup(
+      <RoomPanel
+        roomCode="ABCD"
+        joinUrl={null}
+        qrCodeDataUrl={null}
+        seats={[]}
+        onEndSession={() => {
+          /* unused in this test */
+        }}
+      />,
+    );
+
+    expect(html).not.toContain('data-testid="room-qr"');
+  });
+});

--- a/packages/table-client/src/RoomPanel.tsx
+++ b/packages/table-client/src/RoomPanel.tsx
@@ -1,0 +1,54 @@
+import type { SeatView } from "@table-top-poker/protocol";
+
+export interface RoomPanelProps {
+  readonly roomCode: string;
+  readonly joinUrl: string | null;
+  readonly qrCodeDataUrl: string | null;
+  readonly seats: readonly SeatView[];
+  readonly onEndSession: () => void;
+}
+
+export function RoomPanel({
+  roomCode,
+  joinUrl,
+  qrCodeDataUrl,
+  seats,
+  onEndSession,
+}: RoomPanelProps) {
+  return (
+    <div data-testid="room-panel">
+      <div data-testid="room-code">{roomCode}</div>
+      {qrCodeDataUrl && (
+        <img
+          data-testid="room-qr"
+          src={qrCodeDataUrl}
+          alt={`Scan to join at ${joinUrl ?? ""}`}
+        />
+      )}
+      <ul data-testid="seat-list">
+        {seats.map((seat) => (
+          <li
+            key={seat.id}
+            data-testid={`seat-${String(seat.id)}`}
+            data-claimed={seat.claimed}
+            data-sitting-out={seat.sittingOut}
+          >
+            Seat {seat.id + 1}
+            {seat.claimed
+              ? seat.sittingOut
+                ? " — sitting out"
+                : " — claimed"
+              : " — open"}
+          </li>
+        ))}
+      </ul>
+      <button
+        type="button"
+        data-testid="end-session-button"
+        onClick={onEndSession}
+      >
+        End session
+      </button>
+    </div>
+  );
+}

--- a/packages/table-client/src/StatusBar.test.tsx
+++ b/packages/table-client/src/StatusBar.test.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { StatusBar } from "./StatusBar.js";
+
+describe("StatusBar", () => {
+  it("hides the connection badge before a room exists", () => {
+    const html = renderToStaticMarkup(
+      <StatusBar roomCode={null} connectionStatus="disconnected" />,
+    );
+    expect(html).not.toContain('data-testid="connection-status"');
+  });
+
+  it("shows the connection badge once a room exists", () => {
+    const html = renderToStaticMarkup(
+      <StatusBar roomCode="ABCD" connectionStatus="connected" />,
+    );
+    expect(html).toContain('data-testid="connection-status"');
+    expect(html).toContain("connected");
+  });
+});

--- a/packages/table-client/src/StatusBar.tsx
+++ b/packages/table-client/src/StatusBar.tsx
@@ -1,0 +1,20 @@
+import type { ConnectionStatus } from "./store/connectionSlice.js";
+
+export interface StatusBarProps {
+  readonly roomCode: string | null;
+  readonly connectionStatus: ConnectionStatus;
+}
+
+/** No connection badge before a room exists — there's nothing to connect to yet. */
+export function StatusBar({ roomCode, connectionStatus }: StatusBarProps) {
+  return (
+    <header className="status-bar">
+      <span>Table Top Poker — Table</span>
+      {roomCode !== null && (
+        <span data-testid="connection-status" data-status={connectionStatus}>
+          {connectionStatus}
+        </span>
+      )}
+    </header>
+  );
+}

--- a/packages/table-client/src/api/rooms.test.ts
+++ b/packages/table-client/src/api/rooms.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createRoom, endSession } from "./rooms.js";
+
+describe("createRoom", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts to /rooms and returns the created room", async () => {
+    const body = {
+      code: "ABCD",
+      joinUrl: "http://localhost:3000/join/ABCD",
+      qrCodeDataUrl: "data:image/png;base64,xyz",
+    };
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify(body), { status: 200 }),
+    );
+
+    const room = await createRoom();
+
+    expect(fetch).toHaveBeenCalledWith("/rooms", { method: "POST" });
+    expect(room).toEqual(body);
+  });
+
+  it("throws when the server rejects the request", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 500 }));
+
+    await expect(createRoom()).rejects.toThrow("failed to create room: 500");
+  });
+});
+
+describe("endSession", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts to /rooms/:code/end", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 204 }));
+
+    await endSession("ABCD");
+
+    expect(fetch).toHaveBeenCalledWith("/rooms/ABCD/end", { method: "POST" });
+  });
+
+  it("throws when the server rejects the request", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 404 }));
+
+    await expect(endSession("ABCD")).rejects.toThrow(
+      "failed to end session: 404",
+    );
+  });
+});

--- a/packages/table-client/src/api/rooms.ts
+++ b/packages/table-client/src/api/rooms.ts
@@ -1,0 +1,20 @@
+export interface CreatedRoom {
+  readonly code: string;
+  readonly joinUrl: string;
+  readonly qrCodeDataUrl: string;
+}
+
+export async function createRoom(): Promise<CreatedRoom> {
+  const response = await fetch("/rooms", { method: "POST" });
+  if (!response.ok) {
+    throw new Error(`failed to create room: ${String(response.status)}`);
+  }
+  return (await response.json()) as CreatedRoom;
+}
+
+export async function endSession(code: string): Promise<void> {
+  const response = await fetch(`/rooms/${code}/end`, { method: "POST" });
+  if (!response.ok) {
+    throw new Error(`failed to end session: ${String(response.status)}`);
+  }
+}

--- a/packages/table-client/src/store/roomSlice.ts
+++ b/packages/table-client/src/store/roomSlice.ts
@@ -1,14 +1,32 @@
+import type { RoomView, SeatView } from "@table-top-poker/protocol";
 import type { StateCreator } from "zustand";
 
 export interface RoomSlice {
   readonly roomCode: string | null;
-  readonly setRoomCode: (roomCode: string | null) => void;
+  readonly joinUrl: string | null;
+  readonly qrCodeDataUrl: string | null;
+  readonly seats: readonly SeatView[];
+  readonly setRoomCreated: (room: {
+    code: string;
+    joinUrl: string;
+    qrCodeDataUrl: string;
+  }) => void;
+  readonly setRoomView: (view: RoomView) => void;
+  readonly clearRoom: () => void;
 }
 
-/** Placeholder slice — replaced by the real room `view` snapshot once ticket 13 lands. */
 export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
   roomCode: null,
-  setRoomCode: (roomCode) => {
-    set({ roomCode });
+  joinUrl: null,
+  qrCodeDataUrl: null,
+  seats: [],
+  setRoomCreated: ({ code, joinUrl, qrCodeDataUrl }) => {
+    set({ roomCode: code, joinUrl, qrCodeDataUrl });
+  },
+  setRoomView: (view) => {
+    set({ roomCode: view.code, seats: view.seats });
+  },
+  clearRoom: () => {
+    set({ roomCode: null, joinUrl: null, qrCodeDataUrl: null, seats: [] });
   },
 });

--- a/packages/table-client/src/store/store.test.ts
+++ b/packages/table-client/src/store/store.test.ts
@@ -20,8 +20,33 @@ describe("useTableStore", () => {
 
   it("updates the room slice independently of the connection slice", () => {
     useTableStore.getState().setConnectionStatus("connected");
-    useTableStore.getState().setRoomCode("ABCD");
+    useTableStore.getState().setRoomCreated({
+      code: "ABCD",
+      joinUrl: "http://localhost:3000/join/ABCD",
+      qrCodeDataUrl: "data:image/png;base64,xyz",
+    });
     expect(useTableStore.getState().roomCode).toBe("ABCD");
     expect(useTableStore.getState().connectionStatus).toBe("connected");
+  });
+
+  it("replaces the seat list from a room-view snapshot", () => {
+    useTableStore.getState().setRoomView({
+      code: "ABCD",
+      seats: [{ id: 0, claimed: true, sittingOut: false }],
+    });
+    expect(useTableStore.getState().roomCode).toBe("ABCD");
+    expect(useTableStore.getState().seats).toEqual([
+      { id: 0, claimed: true, sittingOut: false },
+    ]);
+  });
+
+  it("clears the room slice back to its initial state", () => {
+    useTableStore.getState().setRoomView({
+      code: "ABCD",
+      seats: [{ id: 0, claimed: true, sittingOut: false }],
+    });
+    useTableStore.getState().clearRoom();
+    expect(useTableStore.getState().roomCode).toBeNull();
+    expect(useTableStore.getState().seats).toEqual([]);
   });
 });

--- a/packages/table-client/src/ws/getWebSocketUrl.test.ts
+++ b/packages/table-client/src/ws/getWebSocketUrl.test.ts
@@ -13,4 +13,13 @@ describe("getWebSocketUrl", () => {
       "ws://localhost:3000/ws",
     );
   });
+
+  it("appends query params for room-scoped connections", () => {
+    expect(
+      getWebSocketUrl(
+        { protocol: "http:", host: "localhost:3000" },
+        { room: "ABCD", role: "table" },
+      ),
+    ).toBe("ws://localhost:3000/ws?room=ABCD&role=table");
+  });
 });

--- a/packages/table-client/src/ws/getWebSocketUrl.ts
+++ b/packages/table-client/src/ws/getWebSocketUrl.ts
@@ -4,7 +4,11 @@ export interface WsLocation {
 }
 
 /** Derives the WebSocket scheme from `location.protocol` — never hard-coded. */
-export function getWebSocketUrl(location: WsLocation): string {
+export function getWebSocketUrl(
+  location: WsLocation,
+  params: Record<string, string> = {},
+): string {
   const scheme = location.protocol === "https:" ? "wss:" : "ws:";
-  return `${scheme}//${location.host}/ws`;
+  const query = new URLSearchParams(params).toString();
+  return `${scheme}//${location.host}/ws${query ? `?${query}` : ""}`;
 }

--- a/packages/table-client/src/ws/useWebSocket.ts
+++ b/packages/table-client/src/ws/useWebSocket.ts
@@ -1,20 +1,30 @@
+import type { ServerMessage } from "@table-top-poker/protocol";
 import { useEffect } from "react";
 import { useTableStore } from "../store/store.js";
 import { getWebSocketUrl } from "./getWebSocketUrl.js";
 
 /**
- * Opens a WebSocket connection on mount and reflects its lifecycle into the
- * connection slice. No reconnection logic yet — that's ticket 15.
+ * Opens a room-scoped WebSocket connection once a room exists and reflects
+ * its lifecycle into the connection slice. Every `room-view` push replaces
+ * the seat slice. No reconnection logic yet — that's ticket 33.
  */
-export function useWebSocket(): void {
+export function useWebSocket(roomCode: string | null): void {
   const setConnectionStatus = useTableStore(
     (state) => state.setConnectionStatus,
   );
+  const setRoomView = useTableStore((state) => state.setRoomView);
 
   useEffect(() => {
+    if (roomCode === null) {
+      setConnectionStatus("disconnected");
+      return;
+    }
+
     let active = true;
     setConnectionStatus("connecting");
-    const socket = new WebSocket(getWebSocketUrl(window.location));
+    const socket = new WebSocket(
+      getWebSocketUrl(window.location, { room: roomCode, role: "table" }),
+    );
 
     socket.addEventListener("open", () => {
       if (active) setConnectionStatus("connected");
@@ -22,10 +32,15 @@ export function useWebSocket(): void {
     socket.addEventListener("close", () => {
       if (active) setConnectionStatus("disconnected");
     });
+    socket.addEventListener("message", (event: MessageEvent<string>) => {
+      if (!active) return;
+      const message: ServerMessage = JSON.parse(event.data) as ServerMessage;
+      setRoomView(message.view);
+    });
 
     return () => {
       active = false;
       socket.close();
     };
-  }, [setConnectionStatus]);
+  }, [roomCode, setConnectionStatus, setRoomView]);
 }

--- a/packages/table-client/vite.config.ts
+++ b/packages/table-client/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
         target: "ws://localhost:3000",
         ws: true,
       },
+      "/rooms": "http://localhost:3000",
     },
   },
 });


### PR DESCRIPTION
## Summary

- Server: `RoomStore` grows an 8-seat model (`claimSeat`/`clearSeat`/`markHandInProgress`), new HTTP routes (`POST /rooms/:code/seats/:seatId/claim|clear`), `POST /rooms/:code/join` now returns the room's `RoomView`, and `/ws` is room-scoped (`?room=&role=table` or `?room=&seat=&token=`) with `preValidation` rejecting bad params before the socket opens. Every seat change broadcasts a fresh `RoomView` to that room's sockets.
- `protocol`: new `SeatView`/`RoomView`/`ServerMessage` shared types.
- `table-client`: "Create room" landing → QR code + room code + a live seat board (`RoomPanel`) that updates over WS with no manual refresh.
- `player-client`: room-code entry (prefilled from a scanned `/join/:code` URL) → seat picker → claimed-seat panel with a "sitting out" badge. The claim token is persisted to `localStorage` (write-only this ticket — ticket 33 reads it back for reconnect).

## Scope notes for reviewers

- **`GET /join/:code`**: the QR encodes `http://<host>/join/:code`. This ticket adds a route that redirects to `PLAYER_CLIENT_ORIGIN` (an env var) when set — point it at the player-client's Vite dev server locally — and otherwise serves the still-placeholder `public/index.html`, since bundling the real client into the server's static root is ticket 16's job (Pi deployment). So criterion 1 ("scan to reach the join screen") is fully live once `PLAYER_CLIENT_ORIGIN` is configured; unconfigured, the redirect target is honest but inert until ticket 16 lands.
- **Landing screen reading**: the issue's spec source says "explicit Create room / Join room buttons on landing — never inferred from device type." Read against §9's already-decided two-SPA architecture (`table-client` / `player-client` as distinct apps), I implemented this as: `table-client` only ever shows "Create room", `player-client` only ever shows "Join room" — zero user-agent/device-type detection anywhere. No combined landing screen.
- **Sitting-out / force-clear seams**: both use test-only-shaped hooks (`RoomStore.markHandInProgress`, `POST .../seats/:seatId/clear`) rather than real hand-lifecycle or disconnect-detection logic, per the ticket's explicit scoping to tickets 29 and 33 respectively.
- `Seat`/`Room` in `packages/server/src/rooms.ts` are intentionally mutable (in-place), unlike the `readonly` DTOs elsewhere — they're `RoomStore`'s internal aggregate state, not a wire/render type; `toRoomView` is the seam that snapshots them immutably for broadcast. Documented inline.

## Test plan

- [x] `npm run build` (tsc --build, all packages)
- [x] `npm run lint` (eslint + prettier)
- [x] `npm test` — 195 tests passing across 43 files, including new server (`rooms.test.ts`, `app.test.ts`: seat claim/clear, WS room-scoping incl. live broadcast on claim, `/join/:code` redirect + placeholder + 404) and client coverage (stores, WS URL builders, API modules, presentational components)
- [ ] Manual: not run against a real browser/phone this session — no UI changes verified in-browser

Closes #28