### PR TITLE
12 — Action loop

### DIFF
--- a/docs/phase-1-spec.md
+++ b/docs/phase-1-spec.md
@@ -409,8 +409,10 @@ research in `docs/research/frontend-gesture-stack.md`)
 **Player device** (`player-client`)
 
 - Own hole cards, revealed on deal (not fetched later), hidden again once
-  folded (burn-pile, §4).
-- The shared board, mirrored from the same `view`.
+  folded (burn-pile, §4). The shared board is deliberately *not* shown
+  during betting — that's the table device's job, and mirroring it on the
+  phone too was redundant screen clutter — but it does reappear on the
+  showdown screen, alongside each winning seat's revealed hand.
 - The permanent action-intent buttons, restricted to `legalActions` for the
   current state, with `pending` styling while a sent action awaits
   ack/reject.

--- a/packages/engine/src/apply.ts
+++ b/packages/engine/src/apply.ts
@@ -150,6 +150,7 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
           reason: "showdown",
           seed: hand.seed,
           button: hand.button,
+          board: hand.board,
           results,
           winners: event.winners,
         },

--- a/packages/engine/src/complete-hand-state.test.ts
+++ b/packages/engine/src/complete-hand-state.test.ts
@@ -44,4 +44,23 @@ describe("CompleteHandState carries how the hand ended", () => {
       }
     }
   });
+
+  it("carries the full five-card board on a showdown completion", () => {
+    let state = createInitialState([0, 1]);
+    state = playAll(state, [{ type: "startHand", playerId: 0, seed: "s0" }]);
+    state = playAll(state, [
+      { type: "call", playerId: 0 },
+      { type: "check", playerId: 1 },
+      { type: "check", playerId: 1 },
+      { type: "check", playerId: 0 },
+      { type: "check", playerId: 1 },
+      { type: "check", playerId: 0 },
+      { type: "check", playerId: 1 },
+      { type: "check", playerId: 0 },
+    ]);
+
+    if (state.hand?.status !== "complete") throw new Error("expected complete");
+    if (state.hand.reason !== "showdown") throw new Error("expected showdown");
+    expect(state.hand.board).toHaveLength(5);
+  });
 });

--- a/packages/engine/src/decide.ts
+++ b/packages/engine/src/decide.ts
@@ -3,8 +3,8 @@ import { evaluate, winnersOf } from "./evaluate.js";
 import {
   dealCommunityCards,
   dealHoleCards,
-  facingBet,
   initialToAct,
+  legalActions,
   liveSeats,
   nextStreetOf,
   rotateFromButton,
@@ -31,9 +31,7 @@ function isLegal(
   actorSeat: SeatId,
   action: ActionType,
 ): boolean {
-  if (action === "check") return !facingBet(hand, actorSeat);
-  if (action === "call") return facingBet(hand, actorSeat);
-  return true;
+  return legalActions(hand, actorSeat).includes(action);
 }
 
 export function decide(

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -3,6 +3,7 @@ export { decide } from "./decide.js";
 export { evaluate } from "./evaluate.js";
 export type { HandEvaluation } from "./evaluate.js";
 export { createInitialState } from "./room.js";
+export { legalActions } from "./table.js";
 export { ENGINE_LOG_VERSION } from "./version.js";
 export type {
   ActionType,

--- a/packages/engine/src/properties.test.ts
+++ b/packages/engine/src/properties.test.ts
@@ -3,13 +3,8 @@ import { describe, expect, it } from "vitest";
 import { apply } from "./apply.js";
 import { decide } from "./decide.js";
 import { createInitialState } from "./room.js";
-import { facingBet } from "./table.js";
-import type {
-  ActionType,
-  BettingHandState,
-  EngineState,
-  SeatId,
-} from "./types.js";
+import { legalActions } from "./table.js";
+import type { BettingHandState, EngineState } from "./types.js";
 import { must } from "./util.js";
 
 const seatsArb = fc
@@ -116,15 +111,6 @@ describe("property: a rejected command never mutates state", () => {
   });
 });
 
-function legalActionsFor(
-  hand: BettingHandState,
-  actorSeat: SeatId,
-): ActionType[] {
-  return facingBet(hand, actorSeat)
-    ? ["fold", "call", "raise"]
-    : ["fold", "check", "raise"];
-}
-
 function assertBettingInvariants(hand: BettingHandState): void {
   expect(hand.toAct.length).toBeGreaterThan(0);
 
@@ -163,7 +149,7 @@ describe("property: decide/apply keep the betting invariants across a random han
             if (state.hand?.status !== "betting") break;
             const hand = state.hand;
             const actor = must(hand.toAct[0]);
-            const options = legalActionsFor(hand, actor);
+            const options = legalActions(hand, actor);
             const action = must(options[choice % options.length]);
 
             const result = decide(state, { type: action, playerId: actor });

--- a/packages/engine/src/table.test.ts
+++ b/packages/engine/src/table.test.ts
@@ -33,10 +33,6 @@ describe("legalActions", () => {
     if (afterLap.hand?.status !== "betting") {
       throw new Error("expected betting");
     }
-    expect(legalActions(afterLap.hand, 2)).toEqual([
-      "fold",
-      "check",
-      "raise",
-    ]);
+    expect(legalActions(afterLap.hand, 2)).toEqual(["fold", "check", "raise"]);
   });
 });

--- a/packages/engine/src/table.test.ts
+++ b/packages/engine/src/table.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { createInitialState } from "./room.js";
+import { legalActions } from "./table.js";
+import { playAll } from "./test-utils.js";
+
+describe("legalActions", () => {
+  it("offers fold/call/raise to a seat facing a bet preflop", () => {
+    const state = createInitialState([0, 1, 2]);
+    const started = playAll(state, [
+      { type: "startHand", playerId: 0, seed: "s" },
+    ]);
+    if (started.hand?.status !== "betting") {
+      throw new Error("expected betting");
+    }
+    // ring (button 0) = [1, 2, 0]; seat 1 (SB) faces the BB's post.
+    expect(legalActions(started.hand, 1)).toEqual(["fold", "call", "raise"]);
+  });
+
+  it("offers fold/check/raise to the big blind on an unraised preflop", () => {
+    const state = createInitialState([0, 1, 2]);
+    const started = playAll(state, [
+      { type: "startHand", playerId: 0, seed: "s" },
+    ]);
+    if (started.hand?.status !== "betting") {
+      throw new Error("expected betting");
+    }
+    // BB is seat 2 here — its own post already matches, so it may check.
+    const afterLap = playAll(started, [
+      { type: "call", playerId: 1 },
+      { type: "check", playerId: 2 },
+      { type: "call", playerId: 0 },
+    ]);
+    if (afterLap.hand?.status !== "betting") {
+      throw new Error("expected betting");
+    }
+    expect(legalActions(afterLap.hand, 2)).toEqual([
+      "fold",
+      "check",
+      "raise",
+    ]);
+  });
+});

--- a/packages/engine/src/table.ts
+++ b/packages/engine/src/table.ts
@@ -1,5 +1,11 @@
 import { shuffledDeck } from "./deck.js";
-import type { BettingHandState, Card, SeatId, Street } from "./types.js";
+import type {
+  ActionType,
+  BettingHandState,
+  Card,
+  SeatId,
+  Street,
+} from "./types.js";
 import { must } from "./util.js";
 
 /** Reorders `seats` to start right after `button` and end at `button`. */
@@ -90,6 +96,23 @@ export function facingBet(
     hand.street === "preflop" &&
     actorSeat !== bigBlindSeat(hand.ring, hand.button)
   );
+}
+
+/**
+ * The full set of actions `actorSeat` may legally take right now — fold and
+ * raise are always available; check and call are mutually exclusive and
+ * follow `facingBet` (see its own doc comment for the preflop/big-blind
+ * subtlety). The single source of truth for action legality, consumed by
+ * both `decide` (server-side enforcement) and `view` (the client-facing
+ * `legalActions` field) so the two can never drift apart.
+ */
+export function legalActions(
+  hand: Pick<BettingHandState, "street" | "ring" | "button" | "raiseOccurred">,
+  actorSeat: SeatId,
+): ActionType[] {
+  return facingBet(hand, actorSeat)
+    ? ["fold", "call", "raise"]
+    : ["fold", "check", "raise"];
 }
 
 /**

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -121,6 +121,7 @@ export interface ShowdownCompleteHandState {
   readonly reason: "showdown";
   readonly seed: string;
   readonly button: SeatId;
+  readonly board: readonly Card[];
   readonly results: readonly RevealedResult[];
   readonly winners: readonly SeatId[];
 }

--- a/packages/engine/src/view.test.ts
+++ b/packages/engine/src/view.test.ts
@@ -66,6 +66,23 @@ describe("view: own hole cards mid-hand", () => {
   });
 });
 
+describe("view: legalActions", () => {
+  it("is populated for the seat to act and empty for everyone else", () => {
+    const state = onTheFlopThreeWay();
+    if (state.hand?.status !== "betting") throw new Error("expected betting");
+    const actor = must(state.hand.toAct[0]);
+
+    const actorView = view(state, actor);
+    if (actorView.phase !== "betting") throw new Error("expected betting");
+    expect(actorView.legalActions).toEqual(["fold", "check", "raise"]);
+
+    const other = must(state.hand.ring.find((seat) => seat !== actor));
+    const otherView = view(state, other);
+    if (otherView.phase !== "betting") throw new Error("expected betting");
+    expect(otherView.legalActions).toEqual([]);
+  });
+});
+
 describe("view: other seats' hole cards mid-hand", () => {
   it("a seat does not see another live seat's hole cards", () => {
     const state = onTheFlopThreeWay();

--- a/packages/engine/src/view.test.ts
+++ b/packages/engine/src/view.test.ts
@@ -141,6 +141,7 @@ describe("view: post-showdown", () => {
     for (const v of [view(state, 0), view(state, 1), view(state, "table")]) {
       if (v.phase !== "showdown") throw new Error("expected showdown phase");
       expect(v.results.map((r) => r.seatId).sort()).toEqual(expectedSeats);
+      expect(v.board).toHaveLength(5);
       for (const result of v.results) {
         expect(result.holeCards).toHaveLength(2);
       }

--- a/packages/engine/src/view.ts
+++ b/packages/engine/src/view.ts
@@ -1,4 +1,6 @@
+import { legalActions } from "./table.js";
 import type {
+  ActionType,
   Card,
   EngineState,
   RevealedResult,
@@ -38,6 +40,8 @@ export interface PlayerViewBetting {
   readonly seats: readonly SeatSnapshot[];
   readonly yourSeatId: SeatId;
   readonly yourHoleCards: readonly [Card, Card] | null;
+  /** Empty unless it's `yourSeatId`'s turn — see `legalActions` in table.ts. */
+  readonly legalActions: readonly ActionType[];
 }
 
 export interface TableViewBetting {
@@ -113,6 +117,7 @@ export function view(
     ...tableView,
     yourSeatId: seatId,
     yourHoleCards,
+    legalActions: hand.toAct[0] === seatId ? legalActions(hand, seatId) : [],
   };
   return playerView;
 }

