### PR TITLE
feat(server): action clock + auto-fold

### DIFF
--- a/packages/server/src/action-clock.test.ts
+++ b/packages/server/src/action-clock.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+import { ActionClock } from "./action-clock.js";
+
+describe("ActionClock", () => {
+  it("fires the timeout callback after the configured duration", () => {
+    const setTimeoutFn = vi.fn(setTimeout);
+    const clearTimeoutFn = vi.fn(clearTimeout);
+    const clock = new ActionClock(90_000, setTimeoutFn, clearTimeoutFn);
+    const onTimeout = vi.fn();
+
+    clock.schedule("ROOM", onTimeout);
+
+    expect(setTimeoutFn).toHaveBeenCalledWith(expect.any(Function), 90_000);
+  });
+
+  it("clears a room's prior timer when scheduling a new one", () => {
+    const handles: unknown[] = [];
+    const setTimeoutFn = vi.fn((fn: () => void, ms: number) => {
+      const handle = setTimeout(fn, ms);
+      handles.push(handle);
+      return handle;
+    });
+    const clearTimeoutFn = vi.fn(clearTimeout);
+    const clock = new ActionClock(90_000, setTimeoutFn, clearTimeoutFn);
+
+    clock.schedule("ROOM", vi.fn());
+    clock.schedule("ROOM", vi.fn());
+
+    expect(clearTimeoutFn).toHaveBeenCalledWith(handles[0]);
+    expect(clearTimeoutFn).not.toHaveBeenCalledWith(handles[1]);
+  });
+
+  it("keeps separate rooms' timers independent", () => {
+    const setTimeoutFn = vi.fn(setTimeout);
+    const clearTimeoutFn = vi.fn(clearTimeout);
+    const clock = new ActionClock(90_000, setTimeoutFn, clearTimeoutFn);
+
+    clock.schedule("ROOM-A", vi.fn());
+    clock.schedule("ROOM-B", vi.fn());
+
+    expect(clearTimeoutFn).not.toHaveBeenCalled();
+  });
+
+  it("clear() cancels a scheduled timer", () => {
+    const handles: unknown[] = [];
+    const setTimeoutFn = vi.fn((fn: () => void, ms: number) => {
+      const handle = setTimeout(fn, ms);
+      handles.push(handle);
+      return handle;
+    });
+    const clearTimeoutFn = vi.fn(clearTimeout);
+    const clock = new ActionClock(90_000, setTimeoutFn, clearTimeoutFn);
+
+    clock.schedule("ROOM", vi.fn());
+    clock.clear("ROOM");
+
+    expect(clearTimeoutFn).toHaveBeenCalledWith(handles[0]);
+  });
+
+  it("clear() on a room with no timer is a no-op", () => {
+    const clearTimeoutFn = vi.fn(clearTimeout);
+    const clock = new ActionClock(90_000, setTimeout, clearTimeoutFn);
+
+    expect(() => {
+      clock.clear("ROOM");
+    }).not.toThrow();
+    expect(clearTimeoutFn).not.toHaveBeenCalled();
+  });
+
+  it("actually invokes the callback once real time elapses", async () => {
+    const clock = new ActionClock(10);
+    const onTimeout = vi.fn();
+
+    clock.schedule("ROOM", onTimeout);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+
+  it("a cleared timer never fires", async () => {
+    const clock = new ActionClock(10);
+    const onTimeout = vi.fn();
+
+    clock.schedule("ROOM", onTimeout);
+    clock.clear("ROOM");
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/action-clock.ts
+++ b/packages/server/src/action-clock.ts
@@ -1,0 +1,39 @@
+const DEFAULT_TIMEOUT_MS = 90_000;
+
+/**
+ * Per-room "you have N ms to act" timer, fully decoupled from WebSocket
+ * connection state — see docs/phase-1-spec.md §7 (folding stays strictly
+ * clock-driven). Scheduling and clearing functions are injectable so tests
+ * can run this at real-but-tiny durations instead of faking global timers.
+ */
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+export class ActionClock {
+  readonly #timeoutMs: number;
+  readonly #setTimeoutFn: (fn: () => void, ms: number) => TimerHandle;
+  readonly #clearTimeoutFn: (handle: TimerHandle) => void;
+  readonly #timers = new Map<string, TimerHandle>();
+
+  constructor(
+    timeoutMs: number = DEFAULT_TIMEOUT_MS,
+    setTimeoutFn: (fn: () => void, ms: number) => TimerHandle = setTimeout,
+    clearTimeoutFn: (handle: TimerHandle) => void = clearTimeout,
+  ) {
+    this.#timeoutMs = timeoutMs;
+    this.#setTimeoutFn = setTimeoutFn;
+    this.#clearTimeoutFn = clearTimeoutFn;
+  }
+
+  /** Replaces any timer already running for `key` with a fresh one. */
+  schedule(key: string, onTimeout: () => void): void {
+    this.clear(key);
+    this.#timers.set(key, this.#setTimeoutFn(onTimeout, this.#timeoutMs));
+  }
+
+  clear(key: string): void {
+    const handle = this.#timers.get(key);
+    if (handle === undefined) return;
+    this.#clearTimeoutFn(handle);
+    this.#timers.delete(key);
+  }
+}

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -698,3 +698,184 @@ describe("hand command dispatch over WebSocket", () => {
     );
   });
 });
+
+describe("action clock", () => {
+  const ACTION_CLOCK_MS = 200;
+  let app: FastifyInstance;
+  let rooms: RoomStore;
+  let port: number;
+
+  beforeEach(async () => {
+    rooms = new RoomStore();
+    app = await buildApp({ rooms, actionClockMs: ACTION_CLOCK_MS });
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected a bound TCP address");
+    }
+    port = address.port;
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  function connect(query: string): {
+    socket: WebSocket;
+    messages: ServerMessage[];
+  } {
+    const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/ws?${query}`);
+    const messages: ServerMessage[] = [];
+    socket.on("message", (data: Buffer) => {
+      messages.push(JSON.parse(data.toString()) as ServerMessage);
+    });
+    return { socket, messages };
+  }
+
+  async function opened(socket: WebSocket): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      socket.on("open", resolve);
+      socket.on("error", reject);
+    });
+  }
+
+  async function settle(ms = 10): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  async function claimAndConnect(
+    code: string,
+    seatId: number,
+  ): Promise<{ socket: WebSocket; messages: ServerMessage[] }> {
+    const claim = rooms.claimSeat(code, seatId);
+    if (!("seat" in claim)) throw new Error("expected a claimed seat");
+    const conn = connect(
+      `room=${code}&seat=${String(seatId)}&token=${claim.seat.token ?? ""}`,
+    );
+    await opened(conn.socket);
+    return conn;
+  }
+
+  function actionsSeen(messages: ServerMessage[]) {
+    return messages
+      .filter((m) => m.type === "hand-update")
+      .map((m) => m.event)
+      .filter((e) => e.type === "ActionTaken");
+  }
+
+  it("auto-folds the current actor via a synthesized fold once the clock elapses", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    await claimAndConnect(room.code, 0);
+    await claimAndConnect(room.code, 1);
+    await claimAndConnect(room.code, 2);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    // Preflop's first actor is seat 1 (SB) — takes no action at all.
+    await settle(ACTION_CLOCK_MS + 60);
+
+    const folds = actionsSeen(table.messages).filter(
+      (e) => e.action === "fold",
+    );
+    expect(folds).toEqual([
+      expect.objectContaining({ type: "ActionTaken", seatId: 1, action: "fold" }),
+    ]);
+  });
+
+  it("does not auto-fold a seat that acts before the clock elapses", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const seat0 = await claimAndConnect(room.code, 0);
+    const seat1 = await claimAndConnect(room.code, 1);
+    await claimAndConnect(room.code, 2);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    seat1.socket.send(JSON.stringify({ type: "call" }));
+    await settle(ACTION_CLOCK_MS - 50);
+
+    const folds = actionsSeen(table.messages).filter(
+      (e) => e.action === "fold",
+    );
+    expect(folds).toHaveLength(0);
+    for (const conn of [table, seat0, seat1]) {
+      expect(conn.messages.some((m) => m.type === "command-rejected")).toBe(
+        false,
+      );
+    }
+  });
+
+  it("resets the clock onto the new actor after a real action, rather than firing against the old one", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    await claimAndConnect(room.code, 0);
+    const seat1 = await claimAndConnect(room.code, 1);
+    await claimAndConnect(room.code, 2);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    // Seat 1 (SB) acts immediately; seat 2 (BB) then sits idle and should
+    // be the one auto-folded, not seat 1.
+    seat1.socket.send(JSON.stringify({ type: "call" }));
+    await settle(ACTION_CLOCK_MS + 60);
+
+    const folds = actionsSeen(table.messages).filter(
+      (e) => e.action === "fold",
+    );
+    expect(folds).toEqual([
+      expect.objectContaining({ type: "ActionTaken", seatId: 2, action: "fold" }),
+    ]);
+  });
+
+  it("resets the clock onto the new street's first actor after a street transition", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const seat0 = await claimAndConnect(room.code, 0);
+    const seat1 = await claimAndConnect(room.code, 1);
+    const seat2 = await claimAndConnect(room.code, 2);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    // Preflop, no raise: every seat (button included) still owes a decision.
+    seat1.socket.send(JSON.stringify({ type: "call" }));
+    await settle();
+    seat2.socket.send(JSON.stringify({ type: "check" }));
+    await settle();
+    // The button never posted a blind, so it must call the BB's amount
+    // rather than check.
+    seat0.socket.send(JSON.stringify({ type: "call" }));
+    await settle();
+    // No raise occurred, so the BB gets its one-time option before the
+    // street actually closes.
+    seat2.socket.send(JSON.stringify({ type: "check" }));
+    await settle();
+    // Preflop closes; the flop's first actor (seat 1, SB) now idles out.
+    await settle(ACTION_CLOCK_MS + 60);
+
+    const streetsStarted = table.messages
+      .filter((m) => m.type === "hand-update")
+      .map((m) => m.event)
+      .filter((e) => e.type === "StreetStarted");
+    expect(streetsStarted.some((e) => e.street === "flop")).toBe(true);
+
+    const folds = actionsSeen(table.messages).filter(
+      (e) => e.action === "fold",
+    );
+    expect(folds).toEqual([
+      expect.objectContaining({ type: "ActionTaken", seatId: 1, action: "fold" }),
+    ]);
+  });
+});

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -782,7 +782,11 @@ describe("action clock", () => {
       (e) => e.action === "fold",
     );
     expect(folds).toEqual([
-      expect.objectContaining({ type: "ActionTaken", seatId: 1, action: "fold" }),
+      expect.objectContaining({
+        type: "ActionTaken",
+        seatId: 1,
+        action: "fold",
+      }),
     ]);
   });
 
@@ -833,7 +837,11 @@ describe("action clock", () => {
       (e) => e.action === "fold",
     );
     expect(folds).toEqual([
-      expect.objectContaining({ type: "ActionTaken", seatId: 2, action: "fold" }),
+      expect.objectContaining({
+        type: "ActionTaken",
+        seatId: 2,
+        action: "fold",
+      }),
     ]);
   });
 
@@ -875,7 +883,11 @@ describe("action clock", () => {
       (e) => e.action === "fold",
     );
     expect(folds).toEqual([
-      expect.objectContaining({ type: "ActionTaken", seatId: 1, action: "fold" }),
+      expect.objectContaining({
+        type: "ActionTaken",
+        seatId: 1,
+        action: "fold",
+      }),
     ]);
   });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -12,6 +12,7 @@ import Fastify, { type FastifyInstance, type FastifyReply } from "fastify";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { WebSocket } from "ws";
+import { ActionClock } from "./action-clock.js";
 import { joinUrl, roomQrCodeDataUrl } from "./qr.js";
 import {
   type ClaimSeatError,
@@ -28,6 +29,8 @@ const publicIndexPath = fileURLToPath(
 
 export interface BuildAppOptions {
   readonly rooms?: RoomStore;
+  /** Overridable for tests only; production runs `ActionClock`'s 90s default. */
+  readonly actionClockMs?: number;
 }
 
 interface RoomCodeRoute {
@@ -100,6 +103,7 @@ export async function buildApp(
   const rooms = options.rooms ?? new RoomStore();
   const roomSockets = new Map<string, Set<WebSocket>>();
   const socketIdentity = new Map<WebSocket, SeatId | "table">();
+  const actionClock = new ActionClock(options.actionClockMs);
   const app = Fastify();
 
   function send(socket: WebSocket, message: ServerMessage): void {
@@ -155,6 +159,35 @@ export async function buildApp(
     }
   }
 
+  /**
+   * Re-arms the room's action clock against whoever is now on the clock —
+   * called after every command a room accepts, real or synthesized, so the
+   * clock always reflects the live actor. A disconnected socket plays no
+   * part here; only `dispatch` outcomes move this clock, per
+   * docs/phase-1-spec.md §7.
+   */
+  function rescheduleActionClock(code: string): void {
+    const actor = rooms.currentActor(code);
+    if (actor === undefined) {
+      actionClock.clear(code);
+      return;
+    }
+    actionClock.schedule(code, () => {
+      const result = rooms.dispatch(code, actor, "fold");
+      // `actor` was read as the live current actor at schedule time, and
+      // any real action in between would have rescheduled (and thus
+      // replaced) this very timer — so `dispatch` rejecting the
+      // synthesized fold isn't expected to happen. `for` runs zero times
+      // if it somehow does, and the clock still re-arms below.
+      if ("steps" in result) {
+        for (const step of result.steps) {
+          fanOutHandUpdate(code, step);
+        }
+      }
+      rescheduleActionClock(code);
+    });
+  }
+
   await app.register(fastifyStatic, { root: publicDir });
   await app.register(fastifyWebsocket);
 
@@ -182,6 +215,7 @@ export async function buildApp(
   app.post<RoomCodeRoute>("/rooms/:code/end", (request, reply) => {
     const room = findRoomOrReject(rooms, request.params.code, reply);
     if (!room) return;
+    actionClock.clear(room.code);
     rooms.end(room.code);
     return reply.code(204).send();
   });
@@ -328,6 +362,7 @@ export async function buildApp(
           for (const step of dispatchResult.steps) {
             fanOutHandUpdate(code, step);
           }
+          rescheduleActionClock(code);
           if (parseResult.data.type === "startHand") {
             broadcastRoomView(code);
           }

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -276,6 +276,52 @@ describe("RoomStore", () => {
       });
     });
   });
+
+  describe("currentActor", () => {
+    function roomWithClaimedSeats(store: RoomStore, count: number) {
+      const room = store.create();
+      for (let seatId = 0; seatId < count; seatId++) {
+        store.claimSeat(room.code, seatId);
+      }
+      return room;
+    }
+
+    it("is undefined for an unknown room", () => {
+      const store = new RoomStore();
+      expect(store.currentActor("ZZZZ")).toBeUndefined();
+    });
+
+    it("is undefined before any hand has started", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, 2);
+      expect(store.currentActor(room.code)).toBeUndefined();
+    });
+
+    it("is the seat named by the hand's own StreetStarted event", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, 2);
+      const started = store.dispatch(room.code, "table", "startHand");
+      if (!("steps" in started)) throw new Error("expected dispatch steps");
+      const streetStarted = started.steps.at(-1)?.event;
+      if (streetStarted?.type !== "StreetStarted") {
+        throw new Error("expected StreetStarted");
+      }
+
+      expect(store.currentActor(room.code)).toBe(streetStarted.actor);
+    });
+
+    it("advances to the next actor after a legal action", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, 2);
+      store.dispatch(room.code, "table", "startHand");
+      const actor = store.currentActor(room.code);
+      if (actor === undefined) throw new Error("expected a current actor");
+
+      store.dispatch(room.code, actor, "call");
+
+      expect(store.currentActor(room.code)).not.toBe(actor);
+    });
+  });
 });
 
 describe("toRoomView", () => {

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -107,6 +107,13 @@ export class RoomStore {
     return this.#rooms.get(code);
   }
 
+  /** The seat currently owed a decision in `code`'s hand, or undefined between/after hands. */
+  currentActor(code: string): SeatId | undefined {
+    const hand = this.#rooms.get(code)?.engine?.hand;
+    if (hand?.status !== "betting") return undefined;
+    return hand.toAct[0];
+  }
+
   end(code: string): void {
     this.#rooms.delete(code);
   }


### PR DESCRIPTION
## Summary
- Adds a per-room `ActionClock`: a 90s timer arms against whoever's `toAct[0]` is current, re-arms on every accepted command (real or synthesized), and clears on room end.
- On timeout, synthesizes a plain `{ type: 'fold', playerId }` through `RoomStore.dispatch` — the same `decide`/`apply` path a manual fold takes, so no special-cased engine behavior.
- Fully decoupled from WebSocket/disconnect state, per docs/phase-1-spec.md §7 — a connected-but-idle player and a disconnected one behave identically until the clock fires.

Closes #32.

## Test plan
- [x] `ActionClock` unit tests (schedule/clear/replace semantics, real-timer firing)
- [x] `RoomStore.currentActor` unit tests
- [x] WS-level integration tests: fires at 90s (test clock), doesn't fire on an in-time action, resets onto the new actor after a real action, resets onto the new street's first actor after a transition
- [x] Full repo test suite (265 tests) + typecheck + lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUyuPFHBa62G5JQTm9FB1g