### PR TITLE
feat(engine,server,table,player): engine over the wire

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4007,6 +4007,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/zustand": {
       "version": "5.0.14",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
@@ -4076,7 +4084,8 @@
       "name": "@table-top-poker/protocol",
       "version": "0.0.0",
       "dependencies": {
-        "@table-top-poker/engine": "*"
+        "@table-top-poker/engine": "*",
+        "zod": "^4.4.3"
       }
     },
     "packages/server": {

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { claimSeat, joinRoom } from "./api/rooms.js";
+import { Hand } from "./Hand.js";
 import { JoinForm } from "./JoinForm.js";
 import { parseRoomCodeFromPath } from "./join/parseRoomCodeFromPath.js";
 import { SeatPanel } from "./SeatPanel.js";
@@ -16,6 +17,7 @@ export function App() {
   const seatId = usePlayerStore((state) => state.seatId);
   const sittingOut = usePlayerStore((state) => state.sittingOut);
   const connectionStatus = usePlayerStore((state) => state.connectionStatus);
+  const handView = usePlayerStore((state) => state.handView);
   const setRoomView = usePlayerStore((state) => state.setRoomView);
   const setJoinError = usePlayerStore((state) => state.setJoinError);
   const setSeat = usePlayerStore((state) => state.setSeat);
@@ -83,7 +85,12 @@ export function App() {
       <SeatPicker seats={seats} error={claimError} onClaim={handleClaim} />
     );
   } else {
-    content = <SeatPanel seatId={seatId} sittingOut={sittingOut} />;
+    content = (
+      <>
+        <SeatPanel seatId={seatId} sittingOut={sittingOut} />
+        {handView !== null && <Hand view={handView} />}
+      </>
+    );
   }
 
   return (

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -1,0 +1,59 @@
+import type { PlayerView } from "@table-top-poker/protocol";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { Hand } from "./Hand.js";
+
+describe("Hand", () => {
+  it("shows a waiting state before any hand has started", () => {
+    const view: PlayerView = { phase: "no-hand", button: 0 };
+    const html = renderToStaticMarkup(<Hand view={view} />);
+    expect(html).toMatch(/data-testid="hand"[^>]*data-phase="no-hand"/);
+  });
+
+  it("reveals own hole cards and mirrors the shared board", () => {
+    const view: PlayerView = {
+      phase: "betting",
+      button: 0,
+      street: "flop",
+      board: [
+        { rank: "A", suit: "spades" },
+        { rank: "K", suit: "hearts" },
+        { rank: "2", suit: "clubs" },
+      ],
+      toAct: [0],
+      seats: [{ seatId: 0, folded: false }],
+      yourSeatId: 0,
+      yourHoleCards: [
+        { rank: "Q", suit: "diamonds" },
+        { rank: "J", suit: "clubs" },
+      ],
+    };
+    const html = renderToStaticMarkup(<Hand view={view} />);
+
+    expect(html).toMatch(/data-testid="hole-cards"/);
+    expect(html).toContain('data-rank="Q"');
+    expect(html).toContain('data-rank="J"');
+    expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(5);
+  });
+
+  it("hides hole cards once folded, without a placeholder leak", () => {
+    const view: PlayerView = {
+      phase: "betting",
+      button: 0,
+      street: "flop",
+      board: [],
+      toAct: [1],
+      seats: [
+        { seatId: 0, folded: true },
+        { seatId: 1, folded: false },
+      ],
+      yourSeatId: 0,
+      yourHoleCards: null,
+    };
+    const html = renderToStaticMarkup(<Hand view={view} />);
+
+    expect(html).toMatch(/data-testid="no-hole-cards"/);
+    expect(html).not.toContain("data-rank");
+  });
+});

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -1,0 +1,58 @@
+import type { PlayerView } from "@table-top-poker/protocol";
+import { Card } from "@table-top-poker/ui-shared";
+
+export interface HandProps {
+  readonly view: PlayerView;
+}
+
+/**
+ * Own hole cards plus the shared board, mirrored straight from the seat's
+ * `view` — nothing rebuilt from the raw event locally
+ * (docs/phase-1-spec.md §9). Hidden again once folded, a burn-pile per §4:
+ * `yourHoleCards` is already `null` in that view, this never redacts.
+ * No action buttons yet — that's ticket 12.
+ */
+export function Hand({ view }: HandProps) {
+  if (view.phase === "no-hand") {
+    return (
+      <div data-testid="hand" data-phase="no-hand">
+        Waiting for the next hand.
+      </div>
+    );
+  }
+
+  if (view.phase === "folded-out") {
+    return (
+      <div data-testid="hand" data-phase="folded-out">
+        Hand complete.
+      </div>
+    );
+  }
+
+  if (view.phase === "showdown") {
+    return (
+      <div data-testid="hand" data-phase="showdown">
+        Showdown.
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="hand" data-phase="betting" data-street={view.street}>
+      <div data-testid="hole-cards">
+        {view.yourHoleCards ? (
+          view.yourHoleCards.map((card, i) => (
+            <Card key={i} rank={card.rank} suit={card.suit} />
+          ))
+        ) : (
+          <span data-testid="no-hole-cards">Folded</span>
+        )}
+      </div>
+      <div data-testid="community-cards">
+        {view.board.map((card, i) => (
+          <Card key={i} rank={card.rank} suit={card.suit} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/player-client/src/store/handSlice.ts
+++ b/packages/player-client/src/store/handSlice.ts
@@ -1,16 +1,14 @@
-import type { HandEvent, PlayerView } from "@table-top-poker/protocol";
+import type { PlayerView } from "@table-top-poker/protocol";
 import type { StateCreator } from "zustand";
 
 export interface HandSlice {
   readonly handView: PlayerView | null;
-  readonly lastEvent: HandEvent | null;
-  readonly setHandUpdate: (event: HandEvent, view: PlayerView) => void;
+  readonly setHandView: (view: PlayerView) => void;
 }
 
 export const createHandSlice: StateCreator<HandSlice> = (set) => ({
   handView: null,
-  lastEvent: null,
-  setHandUpdate: (event, view) => {
-    set({ handView: view, lastEvent: event });
+  setHandView: (view) => {
+    set({ handView: view });
   },
 });

--- a/packages/player-client/src/store/handSlice.ts
+++ b/packages/player-client/src/store/handSlice.ts
@@ -1,0 +1,16 @@
+import type { HandEvent, PlayerView } from "@table-top-poker/protocol";
+import type { StateCreator } from "zustand";
+
+export interface HandSlice {
+  readonly handView: PlayerView | null;
+  readonly lastEvent: HandEvent | null;
+  readonly setHandUpdate: (event: HandEvent, view: PlayerView) => void;
+}
+
+export const createHandSlice: StateCreator<HandSlice> = (set) => ({
+  handView: null,
+  lastEvent: null,
+  setHandUpdate: (event, view) => {
+    set({ handView: view, lastEvent: event });
+  },
+});

--- a/packages/player-client/src/store/store.ts
+++ b/packages/player-client/src/store/store.ts
@@ -3,13 +3,15 @@ import {
   type ConnectionSlice,
   createConnectionSlice,
 } from "./connectionSlice.js";
+import { createHandSlice, type HandSlice } from "./handSlice.js";
 import { createRoomSlice, type RoomSlice } from "./roomSlice.js";
 import { createSeatSlice, type SeatSlice } from "./seatSlice.js";
 
-export type PlayerStore = ConnectionSlice & RoomSlice & SeatSlice;
+export type PlayerStore = ConnectionSlice & RoomSlice & SeatSlice & HandSlice;
 
 export const usePlayerStore = create<PlayerStore>()((...args) => ({
   ...createConnectionSlice(...args),
   ...createRoomSlice(...args),
   ...createSeatSlice(...args),
+  ...createHandSlice(...args),
 }));

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -1,4 +1,4 @@
-import type { ServerMessage } from "@table-top-poker/protocol";
+import type { PlayerView, ServerMessage } from "@table-top-poker/protocol";
 import { useEffect } from "react";
 import { usePlayerStore } from "../store/store.js";
 import { getWebSocketUrl } from "./getWebSocketUrl.js";
@@ -12,13 +12,19 @@ export interface SeatConnectionParams {
 /**
  * Opens a seat-scoped WebSocket connection once a seat is claimed and
  * reflects its lifecycle into the connection slice. Every `room-view` push
- * replaces the seat list. No reconnection logic yet — that's ticket 33.
+ * replaces the seat list; every `hand-update` replaces the hand slice with
+ * the fresh `view(state, seatId)` the server just computed for this seat —
+ * the view is source of truth (docs/phase-1-spec.md §6), never rebuilt from
+ * the raw event locally. No action-intent module yet (fold/check/call/raise
+ * over this socket) — that's ticket 30. No reconnection logic yet — that's
+ * ticket 33.
  */
 export function useWebSocket(params: SeatConnectionParams | null): void {
   const setConnectionStatus = usePlayerStore(
     (state) => state.setConnectionStatus,
   );
   const setRoomView = usePlayerStore((state) => state.setRoomView);
+  const setHandUpdate = usePlayerStore((state) => state.setHandUpdate);
 
   useEffect(() => {
     if (params === null) {
@@ -45,12 +51,17 @@ export function useWebSocket(params: SeatConnectionParams | null): void {
     socket.addEventListener("message", (event: MessageEvent<string>) => {
       if (!active) return;
       const message: ServerMessage = JSON.parse(event.data) as ServerMessage;
-      setRoomView(message.view);
+      if (message.type === "room-view") {
+        setRoomView(message.view);
+      } else if (message.type === "hand-update") {
+        // The server only ever sends a seat's socket its own `view(state, seatId)`.
+        setHandUpdate(message.event, message.view as PlayerView);
+      }
     });
 
     return () => {
       active = false;
       socket.close();
     };
-  }, [params, setConnectionStatus, setRoomView]);
+  }, [params, setConnectionStatus, setRoomView, setHandUpdate]);
 }

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -24,7 +24,7 @@ export function useWebSocket(params: SeatConnectionParams | null): void {
     (state) => state.setConnectionStatus,
   );
   const setRoomView = usePlayerStore((state) => state.setRoomView);
-  const setHandUpdate = usePlayerStore((state) => state.setHandUpdate);
+  const setHandView = usePlayerStore((state) => state.setHandView);
 
   useEffect(() => {
     if (params === null) {
@@ -55,7 +55,7 @@ export function useWebSocket(params: SeatConnectionParams | null): void {
         setRoomView(message.view);
       } else if (message.type === "hand-update") {
         // The server only ever sends a seat's socket its own `view(state, seatId)`.
-        setHandUpdate(message.event, message.view as PlayerView);
+        setHandView(message.view as PlayerView);
       }
     });
 
@@ -63,5 +63,5 @@ export function useWebSocket(params: SeatConnectionParams | null): void {
       active = false;
       socket.close();
     };
-  }, [params, setConnectionStatus, setRoomView, setHandUpdate]);
+  }, [params, setConnectionStatus, setRoomView, setHandView]);
 }

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@table-top-poker/engine": "*"
+    "@table-top-poker/engine": "*",
+    "zod": "^4.4.3"
   }
 }

--- a/packages/protocol/src/command-schema.test.ts
+++ b/packages/protocol/src/command-schema.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { ClientCommandSchema } from "./command-schema.js";
+
+describe("ClientCommandSchema", () => {
+  it.each(["startHand", "fold", "check", "call", "raise", "nextHand"])(
+    "accepts a bare %s command",
+    (type) => {
+      const result = ClientCommandSchema.safeParse({ type });
+      expect(result.success).toBe(true);
+    },
+  );
+
+  it("rejects an unknown command type", () => {
+    const result = ClientCommandSchema.safeParse({ type: "advance" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a client-supplied playerId or seed", () => {
+    const result = ClientCommandSchema.safeParse({
+      type: "startHand",
+      playerId: 3,
+      seed: "attacker-chosen",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a non-object payload", () => {
+    expect(ClientCommandSchema.safeParse("startHand").success).toBe(false);
+    expect(ClientCommandSchema.safeParse(null).success).toBe(false);
+  });
+});

--- a/packages/protocol/src/command-schema.ts
+++ b/packages/protocol/src/command-schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+/**
+ * Wire-level shape of a command a client sends over the room WebSocket —
+ * deliberately thinner than the engine's `Command` type. `playerId` is
+ * never trusted from the client: the server derives it from the
+ * authenticated socket (room/seat/token query params, §6). `seed` is
+ * never client-supplied either: the server generates it via CSPRNG
+ * (docs/phase-1-spec.md §3). Both fields get filled in server-side before
+ * reaching `decide`.
+ */
+export const ClientCommandSchema = z.discriminatedUnion("type", [
+  z.strictObject({ type: z.literal("startHand") }),
+  z.strictObject({ type: z.literal("fold") }),
+  z.strictObject({ type: z.literal("check") }),
+  z.strictObject({ type: z.literal("call") }),
+  z.strictObject({ type: z.literal("raise") }),
+  z.strictObject({ type: z.literal("nextHand") }),
+]);
+
+export type ClientCommand = z.infer<typeof ClientCommandSchema>;
+export type ClientCommandType = ClientCommand["type"];

--- a/packages/protocol/src/hand.ts
+++ b/packages/protocol/src/hand.ts
@@ -1,0 +1,27 @@
+import type {
+  HandEvent,
+  PlayerView,
+  RejectionReason,
+  TableView,
+} from "@table-top-poker/engine";
+
+/**
+ * Pushed once per domain event produced by a command, to every socket
+ * entitled to see it. Carries both the raw event (future audit/animation)
+ * and a fresh per-recipient view — the view is source of truth
+ * (docs/phase-1-spec.md §6), the event is not replayed against local state.
+ */
+export interface HandUpdateMessage {
+  readonly type: "hand-update";
+  readonly event: HandEvent;
+  readonly view: PlayerView | TableView;
+}
+
+/** A server-rejected command, reason-coded, delivered to the sender only. */
+export type ServerRejectionReason =
+  "invalid-command" | "room-not-found" | "not-enough-players" | "not-permitted";
+
+export interface CommandRejectedMessage {
+  readonly type: "command-rejected";
+  readonly reason: RejectionReason | ServerRejectionReason;
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,2 +1,4 @@
 export * from "@table-top-poker/engine";
+export * from "./command-schema.js";
+export * from "./hand.js";
 export * from "./room.js";

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -1,4 +1,5 @@
 import type { SeatId } from "@table-top-poker/engine";
+import type { CommandRejectedMessage, HandUpdateMessage } from "./hand.js";
 
 /** A seat's public state — never carries its claim token. */
 export interface SeatView {
@@ -13,7 +14,10 @@ export interface RoomView {
 }
 
 /** Pushed over the room's WebSocket whenever seat state changes. */
-export interface ServerMessage {
+export interface RoomViewMessage {
   readonly type: "room-view";
   readonly view: RoomView;
 }
+
+export type ServerMessage =
+  RoomViewMessage | HandUpdateMessage | CommandRejectedMessage;

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -224,11 +224,13 @@ describe("seat claim/clear routes", () => {
 
   it("marks a seat claimed mid-hand as sitting out", async () => {
     const code = await createRoom();
-    rooms.markHandInProgress(code, true);
+    rooms.claimSeat(code, 0);
+    rooms.claimSeat(code, 1);
+    rooms.dispatch(code, "table", "startHand");
 
     const response = await app.inject({
       method: "POST",
-      url: `/rooms/${code}/seats/0/claim`,
+      url: `/rooms/${code}/seats/2/claim`,
     });
 
     expect(response.json<SeatClaimBody>().sittingOut).toBe(true);
@@ -376,5 +378,169 @@ describe("WebSocket upgrade", () => {
     });
     expect(socket.readyState).toBe(WebSocket.OPEN);
     socket.close();
+  });
+});
+
+describe("hand command dispatch over WebSocket", () => {
+  let app: FastifyInstance;
+  let rooms: RoomStore;
+  let port: number;
+
+  beforeEach(async () => {
+    rooms = new RoomStore();
+    app = await buildApp({ rooms });
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected a bound TCP address");
+    }
+    port = address.port;
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  function connect(query: string): {
+    socket: WebSocket;
+    messages: ServerMessage[];
+  } {
+    const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/ws?${query}`);
+    const messages: ServerMessage[] = [];
+    socket.on("message", (data: Buffer) => {
+      messages.push(JSON.parse(data.toString()) as ServerMessage);
+    });
+    return { socket, messages };
+  }
+
+  async function opened(socket: WebSocket): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      socket.on("open", resolve);
+      socket.on("error", reject);
+    });
+  }
+
+  async function settle(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+
+  async function claimAndConnect(
+    code: string,
+    seatId: number,
+  ): Promise<{ socket: WebSocket; messages: ServerMessage[] }> {
+    const claim = rooms.claimSeat(code, seatId);
+    if (!("seat" in claim)) throw new Error("expected a claimed seat");
+    const conn = connect(
+      `room=${code}&seat=${String(seatId)}&token=${claim.seat.token ?? ""}`,
+    );
+    await opened(conn.socket);
+    return conn;
+  }
+
+  it("deals hole cards on startHand, each seat only ever seeing its own cards", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const seat0 = await claimAndConnect(room.code, 0);
+    const seat1 = await claimAndConnect(room.code, 1);
+    const seat2 = await claimAndConnect(room.code, 2);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    const holeCardsFor = (messages: ServerMessage[], seatId: number) => {
+      for (const message of messages) {
+        if (message.type !== "hand-update") continue;
+        const v = message.view;
+        if (
+          "yourSeatId" in v &&
+          v.yourSeatId === seatId &&
+          v.yourHoleCards !== null
+        ) {
+          return v.yourHoleCards;
+        }
+      }
+      return undefined;
+    };
+
+    const cards0 = holeCardsFor(seat0.messages, 0);
+    const cards1 = holeCardsFor(seat1.messages, 1);
+    const cards2 = holeCardsFor(seat2.messages, 2);
+    expect(cards0).toBeDefined();
+    expect(cards1).toBeDefined();
+    expect(cards2).toBeDefined();
+
+    const raw = (messages: ServerMessage[]) => JSON.stringify(messages);
+    for (const [mine, others] of [
+      [cards0, [seat1, seat2]],
+      [cards1, [seat0, seat2]],
+      [cards2, [seat0, seat1]],
+    ] as const) {
+      for (const other of others) {
+        for (const card of mine ?? []) {
+          expect(raw(other.messages)).not.toContain(JSON.stringify(card));
+        }
+      }
+      expect(raw(table.messages)).not.toContain("yourHoleCards");
+    }
+
+    const tableStreetStarted = table.messages.find(
+      (m) => m.type === "hand-update" && m.event.type === "StreetStarted",
+    );
+    expect(tableStreetStarted).toBeDefined();
+  });
+
+  it("excludes a sitting-out seat from the deal and it stays sitting out", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    await claimAndConnect(room.code, 0);
+    await claimAndConnect(room.code, 1);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    const midHandJoin = await claimAndConnect(room.code, 2);
+    await settle();
+    const handUpdates = midHandJoin.messages.filter(
+      (m) => m.type === "hand-update",
+    );
+    expect(handUpdates).toHaveLength(0);
+
+    expect(rooms.get(room.code)?.seats[2]?.sittingOut).toBe(true);
+  });
+
+  it("rejects a malformed command via Zod before it reaches the engine", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "definitely-not-a-command" }));
+    await settle();
+
+    expect(table.messages).toContainEqual({
+      type: "command-rejected",
+      reason: "invalid-command",
+    });
+    expect(rooms.get(room.code)?.engine).toBeNull();
+  });
+
+  it("rejects a player-issued startHand — table-only at the server layer", async () => {
+    const room = rooms.create();
+    const seat0 = await claimAndConnect(room.code, 0);
+    await claimAndConnect(room.code, 1);
+    await settle();
+
+    seat0.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    expect(seat0.messages).toContainEqual({
+      type: "command-rejected",
+      reason: "not-permitted",
+    });
+    expect(rooms.get(room.code)?.engine).toBeNull();
   });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,6 +1,13 @@
 import fastifyStatic from "@fastify/static";
 import fastifyWebsocket from "@fastify/websocket";
-import type { ServerMessage } from "@table-top-poker/protocol";
+import {
+  ClientCommandSchema,
+  view,
+  type CommandRejectedMessage,
+  type HandEvent,
+  type SeatId,
+  type ServerMessage,
+} from "@table-top-poker/protocol";
 import Fastify, { type FastifyInstance, type FastifyReply } from "fastify";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -8,6 +15,7 @@ import type { WebSocket } from "ws";
 import { joinUrl, roomQrCodeDataUrl } from "./qr.js";
 import {
   type ClaimSeatError,
+  type DispatchStep,
   type Room,
   RoomStore,
   toRoomView,
@@ -59,6 +67,28 @@ function findRoomOrReject(
   return room;
 }
 
+/**
+ * `HandEvent` is the engine's full, unredacted truth by design (secrecy
+ * lives solely in `view` — docs/phase-1-spec.md §3/§4). The *wire* event
+ * carried alongside that view is a transport-level exception: `HoleCardsDealt`
+ * must be redacted per recipient before it ever leaves the server, or the
+ * "raw event for audit/animation" bullet in §6 would leak every seat's cards
+ * to every socket regardless of what `view` shows.
+ */
+function redactEventFor(
+  event: HandEvent,
+  identity: SeatId | "table",
+): HandEvent {
+  if (event.type !== "HoleCardsDealt") return event;
+  return {
+    ...event,
+    deals:
+      identity === "table"
+        ? []
+        : event.deals.filter((deal) => deal.seatId === identity),
+  };
+}
+
 /** Seat ids arrive as route/query strings — reject anything that isn't a bare integer. */
 function parseSeatId(raw: string): number | undefined {
   return /^\d+$/.test(raw) ? Number(raw) : undefined;
@@ -69,7 +99,19 @@ export async function buildApp(
 ): Promise<FastifyInstance> {
   const rooms = options.rooms ?? new RoomStore();
   const roomSockets = new Map<string, Set<WebSocket>>();
+  const socketIdentity = new Map<WebSocket, SeatId | "table">();
   const app = Fastify();
+
+  function send(socket: WebSocket, message: ServerMessage): void {
+    socket.send(JSON.stringify(message));
+  }
+
+  function sendRejection(
+    socket: WebSocket,
+    reason: CommandRejectedMessage["reason"],
+  ): void {
+    send(socket, { type: "command-rejected", reason });
+  }
 
   function broadcastRoomView(code: string): void {
     const room = rooms.get(code);
@@ -79,9 +121,37 @@ export async function buildApp(
       type: "room-view",
       view: toRoomView(room),
     };
-    const payload = JSON.stringify(message);
     for (const socket of sockets) {
-      socket.send(payload);
+      send(socket, message);
+    }
+  }
+
+  /**
+   * Fans one event out to every socket in the room, per-recipient: the
+   * table gets `view(state, 'table')`, a seat gets `view(state, seatId)`
+   * only if it was actually dealt into the hand that produced this state —
+   * a sitting-out seat's socket gets nothing, never another seat's cards
+   * (docs/phase-1-spec.md §4, §6).
+   */
+  function fanOutHandUpdate(code: string, step: DispatchStep): void {
+    const sockets = roomSockets.get(code);
+    if (!sockets) return;
+    for (const socket of sockets) {
+      const identity = socketIdentity.get(socket);
+      if (identity === undefined) continue;
+      if (identity === "table") {
+        send(socket, {
+          type: "hand-update",
+          event: redactEventFor(step.event, "table"),
+          view: view(step.state, "table"),
+        });
+      } else if (step.state.seats.includes(identity)) {
+        send(socket, {
+          type: "hand-update",
+          event: redactEventFor(step.event, identity),
+          view: view(step.state, identity),
+        });
+      }
     }
   }
 
@@ -203,6 +273,17 @@ export async function buildApp(
         const code = request.query.room;
         if (code === undefined) return;
 
+        const { role, seat } = request.query;
+        let identity: SeatId | "table";
+        if (role === "table") {
+          identity = "table";
+        } else {
+          const seatId = seat === undefined ? undefined : parseSeatId(seat);
+          if (seatId === undefined) return;
+          identity = seatId;
+        }
+        socketIdentity.set(socket, identity);
+
         let sockets = roomSockets.get(code);
         if (!sockets) {
           sockets = new Set();
@@ -212,15 +293,49 @@ export async function buildApp(
 
         const room = rooms.get(code);
         if (room) {
-          const message: ServerMessage = {
-            type: "room-view",
-            view: toRoomView(room),
-          };
-          socket.send(JSON.stringify(message));
+          send(socket, { type: "room-view", view: toRoomView(room) });
         }
+
+        socket.on("message", (data: Buffer) => {
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(data.toString());
+          } catch {
+            sendRejection(socket, "invalid-command");
+            return;
+          }
+
+          const parseResult = ClientCommandSchema.safeParse(parsed);
+          if (!parseResult.success) {
+            sendRejection(socket, "invalid-command");
+            return;
+          }
+
+          const dispatchResult = rooms.dispatch(
+            code,
+            identity,
+            parseResult.data.type,
+          );
+          if ("error" in dispatchResult) {
+            sendRejection(socket, dispatchResult.error);
+            return;
+          }
+          if ("reason" in dispatchResult) {
+            sendRejection(socket, dispatchResult.reason);
+            return;
+          }
+
+          for (const step of dispatchResult.steps) {
+            fanOutHandUpdate(code, step);
+          }
+          if (parseResult.data.type === "startHand") {
+            broadcastRoomView(code);
+          }
+        });
 
         socket.on("close", () => {
           sockets.delete(socket);
+          socketIdentity.delete(socket);
         });
       },
     );

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -103,14 +103,16 @@ describe("RoomStore", () => {
     it("marks a seat claimed while a hand is in progress as sitting out", () => {
       const store = new RoomStore();
       const room = store.create();
-      store.markHandInProgress(room.code, true);
+      store.claimSeat(room.code, 0);
+      store.claimSeat(room.code, 1);
+      store.dispatch(room.code, "table", "startHand");
 
-      const result = store.claimSeat(room.code, 0);
+      const result = store.claimSeat(room.code, 2);
 
       if (!("seat" in result)) throw new Error("expected a claimed seat");
       expect(typeof result.seat.token).toBe("string");
       expect(result.seat).toMatchObject({
-        id: 0,
+        id: 2,
         claimed: true,
         sittingOut: true,
       });
@@ -147,12 +149,131 @@ describe("RoomStore", () => {
     });
   });
 
-  describe("hand-in-progress flag", () => {
-    it("toggling an unknown room is a no-op", () => {
+  describe("dispatch", () => {
+    function roomWithClaimedSeats(store: RoomStore, count: number) {
+      const room = store.create();
+      for (let seatId = 0; seatId < count; seatId++) {
+        store.claimSeat(room.code, seatId);
+      }
+      return room;
+    }
+
+    it("rejects a command for an unknown room", () => {
       const store = new RoomStore();
-      expect(() => {
-        store.markHandInProgress("ZZZZ", true);
-      }).not.toThrow();
+      expect(store.dispatch("ZZZZ", "table", "startHand")).toEqual({
+        error: "room-not-found",
+      });
+    });
+
+    it("rejects a table-only command sent by a seat", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, 2);
+      expect(store.dispatch(room.code, 0, "startHand")).toEqual({
+        error: "not-permitted",
+      });
+    });
+
+    it("rejects a seat-only command sent by the table", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, 2);
+      expect(store.dispatch(room.code, "table", "fold")).toEqual({
+        error: "not-permitted",
+      });
+    });
+
+    it("rejects starting a hand with fewer than 2 dealt-in seats", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, 1);
+      expect(store.dispatch(room.code, "table", "startHand")).toEqual({
+        reason: "not-enough-players",
+      });
+    });
+
+    it("rejects an action before any hand has started", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, 2);
+      expect(store.dispatch(room.code, 0, "fold")).toEqual({
+        reason: "hand-not-in-progress",
+      });
+    });
+
+    it("starts a hand with a fresh CSPRNG seed, dealing to every claimed seat", () => {
+      let calls = 0;
+      const store = new RoomStore(Math.random, undefined, () => {
+        calls += 1;
+        return `seed-${String(calls)}`;
+      });
+      const room = roomWithClaimedSeats(store, 3);
+
+      const result = store.dispatch(room.code, "table", "startHand");
+
+      if (!("steps" in result)) throw new Error("expected dispatch steps");
+      expect(result.steps.map((step) => step.event.type)).toEqual([
+        "HandStarted",
+        "HoleCardsDealt",
+        "StreetStarted",
+      ]);
+      const holeCardsDealt = result.steps[1]?.event;
+      if (holeCardsDealt?.type !== "HoleCardsDealt") {
+        throw new Error("expected HoleCardsDealt");
+      }
+      expect(holeCardsDealt.deals.map((deal) => deal.seatId).sort()).toEqual([
+        0, 1, 2,
+      ]);
+      expect(room.engine?.hand?.status).toBe("betting");
+    });
+
+    it("excludes a sitting-out seat from the deal and leaves it sitting out", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, 2);
+      store.dispatch(room.code, "table", "startHand");
+      const midHandJoin = store.claimSeat(room.code, 2);
+      if (!("seat" in midHandJoin)) throw new Error("expected a claim");
+      expect(midHandJoin.seat.sittingOut).toBe(true);
+
+      const foldResult = store.dispatch(room.code, 2, "fold");
+
+      expect(foldResult).toEqual({ reason: "not-your-turn" });
+      expect(room.seats[2]?.sittingOut).toBe(true);
+    });
+
+    it("clears sittingOut on every seat dealt into a hand", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, 2);
+
+      store.dispatch(room.code, "table", "startHand");
+
+      expect(room.seats[0]?.sittingOut).toBe(false);
+      expect(room.seats[1]?.sittingOut).toBe(false);
+    });
+
+    it("rejects a second startHand once a hand is already in progress", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, 2);
+      store.dispatch(room.code, "table", "startHand");
+
+      expect(store.dispatch(room.code, "table", "startHand")).toEqual({
+        reason: "hand-already-in-progress",
+      });
+    });
+
+    it("rejects an out-of-turn fold", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, 2);
+      const started = store.dispatch(room.code, "table", "startHand");
+      if (!("steps" in started)) throw new Error("expected dispatch steps");
+      const streetStarted = started.steps.at(-1)?.event;
+      if (streetStarted?.type !== "StreetStarted") {
+        throw new Error("expected StreetStarted");
+      }
+      const outOfTurnSeat = room.seats.find(
+        (seat) => seat.claimed && seat.id !== streetStarted.actor,
+      );
+      if (!outOfTurnSeat) throw new Error("expected an out-of-turn seat");
+
+      expect(store.dispatch(room.code, outOfTurnSeat.id, "fold")).toEqual({
+        reason: "not-your-turn",
+      });
     });
   });
 });

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -1,5 +1,16 @@
 import { randomUUID } from "node:crypto";
-import type { RoomView, SeatId } from "@table-top-poker/protocol";
+import {
+  apply,
+  createInitialState,
+  decide,
+  type ClientCommandType,
+  type Command,
+  type EngineState,
+  type HandEvent,
+  type RejectionReason,
+  type RoomView,
+  type SeatId,
+} from "@table-top-poker/protocol";
 import { generateRoomCode } from "./room-code.js";
 
 export const SEAT_COUNT = 8;
@@ -21,13 +32,32 @@ export interface Seat {
 export interface Room {
   readonly code: string;
   readonly seats: Seat[];
-  handInProgress: boolean;
+  /** Null until the room's first `startHand` — see `RoomStore.dispatch`. */
+  engine: EngineState | null;
 }
 
 export type ClaimSeatError =
   "room-not-found" | "seat-not-found" | "seat-already-claimed";
 
 export type ClaimSeatResult = { seat: Seat } | { error: ClaimSeatError };
+
+/** A step of engine state produced by one dispatched command, event by event. */
+export interface DispatchStep {
+  readonly event: HandEvent;
+  readonly state: EngineState;
+}
+
+export type DispatchRejectionReason = RejectionReason | "not-enough-players";
+
+export type DispatchResult =
+  | { readonly steps: readonly DispatchStep[] }
+  | { readonly error: "room-not-found" | "not-permitted" }
+  | { readonly reason: DispatchRejectionReason };
+
+const TABLE_ONLY_COMMANDS: ReadonlySet<ClientCommandType> = new Set([
+  "startHand",
+  "nextHand",
+]);
 
 function makeSeats(): Seat[] {
   return Array.from({ length: SEAT_COUNT }, (_, id) => ({
@@ -39,25 +69,36 @@ function makeSeats(): Seat[] {
 }
 
 /**
- * In-memory room registry. Seats are structural only — no engine attached
- * yet (ticket 29 wires the engine and takes over `sittingOut` on deal-in).
+ * True once the room's first hand has ever started. `nextHand` reuses the
+ * same `EngineState` for the room's whole life (its `seats` are fixed at
+ * creation, per `createInitialState`), so there's no later point at which a
+ * seat that missed the deal-in is automatically un-sat-out — that's future
+ * scope, not this ticket's.
  */
+function isHandInProgress(room: Room): boolean {
+  return room.engine !== null;
+}
+
+/** In-memory room registry, with the engine wired in behind `dispatch`. */
 export class RoomStore {
   readonly #rooms = new Map<string, Room>();
   readonly #random: () => number;
   readonly #generateToken: () => string;
+  readonly #generateSeed: () => string;
 
   constructor(
     random: () => number = Math.random,
     generateToken: () => string = randomUUID,
+    generateSeed: () => string = randomUUID,
   ) {
     this.#random = random;
     this.#generateToken = generateToken;
+    this.#generateSeed = generateSeed;
   }
 
   create(): Room {
     const code = generateRoomCode((c) => this.#rooms.has(c), this.#random);
-    const room: Room = { code, seats: makeSeats(), handInProgress: false };
+    const room: Room = { code, seats: makeSeats(), engine: null };
     this.#rooms.set(code, room);
     return room;
   }
@@ -80,7 +121,7 @@ export class RoomStore {
 
     seat.claimed = true;
     seat.token = this.#generateToken();
-    seat.sittingOut = room.handInProgress;
+    seat.sittingOut = isHandInProgress(room);
     return { seat };
   }
 
@@ -95,11 +136,71 @@ export class RoomStore {
     seat.sittingOut = false;
   }
 
-  /** Stand-in for the engine-driven flag ticket 29 will maintain. */
-  markHandInProgress(code: string, inProgress: boolean): void {
+  /**
+   * Runs one command through the engine on behalf of an authenticated
+   * socket. `identity` is derived server-side from the WS connection, never
+   * from the message payload — see docs/phase-1-spec.md §6. `startHand` and
+   * `nextHand` are table-only at this layer (the engine itself places no
+   * such restriction); everything else is seat-only. A room's first
+   * `startHand` builds its `EngineState` from the seats currently claimed
+   * and not sitting out — every other seat stays sitting out for that hand.
+   */
+  dispatch(
+    code: string,
+    identity: SeatId | "table",
+    type: ClientCommandType,
+  ): DispatchResult {
     const room = this.#rooms.get(code);
-    if (!room) return;
-    room.handInProgress = inProgress;
+    if (!room) return { error: "room-not-found" };
+
+    const isTableCommand = TABLE_ONLY_COMMANDS.has(type);
+    if (identity === "table" ? !isTableCommand : isTableCommand) {
+      return { error: "not-permitted" };
+    }
+
+    if (type === "startHand" && room.engine === null) {
+      const dealIn = room.seats
+        .filter((seat) => seat.claimed && !seat.sittingOut)
+        .map((seat) => seat.id);
+      if (dealIn.length < 2) return { reason: "not-enough-players" };
+      room.engine = createInitialState(dealIn);
+    }
+
+    if (room.engine === null) return { reason: "hand-not-in-progress" };
+
+    const command = this.#buildCommand(identity, type);
+    const result = decide(room.engine, command);
+    if (!Array.isArray(result)) return { reason: result.reason };
+
+    const steps: DispatchStep[] = [];
+    let state = room.engine;
+    for (const event of result) {
+      state = apply(state, event);
+      steps.push({ event, state });
+    }
+    room.engine = state;
+
+    if (type === "startHand") {
+      for (const seatId of room.engine.seats) {
+        const seat = room.seats[seatId];
+        if (seat) seat.sittingOut = false;
+      }
+    }
+
+    return { steps };
+  }
+
+  /**
+   * `playerId` is unused by the engine for `startHand`/`nextHand` (no
+   * issuer restriction at that layer, per docs/phase-1-spec.md §3) — the
+   * table isn't a seat, so there's no meaningful id to supply; `0` is an
+   * arbitrary placeholder.
+   */
+  #buildCommand(identity: SeatId | "table", type: ClientCommandType): Command {
+    if (type === "startHand" || type === "nextHand") {
+      return { type, playerId: 0, seed: this.#generateSeed() };
+    }
+    return { type, playerId: identity as SeatId };
   }
 }
 

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { createRoom, endSession } from "./api/rooms.js";
+import { Board } from "./Board.js";
 import { RoomPanel } from "./RoomPanel.js";
 import { StatusBar } from "./StatusBar.js";
 import { useTableStore } from "./store/store.js";
@@ -11,10 +12,11 @@ export function App() {
   const qrCodeDataUrl = useTableStore((state) => state.qrCodeDataUrl);
   const seats = useTableStore((state) => state.seats);
   const connectionStatus = useTableStore((state) => state.connectionStatus);
+  const handView = useTableStore((state) => state.handView);
   const setRoomCreated = useTableStore((state) => state.setRoomCreated);
   const clearRoom = useTableStore((state) => state.clearRoom);
 
-  useWebSocket(roomCode);
+  const { send } = useWebSocket(roomCode);
 
   const handleCreateRoom = useCallback(() => {
     createRoom()
@@ -33,6 +35,13 @@ export function App() {
       });
   }, [roomCode, clearRoom]);
 
+  const handleStartHand = useCallback(() => {
+    send({ type: "startHand" });
+  }, [send]);
+
+  const claimedSeatCount = seats.filter((seat) => seat.claimed).length;
+  const canStartHand = handView === null && claimedSeatCount >= 2;
+
   return (
     <div className="app-shell" data-testid="table-client-shell">
       <StatusBar roomCode={roomCode} connectionStatus={connectionStatus} />
@@ -46,13 +55,25 @@ export function App() {
             Create room
           </button>
         ) : (
-          <RoomPanel
-            roomCode={roomCode}
-            joinUrl={joinUrl}
-            qrCodeDataUrl={qrCodeDataUrl}
-            seats={seats}
-            onEndSession={handleEndSession}
-          />
+          <>
+            <RoomPanel
+              roomCode={roomCode}
+              joinUrl={joinUrl}
+              qrCodeDataUrl={qrCodeDataUrl}
+              seats={seats}
+              onEndSession={handleEndSession}
+            />
+            {canStartHand && (
+              <button
+                type="button"
+                data-testid="start-hand-button"
+                onClick={handleStartHand}
+              >
+                Start hand
+              </button>
+            )}
+            {handView !== null && <Board view={handView} seats={seats} />}
+          </>
         )}
       </main>
     </div>

--- a/packages/table-client/src/Board.test.tsx
+++ b/packages/table-client/src/Board.test.tsx
@@ -1,0 +1,78 @@
+import type { SeatView, TableView } from "@table-top-poker/protocol";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { Board } from "./Board.js";
+
+const seats: SeatView[] = [
+  { id: 0, claimed: true, sittingOut: false },
+  { id: 1, claimed: true, sittingOut: false },
+  { id: 2, claimed: true, sittingOut: true },
+  { id: 3, claimed: false, sittingOut: false },
+];
+
+describe("Board", () => {
+  it("renders a waiting state before any hand has started", () => {
+    const view: TableView = { phase: "no-hand", button: 0 };
+    const html = renderToStaticMarkup(<Board view={view} seats={seats} />);
+    expect(html).toMatch(/data-testid="board"[^>]*data-phase="no-hand"/);
+  });
+
+  it("renders community cards, seat status, button and current actor", () => {
+    const view: TableView = {
+      phase: "betting",
+      button: 0,
+      street: "flop",
+      board: [
+        { rank: "A", suit: "spades" },
+        { rank: "K", suit: "hearts" },
+        { rank: "2", suit: "clubs" },
+      ],
+      toAct: [1],
+      seats: [
+        { seatId: 0, folded: false },
+        { seatId: 1, folded: false },
+      ],
+    };
+    const html = renderToStaticMarkup(<Board view={view} seats={seats} />);
+
+    expect(html).toMatch(/data-testid="community-cards"/);
+    expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(3);
+    expect(html).toMatch(
+      /data-testid="board-seat-0"[^>]*data-status="in-hand"[^>]*data-button="true"/,
+    );
+    expect(html).toMatch(
+      /data-testid="board-seat-1"[^>]*data-status="in-hand"[^>]*data-turn="true"/,
+    );
+    expect(html).toMatch(
+      /data-testid="board-seat-2"[^>]*data-status="sitting-out"/,
+    );
+    expect(html).toMatch(/data-testid="board-seat-3"[^>]*data-status="open"/);
+    expect(html).not.toContain("yourHoleCards");
+  });
+
+  it("marks a folded seat", () => {
+    const view: TableView = {
+      phase: "betting",
+      button: 0,
+      street: "preflop",
+      board: [],
+      toAct: [0],
+      seats: [
+        { seatId: 0, folded: false },
+        { seatId: 1, folded: true },
+      ],
+    };
+    const html = renderToStaticMarkup(
+      <Board view={view} seats={seats.slice(0, 2)} />,
+    );
+    expect(html).toMatch(/data-testid="board-seat-1"[^>]*data-status="folded"/);
+  });
+
+  it("renders a fold-out completion with no reveal", () => {
+    const view: TableView = { phase: "folded-out", button: 0, winner: 1 };
+    const html = renderToStaticMarkup(<Board view={view} seats={seats} />);
+    expect(html).toMatch(/data-testid="board"[^>]*data-phase="folded-out"/);
+    expect(html).not.toContain('data-testid="showdown-results"');
+  });
+});

--- a/packages/table-client/src/Board.tsx
+++ b/packages/table-client/src/Board.tsx
@@ -1,0 +1,103 @@
+import type { SeatView, TableView } from "@table-top-poker/protocol";
+import { Card } from "@table-top-poker/ui-shared";
+
+export interface BoardProps {
+  readonly view: TableView;
+  readonly seats: readonly SeatView[];
+}
+
+type SeatStatus = "open" | "sitting-out" | "folded" | "in-hand";
+
+/** The per-seat slice of a betting-phase `TableView`. */
+interface HandSeat {
+  readonly seatId: number;
+  readonly folded: boolean;
+}
+
+/**
+ * Cross-references the room's full seat list against this hand's dealt-in
+ * seats: a claimed seat absent from `handSeats` was excluded from the deal
+ * (sitting out), never a leak — `handSeats` only ever lists seats actually
+ * dealt into the running hand (docs/phase-1-spec.md §4).
+ */
+function statusOf(seat: SeatView, handSeats: readonly HandSeat[]): SeatStatus {
+  if (!seat.claimed) return "open";
+  const handSeat = handSeats.find((s) => s.seatId === seat.id);
+  if (!handSeat) return "sitting-out";
+  return handSeat.folded ? "folded" : "in-hand";
+}
+
+export function Board({ view, seats }: BoardProps) {
+  if (view.phase === "no-hand") {
+    return (
+      <div data-testid="board" data-phase="no-hand">
+        Waiting to deal — button on Seat {view.button + 1}.
+      </div>
+    );
+  }
+
+  if (view.phase === "folded-out") {
+    return (
+      <div data-testid="board" data-phase="folded-out">
+        Hand complete — Seat {view.winner + 1} wins, everyone else folded.
+      </div>
+    );
+  }
+
+  if (view.phase === "showdown") {
+    return (
+      <div data-testid="board" data-phase="showdown">
+        <span data-testid="winners">
+          Winner{view.winners.length > 1 ? "s" : ""}: seat
+          {view.winners.length > 1 ? "s" : ""}{" "}
+          {view.winners.map((seatId) => seatId + 1).join(", ")}
+        </span>
+        <ul data-testid="showdown-results">
+          {view.results.map((result) => (
+            <li
+              key={result.seatId}
+              data-testid={`result-${String(result.seatId)}`}
+            >
+              Seat {result.seatId + 1}: {result.description}
+              {result.holeCards.map((card, i) => (
+                <Card key={i} rank={card.rank} suit={card.suit} />
+              ))}
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+
+  const actor = view.toAct[0];
+
+  return (
+    <div data-testid="board" data-phase="betting" data-street={view.street}>
+      <div data-testid="community-cards">
+        {view.board.map((card, i) => (
+          <Card key={i} rank={card.rank} suit={card.suit} />
+        ))}
+      </div>
+      <ul data-testid="board-seats">
+        {seats.map((seat) => {
+          const status = statusOf(seat, view.seats);
+          const isButton = seat.id === view.button;
+          const isActor = seat.id === actor;
+          return (
+            <li
+              key={seat.id}
+              data-testid={`board-seat-${String(seat.id)}`}
+              data-status={status}
+              data-button={isButton}
+              data-turn={isActor}
+            >
+              Seat {seat.id + 1} — {status}
+              {isButton ? " (button)" : ""}
+              {isActor ? " (to act)" : ""}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/packages/table-client/src/store/handSlice.ts
+++ b/packages/table-client/src/store/handSlice.ts
@@ -1,0 +1,16 @@
+import type { HandEvent, TableView } from "@table-top-poker/protocol";
+import type { StateCreator } from "zustand";
+
+export interface HandSlice {
+  readonly handView: TableView | null;
+  readonly lastEvent: HandEvent | null;
+  readonly setHandUpdate: (event: HandEvent, view: TableView) => void;
+}
+
+export const createHandSlice: StateCreator<HandSlice> = (set) => ({
+  handView: null,
+  lastEvent: null,
+  setHandUpdate: (event, view) => {
+    set({ handView: view, lastEvent: event });
+  },
+});

--- a/packages/table-client/src/store/handSlice.ts
+++ b/packages/table-client/src/store/handSlice.ts
@@ -1,16 +1,14 @@
-import type { HandEvent, TableView } from "@table-top-poker/protocol";
+import type { TableView } from "@table-top-poker/protocol";
 import type { StateCreator } from "zustand";
 
 export interface HandSlice {
   readonly handView: TableView | null;
-  readonly lastEvent: HandEvent | null;
-  readonly setHandUpdate: (event: HandEvent, view: TableView) => void;
+  readonly setHandView: (view: TableView) => void;
 }
 
 export const createHandSlice: StateCreator<HandSlice> = (set) => ({
   handView: null,
-  lastEvent: null,
-  setHandUpdate: (event, view) => {
-    set({ handView: view, lastEvent: event });
+  setHandView: (view) => {
+    set({ handView: view });
   },
 });

--- a/packages/table-client/src/store/store.ts
+++ b/packages/table-client/src/store/store.ts
@@ -3,11 +3,13 @@ import {
   type ConnectionSlice,
   createConnectionSlice,
 } from "./connectionSlice.js";
+import { createHandSlice, type HandSlice } from "./handSlice.js";
 import { createRoomSlice, type RoomSlice } from "./roomSlice.js";
 
-export type TableStore = ConnectionSlice & RoomSlice;
+export type TableStore = ConnectionSlice & RoomSlice & HandSlice;
 
 export const useTableStore = create<TableStore>()((...args) => ({
   ...createConnectionSlice(...args),
   ...createRoomSlice(...args),
+  ...createHandSlice(...args),
 }));

--- a/packages/table-client/src/ws/useWebSocket.ts
+++ b/packages/table-client/src/ws/useWebSocket.ts
@@ -23,7 +23,7 @@ export function useWebSocket(roomCode: string | null): TableSocket {
     (state) => state.setConnectionStatus,
   );
   const setRoomView = useTableStore((state) => state.setRoomView);
-  const setHandUpdate = useTableStore((state) => state.setHandUpdate);
+  const setHandView = useTableStore((state) => state.setHandView);
   const socketRef = useRef<WebSocket | null>(null);
 
   useEffect(() => {
@@ -52,7 +52,7 @@ export function useWebSocket(roomCode: string | null): TableSocket {
         setRoomView(message.view);
       } else if (message.type === "hand-update") {
         // The server only ever sends a table-role socket a `view(state, 'table')`.
-        setHandUpdate(message.event, message.view);
+        setHandView(message.view);
       }
     });
 
@@ -61,7 +61,7 @@ export function useWebSocket(roomCode: string | null): TableSocket {
       socketRef.current = null;
       socket.close();
     };
-  }, [roomCode, setConnectionStatus, setRoomView, setHandUpdate]);
+  }, [roomCode, setConnectionStatus, setRoomView, setHandView]);
 
   const send = useCallback((command: ClientCommand) => {
     socketRef.current?.send(JSON.stringify(command));

--- a/packages/table-client/src/ws/useWebSocket.ts
+++ b/packages/table-client/src/ws/useWebSocket.ts
@@ -1,18 +1,30 @@
-import type { ServerMessage } from "@table-top-poker/protocol";
-import { useEffect } from "react";
+import type { ClientCommand, ServerMessage } from "@table-top-poker/protocol";
+import { useCallback, useEffect, useRef } from "react";
 import { useTableStore } from "../store/store.js";
 import { getWebSocketUrl } from "./getWebSocketUrl.js";
+
+export interface TableSocket {
+  /** No-ops silently while disconnected — buttons are gated on connection state upstream. */
+  readonly send: (command: ClientCommand) => void;
+}
 
 /**
  * Opens a room-scoped WebSocket connection once a room exists and reflects
  * its lifecycle into the connection slice. Every `room-view` push replaces
- * the seat slice. No reconnection logic yet — that's ticket 33.
+ * the seat slice; every `hand-update` replaces the hand slice with the
+ * fresh `view(state, 'table')` the server just computed — the view is
+ * source of truth (docs/phase-1-spec.md §6), never rebuilt from the raw
+ * event locally. `command-rejected` renders nothing on the table device by
+ * design (§9 — only the rejecting player ever sees a rejection). No
+ * reconnection logic yet — that's ticket 33.
  */
-export function useWebSocket(roomCode: string | null): void {
+export function useWebSocket(roomCode: string | null): TableSocket {
   const setConnectionStatus = useTableStore(
     (state) => state.setConnectionStatus,
   );
   const setRoomView = useTableStore((state) => state.setRoomView);
+  const setHandUpdate = useTableStore((state) => state.setHandUpdate);
+  const socketRef = useRef<WebSocket | null>(null);
 
   useEffect(() => {
     if (roomCode === null) {
@@ -25,6 +37,7 @@ export function useWebSocket(roomCode: string | null): void {
     const socket = new WebSocket(
       getWebSocketUrl(window.location, { room: roomCode, role: "table" }),
     );
+    socketRef.current = socket;
 
     socket.addEventListener("open", () => {
       if (active) setConnectionStatus("connected");
@@ -35,12 +48,24 @@ export function useWebSocket(roomCode: string | null): void {
     socket.addEventListener("message", (event: MessageEvent<string>) => {
       if (!active) return;
       const message: ServerMessage = JSON.parse(event.data) as ServerMessage;
-      setRoomView(message.view);
+      if (message.type === "room-view") {
+        setRoomView(message.view);
+      } else if (message.type === "hand-update") {
+        // The server only ever sends a table-role socket a `view(state, 'table')`.
+        setHandUpdate(message.event, message.view);
+      }
     });
 
     return () => {
       active = false;
+      socketRef.current = null;
       socket.close();
     };
-  }, [roomCode, setConnectionStatus, setRoomView]);
+  }, [roomCode, setConnectionStatus, setRoomView, setHandUpdate]);
+
+  const send = useCallback((command: ClientCommand) => {
+    socketRef.current?.send(JSON.stringify(command));
+  }, []);
+
+  return { send };
 }


### PR DESCRIPTION
## Summary
- Wires the poker engine live behind the server: a per-room `EngineState`, table-only `startHand`/`nextHand` and seat-only actions, Zod-validated at the WS boundary before reaching `decide()`.
- Every server→client message carries the raw domain event alongside a fresh per-recipient `view(state, seatId | 'table')` — the view is source of truth. `HoleCardsDealt` is redacted per recipient on the wire so no socket ever sees another seat's cards, even via the raw event.
- Sitting-out seats are excluded from deal-in (`RoomStore.dispatch`) and stay sitting out for that hand.
- `table-client` renders the board (community cards, seat status, current actor, button); `player-client` reveals its own hole cards and mirrors the shared board. No action buttons yet (fold/check/call/raise UI is #30).

Closes #29

## Test plan
- [x] `npx tsc --build` — clean across the workspace
- [x] `npx eslint . && npx prettier --check .` — clean
- [x] `npx vitest run` — 228/228 passing across 48 files
- [x] New WS-level integration tests directly exercise each acceptance criterion: CSPRNG-seeded deal, per-seat card isolation (payload inspection across seats), sitting-out exclusion, and Zod rejection before the engine (`packages/server/src/app.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PBSwRXoV3aCaB4brBxqnqn