--- a/packages/engine/src/view.ts
+++ b/packages/engine/src/view.ts
@@ -27,6 +27,7 @@ interface FoldedOutView {
 interface ShowdownView {
   readonly phase: "showdown";
   readonly button: SeatId;
+  readonly board: readonly Card[];
   readonly results: readonly RevealedResult[];
   readonly winners: readonly SeatId[];
 }
@@ -88,6 +89,7 @@ export function view(
     return {
       phase: "showdown",
       button: hand.button,
+      board: hand.board,
       winners: hand.winners,
       results: hand.results,
     };

--- a/packages/player-client/src/ActionBar.test.tsx
+++ b/packages/player-client/src/ActionBar.test.tsx
@@ -67,5 +67,29 @@ describe("ActionBar", () => {
     expect(html).toContain('data-testid="action-rejection"');
     expect(html).toContain('data-rejected-action="check"');
     expect(html).toContain("isn&#x27;t available right now");
+
+    // Inline on the triggering control: inside check's group, not fold's or call's.
+    const checkGroupStart = html.indexOf('data-testid="action-group-check"');
+    const callGroupStart = html.indexOf('data-testid="action-group-call"');
+    const rejectionStart = html.indexOf('data-testid="action-rejection"');
+    expect(rejectionStart).toBeGreaterThan(checkGroupStart);
+    expect(rejectionStart).toBeLessThan(callGroupStart);
+  });
+
+  it("falls back to a bar-level message when no action is attributed", () => {
+    const html = renderToStaticMarkup(
+      <ActionBar
+        legalActions={[]}
+        pendingAction={null}
+        rejection={{ action: null, reason: "hand-not-in-progress" }}
+        onFold={noop}
+        onCheck={noop}
+        onCall={noop}
+        onRaise={noop}
+      />,
+    );
+
+    expect(html).toContain('data-testid="action-rejection"');
+    expect(html).toContain('data-rejected-action=""');
   });
 });

