### PR TITLE
feat(table): render showdown best hands and add Next hand button

### DIFF
--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { createRoom, endSession } from "./api/rooms.js";
 import { Board } from "./Board.js";
+import { isHandComplete } from "./handComplete.js";
 import { RoomPanel } from "./RoomPanel.js";
 import { StatusBar } from "./StatusBar.js";
 import { useTableStore } from "./store/store.js";
@@ -39,8 +40,13 @@ export function App() {
     send({ type: "startHand" });
   }, [send]);
 
+  const handleNextHand = useCallback(() => {
+    send({ type: "nextHand" });
+  }, [send]);
+
   const claimedSeatCount = seats.filter((seat) => seat.claimed).length;
   const canStartHand = handView === null && claimedSeatCount >= 2;
+  const handComplete = isHandComplete(handView);
 
   return (
     <div className="app-shell" data-testid="table-client-shell">
@@ -70,6 +76,15 @@ export function App() {
                 onClick={handleStartHand}
               >
                 Start hand
+              </button>
+            )}
+            {handComplete && (
+              <button
+                type="button"
+                data-testid="next-hand-button"
+                onClick={handleNextHand}
+              >
+                Next hand
               </button>
             )}
             {handView !== null && <Board view={handView} seats={seats} />}

--- a/packages/table-client/src/Board.test.tsx
+++ b/packages/table-client/src/Board.test.tsx
@@ -75,4 +75,69 @@ describe("Board", () => {
     expect(html).toMatch(/data-testid="board"[^>]*data-phase="folded-out"/);
     expect(html).not.toContain('data-testid="showdown-results"');
   });
+
+  it("renders every live seat's rank and best five cards at showdown, split-aware", () => {
+    const view: TableView = {
+      phase: "showdown",
+      button: 0,
+      board: [
+        { rank: "A", suit: "spades" },
+        { rank: "K", suit: "hearts" },
+        { rank: "2", suit: "clubs" },
+        { rank: "7", suit: "diamonds" },
+        { rank: "9", suit: "clubs" },
+      ],
+      winners: [0, 1],
+      results: [
+        {
+          seatId: 0,
+          rank: 1,
+          description: "Pair of Aces",
+          holeCards: [
+            { rank: "A", suit: "clubs" },
+            { rank: "3", suit: "hearts" },
+          ],
+          bestHand: [
+            { rank: "A", suit: "spades" },
+            { rank: "A", suit: "clubs" },
+            { rank: "K", suit: "hearts" },
+            { rank: "9", suit: "clubs" },
+            { rank: "7", suit: "diamonds" },
+          ],
+        },
+        {
+          seatId: 1,
+          rank: 1,
+          description: "Pair of Aces",
+          holeCards: [
+            { rank: "A", suit: "diamonds" },
+            { rank: "4", suit: "hearts" },
+          ],
+          bestHand: [
+            { rank: "A", suit: "spades" },
+            { rank: "A", suit: "diamonds" },
+            { rank: "K", suit: "hearts" },
+            { rank: "9", suit: "clubs" },
+            { rank: "7", suit: "diamonds" },
+          ],
+        },
+      ],
+    };
+    const html = renderToStaticMarkup(<Board view={view} seats={seats} />);
+
+    expect(html).toMatch(/data-testid="board"[^>]*data-phase="showdown"/);
+    expect(html).toContain('data-testid="winners"');
+    expect(html).toContain("Winners: seats 1, 2");
+    expect(html).toMatch(
+      /data-testid="result-0"[^>]*>Seat 1: Pair of Aces/,
+    );
+    expect(html).toMatch(
+      /data-testid="result-1"[^>]*>Seat 2: Pair of Aces/,
+    );
+    expect((html.match(/data-testid="best-hand-0"/g) ?? []).length).toBe(1);
+    expect((html.match(/data-testid="best-hand-1"/g) ?? []).length).toBe(1);
+    // Each best-hand block shows the full five-card hand, not just the two hole cards.
+    const result0 = html.match(/data-testid="result-0"[\s\S]*?<\/li>/)?.[0] ?? "";
+    expect((result0.match(/data-face-down="false"/g) ?? []).length).toBe(5);
+  });
 });

