### PR TITLE
feat(server,table,player): presence badge, seat-token reconnect, grac…

### DIFF
--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -8,7 +8,11 @@ import { parseRoomCodeFromPath } from "./join/parseRoomCodeFromPath.js";
 import { SeatPanel } from "./SeatPanel.js";
 import { SeatPicker } from "./SeatPicker.js";
 import { StatusBar } from "./StatusBar.js";
-import { saveSeatToken } from "./storage/seatToken.js";
+import {
+  clearSeatToken,
+  loadSeatToken,
+  saveSeatToken,
+} from "./storage/seatToken.js";
 import { usePlayerStore } from "./store/store.js";
 import { useWebSocket } from "./ws/useWebSocket.js";
 
@@ -23,6 +27,8 @@ export function App() {
   const setRoomView = usePlayerStore((state) => state.setRoomView);
   const setJoinError = usePlayerStore((state) => state.setJoinError);
   const setSeat = usePlayerStore((state) => state.setSeat);
+  const clearSeat = usePlayerStore((state) => state.clearSeat);
+  const clearRoom = usePlayerStore((state) => state.clearRoom);
 
   const [defaultRoomCode, setDefaultRoomCode] = useState("");
   const [claimError, setClaimError] = useState<string | null>(null);
@@ -31,7 +37,38 @@ export function App() {
   useEffect(() => {
     const fromPath = parseRoomCodeFromPath(window.location.pathname);
     if (fromPath) setDefaultRoomCode(fromPath);
-  }, []);
+
+    // Silently reclaim a stored seat on mount (docs/phase-1-spec.md §7) — a
+    // cleared/absent token just falls through to the normal join flow.
+    const stored = loadSeatToken(window.localStorage);
+    if (stored === null) return;
+    joinRoom(stored.roomCode)
+      .then((view) => {
+        setRoomView(view);
+        const seat = view.seats.find((s) => s.id === stored.seatId);
+        setSeat({
+          seatId: stored.seatId,
+          sittingOut: seat?.sittingOut ?? false,
+        });
+        setSeatToken(stored.token);
+      })
+      .catch(() => {
+        clearSeatToken(window.localStorage);
+      });
+  }, [setRoomView, setSeat]);
+
+  const handleRejected = useCallback(() => {
+    clearSeatToken(window.localStorage);
+    setSeatToken(null);
+    clearSeat();
+  }, [clearSeat]);
+
+  const handleRoomEnded = useCallback(() => {
+    clearSeatToken(window.localStorage);
+    setSeatToken(null);
+    clearSeat();
+    clearRoom();
+  }, [clearSeat, clearRoom]);
 
   const wsParams = useMemo(() => {
     if (roomCode === null || seatId === null || seatToken === null) {
@@ -39,7 +76,10 @@ export function App() {
     }
     return { roomCode, seatId, token: seatToken };
   }, [roomCode, seatId, seatToken]);
-  const { send } = useWebSocket(wsParams);
+  const { send } = useWebSocket(wsParams, {
+    onRejected: handleRejected,
+    onRoomEnded: handleRoomEnded,
+  });
   const intent = useActionIntent(send);
 
   const handleJoin = useCallback(

--- a/packages/player-client/src/SeatPicker.test.tsx
+++ b/packages/player-client/src/SeatPicker.test.tsx
@@ -10,8 +10,8 @@ describe("SeatPicker", () => {
         error={null}
         onClaim={() => undefined}
         seats={[
-          { id: 0, claimed: false, sittingOut: false },
-          { id: 1, claimed: true, sittingOut: false },
+          { id: 0, claimed: false, sittingOut: false, disconnected: false },
+          { id: 1, claimed: true, sittingOut: false, disconnected: false },
         ]}
       />,
     );

--- a/packages/player-client/src/storage/seatToken.test.ts
+++ b/packages/player-client/src/storage/seatToken.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { saveSeatToken } from "./seatToken.js";
+import { clearSeatToken, loadSeatToken, saveSeatToken } from "./seatToken.js";
 
 function fakeStorage(setItem: (key: string, value: string) => void): Storage {
   const data = new Map<string, string>();
@@ -31,5 +31,46 @@ describe("saveSeatToken", () => {
       "ttp:seat-token",
       JSON.stringify({ roomCode: "ABCD", seatId: 3, token: "tok-1" }),
     );
+  });
+});
+
+describe("loadSeatToken", () => {
+  it("reads back a previously saved token", () => {
+    const storage = fakeStorage(() => undefined);
+    saveSeatToken(storage, { roomCode: "ABCD", seatId: 3, token: "tok-1" });
+
+    expect(loadSeatToken(storage)).toEqual({
+      roomCode: "ABCD",
+      seatId: 3,
+      token: "tok-1",
+    });
+  });
+
+  it("returns null when nothing is stored", () => {
+    const storage = fakeStorage(() => undefined);
+    expect(loadSeatToken(storage)).toBeNull();
+  });
+
+  it("returns null for malformed JSON rather than throwing", () => {
+    const storage = fakeStorage(() => undefined);
+    storage.setItem("ttp:seat-token", "not json");
+    expect(loadSeatToken(storage)).toBeNull();
+  });
+
+  it("returns null for well-formed JSON missing required fields", () => {
+    const storage = fakeStorage(() => undefined);
+    storage.setItem("ttp:seat-token", JSON.stringify({ roomCode: "ABCD" }));
+    expect(loadSeatToken(storage)).toBeNull();
+  });
+});
+
+describe("clearSeatToken", () => {
+  it("removes the stored token", () => {
+    const storage = fakeStorage(() => undefined);
+    saveSeatToken(storage, { roomCode: "ABCD", seatId: 3, token: "tok-1" });
+
+    clearSeatToken(storage);
+
+    expect(loadSeatToken(storage)).toBeNull();
   });
 });

--- a/packages/player-client/src/storage/seatToken.ts
+++ b/packages/player-client/src/storage/seatToken.ts
@@ -17,3 +17,39 @@ export function saveSeatToken(
 ): void {
   storage.setItem(KEY, JSON.stringify(seatToken));
 }
+
+/**
+ * Reads back a stored seat token for auto-reconnect on mount. Malformed or
+ * absent storage both read as "nothing to reclaim" — a cleared/corrupted
+ * localStorage must never fall back to any other seat (docs/phase-1-spec.md §7).
+ */
+export function loadSeatToken(storage: Storage): StoredSeatToken | null {
+  const raw = storage.getItem(KEY);
+  if (raw === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "roomCode" in parsed &&
+      "seatId" in parsed &&
+      "token" in parsed &&
+      typeof parsed.roomCode === "string" &&
+      typeof parsed.seatId === "number" &&
+      typeof parsed.token === "string"
+    ) {
+      return {
+        roomCode: parsed.roomCode,
+        seatId: parsed.seatId,
+        token: parsed.token,
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearSeatToken(storage: Storage): void {
+  storage.removeItem(KEY);
+}

--- a/packages/player-client/src/store/store.test.ts
+++ b/packages/player-client/src/store/store.test.ts
@@ -31,7 +31,7 @@ describe("usePlayerStore", () => {
   it("clears the seat slice independently of the room slice", () => {
     usePlayerStore.getState().setRoomView({
       code: "ABCD",
-      seats: [{ id: 0, claimed: true, sittingOut: false }],
+      seats: [{ id: 0, claimed: true, sittingOut: false, disconnected: false }],
     });
     usePlayerStore.getState().setSeat({ seatId: 0, sittingOut: false });
 
@@ -44,11 +44,11 @@ describe("usePlayerStore", () => {
   it("replaces the seat list from a room-view snapshot", () => {
     usePlayerStore.getState().setRoomView({
       code: "ABCD",
-      seats: [{ id: 0, claimed: true, sittingOut: false }],
+      seats: [{ id: 0, claimed: true, sittingOut: false, disconnected: false }],
     });
     expect(usePlayerStore.getState().roomCode).toBe("ABCD");
     expect(usePlayerStore.getState().seats).toEqual([
-      { id: 0, claimed: true, sittingOut: false },
+      { id: 0, claimed: true, sittingOut: false, disconnected: false },
     ]);
   });
 
@@ -61,7 +61,7 @@ describe("usePlayerStore", () => {
   it("clears the room slice back to its initial state", () => {
     usePlayerStore.getState().setRoomView({
       code: "ABCD",
-      seats: [{ id: 0, claimed: true, sittingOut: false }],
+      seats: [{ id: 0, claimed: true, sittingOut: false, disconnected: false }],
     });
     usePlayerStore.getState().clearRoom();
     expect(usePlayerStore.getState().roomCode).toBeNull();

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -13,25 +13,47 @@ export interface SeatConnectionParams {
   readonly token: string;
 }
 
+export interface UseWebSocketOptions {
+  /**
+   * The socket closed before ever opening — an upgrade-time rejection (a
+   * bad or stale seat token), not a network blip. Retrying would spin
+   * forever against a seat that's gone, so the caller drops back to the
+   * seat picker instead (docs/phase-1-spec.md §7 — a cleared token never
+   * auto-reclaims a seat).
+   */
+  readonly onRejected?: () => void;
+  /** The room ended — manual "End session" or the table's grace window elapsing. */
+  readonly onRoomEnded?: () => void;
+}
+
 export interface SeatSocket {
   /** No-ops silently unless the socket is open — calling `WebSocket.send` before then throws. */
   readonly send: (command: ClientCommand) => void;
 }
 
+const RETRY_DELAY_MS = 1500;
+
 /**
  * Opens a seat-scoped WebSocket connection once a seat is claimed and
  * reflects its lifecycle into the connection slice. Every `room-view` push
- * replaces the seat list; every `hand-update` replaces the hand slice with
- * the fresh `view(state, seatId)` the server just computed for this seat —
- * the view is source of truth (docs/phase-1-spec.md §6), never rebuilt from
- * the raw event locally. That same snapshot also clears any pending/
- * rejected action, since the view is what "next legal action or next view
- * snapshot" (§9) resolves against. `command-rejected` is delivered to the
- * sender only, so it's always this player's own action being rejected — it
- * feeds the action slice's rejection, never a broadcast. No reconnection
- * logic yet — that's ticket 33.
+ * replaces the seat list; every `hand-update`/`view-snapshot` replaces the
+ * hand slice with the fresh `view(state, seatId)` the server just computed
+ * for this seat — the view is source of truth (docs/phase-1-spec.md §6),
+ * never rebuilt from the raw event locally. That same snapshot also clears
+ * any pending/rejected action, since the view is what "next legal action or
+ * next view snapshot" (§9) resolves against. `command-rejected` is
+ * delivered to the sender only, so it's always this player's own action
+ * being rejected — it feeds the action slice's rejection, never a
+ * broadcast.
+ *
+ * A socket that closes after having opened retries after a fixed delay —
+ * a transient drop, not a rejection. One that closes without ever opening
+ * is treated as terminal and is not retried; see `onRejected`.
  */
-export function useWebSocket(params: SeatConnectionParams | null): SeatSocket {
+export function useWebSocket(
+  params: SeatConnectionParams | null,
+  options: UseWebSocketOptions = {},
+): SeatSocket {
   const setConnectionStatus = usePlayerStore(
     (state) => state.setConnectionStatus,
   );
@@ -42,6 +64,8 @@ export function useWebSocket(params: SeatConnectionParams | null): SeatSocket {
   );
   const commandRejected = usePlayerStore((state) => state.commandRejected);
   const socketRef = useRef<WebSocket | null>(null);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
 
   useEffect(() => {
     if (params === null) {
@@ -49,45 +73,69 @@ export function useWebSocket(params: SeatConnectionParams | null): SeatSocket {
       return;
     }
 
+    const seatParams = params;
     let active = true;
-    setConnectionStatus("connecting");
-    const socket = new WebSocket(
-      getWebSocketUrl(window.location, {
-        room: params.roomCode,
-        seat: String(params.seatId),
-        token: params.token,
-      }),
-    );
-    socketRef.current = socket;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
 
-    socket.addEventListener("open", () => {
-      if (active) setConnectionStatus("connected");
-    });
-    socket.addEventListener("close", () => {
-      if (active) setConnectionStatus("disconnected");
-    });
-    socket.addEventListener("message", (event: MessageEvent<string>) => {
+    function connect(): void {
       if (!active) return;
-      const message: ServerMessage = JSON.parse(event.data) as ServerMessage;
-      switch (message.type) {
-        case "room-view":
-          setRoomView(message.view);
-          break;
-        case "hand-update":
-          // The server only ever sends a seat's socket its own `view(state, seatId)`.
-          setHandView(message.view as PlayerView);
-          viewSnapshotReceived();
-          break;
-        case "command-rejected":
-          commandRejected(message.reason);
-          break;
-      }
-    });
+      setConnectionStatus("connecting");
+      let openedOnce = false;
+      const socket = new WebSocket(
+        getWebSocketUrl(window.location, {
+          room: seatParams.roomCode,
+          seat: String(seatParams.seatId),
+          token: seatParams.token,
+        }),
+      );
+      socketRef.current = socket;
+
+      socket.addEventListener("open", () => {
+        openedOnce = true;
+        if (active) setConnectionStatus("connected");
+      });
+      socket.addEventListener("close", () => {
+        if (!active) return;
+        setConnectionStatus("disconnected");
+        if (!openedOnce) {
+          optionsRef.current.onRejected?.();
+          return;
+        }
+        retryTimer = setTimeout(connect, RETRY_DELAY_MS);
+      });
+      socket.addEventListener("message", (event: MessageEvent<string>) => {
+        if (!active) return;
+        const message: ServerMessage = JSON.parse(event.data) as ServerMessage;
+        switch (message.type) {
+          case "room-view":
+            setRoomView(message.view);
+            break;
+          case "hand-update":
+            // The server only ever sends a seat's socket its own `view(state, seatId)`.
+            setHandView(message.view as PlayerView);
+            viewSnapshotReceived();
+            break;
+          case "view-snapshot":
+            setHandView(message.view as PlayerView);
+            viewSnapshotReceived();
+            break;
+          case "command-rejected":
+            commandRejected(message.reason);
+            break;
+          case "room-ended":
+            optionsRef.current.onRoomEnded?.();
+            break;
+        }
+      });
+    }
+
+    connect();
 
     return () => {
       active = false;
+      if (retryTimer !== undefined) clearTimeout(retryTimer);
+      socketRef.current?.close();
       socketRef.current = null;
-      socket.close();
     };
   }, [
     params,

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -1,4 +1,4 @@
-import type { SeatId } from "@table-top-poker/engine";
+import type { PlayerView, SeatId, TableView } from "@table-top-poker/engine";
 import type { CommandRejectedMessage, HandUpdateMessage } from "./hand.js";
 
 /** A seat's public state — never carries its claim token. */
@@ -6,6 +6,8 @@ export interface SeatView {
   readonly id: SeatId;
   readonly claimed: boolean;
   readonly sittingOut: boolean;
+  /** Presence-only badge (ticket 33 §7) — never affects folding or legal actions. */
+  readonly disconnected: boolean;
 }
 
 export interface RoomView {
@@ -19,5 +21,28 @@ export interface RoomViewMessage {
   readonly view: RoomView;
 }
 
+/**
+ * Pushed once, right after a socket opens (fresh join or reconnect), when a
+ * hand is already in progress — a snapshot only, never replayed events
+ * (docs/phase-1-spec.md §7, §9).
+ */
+export interface ViewSnapshotMessage {
+  readonly type: "view-snapshot";
+  readonly view: PlayerView | TableView;
+}
+
+/**
+ * Pushed to every socket in a room when it ends — manual "End session" or
+ * the table device's own 60s reconnect grace window elapsing (§7). Both
+ * paths discard in-memory state the same way.
+ */
+export interface RoomEndedMessage {
+  readonly type: "room-ended";
+}
+
 export type ServerMessage =
-  RoomViewMessage | HandUpdateMessage | CommandRejectedMessage;
+  | RoomViewMessage
+  | HandUpdateMessage
+  | CommandRejectedMessage
+  | ViewSnapshotMessage
+  | RoomEndedMessage;

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -895,6 +895,7 @@ describe("action clock", () => {
 });
 
 describe("presence and reconnection", () => {
+  const ACTION_CLOCK_MS = 200;
   let app: FastifyInstance;
   let rooms: RoomStore;
   let port: number;
@@ -906,6 +907,7 @@ describe("presence and reconnection", () => {
       pingIntervalMs: 15,
       missedPongLimit: 2,
       graceWindowMs: 60,
+      actionClockMs: ACTION_CLOCK_MS,
     });
     await app.listen({ port: 0, host: "127.0.0.1" });
     const address = app.server.address();
@@ -1068,17 +1070,14 @@ describe("presence and reconnection", () => {
     seat0.socket.close();
     await settle();
 
-    // Whoever's turn it is folds — standing in for ticket 14's auto-fold
-    // clock, which this ticket doesn't implement; the reconnect behavior
-    // this test proves (fold-cause-agnostic, per view()'s burn-pile logic)
-    // is identical either way.
+    // Whoever's turn it is gets auto-folded by ticket 14's action clock.
     const engine = rooms.get(room.code)?.engine;
     if (engine?.hand?.status !== "betting") {
       throw new Error("expected a betting hand in progress");
     }
     const toAct = engine.hand.toAct[0];
     if (toAct === undefined) throw new Error("expected an actor");
-    rooms.dispatch(room.code, toAct, "fold");
+    await settle(ACTION_CLOCK_MS + 60);
 
     const reconnected = connect(`room=${room.code}&seat=0&token=${token0}`);
     await opened(reconnected.socket);

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -27,6 +27,7 @@ function unclaimedSeats(): RoomView["seats"] {
     id,
     claimed: false,
     sittingOut: false,
+    disconnected: false,
   }));
 }
 
@@ -346,6 +347,7 @@ describe("WebSocket upgrade", () => {
       id: 0,
       claimed: true,
       sittingOut: false,
+      disconnected: false,
     });
 
     socket.close();
@@ -889,5 +891,268 @@ describe("action clock", () => {
         action: "fold",
       }),
     ]);
+  });
+});
+
+describe("presence and reconnection", () => {
+  let app: FastifyInstance;
+  let rooms: RoomStore;
+  let port: number;
+
+  beforeEach(async () => {
+    rooms = new RoomStore();
+    app = await buildApp({
+      rooms,
+      pingIntervalMs: 15,
+      missedPongLimit: 2,
+      graceWindowMs: 60,
+    });
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected a bound TCP address");
+    }
+    port = address.port;
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  function connect(
+    query: string,
+    wsOptions?: WebSocket.ClientOptions,
+  ): { socket: WebSocket; messages: ServerMessage[] } {
+    const socket = new WebSocket(
+      `ws://127.0.0.1:${String(port)}/ws?${query}`,
+      wsOptions,
+    );
+    const messages: ServerMessage[] = [];
+    socket.on("message", (data: Buffer) => {
+      messages.push(JSON.parse(data.toString()) as ServerMessage);
+    });
+    return { socket, messages };
+  }
+
+  async function opened(socket: WebSocket): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+      socket.on("open", resolve);
+      socket.on("error", reject);
+    });
+  }
+
+  async function settle(ms = 20): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function seatDisconnected(
+    messages: ServerMessage[],
+    seatId: number,
+  ): boolean | undefined {
+    const roomViews = messages.filter(
+      (m): m is Extract<ServerMessage, { type: "room-view" }> =>
+        m.type === "room-view",
+    );
+    const last = roomViews.at(-1);
+    return last?.view.seats.find((s) => s.id === seatId)?.disconnected;
+  }
+
+  it("marks a seat disconnected after 2 missed pongs, cosmetic only", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+
+    const claim = rooms.claimSeat(room.code, 0);
+    if (!("seat" in claim)) throw new Error("expected a claimed seat");
+    const seat0 = connect(
+      `room=${room.code}&seat=0&token=${claim.seat.token ?? ""}`,
+      { autoPong: false },
+    );
+    await opened(seat0.socket);
+
+    // Two ping intervals elapse with no pong reply.
+    await settle(50);
+
+    expect(seatDisconnected(table.messages, 0)).toBe(true);
+    // A presence-only badge never causes a rejection or a fold.
+    expect(rooms.get(room.code)?.seats[0]?.claimed).toBe(true);
+  });
+
+  it("reconnecting with the correct seat token clears the badge and resumes silently", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+
+    const claim = rooms.claimSeat(room.code, 0);
+    if (!("seat" in claim)) throw new Error("expected a claimed seat");
+    const token = claim.seat.token ?? "";
+    const seat0 = connect(`room=${room.code}&seat=0&token=${token}`);
+    await opened(seat0.socket);
+    await settle();
+
+    seat0.socket.close();
+    await settle();
+    expect(rooms.get(room.code)?.seats[0]?.disconnected).toBe(true);
+
+    const reconnected = connect(`room=${room.code}&seat=0&token=${token}`);
+    await opened(reconnected.socket);
+    await settle();
+
+    expect(rooms.get(room.code)?.seats[0]?.disconnected).toBe(false);
+    expect(seatDisconnected(table.messages, 0)).toBe(false);
+  });
+
+  it("delivers a fresh view-snapshot (not event replay) on reconnect mid-hand", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const claim0 = rooms.claimSeat(room.code, 0);
+    const claim1 = rooms.claimSeat(room.code, 1);
+    if (!("seat" in claim0) || !("seat" in claim1)) {
+      throw new Error("expected claimed seats");
+    }
+    const token0 = claim0.seat.token ?? "";
+    const seat0 = connect(`room=${room.code}&seat=0&token=${token0}`);
+    const seat1 = connect(
+      `room=${room.code}&seat=1&token=${claim1.seat.token ?? ""}`,
+    );
+    await opened(seat0.socket);
+    await opened(seat1.socket);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    seat0.socket.close();
+    await settle();
+
+    const reconnected = connect(`room=${room.code}&seat=0&token=${token0}`);
+    await opened(reconnected.socket);
+    await settle();
+
+    const snapshot = reconnected.messages.find(
+      (m) => m.type === "view-snapshot",
+    );
+    expect(snapshot).toBeDefined();
+    expect(reconnected.messages.some((m) => m.type === "hand-update")).toBe(
+      false,
+    );
+  });
+
+  it("lands a reconnecting seat in a folded seat after it folded while away", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const claim0 = rooms.claimSeat(room.code, 0);
+    const claim1 = rooms.claimSeat(room.code, 1);
+    const claim2 = rooms.claimSeat(room.code, 2);
+    if (!("seat" in claim0) || !("seat" in claim1) || !("seat" in claim2)) {
+      throw new Error("expected claimed seats");
+    }
+    const token0 = claim0.seat.token ?? "";
+    const seat0 = connect(`room=${room.code}&seat=0&token=${token0}`);
+    const seat1 = connect(
+      `room=${room.code}&seat=1&token=${claim1.seat.token ?? ""}`,
+    );
+    const seat2 = connect(
+      `room=${room.code}&seat=2&token=${claim2.seat.token ?? ""}`,
+    );
+    await opened(seat0.socket);
+    await opened(seat1.socket);
+    await opened(seat2.socket);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    seat0.socket.close();
+    await settle();
+
+    // Whoever's turn it is folds — standing in for ticket 14's auto-fold
+    // clock, which this ticket doesn't implement; the reconnect behavior
+    // this test proves (fold-cause-agnostic, per view()'s burn-pile logic)
+    // is identical either way.
+    const engine = rooms.get(room.code)?.engine;
+    if (engine?.hand?.status !== "betting") {
+      throw new Error("expected a betting hand in progress");
+    }
+    const toAct = engine.hand.toAct[0];
+    if (toAct === undefined) throw new Error("expected an actor");
+    rooms.dispatch(room.code, toAct, "fold");
+
+    const reconnected = connect(`room=${room.code}&seat=0&token=${token0}`);
+    await opened(reconnected.socket);
+    await settle();
+
+    const snapshot = reconnected.messages.find(
+      (m) => m.type === "view-snapshot",
+    );
+    if (snapshot?.type !== "view-snapshot") {
+      throw new Error("expected a view-snapshot");
+    }
+    const view = snapshot.view;
+    if (!("yourSeatId" in view) || toAct !== 0) {
+      // Only assert the burn-pile shape when seat 0 was the one who folded;
+      // otherwise it just resumes normally, covered by the prior test.
+      return;
+    }
+    expect(view.yourHoleCards).toBeNull();
+  });
+
+  it("rejects a WS connect with a stale token after the seat is cleared", async () => {
+    const room = rooms.create();
+    const claim = rooms.claimSeat(room.code, 0);
+    if (!("seat" in claim)) throw new Error("expected a claimed seat");
+    const token = claim.seat.token ?? "";
+    rooms.clearSeat(room.code, 0);
+
+    const socket = new WebSocket(
+      `ws://127.0.0.1:${String(port)}/ws?room=${room.code}&seat=0&token=${token}`,
+    );
+    const closeCode = await new Promise<number>((resolve) => {
+      socket.on("unexpected-response", (_req, res) => {
+        resolve(res.statusCode ?? 0);
+      });
+    });
+    expect(closeCode).toBe(403);
+  });
+
+  it("ends the room, notifies every socket, and discards in-memory state when the table's grace window elapses", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const claim = rooms.claimSeat(room.code, 0);
+    if (!("seat" in claim)) throw new Error("expected a claimed seat");
+    const seat0 = connect(
+      `room=${room.code}&seat=0&token=${claim.seat.token ?? ""}`,
+    );
+    await opened(seat0.socket);
+    await settle();
+
+    table.socket.close();
+    await settle(120);
+
+    expect(seat0.messages).toContainEqual({ type: "room-ended" });
+    expect(rooms.get(room.code)).toBeUndefined();
+    expect(seat0.socket.readyState).not.toBe(WebSocket.OPEN);
+  });
+
+  it("cancels the grace window when the table reconnects in time", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    await settle();
+
+    table.socket.close();
+    await settle(20);
+
+    const reconnectedTable = connect(`room=${room.code}&role=table`);
+    await opened(reconnectedTable.socket);
+    await settle(120);
+
+    expect(rooms.get(room.code)).toBeDefined();
+    expect(reconnectedTable.messages).not.toContainEqual({
+      type: "room-ended",
+    });
   });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -31,6 +31,12 @@ export interface BuildAppOptions {
   readonly rooms?: RoomStore;
   /** Overridable for tests only; production runs `ActionClock`'s 90s default. */
   readonly actionClockMs?: number;
+  /** How often the server pings every open socket (docs/phase-1-spec.md §7). */
+  readonly pingIntervalMs?: number;
+  /** Missed pongs before a seat's badge flips to "disconnected". */
+  readonly missedPongLimit?: number;
+  /** How long the table device's own socket may stay down before the room ends. */
+  readonly graceWindowMs?: number;
 }
 
 interface RoomCodeRoute {
@@ -101,9 +107,16 @@ export async function buildApp(
   options: BuildAppOptions = {},
 ): Promise<FastifyInstance> {
   const rooms = options.rooms ?? new RoomStore();
+  const pingIntervalMs = options.pingIntervalMs ?? 10_000;
+  const missedPongLimit = options.missedPongLimit ?? 2;
+  const graceWindowMs = options.graceWindowMs ?? 60_000;
   const roomSockets = new Map<string, Set<WebSocket>>();
   const socketIdentity = new Map<WebSocket, SeatId | "table">();
   const actionClock = new ActionClock(options.actionClockMs);
+  const socketRoomCode = new Map<WebSocket, string>();
+  const pingMissed = new Map<WebSocket, number>();
+  /** One timer per room, armed the moment its table-role socket closes. */
+  const tableGraceTimers = new Map<string, NodeJS.Timeout>();
   const app = Fastify();
 
   function send(socket: WebSocket, message: ServerMessage): void {
@@ -129,6 +142,66 @@ export async function buildApp(
       send(socket, message);
     }
   }
+
+  /** Cosmetic presence toggle for a seat's socket — never touches `rooms.dispatch`. */
+  function markPresence(socket: WebSocket, disconnected: boolean): void {
+    const identity = socketIdentity.get(socket);
+    const code = socketRoomCode.get(socket);
+    if (identity === undefined || identity === "table" || code === undefined) {
+      return;
+    }
+    rooms.setSeatDisconnected(code, identity, disconnected);
+    broadcastRoomView(code);
+  }
+
+  /**
+   * Ends a room the same way whether triggered by "End session" or the
+   * table device's own reconnect grace window elapsing (docs/phase-1-spec.md
+   * §7): notify every socket, close them, discard the transport bookkeeping,
+   * then discard the room itself. Hand logs on disk are untouched — this
+   * only ever touches in-memory state.
+   */
+  function endRoom(code: string): void {
+    const sockets = roomSockets.get(code);
+    if (sockets) {
+      for (const socket of sockets) {
+        send(socket, { type: "room-ended" });
+        socket.close();
+        socketIdentity.delete(socket);
+        socketRoomCode.delete(socket);
+        pingMissed.delete(socket);
+      }
+      roomSockets.delete(code);
+    }
+    const timer = tableGraceTimers.get(code);
+    if (timer) {
+      clearTimeout(timer);
+      tableGraceTimers.delete(code);
+    }
+    actionClock.clear(code);
+    rooms.end(code);
+  }
+
+  const pingTimer = setInterval(() => {
+    for (const socket of pingMissed.keys()) {
+      const missed = (pingMissed.get(socket) ?? 0) + 1;
+      pingMissed.set(socket, missed);
+      if (missed === missedPongLimit) {
+        markPresence(socket, true);
+      }
+      try {
+        socket.ping();
+      } catch {
+        // Socket is already on its way down; its 'close' handler cleans up.
+      }
+    }
+  }, pingIntervalMs);
+
+  app.addHook("onClose", (_instance, done) => {
+    clearInterval(pingTimer);
+    for (const timer of tableGraceTimers.values()) clearTimeout(timer);
+    done();
+  });
 
   /**
    * Fans one event out to every socket in the room, per-recipient: the
@@ -215,8 +288,7 @@ export async function buildApp(
   app.post<RoomCodeRoute>("/rooms/:code/end", (request, reply) => {
     const room = findRoomOrReject(rooms, request.params.code, reply);
     if (!room) return;
-    actionClock.clear(room.code);
-    rooms.end(room.code);
+    endRoom(room.code);
     return reply.code(204).send();
   });
 
@@ -317,6 +389,8 @@ export async function buildApp(
           identity = seatId;
         }
         socketIdentity.set(socket, identity);
+        socketRoomCode.set(socket, code);
+        pingMissed.set(socket, 0);
 
         let sockets = roomSockets.get(code);
         if (!sockets) {
@@ -325,10 +399,44 @@ export async function buildApp(
         }
         sockets.add(socket);
 
+        if (identity === "table") {
+          const timer = tableGraceTimers.get(code);
+          if (timer) {
+            clearTimeout(timer);
+            tableGraceTimers.delete(code);
+          }
+        } else {
+          // A reconnecting seat resumes silently, no penalty (§7) — clear
+          // any presence badge a prior drop had set.
+          rooms.setSeatDisconnected(code, identity, false);
+        }
+
         const room = rooms.get(code);
         if (room) {
-          send(socket, { type: "room-view", view: toRoomView(room) });
+          broadcastRoomView(code);
+          // One fresh snapshot on connect, never event replay (§7, §9).
+          if (room.engine !== null) {
+            if (identity === "table") {
+              send(socket, {
+                type: "view-snapshot",
+                view: view(room.engine, "table"),
+              });
+            } else if (room.engine.seats.includes(identity)) {
+              send(socket, {
+                type: "view-snapshot",
+                view: view(room.engine, identity),
+              });
+            }
+          }
         }
+
+        socket.on("pong", () => {
+          const missed = pingMissed.get(socket) ?? 0;
+          pingMissed.set(socket, 0);
+          if (missed >= missedPongLimit) {
+            markPresence(socket, false);
+          }
+        });
 
         socket.on("message", (data: Buffer) => {
           let parsed: unknown;
@@ -371,6 +479,26 @@ export async function buildApp(
         socket.on("close", () => {
           sockets.delete(socket);
           socketIdentity.delete(socket);
+          socketRoomCode.delete(socket);
+          pingMissed.delete(socket);
+
+          if (identity === "table") {
+            // Room may already be gone (this close came from `endRoom` itself
+            // closing every socket) — only arm a fresh grace window for a
+            // room that's still live.
+            if (rooms.get(code) && !tableGraceTimers.has(code)) {
+              tableGraceTimers.set(
+                code,
+                setTimeout(() => {
+                  tableGraceTimers.delete(code);
+                  endRoom(code);
+                }, graceWindowMs),
+              );
+            }
+          } else {
+            rooms.setSeatDisconnected(code, identity, true);
+            broadcastRoomView(code);
+          }
         });
       },
     );

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -64,13 +64,20 @@ describe("RoomStore", () => {
       const result = store.claimSeat(room.code, 0);
 
       expect(result).toEqual({
-        seat: { id: 0, claimed: true, token: "token-0", sittingOut: false },
+        seat: {
+          id: 0,
+          claimed: true,
+          token: "token-0",
+          sittingOut: false,
+          disconnected: false,
+        },
       });
       expect(room.seats[0]).toEqual({
         id: 0,
         claimed: true,
         token: "token-0",
         sittingOut: false,
+        disconnected: false,
       });
     });
 
@@ -130,6 +137,7 @@ describe("RoomStore", () => {
         claimed: false,
         token: null,
         sittingOut: false,
+        disconnected: false,
       });
       const reclaimed = store.claimSeat(room.code, 0);
       if (!("seat" in reclaimed)) throw new Error("expected a claimed seat");
@@ -335,11 +343,12 @@ describe("toRoomView", () => {
     expect(view).toEqual({
       code: room.code,
       seats: [
-        { id: 0, claimed: true, sittingOut: false },
+        { id: 0, claimed: true, sittingOut: false, disconnected: false },
         ...Array.from({ length: SEAT_COUNT - 1 }, (_, i) => ({
           id: i + 1,
           claimed: false,
           sittingOut: false,
+          disconnected: false,
         })),
       ],
     });

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -27,6 +27,8 @@ export interface Seat {
   claimed: boolean;
   token: string | null;
   sittingOut: boolean;
+  /** Cosmetic presence badge only (ticket 33) — never consulted by `dispatch`/`decide`. */
+  disconnected: boolean;
 }
 
 export interface Room {
@@ -65,6 +67,7 @@ function makeSeats(): Seat[] {
     claimed: false,
     token: null,
     sittingOut: false,
+    disconnected: false,
   }));
 }
 
@@ -129,10 +132,11 @@ export class RoomStore {
     seat.claimed = true;
     seat.token = this.#generateToken();
     seat.sittingOut = isHandInProgress(room);
+    seat.disconnected = false;
     return { seat };
   }
 
-  /** Force-clears a claimed seat. Stand-in for real disconnect handling (ticket 33). */
+  /** Force-clears a claimed seat — used by the manual "clear seat" admin action. */
   clearSeat(code: string, seatId: SeatId): void {
     const room = this.#rooms.get(code);
     const seat = room?.seats[seatId];
@@ -141,6 +145,23 @@ export class RoomStore {
     seat.claimed = false;
     seat.token = null;
     seat.sittingOut = false;
+    seat.disconnected = false;
+  }
+
+  /**
+   * Presence-only badge toggle (ticket 33 §7): missed pongs or a socket
+   * closing flip it on, a reconnect or fresh pong flips it off. Purely
+   * cosmetic — never read by `dispatch`, so it can never cause a fold.
+   */
+  setSeatDisconnected(
+    code: string,
+    seatId: SeatId,
+    disconnected: boolean,
+  ): void {
+    const room = this.#rooms.get(code);
+    const seat = room?.seats[seatId];
+    if (!seat) return;
+    seat.disconnected = disconnected;
   }
 
   /**
@@ -219,6 +240,7 @@ export function toRoomView(room: Room): RoomView {
       id: seat.id,
       claimed: seat.claimed,
       sittingOut: seat.sittingOut,
+      disconnected: seat.disconnected,
     })),
   };
 }

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -17,7 +17,9 @@ export function App() {
   const setRoomCreated = useTableStore((state) => state.setRoomCreated);
   const clearRoom = useTableStore((state) => state.clearRoom);
 
-  const { send } = useWebSocket(roomCode);
+  const { send } = useWebSocket(roomCode, {
+    onRoomEnded: clearRoom,
+  });
 
   const handleCreateRoom = useCallback(() => {
     createRoom()

--- a/packages/table-client/src/Board.test.tsx
+++ b/packages/table-client/src/Board.test.tsx
@@ -5,10 +5,10 @@ import { describe, expect, it } from "vitest";
 import { Board } from "./Board.js";
 
 const seats: SeatView[] = [
-  { id: 0, claimed: true, sittingOut: false },
-  { id: 1, claimed: true, sittingOut: false },
-  { id: 2, claimed: true, sittingOut: true },
-  { id: 3, claimed: false, sittingOut: false },
+  { id: 0, claimed: true, sittingOut: false, disconnected: false },
+  { id: 1, claimed: true, sittingOut: false, disconnected: false },
+  { id: 2, claimed: true, sittingOut: true, disconnected: false },
+  { id: 3, claimed: false, sittingOut: false, disconnected: false },
 ];
 
 describe("Board", () => {
@@ -67,6 +67,32 @@ describe("Board", () => {
       <Board view={view} seats={seats.slice(0, 2)} />,
     );
     expect(html).toMatch(/data-testid="board-seat-1"[^>]*data-status="folded"/);
+  });
+
+  it("shows a disconnected badge for a presence-dropped seat", () => {
+    const view: TableView = {
+      phase: "betting",
+      button: 0,
+      street: "preflop",
+      board: [],
+      toAct: [0],
+      seats: [
+        { seatId: 0, folded: false },
+        { seatId: 1, folded: false },
+      ],
+    };
+    const disconnectedSeats: SeatView[] = [
+      { id: 0, claimed: true, sittingOut: false, disconnected: false },
+      { id: 1, claimed: true, sittingOut: false, disconnected: true },
+    ];
+    const html = renderToStaticMarkup(
+      <Board view={view} seats={disconnectedSeats} />,
+    );
+    expect(html).toMatch(
+      /data-testid="board-seat-1"[^>]*data-disconnected="true"/,
+    );
+    expect(html).toContain('data-testid="board-seat-1-disconnected"');
+    expect(html).not.toContain('data-testid="board-seat-0-disconnected"');
   });
 
   it("renders a fold-out completion with no reveal", () => {

--- a/packages/table-client/src/Board.tsx
+++ b/packages/table-client/src/Board.tsx
@@ -92,10 +92,19 @@ export function Board({ view, seats }: BoardProps) {
               data-status={status}
               data-button={isButton}
               data-turn={isActor}
+              data-disconnected={seat.disconnected}
             >
               Seat {seat.id + 1} — {status}
               {isButton ? " (button)" : ""}
               {isActor ? " (to act)" : ""}
+              {seat.disconnected && (
+                <span
+                  data-testid={`board-seat-${String(seat.id)}-disconnected`}
+                >
+                  {" "}
+                  — disconnected
+                </span>
+              )}
             </li>
           );
         })}

--- a/packages/table-client/src/RoomPanel.test.tsx
+++ b/packages/table-client/src/RoomPanel.test.tsx
@@ -11,9 +11,9 @@ describe("RoomPanel", () => {
         joinUrl="http://localhost:3000/join/ABCD"
         qrCodeDataUrl="data:image/png;base64,xyz"
         seats={[
-          { id: 0, claimed: true, sittingOut: false },
-          { id: 1, claimed: true, sittingOut: true },
-          { id: 2, claimed: false, sittingOut: false },
+          { id: 0, claimed: true, sittingOut: false, disconnected: false },
+          { id: 1, claimed: true, sittingOut: true, disconnected: false },
+          { id: 2, claimed: false, sittingOut: false, disconnected: false },
         ]}
         onEndSession={() => {
           /* unused in this test */
@@ -27,6 +27,26 @@ describe("RoomPanel", () => {
     expect(html).toMatch(/data-testid="seat-0"[^>]*data-claimed="true"/);
     expect(html).toMatch(/data-testid="seat-1"[^>]*data-sitting-out="true"/);
     expect(html).toMatch(/data-testid="seat-2"[^>]*data-claimed="false"/);
+  });
+
+  it("shows a disconnected badge only for a claimed, presence-dropped seat", () => {
+    const html = renderToStaticMarkup(
+      <RoomPanel
+        roomCode="ABCD"
+        joinUrl="http://localhost:3000/join/ABCD"
+        qrCodeDataUrl="data:image/png;base64,xyz"
+        seats={[
+          { id: 0, claimed: true, sittingOut: false, disconnected: true },
+          { id: 1, claimed: false, sittingOut: false, disconnected: false },
+        ]}
+        onEndSession={() => {
+          /* unused in this test */
+        }}
+      />,
+    );
+
+    expect(html).toMatch(/data-testid="seat-0"[^>]*data-disconnected="true"/);
+    expect(html).toContain('data-testid="seat-0-disconnected"');
   });
 
   it("omits the QR image when none is available", () => {

--- a/packages/table-client/src/RoomPanel.tsx
+++ b/packages/table-client/src/RoomPanel.tsx
@@ -32,6 +32,7 @@ export function RoomPanel({
             data-testid={`seat-${String(seat.id)}`}
             data-claimed={seat.claimed}
             data-sitting-out={seat.sittingOut}
+            data-disconnected={seat.disconnected}
           >
             Seat {seat.id + 1}
             {seat.claimed
@@ -39,6 +40,12 @@ export function RoomPanel({
                 ? " — sitting out"
                 : " — claimed"
               : " — open"}
+            {seat.claimed && seat.disconnected && (
+              <span data-testid={`seat-${String(seat.id)}-disconnected`}>
+                {" "}
+                — disconnected
+              </span>
+            )}
           </li>
         ))}
       </ul>

--- a/packages/table-client/src/store/store.test.ts
+++ b/packages/table-client/src/store/store.test.ts
@@ -32,18 +32,18 @@ describe("useTableStore", () => {
   it("replaces the seat list from a room-view snapshot", () => {
     useTableStore.getState().setRoomView({
       code: "ABCD",
-      seats: [{ id: 0, claimed: true, sittingOut: false }],
+      seats: [{ id: 0, claimed: true, sittingOut: false, disconnected: false }],
     });
     expect(useTableStore.getState().roomCode).toBe("ABCD");
     expect(useTableStore.getState().seats).toEqual([
-      { id: 0, claimed: true, sittingOut: false },
+      { id: 0, claimed: true, sittingOut: false, disconnected: false },
     ]);
   });
 
   it("clears the room slice back to its initial state", () => {
     useTableStore.getState().setRoomView({
       code: "ABCD",
-      seats: [{ id: 0, claimed: true, sittingOut: false }],
+      seats: [{ id: 0, claimed: true, sittingOut: false, disconnected: false }],
     });
     useTableStore.getState().clearRoom();
     expect(useTableStore.getState().roomCode).toBeNull();

--- a/packages/table-client/src/ws/useWebSocket.ts
+++ b/packages/table-client/src/ws/useWebSocket.ts
@@ -3,28 +3,43 @@ import { useCallback, useEffect, useRef } from "react";
 import { useTableStore } from "../store/store.js";
 import { getWebSocketUrl } from "./getWebSocketUrl.js";
 
+export interface UseWebSocketOptions {
+  /** The room ended — manual "End session" or the table's own grace window elapsing. */
+  readonly onRoomEnded?: () => void;
+}
+
 export interface TableSocket {
   /** No-ops silently while disconnected — buttons are gated on connection state upstream. */
   readonly send: (command: ClientCommand) => void;
 }
 
+const RETRY_DELAY_MS = 1500;
+
 /**
  * Opens a room-scoped WebSocket connection once a room exists and reflects
  * its lifecycle into the connection slice. Every `room-view` push replaces
- * the seat slice; every `hand-update` replaces the hand slice with the
- * fresh `view(state, 'table')` the server just computed — the view is
- * source of truth (docs/phase-1-spec.md §6), never rebuilt from the raw
- * event locally. `command-rejected` renders nothing on the table device by
- * design (§9 — only the rejecting player ever sees a rejection). No
- * reconnection logic yet — that's ticket 33.
+ * the seat slice; every `hand-update`/`view-snapshot` replaces the hand
+ * slice with the fresh `view(state, 'table')` the server just computed —
+ * the view is source of truth (docs/phase-1-spec.md §6), never rebuilt from
+ * the raw event locally. `command-rejected` renders nothing on the table
+ * device by design (§9 — only the rejecting player ever sees a rejection).
+ *
+ * A dropped socket retries after a fixed delay — the table device is
+ * expected to keep trying for the whole 60s grace window (§7); the server,
+ * not this hook, is what ends the room if it never reconnects in time.
  */
-export function useWebSocket(roomCode: string | null): TableSocket {
+export function useWebSocket(
+  roomCode: string | null,
+  options: UseWebSocketOptions = {},
+): TableSocket {
   const setConnectionStatus = useTableStore(
     (state) => state.setConnectionStatus,
   );
   const setRoomView = useTableStore((state) => state.setRoomView);
   const setHandView = useTableStore((state) => state.setHandView);
   const socketRef = useRef<WebSocket | null>(null);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
 
   useEffect(() => {
     if (roomCode === null) {
@@ -32,34 +47,49 @@ export function useWebSocket(roomCode: string | null): TableSocket {
       return;
     }
 
+    const code = roomCode;
     let active = true;
-    setConnectionStatus("connecting");
-    const socket = new WebSocket(
-      getWebSocketUrl(window.location, { room: roomCode, role: "table" }),
-    );
-    socketRef.current = socket;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
 
-    socket.addEventListener("open", () => {
-      if (active) setConnectionStatus("connected");
-    });
-    socket.addEventListener("close", () => {
-      if (active) setConnectionStatus("disconnected");
-    });
-    socket.addEventListener("message", (event: MessageEvent<string>) => {
+    function connect(): void {
       if (!active) return;
-      const message: ServerMessage = JSON.parse(event.data) as ServerMessage;
-      if (message.type === "room-view") {
-        setRoomView(message.view);
-      } else if (message.type === "hand-update") {
-        // The server only ever sends a table-role socket a `view(state, 'table')`.
-        setHandView(message.view);
-      }
-    });
+      setConnectionStatus("connecting");
+      const socket = new WebSocket(
+        getWebSocketUrl(window.location, { room: code, role: "table" }),
+      );
+      socketRef.current = socket;
+
+      socket.addEventListener("open", () => {
+        if (active) setConnectionStatus("connected");
+      });
+      socket.addEventListener("close", () => {
+        if (!active) return;
+        setConnectionStatus("disconnected");
+        retryTimer = setTimeout(connect, RETRY_DELAY_MS);
+      });
+      socket.addEventListener("message", (event: MessageEvent<string>) => {
+        if (!active) return;
+        const message: ServerMessage = JSON.parse(event.data) as ServerMessage;
+        if (message.type === "room-view") {
+          setRoomView(message.view);
+        } else if (message.type === "hand-update") {
+          // The server only ever sends a table-role socket a `view(state, 'table')`.
+          setHandView(message.view);
+        } else if (message.type === "view-snapshot") {
+          setHandView(message.view);
+        } else if (message.type === "room-ended") {
+          optionsRef.current.onRoomEnded?.();
+        }
+      });
+    }
+
+    connect();
 
     return () => {
       active = false;
+      if (retryTimer !== undefined) clearTimeout(retryTimer);
+      socketRef.current?.close();
       socketRef.current = null;
-      socket.close();
     };
   }, [roomCode, setConnectionStatus, setRoomView, setHandView]);
 


### PR DESCRIPTION
## Summary
- WebSocket ping every 10s; a seat is marked "disconnected" (cosmetic table-device badge only) after 2 missed pongs or a socket close — never touches fold state.
- A reconnecting seat's stored token resumes it silently and gets one fresh `view-snapshot`, not event replay.
- The table device's own socket gets a 60s reconnect grace window before the room ends the same way "End session" does — every socket in the room is notified via a new `room-ended` message, then closed; in-memory state is discarded, hand logs on disk are untouched (nothing here writes to disk).
- A bad room/seat/token combo on the WS URL is rejected at the HTTP upgrade (pre-existing logic, now covered by a new test).
- Both player-client and table-client sockets retry after a transient drop; a socket that never opens (stale/cleared token) is treated as terminal and falls back to the seat picker instead of retrying forever.

## Notes
- Ticket 14 (auto-fold clock) landed on `main` after this branch was opened; merged in and the "reconnect after auto-fold" test now exercises the real clock (`actionClockMs`-driven) instead of the manual-fold stand-in.

## Test plan
- [x] `npm run build` (tsc project references) — clean
- [x] `npx eslint .` / `npx prettier --check .` — clean
- [x] Full repo `vitest run` — passing, including presence/reconnect/grace-window/action-clock integration tests in `packages/server/src/app.test.ts`
- [x] `/code-review` (Standards + Spec axes) — no hard violations; one real bug found and fixed (mount-restore hardcoded `sittingOut: false` instead of deriving it from the fetched room view)

Closes #33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VP69yHehj3gNqfdMd8coX