--- a/packages/player-client/src/ActionBar.test.tsx
+++ b/packages/player-client/src/ActionBar.test.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ActionBar } from "./ActionBar.js";
+
+const noop = () => undefined;
+
+function buttonTag(html: string, action: string): string {
+  const match = new RegExp(
+    `<button[^>]*data-testid="action-${action}"[^>]*>`,
+  ).exec(html);
+  if (!match) throw new Error(`no button rendered for ${action}`);
+  return match[0];
+}
+
+describe("ActionBar", () => {
+  it("enables only the legal actions and disables the rest", () => {
+    const html = renderToStaticMarkup(
+      <ActionBar
+        legalActions={["fold", "check", "raise"]}
+        pendingAction={null}
+        rejection={null}
+        onFold={noop}
+        onCheck={noop}
+        onCall={noop}
+        onRaise={noop}
+      />,
+    );
+
+    expect(buttonTag(html, "fold")).not.toContain("disabled");
+    expect(buttonTag(html, "check")).not.toContain("disabled");
+    expect(buttonTag(html, "raise")).not.toContain("disabled");
+    expect(buttonTag(html, "call")).toContain("disabled");
+  });
+
+  it("disables every button while an action is pending, marking the pending one", () => {
+    const html = renderToStaticMarkup(
+      <ActionBar
+        legalActions={["fold", "check", "call", "raise"]}
+        pendingAction="call"
+        rejection={null}
+        onFold={noop}
+        onCheck={noop}
+        onCall={noop}
+        onRaise={noop}
+      />,
+    );
+
+    expect(html).toMatch(/data-testid="action-call"[^>]*data-pending="true"/);
+    expect(html).toMatch(/data-testid="action-fold"[^>]*disabled/);
+    expect(html).not.toContain('data-testid="action-rejection"');
+  });
+
+  it("shows the rejection reason inline", () => {
+    const html = renderToStaticMarkup(
+      <ActionBar
+        legalActions={["fold", "check", "raise"]}
+        pendingAction={null}
+        rejection={{ action: "check", reason: "action-not-legal" }}
+        onFold={noop}
+        onCheck={noop}
+        onCall={noop}
+        onRaise={noop}
+      />,
+    );
+
+    expect(html).toContain('data-testid="action-rejection"');
+    expect(html).toContain('data-rejected-action="check"');
+    expect(html).toContain("isn&#x27;t available right now");
+  });
+});