--- a/packages/table-client/src/Board.test.tsx
+++ b/packages/table-client/src/Board.test.tsx
@@ -128,16 +128,13 @@ describe("Board", () => {
     expect(html).toMatch(/data-testid="board"[^>]*data-phase="showdown"/);
     expect(html).toContain('data-testid="winners"');
     expect(html).toContain("Winners: seats 1, 2");
-    expect(html).toMatch(
-      /data-testid="result-0"[^>]*>Seat 1: Pair of Aces/,
-    );
-    expect(html).toMatch(
-      /data-testid="result-1"[^>]*>Seat 2: Pair of Aces/,
-    );
+    expect(html).toMatch(/data-testid="result-0"[^>]*>Seat 1: Pair of Aces/);
+    expect(html).toMatch(/data-testid="result-1"[^>]*>Seat 2: Pair of Aces/);
     expect((html.match(/data-testid="best-hand-0"/g) ?? []).length).toBe(1);
     expect((html.match(/data-testid="best-hand-1"/g) ?? []).length).toBe(1);
     // Each best-hand block shows the full five-card hand, not just the two hole cards.
-    const result0 = html.match(/data-testid="result-0"[\s\S]*?<\/li>/)?.[0] ?? "";
+    const result0 =
+      /data-testid="result-0"[\s\S]*?<\/li>/.exec(html)?.[0] ?? "";
     expect((result0.match(/data-face-down="false"/g) ?? []).length).toBe(5);
   });
 });

--- a/packages/table-client/src/Board.tsx
+++ b/packages/table-client/src/Board.tsx
@@ -59,9 +59,11 @@ export function Board({ view, seats }: BoardProps) {
               data-testid={`result-${String(result.seatId)}`}
             >
               Seat {result.seatId + 1}: {result.description}
-              {result.holeCards.map((card, i) => (
-                <Card key={i} rank={card.rank} suit={card.suit} />
-              ))}
+              <div data-testid={`best-hand-${String(result.seatId)}`}>
+                {result.bestHand.map((card, i) => (
+                  <Card key={i} rank={card.rank} suit={card.suit} />
+                ))}
+              </div>
             </li>
           ))}
         </ul>

--- a/packages/table-client/src/handComplete.test.ts
+++ b/packages/table-client/src/handComplete.test.ts
@@ -1,0 +1,42 @@
+import type { TableView } from "@table-top-poker/protocol";
+import { describe, expect, it } from "vitest";
+import { isHandComplete } from "./handComplete.js";
+
+describe("isHandComplete", () => {
+  it("is false before any hand has started", () => {
+    const view: TableView = { phase: "no-hand", button: 0 };
+    expect(isHandComplete(view)).toBe(false);
+  });
+
+  it("is false while a hand is being played", () => {
+    const view: TableView = {
+      phase: "betting",
+      button: 0,
+      street: "preflop",
+      board: [],
+      toAct: [0],
+      seats: [],
+    };
+    expect(isHandComplete(view)).toBe(false);
+  });
+
+  it("is false when no hand view exists yet", () => {
+    expect(isHandComplete(null)).toBe(false);
+  });
+
+  it("is true on a fold-out completion", () => {
+    const view: TableView = { phase: "folded-out", button: 0, winner: 1 };
+    expect(isHandComplete(view)).toBe(true);
+  });
+
+  it("is true on a showdown completion", () => {
+    const view: TableView = {
+      phase: "showdown",
+      button: 0,
+      board: [],
+      winners: [0],
+      results: [],
+    };
+    expect(isHandComplete(view)).toBe(true);
+  });
+});

--- a/packages/table-client/src/handComplete.ts
+++ b/packages/table-client/src/handComplete.ts
@@ -6,5 +6,7 @@ import type { TableView } from "@table-top-poker/protocol";
  * §2. Both are the cue for the table device's "Next hand" button.
  */
 export function isHandComplete(view: TableView | null): boolean {
-  return view !== null && (view.phase === "folded-out" || view.phase === "showdown");
+  return (
+    view !== null && (view.phase === "folded-out" || view.phase === "showdown")
+  );
 }

--- a/packages/table-client/src/handComplete.ts
+++ b/packages/table-client/src/handComplete.ts
@@ -1,0 +1,10 @@
+import type { TableView } from "@table-top-poker/protocol";
+
+/**
+ * HAND_COMPLETE is reached by either terminal `TableView` shape — a
+ * fold-out (no reveal) or a showdown (full reveal) — docs/phase-1-spec.md
+ * §2. Both are the cue for the table device's "Next hand" button.
+ */
+export function isHandComplete(view: TableView | null): boolean {
+  return view !== null && (view.phase === "folded-out" || view.phase === "showdown");
+}


### PR DESCRIPTION
## Summary
- Table device now renders each live seat's full five-card best hand (not just their two hole cards) at showdown, satisfying issue #31's "rank and best five cards" acceptance criterion.
- Adds the "Next hand" button to `table-client`, gated on `HAND_COMPLETE` (fold-out or showdown) via a new pure `isHandComplete` helper; pressing it sends the existing `nextHand` wire command.
- Server-side seed generation and engine-side button rotation were already implemented — this closes the remaining table-client UI gap.

Closes #31

## Test plan
- [x] `npm test` — full monorepo suite, 260/260 passing
- [x] New unit tests: `Board.test.tsx` (showdown split-aware best-hand rendering), `handComplete.test.ts` (button-visibility gating)
- [x] `npm run build` — clean typecheck across all packages
- [x] `/code-review` — Standards and Spec axes both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)