--- a/packages/player-client/src/ActionBar.tsx
+++ b/packages/player-client/src/ActionBar.tsx
@@ -46,22 +46,28 @@ export function ActionBar({
   return (
     <div data-testid="action-bar">
       {(["fold", "check", "call", "raise"] as const).map((action) => (
-        <button
-          key={action}
-          type="button"
-          data-testid={`action-${action}`}
-          data-pending={pendingAction === action}
-          disabled={!legalActions.includes(action) || pendingAction !== null}
-          onClick={handlers[action]}
-        >
-          {LABELS[action]}
-        </button>
+        <div key={action} data-testid={`action-group-${action}`}>
+          <button
+            type="button"
+            data-testid={`action-${action}`}
+            data-pending={pendingAction === action}
+            disabled={!legalActions.includes(action) || pendingAction !== null}
+            onClick={handlers[action]}
+          >
+            {LABELS[action]}
+          </button>
+          {rejection !== null && rejection.action === action && (
+            <div data-testid="action-rejection" data-rejected-action={action}>
+              {rejectionCopy(rejection.reason)}
+            </div>
+          )}
+        </div>
       ))}
-      {rejection !== null && (
-        <div
-          data-testid="action-rejection"
-          data-rejected-action={rejection.action ?? ""}
-        >
+      {/* No pending command to attribute the reject to (no correlation id
+          on the wire, docs/phase-1-spec.md §6) — falls back to a bar-level
+          message rather than guessing which button triggered it. */}
+      {rejection !== null && rejection.action === null && (
+        <div data-testid="action-rejection" data-rejected-action="">
           {rejectionCopy(rejection.reason)}
         </div>
       )}

--- a/packages/player-client/src/ActionBar.tsx
+++ b/packages/player-client/src/ActionBar.tsx
@@ -1,0 +1,70 @@
+import type { ActionType } from "@table-top-poker/protocol";
+import { rejectionCopy } from "./actions/rejectionCopy.js";
+import type { ActionRejection } from "./store/actionSlice.js";
+
+export interface ActionBarProps {
+  readonly legalActions: readonly ActionType[];
+  readonly pendingAction: ActionType | null;
+  readonly rejection: ActionRejection | null;
+  readonly onFold: () => void;
+  readonly onCheck: () => void;
+  readonly onCall: () => void;
+  readonly onRaise: () => void;
+}
+
+const LABELS: Record<ActionType, string> = {
+  fold: "Fold",
+  check: "Check",
+  call: "Call",
+  raise: "Raise",
+};
+
+/**
+ * Fold/check/call/raise as the permanent base layer (docs/phase-1-spec.md
+ * §9) — always rendered during a betting phase, never swapped out for
+ * gestures. Disabled unless the action is in `legalActions` and nothing
+ * else is pending; the pressed button carries `data-pending` until its
+ * ack/reject lands. A rejection renders inline, once, near the buttons —
+ * no toast, no persistent banner.
+ */
+export function ActionBar({
+  legalActions,
+  pendingAction,
+  rejection,
+  onFold,
+  onCheck,
+  onCall,
+  onRaise,
+}: ActionBarProps) {
+  const handlers: Record<ActionType, () => void> = {
+    fold: onFold,
+    check: onCheck,
+    call: onCall,
+    raise: onRaise,
+  };
+
+  return (
+    <div data-testid="action-bar">
+      {(["fold", "check", "call", "raise"] as const).map((action) => (
+        <button
+          key={action}
+          type="button"
+          data-testid={`action-${action}`}
+          data-pending={pendingAction === action}
+          disabled={!legalActions.includes(action) || pendingAction !== null}
+          onClick={handlers[action]}
+        >
+          {LABELS[action]}
+        </button>
+      ))}
+      {rejection !== null && (
+        <div
+          data-testid="action-rejection"
+          data-rejected-action={rejection.action ?? ""}
+        >
+          {rejectionCopy(rejection.reason)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { ActionBar } from "./ActionBar.js";
 import { claimSeat, joinRoom } from "./api/rooms.js";
+import { useActionIntent } from "./actions/useActionIntent.js";
 import { Hand } from "./Hand.js";
 import { JoinForm } from "./JoinForm.js";
 import { parseRoomCodeFromPath } from "./join/parseRoomCodeFromPath.js";
@@ -37,7 +39,8 @@ export function App() {
     }
     return { roomCode, seatId, token: seatToken };
   }, [roomCode, seatId, seatToken]);
-  useWebSocket(wsParams);
+  const { send } = useWebSocket(wsParams);
+  const intent = useActionIntent(send);
 
   const handleJoin = useCallback(
     (code: string) => {
@@ -89,6 +92,17 @@ export function App() {
       <>
         <SeatPanel seatId={seatId} sittingOut={sittingOut} />
         {handView !== null && <Hand view={handView} />}
+        {handView !== null && handView.phase === "betting" && (
+          <ActionBar
+            legalActions={intent.legalActions}
+            pendingAction={intent.pendingAction}
+            rejection={intent.rejection}
+            onFold={intent.fold}
+            onCheck={intent.check}
+            onCall={intent.call}
+            onRaise={intent.raise}
+          />
+        )}
       </>
     );
   }

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -11,7 +11,7 @@ describe("Hand", () => {
     expect(html).toMatch(/data-testid="hand"[^>]*data-phase="no-hand"/);
   });
 
-  it("reveals own hole cards and mirrors the shared board", () => {
+  it("reveals own hole cards but never the shared board mid-hand", () => {
     const view: PlayerView = {
       phase: "betting",
       button: 0,
@@ -35,7 +35,9 @@ describe("Hand", () => {
     expect(html).toMatch(/data-testid="hole-cards"/);
     expect(html).toContain('data-rank="Q"');
     expect(html).toContain('data-rank="J"');
-    expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(5);
+    expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(2);
+    expect(html).not.toContain('data-testid="community-cards"');
+    expect(html).not.toContain('data-rank="A"');
   });
 
   it("hides hole cards once folded, without a placeholder leak", () => {
@@ -57,5 +59,64 @@ describe("Hand", () => {
 
     expect(html).toMatch(/data-testid="no-hole-cards"/);
     expect(html).not.toContain("data-rank");
+  });
+
+  it("shows the board and the winning hand(s) below it at showdown", () => {
+    const view: PlayerView = {
+      phase: "showdown",
+      button: 0,
+      board: [
+        { rank: "A", suit: "spades" },
+        { rank: "K", suit: "hearts" },
+        { rank: "2", suit: "clubs" },
+        { rank: "9", suit: "diamonds" },
+        { rank: "4", suit: "spades" },
+      ],
+      results: [
+        {
+          seatId: 0,
+          rank: 1,
+          bestHand: [
+            { rank: "A", suit: "spades" },
+            { rank: "A", suit: "diamonds" },
+            { rank: "K", suit: "hearts" },
+            { rank: "9", suit: "diamonds" },
+            { rank: "4", suit: "spades" },
+          ],
+          description: "Pair of Aces",
+          holeCards: [
+            { rank: "A", suit: "diamonds" },
+            { rank: "7", suit: "clubs" },
+          ],
+        },
+        {
+          seatId: 1,
+          rank: 2,
+          bestHand: [
+            { rank: "A", suit: "spades" },
+            { rank: "K", suit: "hearts" },
+            { rank: "K", suit: "clubs" },
+            { rank: "9", suit: "diamonds" },
+            { rank: "4", suit: "spades" },
+          ],
+          description: "Pair of Kings",
+          holeCards: [
+            { rank: "K", suit: "clubs" },
+            { rank: "3", suit: "hearts" },
+          ],
+        },
+      ],
+      winners: [0],
+    };
+    const html = renderToStaticMarkup(<Hand view={view} />);
+
+    expect(html).toMatch(/data-testid="hand"[^>]*data-phase="showdown"/);
+    expect(html).toContain('data-testid="community-cards"');
+    expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(7);
+
+    expect(html).toContain('data-testid="winning-hand-0"');
+    expect(html).not.toContain('data-testid="winning-hand-1"');
+    expect(html).toContain("Pair of Aces");
+    expect(html).not.toContain("Pair of Kings");
   });
 });

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -28,6 +28,7 @@ describe("Hand", () => {
         { rank: "Q", suit: "diamonds" },
         { rank: "J", suit: "clubs" },
       ],
+      legalActions: ["fold", "check", "raise"],
     };
     const html = renderToStaticMarkup(<Hand view={view} />);
 
@@ -50,6 +51,7 @@ describe("Hand", () => {
       ],
       yourSeatId: 0,
       yourHoleCards: null,
+      legalActions: [],
     };
     const html = renderToStaticMarkup(<Hand view={view} />);
 

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -6,10 +6,13 @@ export interface HandProps {
 }
 
 /**
- * Own hole cards plus the shared board, mirrored straight from the seat's
- * `view` — nothing rebuilt from the raw event locally
- * (docs/phase-1-spec.md §9). Hidden again once folded, a burn-pile per §4:
- * `yourHoleCards` is already `null` in that view, this never redacts.
+ * Own hole cards, mirrored straight from the seat's `view` — nothing
+ * rebuilt from the raw event locally (docs/phase-1-spec.md §9). Hidden
+ * again once folded, a burn-pile per §4: `yourHoleCards` is already `null`
+ * in that view, this never redacts. The shared board is deliberately not
+ * shown here mid-hand — the player device stays hole-cards-only, the board
+ * lives on the table device — but does reappear on the showdown screen,
+ * alongside the winning hand(s), since there's nothing left to keep secret.
  * Action buttons live in `ActionBar`, rendered alongside this by `App`.
  */
 export function Hand({ view }: HandProps) {
@@ -30,9 +33,31 @@ export function Hand({ view }: HandProps) {
   }
 
   if (view.phase === "showdown") {
+    const winningResults = view.results.filter((result) =>
+      view.winners.includes(result.seatId),
+    );
     return (
       <div data-testid="hand" data-phase="showdown">
-        Showdown.
+        <div data-testid="community-cards">
+          {view.board.map((card, i) => (
+            <Card key={i} rank={card.rank} suit={card.suit} />
+          ))}
+        </div>
+        <ul data-testid="winning-hands">
+          {winningResults.map((result) => (
+            <li
+              key={result.seatId}
+              data-testid={`winning-hand-${String(result.seatId)}`}
+            >
+              Seat {result.seatId + 1}: {result.description}
+              <div data-testid={`winning-cards-${String(result.seatId)}`}>
+                {result.holeCards.map((card, i) => (
+                  <Card key={i} rank={card.rank} suit={card.suit} />
+                ))}
+              </div>
+            </li>
+          ))}
+        </ul>
       </div>
     );
   }
@@ -47,11 +72,6 @@ export function Hand({ view }: HandProps) {
         ) : (
           <span data-testid="no-hole-cards">Folded</span>
         )}
-      </div>
-      <div data-testid="community-cards">
-        {view.board.map((card, i) => (
-          <Card key={i} rank={card.rank} suit={card.suit} />
-        ))}
       </div>
     </div>
   );

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -10,7 +10,7 @@ export interface HandProps {
  * `view` — nothing rebuilt from the raw event locally
  * (docs/phase-1-spec.md §9). Hidden again once folded, a burn-pile per §4:
  * `yourHoleCards` is already `null` in that view, this never redacts.
- * No action buttons yet — that's ticket 12.
+ * Action buttons live in `ActionBar`, rendered alongside this by `App`.
  */
 export function Hand({ view }: HandProps) {
   if (view.phase === "no-hand") {

--- a/packages/player-client/src/actions/legalActionsFromView.test.ts
+++ b/packages/player-client/src/actions/legalActionsFromView.test.ts
@@ -1,0 +1,29 @@
+import type { PlayerView } from "@table-top-poker/protocol";
+import { describe, expect, it } from "vitest";
+import { legalActionsFromView } from "./legalActionsFromView.js";
+
+describe("legalActionsFromView", () => {
+  it("is empty before any hand has started", () => {
+    const view: PlayerView = { phase: "no-hand", button: 0 };
+    expect(legalActionsFromView(view)).toEqual([]);
+  });
+
+  it("is empty when there is no view yet", () => {
+    expect(legalActionsFromView(null)).toEqual([]);
+  });
+
+  it("mirrors the view's legalActions during betting", () => {
+    const view: PlayerView = {
+      phase: "betting",
+      button: 0,
+      street: "preflop",
+      board: [],
+      toAct: [0],
+      seats: [{ seatId: 0, folded: false }],
+      yourSeatId: 0,
+      yourHoleCards: null,
+      legalActions: ["fold", "check", "raise"],
+    };
+    expect(legalActionsFromView(view)).toEqual(["fold", "check", "raise"]);
+  });
+});

--- a/packages/player-client/src/actions/legalActionsFromView.ts
+++ b/packages/player-client/src/actions/legalActionsFromView.ts
@@ -1,0 +1,13 @@
+import type { ActionType, PlayerView } from "@table-top-poker/protocol";
+
+/**
+ * The engine already scopes `PlayerViewBetting.legalActions` to empty
+ * unless it's this seat's turn (engine/src/view.ts) — this just extends
+ * that to the non-betting phases and the pre-connection `null` view, so
+ * callers never branch on `view.phase` themselves.
+ */
+export function legalActionsFromView(
+  view: PlayerView | null,
+): readonly ActionType[] {
+  return view !== null && view.phase === "betting" ? view.legalActions : [];
+}

--- a/packages/player-client/src/actions/rejectionCopy.test.ts
+++ b/packages/player-client/src/actions/rejectionCopy.test.ts
@@ -1,0 +1,30 @@
+import type {
+  RejectionReason,
+  ServerRejectionReason,
+} from "@table-top-poker/protocol";
+import { describe, expect, it } from "vitest";
+import { rejectionCopy } from "./rejectionCopy.js";
+
+const ALL_REASONS: (RejectionReason | ServerRejectionReason)[] = [
+  "not-your-turn",
+  "action-not-legal",
+  "hand-not-in-progress",
+  "hand-already-in-progress",
+  "stale-next-hand",
+  "invalid-command",
+  "room-not-found",
+  "not-enough-players",
+  "not-permitted",
+];
+
+describe("rejectionCopy", () => {
+  it("returns distinct, non-empty copy for every reason code", () => {
+    const copy = ALL_REASONS.map(rejectionCopy);
+    expect(copy.every((text) => text.length > 0)).toBe(true);
+    expect(new Set(copy).size).toBe(ALL_REASONS.length);
+  });
+
+  it("names the sender's own turn for not-your-turn", () => {
+    expect(rejectionCopy("not-your-turn")).toMatch(/turn/i);
+  });
+});

--- a/packages/player-client/src/actions/rejectionCopy.ts
+++ b/packages/player-client/src/actions/rejectionCopy.ts
@@ -1,0 +1,37 @@
+import type {
+  RejectionReason,
+  ServerRejectionReason,
+} from "@table-top-poker/protocol";
+
+/**
+ * Display copy for an inline rejection, exhaustively switched
+ * (eslint's switch-exhaustiveness-check) so a new reason code added to
+ * either union is a build failure here, not a silent blank message.
+ * `hand-already-in-progress` and `stale-next-hand` can't actually reach an
+ * action button (they're `startHand`/`nextHand`-only reasons) but the type
+ * doesn't know that, so they get terse copy rather than a `default`.
+ */
+export function rejectionCopy(
+  reason: RejectionReason | ServerRejectionReason,
+): string {
+  switch (reason) {
+    case "not-your-turn":
+      return "It's not your turn yet.";
+    case "action-not-legal":
+      return "That action isn't available right now.";
+    case "hand-not-in-progress":
+      return "There's no hand in progress.";
+    case "hand-already-in-progress":
+      return "A hand is already in progress.";
+    case "stale-next-hand":
+      return "That hand has already moved on.";
+    case "invalid-command":
+      return "That didn't go through — try again.";
+    case "room-not-found":
+      return "This room no longer exists.";
+    case "not-enough-players":
+      return "Not enough players to start.";
+    case "not-permitted":
+      return "That's not something you can do.";
+  }
+}

--- a/packages/player-client/src/actions/useActionIntent.test.ts
+++ b/packages/player-client/src/actions/useActionIntent.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { canAct } from "./useActionIntent.js";
+
+describe("canAct", () => {
+  it("allows a legal action when nothing is pending", () => {
+    expect(canAct(["fold", "check", "raise"], null, "check")).toBe(true);
+  });
+
+  it("refuses an action that isn't currently legal", () => {
+    expect(canAct(["fold", "check", "raise"], null, "call")).toBe(false);
+  });
+
+  it("refuses any action while one is already pending, even a legal one", () => {
+    expect(canAct(["fold", "check", "raise"], "fold", "check")).toBe(false);
+  });
+});

--- a/packages/player-client/src/actions/useActionIntent.ts
+++ b/packages/player-client/src/actions/useActionIntent.ts
@@ -1,0 +1,61 @@
+import type { ActionType, ClientCommand } from "@table-top-poker/protocol";
+import { useCallback } from "react";
+import { usePlayerStore } from "../store/store.js";
+import type { ActionRejection } from "../store/actionSlice.js";
+import { legalActionsFromView } from "./legalActionsFromView.js";
+
+export interface ActionIntent {
+  readonly legalActions: readonly ActionType[];
+  readonly pendingAction: ActionType | null;
+  readonly rejection: ActionRejection | null;
+  readonly fold: () => void;
+  readonly check: () => void;
+  readonly call: () => void;
+  readonly raise: () => void;
+}
+
+/**
+ * The action-intent module (docs/phase-1-spec.md §9): `fold`/`check`/
+ * `call`/`raise`, plus `legalActions` derived from the latest view
+ * snapshot. Each function is a no-op unless the action is currently legal
+ * and nothing else is already pending — buttons are expected to disable
+ * themselves off this same state, this is the belt-and-braces guard.
+ */
+export function useActionIntent(
+  send: (command: ClientCommand) => void,
+): ActionIntent {
+  const handView = usePlayerStore((state) => state.handView);
+  const pendingAction = usePlayerStore((state) => state.pendingAction);
+  const rejection = usePlayerStore((state) => state.rejection);
+  const sendStarted = usePlayerStore((state) => state.sendStarted);
+
+  const legalActions = legalActionsFromView(handView);
+
+  const act = useCallback(
+    (action: ActionType) => {
+      if (pendingAction !== null) return;
+      if (!legalActions.includes(action)) return;
+      sendStarted(action);
+      send({ type: action });
+    },
+    [pendingAction, legalActions, sendStarted, send],
+  );
+
+  return {
+    legalActions,
+    pendingAction,
+    rejection,
+    fold: () => {
+      act("fold");
+    },
+    check: () => {
+      act("check");
+    },
+    call: () => {
+      act("call");
+    },
+    raise: () => {
+      act("raise");
+    },
+  };
+}

--- a/packages/player-client/src/actions/useActionIntent.ts
+++ b/packages/player-client/src/actions/useActionIntent.ts
@@ -15,11 +15,23 @@ export interface ActionIntent {
 }
 
 /**
+ * Whether `action` may be sent right now: it must be legal in the latest
+ * view and nothing else already in flight. Buttons are expected to disable
+ * themselves off this same state (`legalActions`/`pendingAction`) — this is
+ * the belt-and-braces guard against a stale click slipping through.
+ */
+export function canAct(
+  legalActions: readonly ActionType[],
+  pendingAction: ActionType | null,
+  action: ActionType,
+): boolean {
+  return pendingAction === null && legalActions.includes(action);
+}
+
+/**
  * The action-intent module (docs/phase-1-spec.md §9): `fold`/`check`/
  * `call`/`raise`, plus `legalActions` derived from the latest view
- * snapshot. Each function is a no-op unless the action is currently legal
- * and nothing else is already pending — buttons are expected to disable
- * themselves off this same state, this is the belt-and-braces guard.
+ * snapshot.
  */
 export function useActionIntent(
   send: (command: ClientCommand) => void,
@@ -33,8 +45,7 @@ export function useActionIntent(
 
   const act = useCallback(
     (action: ActionType) => {
-      if (pendingAction !== null) return;
-      if (!legalActions.includes(action)) return;
+      if (!canAct(legalActions, pendingAction, action)) return;
       sendStarted(action);
       send({ type: action });
     },

--- a/packages/player-client/src/store/actionSlice.ts
+++ b/packages/player-client/src/store/actionSlice.ts
@@ -1,0 +1,51 @@
+import type {
+  ActionType,
+  RejectionReason,
+  ServerRejectionReason,
+} from "@table-top-poker/protocol";
+import type { StateCreator } from "zustand";
+
+export interface ActionRejection {
+  /**
+   * The action `reason` was rejecting, or `null` if a `command-rejected`
+   * arrived with nothing pending — `command-rejected` carries no
+   * correlation id (docs/phase-1-spec.md §6), so this is a best-effort
+   * attribution, not a guarantee.
+   */
+  readonly action: ActionType | null;
+  readonly reason: RejectionReason | ServerRejectionReason;
+}
+
+export interface ActionSlice {
+  readonly pendingAction: ActionType | null;
+  readonly rejection: ActionRejection | null;
+  readonly sendStarted: (action: ActionType) => void;
+  readonly commandRejected: (
+    reason: RejectionReason | ServerRejectionReason,
+  ) => void;
+  readonly viewSnapshotReceived: () => void;
+}
+
+/**
+ * Tracks the one command a player may have in flight. `sendStarted` also
+ * clears any stale rejection, so pressing another button dismisses the old
+ * failure message even before a fresh view arrives — matching the "clears
+ * on the player's next legal action or next view snapshot" rule in
+ * docs/phase-1-spec.md §9.
+ */
+export const createActionSlice: StateCreator<ActionSlice> = (set) => ({
+  pendingAction: null,
+  rejection: null,
+  sendStarted: (action) => {
+    set({ pendingAction: action, rejection: null });
+  },
+  commandRejected: (reason) => {
+    set((state) => ({
+      pendingAction: null,
+      rejection: { action: state.pendingAction, reason },
+    }));
+  },
+  viewSnapshotReceived: () => {
+    set({ pendingAction: null, rejection: null });
+  },
+});

--- a/packages/player-client/src/store/store.test.ts
+++ b/packages/player-client/src/store/store.test.ts
@@ -67,4 +67,44 @@ describe("usePlayerStore", () => {
     expect(usePlayerStore.getState().roomCode).toBeNull();
     expect(usePlayerStore.getState().seats).toEqual([]);
   });
+
+  it("marks an action pending on send, with no rejection yet", () => {
+    usePlayerStore.getState().sendStarted("call");
+    expect(usePlayerStore.getState().pendingAction).toBe("call");
+    expect(usePlayerStore.getState().rejection).toBeNull();
+  });
+
+  it("clears pending and attributes the reason to it on reject", () => {
+    usePlayerStore.getState().sendStarted("raise");
+    usePlayerStore.getState().commandRejected("not-your-turn");
+    expect(usePlayerStore.getState().pendingAction).toBeNull();
+    expect(usePlayerStore.getState().rejection).toEqual({
+      action: "raise",
+      reason: "not-your-turn",
+    });
+  });
+
+  it("attributes a reject with nothing pending to no action", () => {
+    usePlayerStore.getState().commandRejected("invalid-command");
+    expect(usePlayerStore.getState().rejection).toEqual({
+      action: null,
+      reason: "invalid-command",
+    });
+  });
+
+  it("clears pending and any rejection on the next view snapshot", () => {
+    usePlayerStore.getState().sendStarted("fold");
+    usePlayerStore.getState().commandRejected("action-not-legal");
+    usePlayerStore.getState().viewSnapshotReceived();
+    expect(usePlayerStore.getState().pendingAction).toBeNull();
+    expect(usePlayerStore.getState().rejection).toBeNull();
+  });
+
+  it("dismisses a stale rejection as soon as another action is sent", () => {
+    usePlayerStore.getState().sendStarted("check");
+    usePlayerStore.getState().commandRejected("action-not-legal");
+    usePlayerStore.getState().sendStarted("fold");
+    expect(usePlayerStore.getState().rejection).toBeNull();
+    expect(usePlayerStore.getState().pendingAction).toBe("fold");
+  });
 });

--- a/packages/player-client/src/store/store.ts
+++ b/packages/player-client/src/store/store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { createActionSlice, type ActionSlice } from "./actionSlice.js";
 import {
   type ConnectionSlice,
   createConnectionSlice,
@@ -7,11 +8,13 @@ import { createHandSlice, type HandSlice } from "./handSlice.js";
 import { createRoomSlice, type RoomSlice } from "./roomSlice.js";
 import { createSeatSlice, type SeatSlice } from "./seatSlice.js";
 
-export type PlayerStore = ConnectionSlice & RoomSlice & SeatSlice & HandSlice;
+export type PlayerStore =
+  ConnectionSlice & RoomSlice & SeatSlice & HandSlice & ActionSlice;
 
 export const usePlayerStore = create<PlayerStore>()((...args) => ({
   ...createConnectionSlice(...args),
   ...createRoomSlice(...args),
   ...createSeatSlice(...args),
   ...createHandSlice(...args),
+  ...createActionSlice(...args),
 }));

--- a/packages/player-client/src/store/store.ts
+++ b/packages/player-client/src/store/store.ts
@@ -8,8 +8,11 @@ import { createHandSlice, type HandSlice } from "./handSlice.js";
 import { createRoomSlice, type RoomSlice } from "./roomSlice.js";
 import { createSeatSlice, type SeatSlice } from "./seatSlice.js";
 
-export type PlayerStore =
-  ConnectionSlice & RoomSlice & SeatSlice & HandSlice & ActionSlice;
+export type PlayerStore = ConnectionSlice &
+  RoomSlice &
+  SeatSlice &
+  HandSlice &
+  ActionSlice;
 
 export const usePlayerStore = create<PlayerStore>()((...args) => ({
   ...createConnectionSlice(...args),

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -1,5 +1,9 @@
-import type { PlayerView, ServerMessage } from "@table-top-poker/protocol";
-import { useEffect } from "react";
+import type {
+  ClientCommand,
+  PlayerView,
+  ServerMessage,
+} from "@table-top-poker/protocol";
+import { useCallback, useEffect, useRef } from "react";
 import { usePlayerStore } from "../store/store.js";
 import { getWebSocketUrl } from "./getWebSocketUrl.js";
 
@@ -9,22 +13,35 @@ export interface SeatConnectionParams {
   readonly token: string;
 }
 
+export interface SeatSocket {
+  /** No-ops silently while disconnected — buttons are gated on connection state upstream. */
+  readonly send: (command: ClientCommand) => void;
+}
+
 /**
  * Opens a seat-scoped WebSocket connection once a seat is claimed and
  * reflects its lifecycle into the connection slice. Every `room-view` push
  * replaces the seat list; every `hand-update` replaces the hand slice with
  * the fresh `view(state, seatId)` the server just computed for this seat —
  * the view is source of truth (docs/phase-1-spec.md §6), never rebuilt from
- * the raw event locally. No action-intent module yet (fold/check/call/raise
- * over this socket) — that's ticket 30. No reconnection logic yet — that's
- * ticket 33.
+ * the raw event locally. That same snapshot also clears any pending/
+ * rejected action, since the view is what "next legal action or next view
+ * snapshot" (§9) resolves against. `command-rejected` is delivered to the
+ * sender only, so it's always this player's own action being rejected — it
+ * feeds the action slice's rejection, never a broadcast. No reconnection
+ * logic yet — that's ticket 33.
  */
-export function useWebSocket(params: SeatConnectionParams | null): void {
+export function useWebSocket(params: SeatConnectionParams | null): SeatSocket {
   const setConnectionStatus = usePlayerStore(
     (state) => state.setConnectionStatus,
   );
   const setRoomView = usePlayerStore((state) => state.setRoomView);
   const setHandView = usePlayerStore((state) => state.setHandView);
+  const viewSnapshotReceived = usePlayerStore(
+    (state) => state.viewSnapshotReceived,
+  );
+  const commandRejected = usePlayerStore((state) => state.commandRejected);
+  const socketRef = useRef<WebSocket | null>(null);
 
   useEffect(() => {
     if (params === null) {
@@ -41,6 +58,7 @@ export function useWebSocket(params: SeatConnectionParams | null): void {
         token: params.token,
       }),
     );
+    socketRef.current = socket;
 
     socket.addEventListener("open", () => {
       if (active) setConnectionStatus("connected");
@@ -56,12 +74,29 @@ export function useWebSocket(params: SeatConnectionParams | null): void {
       } else if (message.type === "hand-update") {
         // The server only ever sends a seat's socket its own `view(state, seatId)`.
         setHandView(message.view as PlayerView);
+        viewSnapshotReceived();
+      } else {
+        commandRejected(message.reason);
       }
     });
 
     return () => {
       active = false;
+      socketRef.current = null;
       socket.close();
     };
-  }, [params, setConnectionStatus, setRoomView, setHandView]);
+  }, [
+    params,
+    setConnectionStatus,
+    setRoomView,
+    setHandView,
+    viewSnapshotReceived,
+    commandRejected,
+  ]);
+
+  const send = useCallback((command: ClientCommand) => {
+    socketRef.current?.send(JSON.stringify(command));
+  }, []);
+
+  return { send };
 }

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -14,7 +14,7 @@ export interface SeatConnectionParams {
 }
 
 export interface SeatSocket {
-  /** No-ops silently while disconnected — buttons are gated on connection state upstream. */
+  /** No-ops silently unless the socket is open — calling `WebSocket.send` before then throws. */
   readonly send: (command: ClientCommand) => void;
 }
 
@@ -69,14 +69,18 @@ export function useWebSocket(params: SeatConnectionParams | null): SeatSocket {
     socket.addEventListener("message", (event: MessageEvent<string>) => {
       if (!active) return;
       const message: ServerMessage = JSON.parse(event.data) as ServerMessage;
-      if (message.type === "room-view") {
-        setRoomView(message.view);
-      } else if (message.type === "hand-update") {
-        // The server only ever sends a seat's socket its own `view(state, seatId)`.
-        setHandView(message.view as PlayerView);
-        viewSnapshotReceived();
-      } else {
-        commandRejected(message.reason);
+      switch (message.type) {
+        case "room-view":
+          setRoomView(message.view);
+          break;
+        case "hand-update":
+          // The server only ever sends a seat's socket its own `view(state, seatId)`.
+          setHandView(message.view as PlayerView);
+          viewSnapshotReceived();
+          break;
+        case "command-rejected":
+          commandRejected(message.reason);
+          break;
       }
     });
 
@@ -95,7 +99,8 @@ export function useWebSocket(params: SeatConnectionParams | null): SeatSocket {
   ]);
 
   const send = useCallback((command: ClientCommand) => {
-    socketRef.current?.send(JSON.stringify(command));
+    if (socketRef.current?.readyState !== WebSocket.OPEN) return;
+    socketRef.current.send(JSON.stringify(command));
   }, []);
 
   return { send };

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -543,4 +543,158 @@ describe("hand command dispatch over WebSocket", () => {
     });
     expect(rooms.get(room.code)?.engine).toBeNull();
   });
+
+  it("plays a full betting round preflop through river, every action type exercised, over the wire", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const seat0 = await claimAndConnect(room.code, 0);
+    const seat1 = await claimAndConnect(room.code, 1);
+    const seat2 = await claimAndConnect(room.code, 2);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    // button = seat 0, ring = [1, 2, 0], BB = seat 2 (see rooms.ts/room.ts).
+    // Preflop: SB calls, BB raises — forcing seat 0 and seat 1 to act again
+    // (street closure waits for every live player since the raise, not just
+    // one lap), both call, street closes.
+    seat1.socket.send(JSON.stringify({ type: "call" }));
+    await settle();
+    seat2.socket.send(JSON.stringify({ type: "raise" }));
+    await settle();
+    seat0.socket.send(JSON.stringify({ type: "call" }));
+    await settle();
+    seat1.socket.send(JSON.stringify({ type: "call" }));
+    await settle();
+
+    // Flop: everyone checks.
+    seat1.socket.send(JSON.stringify({ type: "check" }));
+    await settle();
+    seat2.socket.send(JSON.stringify({ type: "check" }));
+    await settle();
+    seat0.socket.send(JSON.stringify({ type: "check" }));
+    await settle();
+
+    // Turn: seat 0 folds instead of its final check — two live players
+    // remain, so the hand keeps going rather than folding out.
+    seat1.socket.send(JSON.stringify({ type: "check" }));
+    await settle();
+    seat2.socket.send(JSON.stringify({ type: "check" }));
+    await settle();
+    seat0.socket.send(JSON.stringify({ type: "fold" }));
+    await settle();
+
+    // River: the two remaining live seats check down to showdown.
+    seat1.socket.send(JSON.stringify({ type: "check" }));
+    await settle();
+    seat2.socket.send(JSON.stringify({ type: "check" }));
+    await settle();
+
+    const events = table.messages
+      .filter((m) => m.type === "hand-update")
+      .map((m) => m.event);
+
+    const actionsSeen = new Set(
+      events.filter((e) => e.type === "ActionTaken").map((e) => e.action),
+    );
+    expect(actionsSeen).toEqual(new Set(["call", "raise", "check", "fold"]));
+
+    const streetsStarted = new Set(
+      events.filter((e) => e.type === "StreetStarted").map((e) => e.street),
+    );
+    expect(streetsStarted).toEqual(
+      new Set(["preflop", "flop", "turn", "river"]),
+    );
+
+    expect(events.some((e) => e.type === "ShowdownReached")).toBe(true);
+    expect(events.some((e) => e.type === "HandFoldedOut")).toBe(false);
+    expect(events.filter((e) => e.type === "HandComplete")).toHaveLength(1);
+
+    for (const conn of [table, seat0, seat1, seat2]) {
+      expect(conn.messages.some((m) => m.type === "command-rejected")).toBe(
+        false,
+      );
+    }
+  });
+
+  it("rejects an out-of-turn action, visible only to the sender", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const seat0 = await claimAndConnect(room.code, 0);
+    const seat1 = await claimAndConnect(room.code, 1);
+    await claimAndConnect(room.code, 2);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    // Preflop's first actor is seat 1 (SB), not seat 0.
+    seat0.socket.send(JSON.stringify({ type: "check" }));
+    await settle();
+
+    expect(seat0.messages).toContainEqual({
+      type: "command-rejected",
+      reason: "not-your-turn",
+    });
+    expect(seat1.messages).not.toContainEqual(
+      expect.objectContaining({ type: "command-rejected" }),
+    );
+    expect(table.messages).not.toContainEqual(
+      expect.objectContaining({ type: "command-rejected" }),
+    );
+  });
+
+  it("rejects an illegal action, visible only to the sender and never on the table device", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const seat0 = await claimAndConnect(room.code, 0);
+    const seat1 = await claimAndConnect(room.code, 1);
+    const seat2 = await claimAndConnect(room.code, 2);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    // Seat 1 (SB) faces the BB's post and can't check.
+    seat1.socket.send(JSON.stringify({ type: "check" }));
+    await settle();
+
+    expect(seat1.messages).toContainEqual({
+      type: "command-rejected",
+      reason: "action-not-legal",
+    });
+    expect(seat0.messages).not.toContainEqual(
+      expect.objectContaining({ type: "command-rejected" }),
+    );
+    expect(seat2.messages).not.toContainEqual(
+      expect.objectContaining({ type: "command-rejected" }),
+    );
+    expect(table.messages).not.toContainEqual(
+      expect.objectContaining({ type: "command-rejected" }),
+    );
+  });
+
+  it("rejects an action before any hand has started, sender-only", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const seat0 = await claimAndConnect(room.code, 0);
+    await claimAndConnect(room.code, 1);
+    await settle();
+
+    seat0.socket.send(JSON.stringify({ type: "check" }));
+    await settle();
+
+    expect(seat0.messages).toContainEqual({
+      type: "command-rejected",
+      reason: "hand-not-in-progress",
+    });
+    expect(table.messages).not.toContainEqual(
+      expect.objectContaining({ type: "command-rejected" }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Engine: `legalActions(hand, actorSeat)` in `table.ts` becomes the single source of truth for action legality — `decide`'s `isLegal` now delegates to it, and it's exposed on `PlayerViewBetting.legalActions` (empty unless it's that seat's turn).
- player-client: an action-intent module (`useActionIntent`: `fold()/check()/call()/raise()` + derived `legalActions`), an `ActionBar` component as the permanent button layer, and an action slice tracking one in-flight command as `pending` until ack (next view snapshot) or reject lands. A reject renders inline on the triggering button via an exhaustively-switched reason-to-copy map and clears on the next legal action or view snapshot.
- `useWebSocket` now returns `send` and forwards `command-rejected` into the store; table-client is untouched — it already drops that message type by construction.
- server: added WS-level test coverage for the action-command paths, including a full preflop-through-river round exercising fold/check/call/raise and street closure across a mid-street raise, and sender-only rejection for `not-your-turn`/`action-not-legal`/`hand-not-in-progress`.

Closes #30.

## Test plan
- [x] `npx vitest run` (full workspace) passes
- [x] `npx tsc --build tsconfig.json` clean
- [x] `npx eslint .` and `npx prettier --check .` clean
- [x] `/code-review` run (Standards + Spec axes); findings addressed in the last commit