### PR TITLE
docs(design): attach the UI-design prototype for the visual-reskin map

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,6 @@ package-lock.json
 # docs weren't written with Prettier's prose-wrap in mind, and reformatting
 # them is unrelated churn for whichever change first adds this config.
 *.md
+
+# Vendored/generated design-team prototype, not authored to this repo's style.
+docs/design/

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,8 @@
+# UI design prototype
+
+Source: [Table Top Poker](https://claude.ai/design/p/0bfbf4f5-fb32-4e3a-bc8a-1846be21c6a5?file=Table+Top+Poker.dc.html), a Claude Design project from the design team.
+
+- `table-top-poker-prototype.dc.html` — the interactive mock, covering both the table client (iPad landscape) and player client (phone): room create/join with QR, seat picking, house rules settings, live board/seats/actor state, hole cards, action bar, and showdown.
+- `support.js` — generated runtime the prototype's `.dc.html` depends on. Do not hand-edit; re-pull from the design project if it changes.
+
+Referenced by [Map: visual design pass for the Phase 1 table and player clients](https://github.com/ewanhardingham/table-top-poker/issues/57) and its tickets. The prototype's own JS state machine (bot fill, hand simulation) is demo scaffolding, not a spec for the real engine/server — the real clients get their state from the server via the existing WebSocket protocol.

--- a/docs/design/support.js
+++ b/docs/design/support.js
@@ -1,0 +1,1911 @@
+// GENERATED from dc-runtime/src/*.ts — do not edit. Rebuild with `cd dc-runtime && bun run build`.
+"use strict";
+(() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
+  // src/react.ts
+  function getReact() {
+    const R = window.React;
+    if (!R) throw new Error("dc-runtime: window.React is not available yet");
+    return R;
+  }
+  function getReactDOM() {
+    const RD = window.ReactDOM;
+    if (!RD) throw new Error("dc-runtime: window.ReactDOM is not available yet");
+    return RD;
+  }
+  var h = ((...args) => getReact().createElement(
+    ...args
+  ));
+
+  // src/parse.ts
+  function parseDcDocument(doc) {
+    const dc = doc.querySelector("x-dc");
+    if (!dc) return null;
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template: dc.innerHTML,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDcText(src) {
+    const openMatch = /<x-dc(?:\s[^>]*)?>/.exec(src);
+    if (!openMatch) return null;
+    const close = src.lastIndexOf("</x-dc>");
+    if (close === -1 || close < openMatch.index) return null;
+    const template = src.slice(openMatch.index + openMatch[0].length, close);
+    const doc = new DOMParser().parseFromString(src, "text/html");
+    const scriptEl = doc.querySelector("script[data-dc-script]");
+    const { props, preview } = parseDataProps(
+      scriptEl?.getAttribute("data-props") ?? null
+    );
+    return {
+      template,
+      js: scriptEl ? scriptEl.textContent || "" : "",
+      props,
+      preview
+    };
+  }
+  function parseDataProps(raw) {
+    if (!raw) return { props: null, preview: null };
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { props: null, preview: null };
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { props: null, preview: null };
+    }
+    const obj = parsed;
+    const preview = obj.$preview && typeof obj.$preview === "object" ? obj.$preview : null;
+    const rest = {};
+    for (const k of Object.keys(obj)) {
+      if (k[0] !== "$") rest[k] = obj[k];
+    }
+    return { props: Object.keys(rest).length ? rest : null, preview };
+  }
+  function dcNameFromPath(pathname) {
+    let p = pathname || "";
+    try {
+      p = decodeURIComponent(p);
+    } catch {
+    }
+    const base = p.split("/").pop() || "Root";
+    return base.replace(/\.dc\.html$/, "").replace(/\.html?$/, "") || "Root";
+  }
+
+  // src/boot.ts
+  var BASE_CSS = `
+    .sc-placeholder{background:color-mix(in srgb,currentColor 8%,transparent);
+      border:1px solid color-mix(in srgb,currentColor 50%,transparent);
+      border-radius:2px;box-sizing:border-box;overflow:hidden}
+    @keyframes sc-shine{0%{background-position:100% 50%}100%{background-position:0% 50%}}
+    html.sc-dc-streaming .sc-placeholder,
+    html.sc-dc-streaming .sc-interp.sc-missing{position:relative;
+      background:color-mix(in srgb,currentColor 5%,transparent);
+      border-color:transparent}
+    html.sc-dc-streaming .sc-placeholder::before,
+    html.sc-dc-streaming .sc-interp.sc-missing::before{content:'';
+      position:absolute;inset:0;pointer-events:none;
+      background:linear-gradient(90deg,rgba(217,119,87,0) 25%,rgba(247,225,211,.95) 37%,rgba(217,119,87,0) 63%);
+      background-size:400% 100%;animation:sc-shine 1.4s ease infinite}
+    html.sc-dc-streaming .sc-placeholder:nth-child(n+9 of .sc-placeholder)::before,
+    html.sc-dc-streaming .sc-interp.sc-missing:nth-child(n+9 of .sc-interp.sc-missing)::before{animation:none;
+      background:color-mix(in srgb,currentColor 8%,transparent)}
+    .sc-placeholder-error{padding:4px 8px;font:11px/1.4 ui-monospace,monospace;
+      color:color-mix(in srgb,currentColor 70%,transparent);word-break:break-word}
+    .sc-interp.sc-missing{display:inline-block;width:2em;height:1em;overflow:hidden;
+      vertical-align:text-bottom;background:rgba(255,255,255,.3);border:1px solid rgba(0,0,0,.5);
+      border-radius:2px;box-sizing:border-box;color:transparent;
+      user-select:none}
+    .sc-interp.sc-unresolved{font-family:ui-monospace,monospace;font-size:.85em;
+      color:color-mix(in srgb,currentColor 50%,transparent);
+      background:color-mix(in srgb,currentColor 10%,transparent);border-radius:3px;
+      padding:0 3px}
+    .sc-host.sc-has-error{position:relative}
+    .sc-logic-error{position:absolute;top:8px;left:8px;z-index:2147483647;max-width:60ch;
+      padding:6px 10px;background:#b00020;color:#fff;font:12px/1.4 ui-monospace,monospace;
+      border-radius:4px;white-space:pre-wrap;pointer-events:none}
+    /* Mirrors PRINT_BASELINE_CSS in apps/web deck-stage-export.ts \u2014 keep both
+       in sync until dc-runtime regains a build step. */
+    @media print {
+      @page { margin: 0.5cm; }
+      figure, table { break-inside: avoid; }
+      #dc-root, #dc-root > .sc-host { height: auto; }
+      *, *::before, *::after {
+        print-color-adjust: exact; -webkit-print-color-adjust: exact;
+        backdrop-filter: none !important; -webkit-backdrop-filter: none !important;
+        animation-delay: -99s !important; animation-duration: .001s !important;
+        animation-iteration-count: 1 !important; animation-fill-mode: both !important;
+        animation-play-state: running !important; transition-duration: 0s !important;
+      }
+    }
+  `;
+  var FULL_PAGE_CSS = "html,body{height:100%;margin:0}#dc-root,#dc-root>.sc-host{height:100%}";
+  function rootNameForDocument(doc, loc) {
+    let bootPath = loc.pathname || "";
+    if (!/\.dc\.html?$/i.test(safeDecode(bootPath))) {
+      try {
+        bootPath = new URL(doc.baseURI || "/").pathname;
+      } catch {
+      }
+    }
+    return dcNameFromPath(bootPath);
+  }
+  function safeDecode(s) {
+    try {
+      return decodeURIComponent(s);
+    } catch {
+      return s;
+    }
+  }
+  function boot(runtime, doc = document) {
+    const parsed = parseDcDocument(doc);
+    if (!parsed) return null;
+    const React = getReact();
+    const rootName = rootNameForDocument(doc, location);
+    runtime.markFetched(rootName);
+    runtime.setRootName(rootName);
+    runtime.adoptParsed(rootName, parsed);
+    if (!window.__resources) {
+      fetch(location.href).then((res) => res.ok ? res.text() : "").then((t) => {
+        const raw = t ? parseDcText(t) : null;
+        if (raw?.template) runtime.updateHtml(rootName, raw.template);
+      }).catch(() => {
+      });
+    }
+    const dc = doc.querySelector("x-dc");
+    const hostEl = doc.createElement("div");
+    hostEl.id = "dc-root";
+    dc.replaceWith(hostEl);
+    if (!parsed.preview) {
+      const s = doc.createElement("style");
+      s.textContent = FULL_PAGE_CSS;
+      doc.head.appendChild(s);
+    }
+    const Root = runtime.getDC(rootName);
+    const entry = runtime.registry.get(rootName);
+    function StandaloneRoot() {
+      const [, setTick] = React.useState(0);
+      React.useEffect(() => {
+        const sub = () => setTick((n) => n + 1);
+        entry.subs.add(sub);
+        return () => {
+          entry.subs.delete(sub);
+        };
+      }, []);
+      const defaults = React.useMemo(() => {
+        const d = {};
+        for (const k in entry.propsMeta || {}) {
+          const v = entry.propsMeta?.[k]?.default;
+          if (v !== void 0) d[k] = v;
+        }
+        return d;
+      }, [entry.propsMeta]);
+      return h(Root, { ...defaults, ...entry.propOverrides || {} });
+    }
+    const ReactDOM = getReactDOM();
+    if (ReactDOM.createRoot)
+      ReactDOM.createRoot(hostEl).render(h(StandaloneRoot));
+    else ReactDOM.render(h(StandaloneRoot), hostEl);
+    return rootName;
+  }
+
+  // src/expr.ts
+  var IDENT_RE = /^[A-Za-z_$][A-Za-z0-9_$]*/;
+  var NUMBER_RE = /^-?\d+(\.\d+)?$/;
+  function resolve(vals, src) {
+    const expr = String(src).trim();
+    if (!expr) return void 0;
+    if (expr[0] === "(" && expr[expr.length - 1] === ")" && parensWrapWhole(expr)) {
+      return resolve(vals, expr.slice(1, -1));
+    }
+    const eq = findTopLevelEquality(expr);
+    if (eq) {
+      const lv = resolve(vals, expr.slice(0, eq.index));
+      const rv = resolve(vals, expr.slice(eq.index + eq.op.length));
+      switch (eq.op) {
+        case "===":
+          return lv === rv;
+        case "!==":
+          return lv !== rv;
+        case "==":
+          return lv == rv;
+        default:
+          return lv != rv;
+      }
+    }
+    if (expr[0] === "!") return !resolve(vals, expr.slice(1));
+    if (expr === "true") return true;
+    if (expr === "false") return false;
+    if (expr === "null") return null;
+    if (expr === "undefined") return void 0;
+    if (NUMBER_RE.test(expr)) return Number(expr);
+    if (expr.length >= 2 && (expr[0] === '"' || expr[0] === "'") && expr[expr.length - 1] === expr[0]) {
+      return expr.slice(1, -1);
+    }
+    return resolvePath(vals, expr);
+  }
+  function parensWrapWhole(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length - 1; i++) {
+      if (expr[i] === "(") depth++;
+      else if (expr[i] === ")") {
+        depth--;
+        if (depth === 0) return false;
+      }
+    }
+    return true;
+  }
+  function findTopLevelEquality(expr) {
+    let depth = 0;
+    for (let i = 0; i < expr.length; i++) {
+      const c = expr[i];
+      if (c === "[" || c === "(") depth++;
+      else if (c === "]" || c === ")") depth--;
+      else if (depth === 0 && (c === "=" || c === "!") && expr[i + 1] === "=") {
+        if (i > 0 && (expr[i - 1] === "=" || expr[i - 1] === "!")) continue;
+        if (!expr.slice(0, i).trim()) continue;
+        const op = expr[i + 2] === "=" ? c + "==" : c + "=";
+        return { index: i, op };
+      }
+    }
+    return null;
+  }
+  function resolvePath(vals, expr) {
+    const head = expr.match(IDENT_RE);
+    if (!head) return void 0;
+    let cur = vals == null ? void 0 : vals[head[0]];
+    let i = head[0].length;
+    while (i < expr.length) {
+      if (expr[i] === ".") {
+        const m = expr.slice(i + 1).match(IDENT_RE) || expr.slice(i + 1).match(/^\d+/);
+        if (!m) return void 0;
+        cur = cur == null ? void 0 : cur[m[0]];
+        i += 1 + m[0].length;
+      } else if (expr[i] === "[") {
+        let depth = 1;
+        let j = i + 1;
+        while (j < expr.length && depth > 0) {
+          if (expr[j] === "[") depth++;
+          else if (expr[j] === "]") {
+            depth--;
+            if (depth === 0) break;
+          }
+          j++;
+        }
+        if (depth !== 0) return void 0;
+        const key = resolve(vals, expr.slice(i + 1, j));
+        cur = cur == null ? void 0 : cur[key];
+        i = j + 1;
+      } else {
+        return void 0;
+      }
+    }
+    return cur;
+  }
+
+  // src/encode.ts
+  var CAMEL_ATTR = "sc-camel-";
+  var INLINE_TEXT_TAGS = new Set(
+    "a abbr b bdi bdo br cite code del dfn em i ins kbd mark q s samp small span strike strong sub sup u var wbr".split(
+      " "
+    )
+  );
+  var RAW_WRAP = {
+    select: "sc-raw-select",
+    table: "sc-raw-table",
+    tbody: "sc-raw-tbody",
+    thead: "sc-raw-thead",
+    tfoot: "sc-raw-tfoot",
+    tr: "sc-raw-tr",
+    td: "sc-raw-td",
+    th: "sc-raw-th",
+    caption: "sc-raw-caption"
+  };
+  var RAW_UNWRAP = Object.fromEntries(
+    Object.entries(RAW_WRAP).map(([k, v]) => [v, k])
+  );
+  var EVENT_MAP = {
+    onclick: "onClick",
+    onchange: "onChange",
+    oninput: "onInput",
+    onsubmit: "onSubmit",
+    onkeydown: "onKeyDown",
+    onkeyup: "onKeyUp",
+    onkeypress: "onKeyPress",
+    onmousedown: "onMouseDown",
+    onmouseup: "onMouseUp",
+    onmouseenter: "onMouseEnter",
+    onmouseleave: "onMouseLeave",
+    onfocus: "onFocus",
+    onblur: "onBlur",
+    ondoubleclick: "onDoubleClick",
+    oncontextmenu: "onContextMenu",
+    onmousemove: "onMouseMove",
+    onmouseover: "onMouseOver",
+    onmouseout: "onMouseOut",
+    onpointerdown: "onPointerDown",
+    onpointerup: "onPointerUp",
+    onpointermove: "onPointerMove",
+    onpointerenter: "onPointerEnter",
+    onpointerleave: "onPointerLeave",
+    onpointercancel: "onPointerCancel",
+    onpointerover: "onPointerOver",
+    onpointerout: "onPointerOut",
+    ongotpointercapture: "onGotPointerCapture",
+    onlostpointercapture: "onLostPointerCapture",
+    ontouchstart: "onTouchStart",
+    ontouchend: "onTouchEnd",
+    ontouchmove: "onTouchMove",
+    ontouchcancel: "onTouchCancel",
+    ondragstart: "onDragStart",
+    ondragend: "onDragEnd",
+    ondragenter: "onDragEnter",
+    ondragleave: "onDragLeave",
+    ondragover: "onDragOver",
+    onanimationstart: "onAnimationStart",
+    onanimationend: "onAnimationEnd",
+    onanimationiteration: "onAnimationIteration",
+    ontransitionend: "onTransitionEnd"
+  };
+  var ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+  var IMPORT_SELF_CLOSE_RE = new RegExp(
+    "<(x-import|dc-import)(" + ATTRS + ")/>",
+    "gi"
+  );
+  var CAMEL_ATTR_RE = /(\s)([a-z]+[A-Z][A-Za-z0-9]*)(\s*=)/g;
+  function encodeCamelAttrs(html) {
+    return html.replace(
+      CAMEL_ATTR_RE,
+      (_, sp, name, eq) => sp + CAMEL_ATTR + name.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase()) + eq
+    );
+  }
+  function encodeCase(html) {
+    html = html.replace(
+      IMPORT_SELF_CLOSE_RE,
+      (_, t, a) => "<" + t + a + "></" + t + ">"
+    );
+    html = html.replace(/<helmet(\s|>)/gi, "<sc-helmet$1");
+    html = html.replace(/<\/helmet\s*>/gi, "</sc-helmet>");
+    html = encodeCamelAttrs(html);
+    for (const [real, alias] of Object.entries(RAW_WRAP)) {
+      html = html.replace(
+        new RegExp("(</?)" + real + "(?=[\\s>])", "gi"),
+        "$1" + alias
+      );
+    }
+    return html;
+  }
+  function kebabToCamel(s) {
+    return s.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  }
+  function cssToObj(css) {
+    const o = {};
+    for (const decl of css.split(";")) {
+      const i = decl.indexOf(":");
+      if (i < 0) continue;
+      const prop = decl.slice(0, i).trim();
+      o[prop.startsWith("--") ? prop : kebabToCamel(prop)] = decl.slice(i + 1).trim();
+    }
+    return o;
+  }
+  function compileAttr(raw) {
+    const whole = raw.match(/^\s*\{\{([\s\S]+?)\}\}\s*$/);
+    if (whole) {
+      const path = whole[1];
+      return (vals) => resolve(vals, path);
+    }
+    if (raw.includes("{{")) {
+      const parts = raw.split(/\{\{([\s\S]+?)\}\}/g);
+      return (vals) => parts.map((s, i) => i & 1 ? resolve(vals, s) ?? "" : s).join("");
+    }
+    return () => raw;
+  }
+
+  // src/compile.ts
+  function collectProps(node, kind, host) {
+    const propGetters = [];
+    const pseudoClasses = [];
+    let hintSize = null;
+    for (const { name, value } of [...node.attributes]) {
+      if (name === "sc-name" || name === "data-dc-tpl") continue;
+      let key = name;
+      if (key.startsWith(CAMEL_ATTR))
+        key = kebabToCamel(key.slice(CAMEL_ATTR.length));
+      if (key === "hint-size") {
+        hintSize = value;
+        continue;
+      }
+      if (key.startsWith("style-")) {
+        pseudoClasses.push(host.pseudoClass(key.slice(6), value));
+        continue;
+      }
+      if (kind !== "dom") {
+        if (key.includes("-") && !(kind === "x-import" && (key.startsWith("aria-") || key.startsWith("data-"))))
+          key = kebabToCamel(key);
+      } else {
+        if (key === "class") key = "className";
+        else if (key === "for") key = "htmlFor";
+        else if (key.startsWith("on"))
+          key = EVENT_MAP[key] || "on" + key[2].toUpperCase() + key.slice(3);
+      }
+      propGetters.push([key, compileAttr(value)]);
+    }
+    return { propGetters, pseudoClasses, hintSize };
+  }
+  var HOST_STYLE_PROPS = /* @__PURE__ */ new Set([
+    "position",
+    "left",
+    "right",
+    "top",
+    "bottom",
+    "inset",
+    "width",
+    "height",
+    "z-index",
+    "transform"
+  ]);
+  function hostPositionStyle(style) {
+    const all = typeof style === "string" ? cssToObj(style) : style != null && typeof style === "object" ? style : null;
+    if (!all) return void 0;
+    const out = {};
+    for (const [k, v] of Object.entries(all)) {
+      const kebab = k.replace(/[A-Z]/g, (c) => "-" + c.toLowerCase());
+      if (HOST_STYLE_PROPS.has(kebab)) out[k] = v;
+    }
+    return Object.keys(out).length ? out : void 0;
+  }
+  function compileTemplate(html, host) {
+    const tpl = document.createElement("template");
+    //! nosemgrep: direct-inner-html-assignment
+    tpl.innerHTML = encodeCase(html);
+    let tplN = 0;
+    (function stamp(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        node.setAttribute("data-dc-tpl", String(tplN++));
+      }
+      for (const c of node.childNodes) stamp(c);
+    })(tpl.content);
+    const builders = walkChildren(tpl.content, host);
+    const render = ((vals, ctx) => builders.map((b, i) => b(vals || {}, ctx, i)));
+    render.__annotated = tpl.innerHTML;
+    return render;
+  }
+  function walkChildren(node, host) {
+    return [...node.childNodes].map((c) => walk(c, host)).filter((b) => b != null);
+  }
+  var SLIDE_ID_VALUE_RE = /^[0-9a-f]{8}$/;
+  var DECK_CONTROL_FLOW_RE = /^(sc-if|sc-for|sc-else|dc-import|x-import)$/;
+  var DECK_AUX_RE = /^(template|script|style|sc-helmet|helmet)$/;
+  function isDeckMountTag(el) {
+    if (el.localName === "deck-stage") return true;
+    return el.localName === "x-import" && (el.getAttribute("component-from-global-scope") || "") === "deck-stage";
+  }
+  function walkDeckChildren(el, host) {
+    const pairs = [...el.childNodes].map((c) => ({ c, b: walk(c, host) })).filter((p) => p.b !== null);
+    const kids = pairs.map((p) => p.b);
+    const seen = /* @__PURE__ */ new Set();
+    const wsSeen = /* @__PURE__ */ new Map();
+    const keys = [];
+    const nextSlideId = new Array(pairs.length);
+    {
+      let upcoming = null;
+      for (let j = pairs.length - 1; j >= 0; j--) {
+        const n = pairs[j].c;
+        if (n.nodeType === Node.ELEMENT_NODE) {
+          const t = n.localName;
+          upcoming = !DECK_AUX_RE.test(t) && !DECK_CONTROL_FLOW_RE.test(t) ? n.getAttribute("data-om-slide-id") : null;
+        }
+        nextSlideId[j] = upcoming;
+      }
+    }
+    for (let j = 0; j < pairs.length; j++) {
+      const { c } = pairs[j];
+      if (c.nodeType === Node.TEXT_NODE) {
+        if ((c.nodeValue ?? "").trim() === "") {
+          const base = nextSlideId[j] ? "omid-ws:" + nextSlideId[j] : "omid-ws:aux";
+          const n = wsSeen.get(base) ?? 0;
+          wsSeen.set(base, n + 1);
+          keys.push(n === 0 ? base : base + ":" + n);
+          continue;
+        }
+        return { kids, keys: null };
+      }
+      if (c.nodeType !== Node.ELEMENT_NODE) {
+        keys.push(j);
+        continue;
+      }
+      const child = c;
+      const tag = child.localName;
+      if (DECK_AUX_RE.test(tag)) {
+        keys.push(j);
+        continue;
+      }
+      if (DECK_CONTROL_FLOW_RE.test(tag)) return { kids, keys: null };
+      const v = child.getAttribute("data-om-slide-id");
+      if (!v || !SLIDE_ID_VALUE_RE.test(v) || seen.has(v)) {
+        return { kids, keys: null };
+      }
+      seen.add(v);
+      keys.push("omid:" + v);
+    }
+    return { kids, keys };
+  }
+  function renderDeckKids(kids, kidKeys, vals, ctx) {
+    return kids.map((b, j) => {
+      const k = kidKeys ? kidKeys[j] : j;
+      const out = b(vals, ctx, k);
+      return kidKeys != null && typeof out === "string" ? h(getReact().Fragment, { key: k }, out) : out;
+    });
+  }
+  function walk(node, host) {
+    if (node.nodeType === Node.TEXT_NODE) return walkText(node);
+    if (node.nodeType !== Node.ELEMENT_NODE) return null;
+    const el = node;
+    const tag = el.tagName.toLowerCase();
+    if (tag === "sc-for") return walkFor(el, host);
+    if (tag === "sc-if") return walkIf(el, host);
+    if (tag === "x-import") return walkXImport(el, host);
+    if (tag === "sc-helmet") return host.helmet(el);
+    if (tag === "dc-import") return walkComponent(el, host);
+    return walkElement(el, host);
+  }
+  var warnedHoles = /* @__PURE__ */ new Set();
+  function warnUnresolved(ctx, what) {
+    const key = (ctx?.__name || "?") + "\0" + what;
+    if (warnedHoles.has(key)) return;
+    warnedHoles.add(key);
+    console.warn("[dc-runtime] " + (ctx?.__name || "template") + ": " + what);
+  }
+  function walkText(node) {
+    const txt = node.nodeValue ?? "";
+    if (!txt.includes("{{")) {
+      if (!txt.trim() && !txt.includes(" ")) return null;
+      return () => txt;
+    }
+    const parts = txt.split(/\{\{([\s\S]+?)\}\}/g);
+    return (vals, ctx, key) => h(
+      getReact().Fragment,
+      { key },
+      ...parts.map((p, i) => {
+        if (!(i & 1)) return p;
+        const v = resolve(vals, p);
+        if (v === void 0) {
+          if (!ctx?.__streamingNow) {
+            if (document.body?.hasAttribute("data-dc-editor-on")) {
+              return h(
+                "span",
+                { key: i, className: "sc-interp sc-unresolved" },
+                "{{ " + p.trim() + " }}"
+              );
+            }
+            warnUnresolved(
+              ctx,
+              "{{ " + p.trim() + " }} never resolved \u2014 rendered as empty"
+            );
+            return null;
+          }
+          return h(
+            "span",
+            { key: i, className: "sc-interp sc-missing" },
+            p.trim()
+          );
+        }
+        if (getReact().isValidElement(v) || Array.isArray(v)) {
+          return h(getReact().Fragment, { key: i }, v);
+        }
+        if (v === null || typeof v === "boolean") return null;
+        return h("span", { key: i, className: "sc-interp" }, String(v));
+      })
+    );
+  }
+  function walkFor(el, host) {
+    const listGet = compileAttr(el.getAttribute("list") || "");
+    const asName = el.getAttribute("as") || "item";
+    const hintN = parseInt(el.getAttribute("hint-placeholder-count") || "0", 10);
+    const kids = walkChildren(el, host);
+    const listSrc = el.getAttribute("list") || "";
+    return (vals, ctx, key) => {
+      let list = listGet(vals);
+      if (!Array.isArray(list)) {
+        if (!ctx?.__streamingNow) {
+          if (list !== void 0 && list !== null) {
+            warnUnresolved(
+              ctx,
+              'sc-for list="' + listSrc + '" is not an array (' + typeof list + ")"
+            );
+          }
+          list = [];
+        } else {
+          list = hintN > 0 ? Array(hintN).fill(void 0) : [];
+        }
+      }
+      return h(
+        getReact().Fragment,
+        { key },
+        list.map((item, i) => {
+          const sub = { ...vals, [asName]: item, $index: i };
+          return h(
+            getReact().Fragment,
+            { key: i },
+            kids.map((b, j) => b(sub, ctx, j))
+          );
+        })
+      );
+    };
+  }
+  function walkIf(el, host) {
+    const valGet = compileAttr(el.getAttribute("value") || "");
+    const hintRaw = el.getAttribute("hint-placeholder-val");
+    const hintGet = hintRaw != null ? compileAttr(hintRaw) : null;
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      let v = valGet(vals);
+      if (v === void 0 && hintGet && ctx?.__streamingNow) v = hintGet(vals);
+      return v ? h(
+        getReact().Fragment,
+        { key },
+        kids.map((b, j) => b(vals, ctx, j))
+      ) : null;
+    };
+  }
+  function walkComponent(el, host) {
+    const name = el.getAttribute("name") || el.getAttribute("component") || "";
+    el.removeAttribute("name");
+    el.removeAttribute("component");
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const { propGetters, hintSize } = collectProps(el, "dc-import", host);
+    const kids = walkChildren(el, host);
+    return (vals, ctx, key) => {
+      const props = {
+        key,
+        __hintSize: hintSize,
+        __tplId: tplId,
+        __hostStyle: styleGet ? hostPositionStyle(styleGet(vals)) : void 0
+      };
+      for (const [k, g] of propGetters) {
+        const v = g(vals);
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (kids.length) props.children = kids.map((b, j) => b(vals, ctx, j));
+      return h(host.component(name), props);
+    };
+  }
+  function walkXImport(el, host) {
+    const globalNameGet = compileAttr(
+      el.getAttribute("component-from-global-scope") || ""
+    );
+    const exportNameGet = compileAttr(
+      el.getAttribute("component") || el.getAttribute("name") || ""
+    );
+    const fromRaw = el.getAttribute("from") || (el.getAttribute("component-from-global-scope") ? "" : el.getAttribute("src") || el.getAttribute("import") || "");
+    const urls = fromRaw.trim() ? fromRaw.trim().split(/\s+/) : [];
+    const url = urls.length ? urls[urls.length - 1] : "";
+    const kindOf = (u) => /\.(jsx|tsx)(\?|#|$)/i.test(u) ? "jsx" : "js";
+    const tplId = el.getAttribute("data-dc-tpl");
+    const styleRaw = el.getAttribute("style");
+    el.removeAttribute("style");
+    const styleGet = styleRaw != null ? compileAttr(styleRaw) : null;
+    const wrap = tplId != null || styleGet != null;
+    const { propGetters, hintSize } = collectProps(el, "x-import", host);
+    const hasContent = el.children.length > 0 || !!(el.textContent || "").trim();
+    const deckKeyed = hasContent && isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : hasContent ? walkChildren(el, host) : [];
+    const kidKeys = deckKeyed?.keys ?? null;
+    const urlBindable = fromRaw.includes("{{");
+    if (urls.length && !urlBindable) {
+      let prev;
+      for (const u of urls) prev = host.loadExternal(kindOf(u), u, prev);
+    }
+    const evalName = (g, vals) => {
+      const v = g(vals);
+      const s = v == null ? "" : String(v);
+      return s.includes("{{") ? "" : s;
+    };
+    return (vals, ctx, key) => {
+      const globalName = evalName(globalNameGet, vals);
+      const name = globalName || evalName(exportNameGet, vals);
+      const C = !name || urlBindable ? null : globalName ? host.resolveExternalGlobal(url, globalName) : host.resolveExternal(url, name);
+      const hostStyle = styleGet ? hostPositionStyle(styleGet(vals)) : void 0;
+      const wrapper = wrap ? {
+        key,
+        className: "sc-host-x",
+        "data-dc-tpl": tplId,
+        style: hostStyle || { display: "contents" }
+      } : null;
+      if (!C) {
+        const error = urlBindable ? "x-import `from` cannot contain {{ \u2026 }} \u2014 module URLs are resolved at parse time; use a literal URL" : host.resolveExternalError(url, name);
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      const props = wrapper ? {} : { key };
+      let unresolvedHole = false;
+      for (const [k, g] of propGetters) {
+        if (k === "component" || k === "componentFromGlobalScope" || k === "from") {
+          continue;
+        }
+        const v = g(vals);
+        if (v === void 0) unresolvedHole = true;
+        if (k === "dcProps") {
+          if (v && typeof v === "object") Object.assign(props, v);
+          continue;
+        }
+        props[k] = v;
+      }
+      if (unresolvedHole && ctx?.__htmlStreamingNow) {
+        const ph = host.placeholder({
+          key: wrapper ? void 0 : key,
+          name,
+          hintSize,
+          error: null
+        });
+        return wrapper ? h("div", wrapper, ph) : ph;
+      }
+      if (kids.length) {
+        props.children = renderDeckKids(kids, kidKeys, vals, ctx);
+      }
+      return wrapper ? h("div", wrapper, h(C, props)) : h(C, props);
+    };
+  }
+  function contentKey(el) {
+    const clone = el.cloneNode(true);
+    for (const d of clone.querySelectorAll("*")) {
+      while (d.attributes.length) d.removeAttribute(d.attributes[0].name);
+    }
+    const s = clone.innerHTML;
+    let h2 = 5381;
+    for (let i = 0; i < s.length; i++) h2 = (h2 << 5) + h2 + s.charCodeAt(i) | 0;
+    return s.length + "." + (h2 >>> 0).toString(36);
+  }
+  var NEVER_CONTENT_KEYED = new Set(
+    "script style textarea option title select canvas iframe video audio".split(
+      " "
+    )
+  );
+  var NOT_INLINE_SELECTOR = ":not(" + [...INLINE_TEXT_TAGS].join(",") + ")";
+  function walkElement(el, host) {
+    const realTag = RAW_UNWRAP[el.localName] || el.localName;
+    const tplId = el.getAttribute("data-dc-tpl");
+    const inlineOnly = el.childNodes.length > 0 && !NEVER_CONTENT_KEYED.has(realTag) && el.querySelector(NOT_INLINE_SELECTOR) === null;
+    const keySuffix = inlineOnly ? "|" + contentKey(el) : "";
+    const { propGetters, pseudoClasses } = collectProps(el, "dom", host);
+    const deckKeyed = isDeckMountTag(el) ? walkDeckChildren(el, host) : null;
+    const kids = deckKeyed ? deckKeyed.kids : walkChildren(el, host);
+    const kidKeys = deckKeyed?.keys ?? null;
+    return (vals, ctx, key) => {
+      const props = {
+        key: key + keySuffix,
+        "data-dc-tpl": tplId
+      };
+      for (const [k, g] of propGetters) {
+        let v = g(vals);
+        if (k === "style" && typeof v === "string") v = cssToObj(v);
+        if ((k === "value" || k === "checked") && v === void 0) {
+          v = k === "checked" ? false : "";
+        }
+        props[k] = v;
+      }
+      if (pseudoClasses.length) {
+        props.className = [props.className, ...pseudoClasses].filter(Boolean).join(" ");
+      }
+      return h(realTag, props, ...renderDeckKids(kids, kidKeys, vals, ctx));
+    };
+  }
+
+  // src/logic.ts
+  var StreamableLogic = class {
+    constructor(props) {
+      __publicField(this, "props");
+      __publicField(this, "state", {});
+      /** Back-pointer to the wrapper component, installed after construction. */
+      __publicField(this, "__host");
+      this.props = props || {};
+    }
+    setState(update, cb) {
+      this.__host && this.__host.__setLogicState(update, cb);
+    }
+    forceUpdate() {
+      this.__host && this.__host.forceUpdate();
+    }
+    componentDidMount() {
+    }
+    componentDidUpdate(_prevProps) {
+    }
+    componentWillUnmount() {
+    }
+    /** The flat object the template renders against (merged over props). */
+    renderVals() {
+      return {};
+    }
+  };
+  function evalDcLogic(src) {
+    //! nosemgrep: eval-and-function-constructor
+    const fn = new Function(
+      "DCLogic",
+      "StreamableLogic",
+      "React",
+      src + '\n;return (typeof Component!=="undefined"&&Component)||undefined;'
+    );
+    return fn(StreamableLogic, StreamableLogic, getReact());
+  }
+
+  // src/component.ts
+  function shallowEqual(a, b) {
+    if (!b) return false;
+    const ak = Object.keys(a).filter((k) => k !== "children");
+    const bk = Object.keys(b).filter((k) => k !== "children");
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) if (a[k] !== b[k]) return false;
+    return true;
+  }
+  function Placeholder({
+    name,
+    hintSize,
+    streaming,
+    error
+  }) {
+    const [w, hgt] = (hintSize || "100%,60px").split(",");
+    return h(
+      "div",
+      {
+        className: "sc-placeholder" + (streaming ? " sc-streaming" : ""),
+        style: { width: w.trim(), height: hgt && hgt.trim() },
+        title: name
+      },
+      error ? h(
+        "div",
+        { className: "sc-placeholder-error" },
+        (name ? name + ": " : "") + error
+      ) : null
+    );
+  }
+  function hintToMin(hint) {
+    if (!hint) return void 0;
+    const [w, hgt] = hint.split(",");
+    return { minWidth: w.trim(), minHeight: hgt && hgt.trim() };
+  }
+  function createComponentFactory(registry, ensureFetched) {
+    const React = getReact();
+    const AncestorContext = React.createContext([]);
+    class StreamableComponent extends React.Component {
+      constructor(props) {
+        super(props);
+        __publicField(this, "__name");
+        __publicField(this, "__sub");
+        __publicField(this, "__needsDidMount", false);
+        /** Snapshot of the registry's streaming flags taken at render time —
+         *  builders read it off the RenderCtx (this) to pick placeholder vs
+         *  render-nothing for unresolved values. */
+        __publicField(this, "__streamingNow", false);
+        __publicField(this, "__htmlStreamingNow", false);
+        /** When a construct throws, remember the (class, registry.ver, props)
+         *  triple so render-time reconcile doesn't re-attempt it on every parent
+         *  re-render. A registry bump (new class, template, external module
+         *  resolving via bumpAll) changes `ver` and breaks the memo so an
+         *  env-dependent constructor can self-heal. */
+        __publicField(this, "__failedLogic", null);
+        __publicField(this, "__failedUserProps", null);
+        __publicField(this, "__failedVer", -1);
+        /** Per-instance constructor error — kept here (not on the registry entry)
+         *  so one instance's successful construct can't hide a sibling's failure,
+         *  and a construct can never wipe an eval error `updateJs` recorded on
+         *  `r.logicError`. */
+        __publicField(this, "__ctorError", null);
+        __publicField(this, "logic");
+        this.__name = props.__name;
+        this.state = { __v: 0, __err: null };
+        this.__sub = () => {
+          if (this.state.__err) this.setState({ __err: null });
+          this.forceUpdate();
+        };
+        this.__makeLogic(registry.get(this.__name).Logic, null);
+        ensureFetched(this.__name);
+      }
+      /** Error-boundary hook: a render crash anywhere in this DC's subtree
+       *  (its own template, an x-import'd component, a child DC without its
+       *  own deeper boundary) lands here instead of unmounting the page. */
+      static getDerivedStateFromError(e) {
+        return { __err: e instanceof Error && e.message ? e.message : String(e) };
+      }
+      componentDidCatch(e, info) {
+        console.error(
+          "[dc-runtime] render error in <" + this.__name + ">:",
+          e,
+          info?.componentStack || ""
+        );
+      }
+      /** Instantiate the logic class (or the no-op base) and adopt `prevState`
+       *  over its initial state — used both at mount and on hot-swap. */
+      __makeLogic(Logic, prevState) {
+        const L = Logic || StreamableLogic;
+        try {
+          this.logic = new L(this.__userProps());
+          this.__failedLogic = null;
+          this.__failedUserProps = null;
+          this.__ctorError = null;
+        } catch (e) {
+          console.error(e);
+          this.__failedLogic = Logic;
+          this.__failedUserProps = this.__userProps();
+          this.__failedVer = registry.get(this.__name).ver;
+          this.__ctorError = this.__name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+          this.logic = new StreamableLogic(
+            this.__userProps()
+          );
+        }
+        this.logic.__host = this;
+        if (prevState)
+          this.logic.state = { ...this.logic.state || {}, ...prevState };
+      }
+      /** The props the author's logic + template see — internal __-prefixed
+       *  wiring stripped. */
+      __userProps() {
+        const { __name, __hintSize, __tplId, __hostStyle, ...rest } = this.props;
+        return rest;
+      }
+      __setLogicState(update, cb) {
+        const prev = this.logic.state;
+        const patch = typeof update === "function" ? update(prev) : update;
+        this.logic.state = { ...prev, ...patch };
+        this.setState((s) => ({ __v: s.__v + 1 }), cb);
+      }
+      /** Swap the logic instance when the registry's Logic class changed
+       *  (streaming completion, hot reload). State carries over; didMount
+       *  re-fires after the swap commits so refs exist. */
+      __reconcileLogic() {
+        const r = registry.get(this.__name);
+        const Next = r.Logic;
+        const Cur = this.logic.constructor;
+        if (Next === Cur || !Next && Cur === StreamableLogic || Next === this.__failedLogic && r.ver === this.__failedVer && shallowEqual(this.__userProps(), this.__failedUserProps)) {
+          return;
+        }
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+        this.__makeLogic(Next, this.logic.state);
+        this.__needsDidMount = true;
+      }
+      componentDidMount() {
+        registry.get(this.__name).subs.add(this.__sub);
+        try {
+          this.logic.componentDidMount();
+        } catch (e) {
+          console.error(e);
+        }
+      }
+      componentDidUpdate(prevProps) {
+        this.logic.props = this.__userProps();
+        if (this.__needsDidMount) {
+          if (this.state.__err || !registry.get(this.__name).tpl) return;
+          this.__needsDidMount = false;
+          try {
+            this.logic.componentDidMount();
+          } catch (e) {
+            console.error(e);
+          }
+        } else {
+          try {
+            this.logic.componentDidUpdate(prevProps);
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      componentWillUnmount() {
+        registry.get(this.__name).subs.delete(this.__sub);
+        if (!this.__needsDidMount) {
+          try {
+            this.logic.componentWillUnmount();
+          } catch (e) {
+            console.error(e);
+          }
+        }
+      }
+      render() {
+        const r = registry.get(this.__name);
+        const cls = "sc-host" + (r.htmlStreaming ? " sc-streaming-html" : "") + (r.jsStreaming ? " sc-streaming-js" : "");
+        const hintStyle = r.htmlStreaming ? hintToMin(this.props.__hintSize) : void 0;
+        const hostStyle = this.props.__hostStyle || hintStyle ? { ...hintStyle || {}, ...this.props.__hostStyle || {} } : void 0;
+        const hostBase = {
+          className: cls,
+          style: hostStyle,
+          "data-sc-name": this.__name,
+          "data-dc-tpl": this.props.__tplId
+        };
+        const chain = Array.isArray(this.context) ? this.context : [];
+        if (chain.includes(this.__name)) {
+          const cycle = [
+            ...chain.slice(chain.indexOf(this.__name)),
+            this.__name
+          ].join(" \u2192 ");
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: "circular import: " + cycle
+            })
+          );
+        }
+        if (this.state.__err) {
+          return h(
+            "div",
+            { ...hostBase, className: cls + " sc-has-error" },
+            h(
+              "div",
+              { className: "sc-logic-error", "data-omelette-chrome": "" },
+              this.__name + ": " + this.state.__err
+            ),
+            h(Placeholder, {
+              name: this.__name,
+              hintSize: this.props.__hintSize,
+              error: this.state.__err
+            })
+          );
+        }
+        this.__reconcileLogic();
+        if (!r.tpl) {
+          return h(
+            "div",
+            hostBase,
+            h(Placeholder, { name: this.__name, hintSize: this.props.__hintSize })
+          );
+        }
+        const userProps = this.__userProps();
+        this.logic.props = userProps;
+        let vals = userProps;
+        let renderErr = r.logicError || this.__ctorError;
+        try {
+          vals = { ...userProps, ...this.logic.renderVals() || {} };
+        } catch (e) {
+          console.error(e);
+          renderErr = this.__name + ".renderVals(): " + (e instanceof Error && e.message ? e.message : String(e));
+        }
+        this.__streamingNow = !!(r.htmlStreaming || r.jsStreaming);
+        this.__htmlStreamingNow = !!r.htmlStreaming;
+        return h(
+          "div",
+          { ...hostBase, className: cls + (renderErr ? " sc-has-error" : "") },
+          renderErr && h(
+            "div",
+            { className: "sc-logic-error", "data-omelette-chrome": "" },
+            renderErr
+          ),
+          h(
+            AncestorContext.Provider,
+            { value: [...chain, this.__name] },
+            r.tpl(vals, this)
+          )
+        );
+      }
+    }
+    __publicField(StreamableComponent, "contextType", AncestorContext);
+    const named = /* @__PURE__ */ new Map();
+    function getDC(name) {
+      const hit = named.get(name);
+      if (hit) return hit;
+      function Dispatcher(p) {
+        const [, setTick] = React.useState(0);
+        React.useEffect(() => {
+          const sub = () => setTick((n) => n + 1);
+          registry.get(name).subs.add(sub);
+          return () => {
+            registry.get(name).subs.delete(sub);
+          };
+        }, []);
+        ensureFetched(name);
+        return h(StreamableComponent, { ...p, __name: name });
+      }
+      Dispatcher.displayName = name;
+      named.set(name, Dispatcher);
+      return Dispatcher;
+    }
+    return {
+      getDC,
+      StreamableComponent
+    };
+  }
+
+  // src/bundled.ts
+  function bundledBlob(url) {
+    const blobs = window.__resourceBlobs;
+    const b = blobs ? blobs[url.split("#")[0]] : void 0;
+    return b instanceof Blob ? b : null;
+  }
+
+  // src/cdn.ts
+  var REACT_URL = "https://unpkg.com/react@18.3.1/umd/react.production.min.js";
+  var REACT_SRI = "sha384-DGyLxAyjq0f9SPpVevD6IgztCFlnMF6oW/XQGmfe+IsZ8TqEiDrcHkMLKI6fiB/Z";
+  var REACT_DOM_URL = "https://unpkg.com/react-dom@18.3.1/umd/react-dom.production.min.js";
+  var REACT_DOM_SRI = "sha384-gTGxhz21lVGYNMcdJOyq01Edg0jhn/c22nsx0kyqP0TxaV5WVdsSH1fSDUf5YJj1";
+  var BABEL_URL = "https://unpkg.com/@babel/standalone@7.29.0/babel.min.js";
+  var BABEL_SRI = "sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y";
+  function cdnScriptFor(url, sri) {
+    const res = window.__resources;
+    const v = res ? res[url] : void 0;
+    return typeof v === "string" && v ? { src: v } : { src: url, integrity: sri };
+  }
+
+  // src/external.ts
+  var isCustomElementName = (n) => !n.includes(".") && n.includes("-");
+  function isRenderableType(g) {
+    if (typeof g === "function") return !isElementClass(g);
+    return typeof g === "object" && g !== null && typeof g.$$typeof === "symbol";
+  }
+  function resolveDottedPath(root, name) {
+    let cur = root;
+    for (const seg of name.split(".")) {
+      if (cur == null) return void 0;
+      cur = cur[seg];
+    }
+    return cur;
+  }
+  var GLOBAL_POLL_INTERVAL_MS = 50;
+  var GLOBAL_POLL_TIMEOUT_MS = 3e4;
+  function createExternalModules(onResolved) {
+    const cache = /* @__PURE__ */ new Map();
+    let babelLoading = null;
+    const reportedMissing = /* @__PURE__ */ new Map();
+    const polling = /* @__PURE__ */ new Set();
+    function ensureBabel() {
+      if (window.Babel) return Promise.resolve();
+      if (babelLoading) return babelLoading;
+      const babel = cdnScriptFor(BABEL_URL, BABEL_SRI);
+      babelLoading = new Promise((res, rej) => {
+        const s = document.createElement("script");
+        s.src = babel.src;
+        if (babel.integrity) {
+          s.integrity = babel.integrity;
+          s.crossOrigin = "anonymous";
+        }
+        s.onload = () => res();
+        s.onerror = rej;
+        document.head.appendChild(s);
+      });
+      return babelLoading;
+    }
+    const pending = /* @__PURE__ */ new Map();
+    function load(kind, url, after) {
+      const existing = pending.get(url);
+      if (existing) return existing;
+      cache.set(url, null);
+      console.info("[dc-runtime] x-import: loading", url, "(" + kind + ")");
+      const ready = Promise.all([
+        kind === "jsx" ? ensureBabel() : Promise.resolve(),
+        after ?? Promise.resolve()
+      ]);
+      const p = ready.then(() => {
+        const pre = bundledBlob(url);
+        if (pre) return pre.text();
+        return fetch(url).then((r) => {
+          if (!r.ok) throw new Error("HTTP " + r.status);
+          return r.text();
+        });
+      }).then((src) => {
+        const code = kind === "jsx" ? window.Babel.transform(src, {
+          filename: url,
+          presets: ["react", "typescript"]
+        }).code : src;
+        const module = { exports: {} };
+        const before = new Set(Object.keys(window));
+        //! nosemgrep: eval-and-function-constructor
+        new Function("React", "module", "exports", "require", code)(
+          getReact(),
+          module,
+          module.exports,
+          () => ({})
+        );
+        const globals = {};
+        for (const k of Object.keys(window)) {
+          if (!before.has(k) && typeof window[k] === "function") {
+            globals[k] = window[k];
+          }
+        }
+        cache.set(url, { mod: module.exports, globals });
+        console.info(
+          "[dc-runtime] x-import: loaded",
+          url,
+          "\u2014 exports:",
+          Object.keys(module.exports),
+          "window globals:",
+          Object.keys(globals)
+        );
+        onResolved();
+      }).catch((e) => {
+        cache.set(url, {
+          mod: {},
+          globals: {},
+          error: "failed to load: " + (e instanceof Error && e.message ? e.message : String(e))
+        });
+        console.error(
+          "[dc-runtime] x-import: FAILED to load",
+          url,
+          "(" + kind + ")",
+          e
+        );
+        onResolved();
+      });
+      pending.set(url, p);
+      return p;
+    }
+    function resolve2(url, name) {
+      const entry = cache.get(url);
+      if (!entry) return null;
+      const { mod, globals } = entry;
+      const C = mod && mod[name] || globals && globals[name] || typeof window !== "undefined" && window[name] || mod && mod.default;
+      if (typeof C === "function") return C;
+      const key = url + "\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(
+          key,
+          entry.error || 'no export named "' + name + '" (has: ' + Object.keys(mod).join(", ") + ")"
+        );
+        console.error(
+          "[dc-runtime] x-import: module",
+          url,
+          "loaded but has no component named",
+          JSON.stringify(name),
+          "\u2014 available exports:",
+          Object.keys(mod),
+          "window globals:",
+          Object.keys(globals),
+          ". The module must `module.exports = {" + name + "}` or set `window." + name + "`."
+        );
+      }
+      return null;
+    }
+    function waitForGlobal(name) {
+      if (polling.has(name)) return;
+      polling.add(name);
+      const started = Date.now();
+      const isCE = isCustomElementName(name);
+      const tick = () => {
+        const found = isCE ? customElements.get(name) : isRenderableType(resolveDottedPath(window, name));
+        if (found) {
+          polling.delete(name);
+          onResolved();
+          return;
+        }
+        if (Date.now() - started >= GLOBAL_POLL_TIMEOUT_MS) {
+          console.warn(
+            "[dc-runtime] x-import: global",
+            JSON.stringify(name),
+            "never appeared on window after " + GLOBAL_POLL_TIMEOUT_MS + "ms"
+          );
+          return;
+        }
+        setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+      };
+      setTimeout(tick, GLOBAL_POLL_INTERVAL_MS);
+    }
+    function resolveGlobal(url, name) {
+      const isCE = isCustomElementName(name);
+      if (!url) {
+        if (isCE) {
+          if (customElements.get(name)) return name;
+          waitForGlobal(name);
+          return null;
+        }
+        const g2 = resolveDottedPath(window, name);
+        if (isRenderableType(g2)) return g2;
+        waitForGlobal(name);
+        return null;
+      }
+      const entry = cache.get(url);
+      if (!entry) return null;
+      if (isCE && customElements.get(name)) return name;
+      const g = entry.globals[name] ?? resolveDottedPath(window, name);
+      if (isRenderableType(g)) return g;
+      if (name.includes(".")) return null;
+      const key = url + "\0global\0" + name;
+      if (!reportedMissing.has(key)) {
+        reportedMissing.set(key, null);
+        if (isCE && !customElements.get(name)) {
+          console.warn(
+            "[dc-runtime] x-import:",
+            url,
+            "loaded but no custom element",
+            JSON.stringify(name),
+            "is registered and window." + name + " is not a function \u2014 rendering <" + name + "> as an unknown element."
+          );
+        }
+      }
+      return name;
+    }
+    function getError(url, name) {
+      const entry = cache.get(url);
+      if (entry?.error) return entry.error;
+      return reportedMissing.get(url + "\0" + name) || null;
+    }
+    return { load, resolve: resolve2, resolveGlobal, getError };
+  }
+  function isElementClass(g) {
+    try {
+      return typeof g === "function" && typeof HTMLElement !== "undefined" && g.prototype instanceof HTMLElement;
+    } catch {
+      return false;
+    }
+  }
+
+  // src/atomics.ts
+  var ATOMIC_CSS = (
+    // layout
+    ".fx{display:flex}.col{display:flex;flex-direction:column}.grid{display:grid}.ac{align-items:center}.jc{justify-content:center}.jb{justify-content:space-between}.f1{flex:1}.noshrink{flex-shrink:0}.wrap{flex-wrap:wrap}.fw5{font-weight:500}.fw6{font-weight:600}.fw7{font-weight:700}.fw8{font-weight:800}.fs11{font-size:11px}.fs12{font-size:12px}.fs13{font-size:13px}.fs14{font-size:14px}.fs15{font-size:15px}.fs16{font-size:16px}.fs20{font-size:20px}.fs22{font-size:22px}.upper{text-transform:uppercase}.tc{text-align:center}.nowrap{white-space:nowrap}.gap8{gap:8px}.gap10{gap:10px}.gap12{gap:12px}.gap16{gap:16px}.gap24{gap:24px}.m0{margin:0}.mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mb8{margin-bottom:8px}.mb12{margin-bottom:12px}.mb16{margin-bottom:16px}.posrel{position:relative}.posabs{position:absolute}.round{border-radius:50%}.ohide{overflow:hidden}.bbox{box-sizing:border-box}.pointer{cursor:pointer}.w100{width:100%}.b0{border:none}"
+  );
+
+  // src/helmet.ts
+  var DESIGN_DOC_MODE_RE = /<meta\b[^>]*\bname\s*=\s*["']design_doc_mode["'][^>]*\b(?:content|value)\s*=\s*["'](\w+)["']/i;
+  var CANVAS_BG_LIGHT = "#f0eee6";
+  var CANVAS_BG_DARK = "#2e2c26";
+  function createHelmetManager(doc, isStreaming) {
+    const mounted = /* @__PURE__ */ new Set();
+    const live = /* @__PURE__ */ new Map();
+    let designDocMode = null;
+    let canvasStyleEl = null;
+    let appTheme = "light";
+    try {
+      const ds = doc.documentElement.dataset.theme;
+      appTheme = ds === "dark" || ds === "light" ? ds : new URLSearchParams(doc.defaultView?.location.search ?? "").get(
+        "theme"
+      ) === "dark" ? "dark" : "light";
+    } catch {
+    }
+    function applyCanvasBg() {
+      if (!canvasStyleEl) return;
+      const bg = appTheme === "dark" ? CANVAS_BG_DARK : CANVAS_BG_LIGHT;
+      canvasStyleEl.textContent = `html,body{background:${bg}}#dc-root>.sc-host{position:relative}`;
+    }
+    function postDesignMode(mode) {
+      if (window.parent === window) return;
+      try {
+        window.parent.postMessage({ type: "__dc_design_mode", mode }, "*");
+      } catch {
+      }
+    }
+    function setDesignDocMode(mode) {
+      if (mode === designDocMode) return;
+      designDocMode = mode;
+      postDesignMode(mode);
+      if (mode === "canvas") {
+        doc.documentElement.setAttribute("data-dc-canvas", "");
+        canvasStyleEl = doc.createElement("style");
+        canvasStyleEl.setAttribute("data-dc-canvas", "");
+        applyCanvasBg();
+        doc.head.appendChild(canvasStyleEl);
+      } else {
+        doc.documentElement.removeAttribute("data-dc-canvas");
+        canvasStyleEl?.remove();
+        canvasStyleEl = null;
+      }
+    }
+    window.addEventListener("message", (e) => {
+      const type = e.data && e.data.type;
+      if (type === "__dc_theme") {
+        const t = e.data.theme;
+        if (t === "light" || t === "dark") {
+          appTheme = t;
+          applyCanvasBg();
+        }
+        return;
+      }
+      if (!designDocMode || type !== "__dc_probe") return;
+      postDesignMode(designDocMode);
+    });
+    function compile(node) {
+      const raw = [...node.children];
+      const helmetClosed = node.nextSibling != null || node.parentNode?.nextSibling != null;
+      if (node.hasAttribute("data-dc-atomics") && !mounted.has("__dc-atomics")) {
+        mounted.add("__dc-atomics");
+        const el = doc.createElement("style");
+        el.id = "__dc-atomics";
+        el.textContent = ATOMIC_CSS;
+        doc.head.appendChild(el);
+      }
+      return (_vals, ctx) => {
+        const name = ctx && ctx.__name || "";
+        const streaming = !!(name && isStreaming(name));
+        for (let i = 0; i < raw.length; i++) {
+          const child = raw[i];
+          const tag = child.tagName;
+          const mayBePartial = streaming && !helmetClosed && i === raw.length - 1;
+          if (tag === "SCRIPT") {
+            if (mayBePartial) continue;
+            const key = "SCRIPT|" + (child.getAttribute("src") || child.textContent || "");
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            const el = doc.createElement("script");
+            for (const { name: an, value } of [...child.attributes])
+              el.setAttribute(an, value);
+            if (child.textContent) el.textContent = child.textContent;
+            doc.head.appendChild(el);
+          } else if (tag === "LINK" || tag === "META") {
+            if (mayBePartial) continue;
+            const key = tag + "|" + (child.getAttribute("href") || child.getAttribute("src") || child.outerHTML);
+            if (mounted.has(key)) continue;
+            mounted.add(key);
+            if (tag === "LINK") {
+              const rel = (child.getAttribute("rel") || "").toLowerCase().split(/\s+/);
+              const href = (child.getAttribute("href") || "").trim();
+              const res = window.__resources;
+              const pre = res && rel.includes("stylesheet") && !rel.includes("alternate") ? res[href] : void 0;
+              const blob = typeof pre === "string" && pre ? bundledBlob(pre) : null;
+              if (blob) {
+                const el = doc.createElement("style");
+                if (child.hasAttribute("disabled")) {
+                  el.setAttribute("media", "not all");
+                } else if (child.getAttribute("media")) {
+                  el.setAttribute("media", child.getAttribute("media"));
+                }
+                if (child.getAttribute("title"))
+                  el.setAttribute("title", child.getAttribute("title"));
+                void blob.text().then((css) => {
+                  el.textContent = css;
+                });
+                doc.head.appendChild(el);
+                continue;
+              }
+            }
+            doc.head.appendChild(child.cloneNode(true));
+          } else {
+            const key = name + "|" + i;
+            let el = live.get(key);
+            if (!el || el.tagName !== tag) {
+              if (el) el.remove();
+              el = doc.createElement(tag.toLowerCase());
+              live.set(key, el);
+              doc.head.appendChild(el);
+            }
+            for (const { name: an, value } of [...child.attributes]) {
+              if (el.getAttribute(an) !== value) el.setAttribute(an, value);
+            }
+            if (el.textContent !== child.textContent)
+              el.textContent = child.textContent;
+          }
+        }
+        return null;
+      };
+    }
+    return { compile, setDesignDocMode };
+  }
+
+  // src/pseudo.ts
+  function scanUnquotedUrl(css, i) {
+    if (css[i] !== "u" && css[i] !== "U" || css.slice(i, i + 4).toLowerCase() !== "url(" || /[a-z0-9_-]/i.test(css[i - 1] ?? "")) {
+      return -1;
+    }
+    let j = i + 4;
+    while (j < css.length && /\s/.test(css[j])) j++;
+    if (css[j] === '"' || css[j] === "'") return -1;
+    while (j < css.length && css[j] !== ")") {
+      if (css[j] === "\\") j++;
+      j++;
+    }
+    return j < css.length ? j + 1 : css.length;
+  }
+  function stripComments(css) {
+    let out = "";
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") {
+          out += c + (css[i + 1] ?? "");
+          i++;
+          continue;
+        }
+        if (c === quote) quote = "";
+        out += c;
+      } else if (c === "'" || c === '"') {
+        quote = c;
+        out += c;
+      } else if (c === "/" && css[i + 1] === "*") {
+        const end = css.indexOf("*/", i + 2);
+        i = end === -1 ? css.length : end + 1;
+        out += " ";
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end === -1) out += c;
+        else {
+          out += css.slice(i, end);
+          i = end - 1;
+        }
+      }
+    }
+    return out;
+  }
+  function importantify(css) {
+    css = stripComments(css);
+    const decls = [];
+    let start = 0;
+    let depth = 0;
+    let quote = "";
+    for (let i = 0; i < css.length; i++) {
+      const c = css[i];
+      if (quote) {
+        if (c === "\\") i++;
+        else if (c === quote) quote = "";
+      } else if (c === "'" || c === '"') quote = c;
+      else if (c === "(") depth++;
+      else if (c === ")") depth = Math.max(0, depth - 1);
+      else if (c === ";" && depth === 0) {
+        decls.push(css.slice(start, i));
+        start = i + 1;
+      } else {
+        const end = scanUnquotedUrl(css, i);
+        if (end !== -1) i = end - 1;
+      }
+    }
+    decls.push(css.slice(start));
+    return decls.map((d) => d.trim()).filter(Boolean).map((d) => /!\s*important$/i.test(d) ? d : d + " !important").join(";");
+  }
+  function createPseudoSheet(doc) {
+    let el = null;
+    const cache = /* @__PURE__ */ new Map();
+    let n = 0;
+    return (pseudo, css) => {
+      const k = pseudo + "|" + css;
+      const hit = cache.get(k);
+      if (hit) return hit;
+      if (!el) {
+        el = doc.createElement("style");
+        doc.head.appendChild(el);
+      }
+      const cls = "scp" + (n++).toString(36);
+      const isPseudoElement = pseudo === "before" || pseudo === "after";
+      const sel = isPseudoElement ? "." + cls + "::" + pseudo : "." + cls + ":" + pseudo;
+      el.sheet.insertRule(
+        sel + "{" + (isPseudoElement ? css : importantify(css)) + "}",
+        el.sheet.cssRules.length
+      );
+      cache.set(k, cls);
+      return cls;
+    };
+  }
+
+  // src/registry.ts
+  function createRegistry() {
+    const entries = /* @__PURE__ */ Object.create(null);
+    function get(name) {
+      return entries[name] || (entries[name] = {
+        html: "",
+        tpl: null,
+        Logic: null,
+        jsStreaming: false,
+        htmlStreaming: false,
+        ver: 0,
+        subs: /* @__PURE__ */ new Set(),
+        fetched: false
+      });
+    }
+    function bump(name) {
+      const r = get(name);
+      r.ver++;
+      for (const fn of r.subs) fn();
+    }
+    return {
+      entries,
+      get,
+      bump,
+      bumpAll() {
+        for (const n in entries) bump(n);
+      }
+    };
+  }
+
+  // src/runtime.ts
+  var COMPONENT_DIR = ".";
+  function createRuntime(doc = document) {
+    const registry = createRegistry();
+    const pseudoClass = createPseudoSheet(doc);
+    const helmet = createHelmetManager(
+      doc,
+      (name) => registry.get(name).htmlStreaming
+    );
+    const external = createExternalModules(() => registry.bumpAll());
+    const factory = createComponentFactory(registry, ensureFetched);
+    const host = {
+      component: (name) => factory.getDC(name),
+      placeholder: (props) => h(Placeholder, props),
+      helmet: (node) => helmet.compile(node),
+      loadExternal: (kind, url, after) => external.load(kind, url, after),
+      resolveExternal: (url, name) => external.resolve(url, name),
+      resolveExternalGlobal: (url, name) => external.resolveGlobal(url, name),
+      resolveExternalError: (url, name) => external.getError(url, name),
+      pseudoClass
+    };
+    function ensureFetched(name) {
+      const r = registry.get(name);
+      if (r.fetched) return;
+      r.fetched = true;
+      const url = COMPONENT_DIR + "/" + encodeURIComponent(name) + ".dc.html";
+      const res = window.__resources;
+      const pre = res ? res[url] : void 0;
+      const target = typeof pre === "string" && pre ? pre : url;
+      const blob = bundledBlob(target);
+      (blob ? blob.text() : fetch(target).then((res2) => {
+        if (!res2.ok) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '" failed:',
+            url,
+            "returned",
+            res2.status,
+            "\u2014 the reference renders as an empty placeholder."
+          );
+          return "";
+        }
+        return res2.text();
+      })).then((t) => {
+        if (!t) return;
+        const parsed = parseDcText(t);
+        if (!parsed) {
+          console.error(
+            '[dc-runtime] sibling fetch for "' + name + '":',
+            url,
+            "has no <x-dc> block \u2014 not a Design Component."
+          );
+          return;
+        }
+        if (parsed.props) r.propsMeta = parsed.props;
+        if (parsed.preview) r.preview = parsed.preview;
+        if (parsed.template && !r.html) updateHtml(name, parsed.template);
+        if (parsed.js && !r.Logic) updateJs(name, parsed.js);
+      }).catch(
+        (e) => console.error(
+          '[dc-runtime] sibling fetch for "' + name + '" threw:',
+          url,
+          e
+        )
+      );
+    }
+    let rootName = null;
+    function updateHtml(name, html) {
+      const r = registry.get(name);
+      r.html = html;
+      if (name === rootName) {
+        const mode = DESIGN_DOC_MODE_RE.exec(html)?.[1] ?? null;
+        if (mode || !r.htmlStreaming) helmet.setDesignDocMode(mode);
+      }
+      try {
+        r.tpl = compileTemplate(html, host);
+      } catch (e) {
+        console.error("[dc-runtime] template compile FAILED for", name, e);
+      }
+      registry.bump(name);
+    }
+    function updateJs(name, src) {
+      const r = registry.get(name);
+      const seq = r.jsSeq = (r.jsSeq || 0) + 1;
+      try {
+        const Cls = evalDcLogic(src);
+        if (r.jsSeq !== seq) return;
+        if (typeof Cls !== "function") {
+          r.logicError = name + ".dc.html: <script data-dc-script> must define `class Component extends DCLogic`";
+        } else {
+          r.logicError = null;
+          r.Logic = Cls;
+        }
+      } catch (e) {
+        if (r.jsSeq !== seq) return;
+        console.error(
+          "[dc-runtime] logic class eval FAILED for",
+          name,
+          "\u2014 the template renders with props only.",
+          e
+        );
+        r.logicError = name + ": " + (e instanceof Error && e.message ? e.message : String(e));
+      }
+      registry.bump(name);
+    }
+    function setStreaming(name, kind, on) {
+      const r = registry.get(name);
+      if (kind === "html") r.htmlStreaming = !!on;
+      else r.jsStreaming = !!on;
+      let any = false;
+      for (const n in registry.entries) {
+        const e = registry.entries[n];
+        if (e && (e.htmlStreaming || e.jsStreaming)) {
+          any = true;
+          break;
+        }
+      }
+      doc.documentElement.classList.toggle("sc-dc-streaming", any);
+      registry.bump(name);
+    }
+    function dcUpdate(name, kind, content, streaming) {
+      if (streaming) registry.get(name).fetched = true;
+      if (kind === "html") {
+        setStreaming(name, "html", !!streaming);
+        updateHtml(name, content);
+      } else if (kind === "js") {
+        setStreaming(name, "js", !!streaming);
+        if (!streaming) updateJs(name, content);
+      } else if (kind === "props") {
+        const { props, preview } = parseDataProps(content);
+        const r = registry.get(name);
+        r.propsMeta = props ?? void 0;
+        r.preview = preview;
+        registry.bump(name);
+      }
+    }
+    function setProps(name, overrides) {
+      registry.get(name).propOverrides = overrides && typeof overrides === "object" ? { ...overrides } : null;
+      registry.bump(name);
+    }
+    function adoptParsed(name, parsed) {
+      if (!parsed) return;
+      const r = registry.get(name);
+      if (parsed.props) r.propsMeta = parsed.props;
+      if (parsed.preview) r.preview = parsed.preview;
+      if (parsed.template) updateHtml(name, parsed.template);
+      if (parsed.js) updateJs(name, parsed.js);
+    }
+    return {
+      registry,
+      getDC: factory.getDC,
+      updateHtml,
+      updateJs,
+      dcUpdate,
+      setProps,
+      adoptParsed,
+      setRootName: (name) => {
+        rootName = name;
+      },
+      markFetched: (name) => {
+        registry.get(name).fetched = true;
+      },
+      annotatedTemplate: (name) => {
+        const r = registry.get(name);
+        return r.tpl && r.tpl.__annotated || null;
+      },
+      templateSource: (name) => registry.get(name).html || null,
+      StreamableLogic
+    };
+  }
+
+  // src/stream-state.ts
+  function createStreamTracker(staleMs = 6e4, now = Date.now) {
+    const since = /* @__PURE__ */ new Map();
+    const liveOne = (n) => {
+      const t = since.get(n);
+      if (t === void 0) return false;
+      if (now() - t > staleMs) {
+        since.delete(n);
+        return false;
+      }
+      return true;
+    };
+    return {
+      push(name, streaming, viewportKey) {
+        if (viewportKey === "dc-model") return;
+        if (streaming) since.set(name, now());
+        else since.delete(name);
+      },
+      live(name) {
+        if (name !== void 0) return liveOne(name);
+        for (const n of [...since.keys()]) if (liveOne(n)) return true;
+        return false;
+      }
+    };
+  }
+
+  // src/index.ts
+  function hideRawTemplate() {
+    const s = document.createElement("style");
+    s.textContent = "x-dc{display:none!important}";
+    document.head.appendChild(s);
+  }
+  function loadScript(src, integrity) {
+    return new Promise((resolve2, reject) => {
+      //! nosemgrep: create-script-element
+      const s = document.createElement("script");
+      s.src = src;
+      if (integrity) {
+        s.integrity = integrity;
+        s.crossOrigin = "anonymous";
+      }
+      s.async = false;
+      s.onload = () => resolve2();
+      s.onerror = () => reject(new Error(`failed to load ${src}`));
+      document.head.appendChild(s);
+    });
+  }
+  function loadReactUmd() {
+    const w = window;
+    if (w.React && w.ReactDOM) return Promise.resolve();
+    const react = cdnScriptFor(REACT_URL, REACT_SRI);
+    const reactDom = cdnScriptFor(REACT_DOM_URL, REACT_DOM_SRI);
+    return Promise.all([
+      loadScript(react.src, react.integrity),
+      loadScript(reactDom.src, reactDom.integrity)
+    ]).then(() => void 0);
+  }
+  function init() {
+    const runtime = createRuntime(document);
+    let rootName = "Root";
+    const baseCss = document.createElement("style");
+    baseCss.textContent = BASE_CSS;
+    document.head.prepend(baseCss);
+    const notifyHost = () => {
+      if (window.parent === window) return;
+      const r = runtime.registry.entries[rootName];
+      try {
+        window.parent.postMessage(
+          {
+            type: "__dc_booted",
+            rootName,
+            propsMeta: r && r.propsMeta || null,
+            preview: r && r.preview || null
+          },
+          "*"
+        );
+      } catch {
+      }
+    };
+    const streams = createStreamTracker();
+    const api = {
+      __dcUpdate: (name, kind, content, streaming, viewportKey) => {
+        streams.push(name, streaming, viewportKey);
+        runtime.dcUpdate(name, kind, content, streaming);
+        if (name === rootName && !streaming && kind === "props") notifyHost();
+      },
+      __dcStreaming: (name) => streams.live(name),
+      __dcSetProps: (name, overrides) => runtime.setProps(name, overrides),
+      /** Name of the component currently mounted as the page root — DC tools
+       *  push their template-stream here when targeting "the open page". */
+      __dcRootName: () => rootName,
+      /** Editor bridge — the encoded, `data-dc-tpl`-annotated template source.
+       *  The host editor parses this into its own template DOM so it can map a
+       *  rendered node (carrying the same `data-dc-tpl`) back to the source
+       *  node that emitted it. Returns the encoded form (`sc-camel-*` attrs,
+       *  `<sc-raw-*>`/`<sc-helmet>` tags); the editor decodes on serialize. */
+      __dcAnnotatedTemplate: (name) => runtime.annotatedTemplate(name),
+      /** Editor bridge — the *original* (decoded) template source. */
+      __dcTemplateSource: (name) => runtime.templateSource(name),
+      __dcBoot: () => {
+        rootName = boot(runtime, document) ?? rootName;
+        notifyHost();
+      },
+      __dcRegistry: runtime.registry.entries,
+      getDC: (name) => runtime.getDC(name),
+      // `DCLogic` is the documented base class name; `StreamableLogic` is the
+      // implementation alias kept for any project that already references it.
+      DCLogic: runtime.StreamableLogic,
+      StreamableLogic: runtime.StreamableLogic
+    };
+    Object.assign(window, api);
+    window.__dcContentKeyed = true;
+    if (document.readyState !== "loading") api.__dcBoot();
+    else document.addEventListener("DOMContentLoaded", () => api.__dcBoot());
+  }
+  hideRawTemplate();
+  loadReactUmd().then(init).catch((err) => {
+    console.error("[dc] failed to load React or boot:", err);
+    throw err;
+  });
+})();

--- a/docs/design/table-top-poker-prototype.dc.html
+++ b/docs/design/table-top-poker-prototype.dc.html
@@ -1,0 +1,1000 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet data-dc-atomics>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700;800;900&family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+html,body{margin:0;padding:0;background:#0b0a09;}
+*{box-sizing:border-box;-webkit-tap-highlight-color:transparent}
+a{color:#a81d1c;text-decoration:none}a:hover{color:#e2bd63}
+button{font-family:inherit;cursor:pointer;border:0;background:none;color:inherit}
+@keyframes dealIn{from{opacity:0;transform:translateY(-18px) rotate(-6deg) scale(.9)}to{opacity:1;transform:none}}
+@keyframes flipIn{from{opacity:0;transform:rotateY(-92deg)}to{opacity:1;transform:none}}
+@keyframes actorGlow{0%,100%{box-shadow:0 0 0 2px rgba(229,68,60,.95),0 0 34px 6px rgba(229,68,60,.30)}50%{box-shadow:0 0 0 3px rgba(255,120,110,1),0 0 54px 14px rgba(229,68,60,.5)}}
+@keyframes turnPulse{0%,100%{opacity:.55}50%{opacity:1}}
+@keyframes riseIn{from{opacity:0;transform:translateY(12px)}to{opacity:1;transform:none}}
+@keyframes sheen{from{transform:translateX(-120%)}to{transform:translateX(220%)}}
+</style>
+</helmet>
+
+<div style="min-height:100vh;background:radial-gradient(1200px 700px at 50% -10%,#1d1415 0%,#080607 62%);font-family:'IBM Plex Sans',system-ui,sans-serif;color:#f3ece1;display:flex;flex-direction:column;align-items:center;padding:22px 20px 40px;gap:18px;overflow-x:hidden">
+
+  <div style="width:100%;max-width:1740px;display:flex;align-items:flex-end;justify-content:space-between;gap:24px;flex-wrap:wrap">
+    <div style="display:flex;flex-direction:column;gap:2px">
+      <div style="font-family:'IBM Plex Mono',monospace;font-size:10.5px;letter-spacing:.22em;text-transform:uppercase;color:#8a7a63">Interactive prototype · table + phone</div>
+      <div style="font-family:'Archivo',system-ui,sans-serif;font-weight:800;letter-spacing:-.025em;font-size:31px;line-height:1.1;color:#f6efe2">Table&nbsp;Top&nbsp;Poker</div>
+    </div>
+    <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
+      <div style="font-family:'IBM Plex Mono',monospace;font-size:10.5px;letter-spacing:.14em;text-transform:uppercase;color:#7d6f5c;padding-right:6px">{{ demoHint }}</div>
+      <button onClick="{{ autoPlay }}" style="font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.1em;text-transform:uppercase;padding:9px 15px;border:1px solid rgba(229,68,60,.45);border-radius:999px;color:#f0968e;background:rgba(229,68,60,.07)" style-hover="background:rgba(229,68,60,.16)">Auto-play a hand</button>
+      <button onClick="{{ resetDemo }}" style="font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.1em;text-transform:uppercase;padding:9px 15px;border:1px solid rgba(255,255,255,.14);border-radius:999px;color:#a89b88;background:rgba(255,255,255,.03)" style-hover="color:#f3ece1;border-color:rgba(255,255,255,.3)">Reset</button>
+    </div>
+  </div>
+
+  <div style="display:flex;align-items:flex-start;justify-content:center;gap:34px;transform-origin:top center;{{ stageStyle }}">
+
+    <!-- ═══════════════ TABLE CLIENT (iPad landscape) ═══════════════ -->
+    <div style="display:flex;flex-direction:column;gap:11px;flex:none">
+      <div style="display:flex;align-items:baseline;gap:9px;padding-left:4px">
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:10px;letter-spacing:.2em;text-transform:uppercase;color:#e0a49d">Table client</span>
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:10px;color:#6d6151">iPad · 1180×820</span>
+      </div>
+      <div style="width:1244px;height:884px;flex:none;border-radius:38px;padding:32px;background:linear-gradient(150deg,#2a2622,#141210 55%,#221f1b);box-shadow:0 40px 90px -30px rgba(0,0,0,.9),inset 0 1px 0 rgba(255,255,255,.07)">
+        <div style="width:1180px;height:820px;border-radius:14px;overflow:hidden;position:relative;background:#0a0708;{{ roomStyle }}">
+
+          <!-- table surface: rectangular felt filling the whole screen, black rail -->
+          <div style="position:absolute;inset:0;background:linear-gradient(160deg,#1a1516,#0a0708 60%,#161011)"></div>
+          <div style="position:absolute;inset:16px;border-radius:10px;background:linear-gradient(180deg,#6a1a1f 0%,#4b1317 42%,#2c0c0f 100%);box-shadow:inset 0 0 180px 60px rgba(0,0,0,.62),inset 0 2px 0 rgba(255,255,255,.08),0 0 0 1px rgba(0,0,0,.8),0 22px 60px -18px rgba(0,0,0,.9)">
+            <div style="position:absolute;inset:0;border-radius:10px;background:radial-gradient(80% 110% at 50% 42%,rgba(255,255,255,.05),transparent 60%)"></div>
+            <div style="position:absolute;inset:112px 190px;border-radius:999px;border:1px solid rgba(255,255,255,.09)"></div>
+          </div>
+
+
+          <!-- top-right: join code toggle -->
+          <sc-if value="{{ hasRoom }}" hint-placeholder-val="{{ true }}">
+            <div style="position:absolute;left:50%;top:22px;transform:translateX(-50%);z-index:11;display:flex;align-items:center;gap:12px">
+              <button onClick="{{ toggleJoin }}" style="display:flex;align-items:center;gap:11px;padding:10px 16px;border-radius:999px;background:rgba(10,13,11,.6);border:1px solid rgba(229,68,60,.32);backdrop-filter:blur(6px)" style-hover="border-color:rgba(240,120,110,.8)">
+                <span style="font-family:'IBM Plex Mono',monospace;font-size:10px;font-weight:600;letter-spacing:.2em;text-transform:uppercase;color:#9c8f79">{{ joinToggleLabel }}</span>
+                <span style="font-family:'IBM Plex Mono',monospace;font-weight:700;font-size:17px;letter-spacing:.14em;color:#f6dcd8">{{ joinToggleCode }}</span>
+              </button>
+            </div>
+          </sc-if>
+
+          <!-- top-right: table settings -->
+          <div style="position:absolute;right:24px;top:20px;z-index:12">
+            <button onClick="{{ openSettings }}" style="width:52px;height:52px;border-radius:16px;border:1px solid rgba(255,255,255,.16);background:rgba(12,7,8,.62);backdrop-filter:blur(6px);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:5px" style-hover="border-color:rgba(250,234,231,.6);background:rgba(20,10,11,.8)">
+              <span style="width:20px;height:2px;border-radius:2px;background:#f4e6e3;display:block"></span>
+              <span style="width:20px;height:2px;border-radius:2px;background:#f4e6e3;display:block"></span>
+              <span style="width:20px;height:2px;border-radius:2px;background:#f4e6e3;display:block"></span>
+            </button>
+          </div>
+
+          <!-- settings overlay -->
+          <sc-if value="{{ settingsOpen }}" hint-placeholder-val="{{ false }}">
+            <div style="position:absolute;inset:0;z-index:14;display:flex;align-items:center;justify-content:center;background:rgba(6,4,4,.66);backdrop-filter:blur(5px)">
+              <div style="width:660px;max-height:768px;overflow:hidden;border-radius:22px;background:linear-gradient(180deg,#1d1214,#100a0b);border:1px solid rgba(255,255,255,.1);box-shadow:0 44px 90px -30px rgba(0,0,0,.95);display:flex;flex-direction:column">
+                <div style="padding:26px 30px 20px;display:flex;align-items:flex-start;justify-content:space-between;gap:20px;border-bottom:1px solid rgba(255,255,255,.08)">
+                  <div style="display:flex;flex-direction:column;gap:4px">
+                    <span style="font-family:'IBM Plex Mono',monospace;font-size:10px;letter-spacing:.24em;text-transform:uppercase;color:#a08b88">Table settings</span>
+                    <span style="font-family:'Archivo',system-ui,sans-serif;font-weight:800;letter-spacing:-.03em;font-size:30px;line-height:1.1;color:#f7ece9">House rules</span>
+                  </div>
+                  <button onClick="{{ closeSettings }}" style="width:42px;height:42px;border-radius:13px;border:1px solid rgba(255,255,255,.14);color:#e5d8d5;font-size:17px" style-hover="border-color:rgba(255,255,255,.4);color:#fff">✕</button>
+                </div>
+                <div style="padding:6px 30px 24px;overflow-y:auto;display:flex;flex-direction:column">
+                  <sc-for list="{{ steppers }}" as="r" hint-placeholder-count="2">
+                    <div style="padding:19px 0;display:flex;align-items:center;justify-content:space-between;gap:24px;border-bottom:1px solid rgba(255,255,255,.06)">
+                      <div style="display:flex;flex-direction:column;gap:4px;min-width:0">
+                        <span style="font-size:17px;font-weight:600;color:#f6ebe8">{{ r.label }}</span>
+                        <span style="font-size:13.5px;line-height:1.45;color:#a89693">{{ r.desc }}</span>
+                      </div>
+                      <div style="flex:none;display:flex;align-items:center;gap:12px;padding:6px;border-radius:14px;background:rgba(255,255,255,.05);border:1px solid rgba(255,255,255,.09)">
+                        <button onClick="{{ r.dec }}" style="width:42px;height:42px;border-radius:11px;background:rgba(255,255,255,.06);font-size:22px;line-height:1;color:#f4e6e3" style-hover="background:rgba(255,255,255,.14)">−</button>
+                        <span style="min-width:56px;text-align:center;font-family:'Archivo',system-ui,sans-serif;font-weight:800;font-size:26px;letter-spacing:-.03em;color:#faeae7">{{ r.value }}</span>
+                        <button onClick="{{ r.inc }}" style="width:42px;height:42px;border-radius:11px;background:rgba(255,255,255,.06);font-size:20px;line-height:1;color:#f4e6e3" style-hover="background:rgba(255,255,255,.14)">+</button>
+                      </div>
+                    </div>
+                  </sc-for>
+                  <sc-for list="{{ toggles }}" as="t" hint-placeholder-count="4">
+                    <div style="padding:15px 0;display:flex;align-items:center;justify-content:space-between;gap:24px;border-bottom:1px solid rgba(255,255,255,.06)">
+                      <div style="display:flex;flex-direction:column;gap:4px;min-width:0">
+                        <span style="font-size:17px;font-weight:600;color:#f6ebe8">{{ t.label }}</span>
+                        <span style="font-size:13.5px;line-height:1.45;color:#a89693">{{ t.desc }}</span>
+                      </div>
+                      <button onClick="{{ t.toggle }}" style="flex:none;width:66px;height:38px;border-radius:999px;padding:4px;display:flex;align-items:center;{{ t.trackStyle }}">
+                        <span style="width:30px;height:30px;border-radius:50%;transition:transform .18s ease;{{ t.knobStyle }}"></span>
+                      </button>
+                    </div>
+                  </sc-for>
+                  <div style="padding-top:20px;display:flex;align-items:center;justify-content:space-between;gap:16px">
+                    <span style="font-family:'IBM Plex Mono',monospace;font-size:10.5px;letter-spacing:.16em;text-transform:uppercase;color:#7d6a68">Applies from the next hand</span>
+                    <button onClick="{{ closeSettings }}" style="padding:15px 30px;border-radius:999px;background:linear-gradient(180deg,#fbf6f3,#e0cdc7);color:#1b0708;font-weight:700;font-size:15.5px;letter-spacing:.02em" style-hover="filter:brightness(1.04)">Done</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </sc-if>
+          <sc-if value="{{ isIdle }}" hint-placeholder-val="{{ true }}">
+            <div style="position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:26px;z-index:5">
+              <button onClick="{{ createRoom }}" style="padding:20px 44px;border-radius:999px;background:linear-gradient(180deg,#fbf6f3,#e0cdc7);color:#1b0708;font-weight:700;font-size:19px;letter-spacing:.05em;box-shadow:0 16px 40px -14px rgba(229,68,60,.6),inset 0 1px 0 rgba(255,255,255,.5)" style-hover="filter:brightness(1.07)" style-active="transform:translateY(1px)">Create room</button>
+            </div>
+          </sc-if>
+
+          <!-- centre: join panel (lobby, or toggled open mid-hand) -->
+          <sc-if value="{{ showJoinPanel }}" hint-placeholder-val="{{ true }}">
+            <div style="position:absolute;inset:0;z-index:10;display:flex;align-items:center;justify-content:center;background:rgba(5,8,7,.5)">
+            <div style="display:flex;align-items:center;gap:38px;padding:26px 34px;border-radius:22px;background:rgba(6,9,8,.62);border:1px solid rgba(255,255,255,.08);box-shadow:0 30px 70px -24px rgba(0,0,0,.85);backdrop-filter:blur(3px);animation:riseIn .4s ease both">
+              <div style="padding:14px;background:#f6f1e6;border-radius:14px;box-shadow:0 10px 30px -10px rgba(0,0,0,.7)">{{ qr }}</div>
+              <div style="display:flex;flex-direction:column;gap:10px;align-items:flex-start">
+                <span style="font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.24em;text-transform:uppercase;color:#9c8f79">Scan or enter code</span>
+                <span style="font-family:'IBM Plex Mono',monospace;font-weight:700;font-size:104px;line-height:.92;letter-spacing:.1em;color:#faeae7;text-shadow:0 4px 30px rgba(229,68,60,.4)">{{ roomCode }}</span>
+                <span style="font-family:'IBM Plex Mono',monospace;font-size:12px;color:#7f7260">{{ joinUrl }}</span>
+                <div style="margin-top:8px;font-size:14px;color:#b8ab96">{{ lobbyHint }}</div>
+                <sc-if value="{{ joinPanelDismissable }}" hint-placeholder-val="{{ false }}">
+                  <button onClick="{{ toggleJoin }}" style="margin-top:10px;padding:12px 22px;border-radius:999px;border:1px solid rgba(255,255,255,.18);font-family:'IBM Plex Mono',monospace;font-size:11px;font-weight:600;letter-spacing:.18em;text-transform:uppercase;color:#cdbfa6" style-hover="color:#fff;border-color:rgba(255,255,255,.4)">Hide</button>
+                </sc-if>
+              </div>
+            </div>
+            </div>
+          </sc-if>
+
+          <!-- ── centre: board ── -->
+          <sc-if value="{{ showBoard }}" hint-placeholder-val="{{ true }}">
+            <div style="position:absolute;inset:0;z-index:5;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:20px;pointer-events:none">
+              <div style="display:flex;gap:14px;align-items:center;min-height:174px">
+                <sc-for list="{{ board }}" as="c" hint-placeholder-count="5">
+                  <div style="width:120px;height:170px;border-radius:11px;background:linear-gradient(170deg,#fffdf7,#efe7d6);border:1px solid rgba(0,0,0,.22);box-shadow:0 16px 30px -12px rgba(0,0,0,.75);display:flex;flex-direction:column;justify-content:space-between;padding:11px 13px;animation:dealIn .4s cubic-bezier(.2,.8,.2,1) both">
+                    <div style="display:flex;align-items:baseline;gap:5px">
+                      <span style="font-family:'IBM Plex Sans',sans-serif;font-weight:700;font-size:46px;line-height:.9;letter-spacing:-.02em;{{ c.colorStyle }}">{{ c.rank }}</span>
+                      <span style="font-size:26px;line-height:1;{{ c.colorStyle }}">{{ c.sym }}</span>
+                    </div>
+                    <div style="text-align:right;font-size:56px;line-height:.8;{{ c.colorStyle }}">{{ c.sym }}</div>
+                  </div>
+                </sc-for>
+                <sc-for list="{{ boardSlots }}" as="s" hint-placeholder-count="0">
+                  <div style="width:120px;height:170px;border-radius:11px;border:1px dashed rgba(255,255,255,.12);background:rgba(0,0,0,.14)"></div>
+                </sc-for>
+              </div>
+            </div>
+          </sc-if>
+
+          <!-- ── seats: number, blinds/button, whose turn ── -->
+          <sc-for list="{{ seats }}" as="s" hint-placeholder-count="8">
+            <div style="position:absolute;z-index:7;width:120px;transform:translate(-50%,-50%);display:flex;flex-direction:column;align-items:center;gap:8px;{{ s.posStyle }}">
+              <div style="border-radius:16px;padding:8px;display:flex;flex-direction:column;align-items:center;gap:7px;{{ s.podStyle }}">
+                <div style="width:60px;height:60px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center;font-family:'Archivo',system-ui,sans-serif;font-weight:800;font-size:27px;letter-spacing:-.03em;{{ s.avatarStyle }}">{{ s.badge }}</div>
+                <sc-for list="{{ s.markers }}" as="m" hint-placeholder-count="0">
+                  <div style="position:absolute;display:flex;align-items:center;justify-content:center;height:30px;min-width:30px;padding:0 8px;border-radius:999px;font-family:'IBM Plex Mono',monospace;font-size:11px;font-weight:700;letter-spacing:.04em;{{ m.style }}">{{ m.label }}</div>
+                </sc-for>
+                <sc-for list="{{ s.cards }}" as="c" hint-placeholder-count="0">
+                  <div style="position:absolute;width:40px;height:56px;border-radius:6px;display:flex;flex-direction:column;align-items:center;justify-content:center;line-height:1;animation:flipIn .35s ease both;{{ c.miniStyle }}">
+                    <span style="font-family:'Archivo',system-ui,sans-serif;font-weight:800;font-size:19px">{{ c.rank }}</span>
+                    <span style="font-size:13px">{{ c.sym }}</span>
+                  </div>
+                </sc-for>
+              </div>
+              <sc-if value="{{ s.isActor }}" hint-placeholder-val="{{ true }}">
+                <div style="padding:5px 13px;border-radius:999px;background:#e5443c;color:#fff;font-family:'IBM Plex Mono',monospace;font-size:10.5px;font-weight:700;letter-spacing:.2em;text-transform:uppercase;white-space:nowrap;box-shadow:0 8px 24px -6px rgba(229,68,60,.95)">To act</div>
+              </sc-if>
+            </div>
+          </sc-for>
+
+          <!-- ── table controls (bottom-right rail) ── -->
+          <div style="position:absolute;right:26px;top:50%;transform:translateY(-50%);z-index:8;display:flex;flex-direction:column;align-items:flex-end;gap:12px">
+            <sc-if value="{{ canStartHand }}" hint-placeholder-val="{{ true }}">
+              <button onClick="{{ startHand }}" style="padding:17px 34px;border-radius:999px;background:linear-gradient(180deg,#fbf6f3,#e0cdc7);color:#1b0708;font-weight:700;font-size:16px;letter-spacing:.04em;box-shadow:0 14px 34px -12px rgba(229,68,60,.7),inset 0 1px 0 rgba(255,255,255,.5)" style-hover="filter:brightness(1.07)">Deal hand</button>
+            </sc-if>
+            <sc-if value="{{ isComplete }}" hint-placeholder-val="{{ true }}">
+              <button onClick="{{ nextHand }}" style="padding:17px 34px;border-radius:999px;background:linear-gradient(180deg,#fbf6f3,#e0cdc7);color:#1b0708;font-weight:700;font-size:16px;letter-spacing:.04em;box-shadow:0 14px 34px -12px rgba(229,68,60,.7),inset 0 1px 0 rgba(255,255,255,.5)" style-hover="filter:brightness(1.07)">Next hand</button>
+            </sc-if>
+            <sc-if value="{{ hasRoom }}" hint-placeholder-val="{{ true }}">
+              <button onClick="{{ endSession }}" style="padding:15px 22px;border-radius:999px;border:1px solid rgba(255,255,255,.14);color:#a89b88;font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.14em;text-transform:uppercase;background:rgba(0,0,0,.28)" style-hover="color:#f3ece1;border-color:rgba(255,255,255,.32)">End session</button>
+            </sc-if>
+          </div>
+
+        </div>
+      </div>
+    </div>
+
+    <!-- ═══════════════ PLAYER CLIENT (phone) ═══════════════ -->
+    <div style="display:flex;flex-direction:column;gap:11px;flex:none">
+      <div style="display:flex;align-items:baseline;gap:9px;padding-left:4px">
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:10px;letter-spacing:.2em;text-transform:uppercase;color:#e0a49d">Player client</span>
+        <span style="font-family:'IBM Plex Mono',monospace;font-size:10px;color:#6d6151">{{ phoneSeatLabel }}</span>
+      </div>
+      <div style="width:426px;height:900px;flex:none;border-radius:56px;padding:15px;background:linear-gradient(160deg,#312c27,#131110 60%,#262220);box-shadow:0 40px 90px -30px rgba(0,0,0,.9),inset 0 1px 0 rgba(255,255,255,.08)">
+        <div style="width:396px;height:870px;border-radius:44px;overflow:hidden;position:relative;display:flex;flex-direction:column;{{ phoneBgStyle }}">
+
+          <!-- status bar -->
+          <div style="height:52px;flex:none;display:flex;align-items:center;justify-content:space-between;padding:0 26px;font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.1em;color:rgba(243,236,225,.62)">
+            <span>9:41</span>
+            <span style="width:118px;height:26px;border-radius:999px;background:#0a0908"></span>
+            <span>{{ phoneConn }}</span>
+          </div>
+
+          <!-- header -->
+          <div style="flex:none;padding:4px 22px 14px;display:flex;align-items:center;justify-content:space-between;gap:12px">
+            <div style="display:flex;flex-direction:column;gap:1px;min-width:0">
+              <span style="font-family:'IBM Plex Mono',monospace;font-size:9.5px;letter-spacing:.24em;text-transform:uppercase;color:#8a7c67">{{ phoneKicker }}</span>
+              <span style="font-family:'Archivo',system-ui,sans-serif;font-weight:800;letter-spacing:-.025em;font-size:24px;line-height:1.15;color:#f4ead9;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">{{ phoneTitle }}</span>
+            </div>
+            <sc-if value="{{ seated }}" hint-placeholder-val="{{ true }}">
+              <button onClick="{{ openMenu }}" style="width:46px;height:46px;flex:none;border-radius:14px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.05);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px" style-hover="background:rgba(255,255,255,.11)">
+                <span style="width:18px;height:1.5px;background:#e6dccc;display:block"></span>
+                <span style="width:18px;height:1.5px;background:#e6dccc;display:block"></span>
+                <span style="width:18px;height:1.5px;background:#e6dccc;display:block"></span>
+              </button>
+            </sc-if>
+          </div>
+
+          <!-- ── join screen ── -->
+          <sc-if value="{{ pJoin }}" hint-placeholder-val="{{ true }}">
+            <div style="flex:1;display:flex;flex-direction:column;justify-content:center;gap:20px;padding:0 26px 34px">
+              <div style="font-size:14.5px;line-height:1.5;color:#b5a894">Enter the four letters shown in the middle of the table, or scan its code.</div>
+              <div style="display:flex;gap:10px">
+                <sc-for list="{{ codeBoxes }}" as="b" hint-placeholder-count="4">
+                  <div style="flex:1;aspect-ratio:1/1.15;border-radius:16px;display:flex;align-items:center;justify-content:center;font-family:'IBM Plex Mono',monospace;font-weight:700;font-size:42px;{{ b.style }}">{{ b.char }}</div>
+                </sc-for>
+              </div>
+              <div style="display:grid;grid-template-columns:repeat(5,1fr);gap:8px">
+                <sc-for list="{{ keys }}" as="k" hint-placeholder-count="25">
+                  <button onClick="{{ k.press }}" style="height:52px;border-radius:13px;border:1px solid rgba(255,255,255,.09);background:rgba(255,255,255,.04);font-family:'IBM Plex Mono',monospace;font-size:18px;font-weight:600;color:#efe6d6" style-hover="background:rgba(255,255,255,.1)" style-active="transform:translateY(1px)">{{ k.label }}</button>
+                </sc-for>
+              </div>
+              <button onClick="{{ joinRoom }}" style="height:62px;border-radius:18px;font-size:17px;font-weight:700;letter-spacing:.03em;{{ joinBtnStyle }}">{{ joinBtnLabel }}</button>
+              <sc-if value="{{ joinError }}" hint-placeholder-val="{{ false }}">
+                <div style="font-size:13.5px;color:#e88b7d;text-align:center">That room code doesn't exist — check the table screen.</div>
+              </sc-if>
+            </div>
+          </sc-if>
+
+          <!-- ── seat picker ── -->
+          <sc-if value="{{ pSeatPick }}" hint-placeholder-val="{{ false }}">
+            <div style="flex:1;overflow:hidden;display:flex;flex-direction:column;gap:14px;padding:0 22px 26px">
+              <div style="font-size:14.5px;line-height:1.5;color:#b5a894">Pick where you're sitting. Seat order sets the button and blinds.</div>
+              <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px">
+                <sc-for list="{{ seatOptions }}" as="o" hint-placeholder-count="8">
+                  <button onClick="{{ o.claim }}" style="border-radius:16px;padding:14px 13px;display:flex;align-items:center;gap:11px;text-align:left;{{ o.style }}">
+                    <span style="width:34px;height:34px;border-radius:50%;flex:none;display:flex;align-items:center;justify-content:center;font-family:'IBM Plex Mono',monospace;font-weight:700;font-size:12px;{{ o.avatarStyle }}">{{ o.badge }}</span>
+                    <span style="display:flex;flex-direction:column;gap:2px;min-width:0">
+                      <span style="font-size:14.5px;font-weight:600;color:#f2e9d9">{{ o.title }}</span>
+                      <span style="font-family:'IBM Plex Mono',monospace;font-size:9.5px;letter-spacing:.14em;text-transform:uppercase;color:#9b8f7c">{{ o.sub }}</span>
+                    </span>
+                  </button>
+                </sc-for>
+              </div>
+            </div>
+          </sc-if>
+
+          <!-- ── seated: wait / play / folded / showdown ── -->
+          <sc-if value="{{ seated }}" hint-placeholder-val="{{ false }}">
+            <div style="flex:1;display:flex;flex-direction:column;min-height:0">
+
+              <!-- turn banner -->
+              <div style="margin:0 22px 16px;flex:none;border-radius:18px;padding:15px 18px;display:flex;align-items:center;gap:13px;{{ bannerStyle }}">
+                <span style="width:11px;height:11px;border-radius:50%;flex:none;{{ bannerDotStyle }}"></span>
+                <div style="display:flex;flex-direction:column;gap:2px;min-width:0">
+                  <span style="font-family:'IBM Plex Mono',monospace;font-size:10px;letter-spacing:.22em;text-transform:uppercase;{{ bannerKickerStyle }}">{{ bannerKicker }}</span>
+                  <span style="font-size:17px;font-weight:600;line-height:1.25;{{ bannerTextStyle }}">{{ bannerText }}</span>
+                </div>
+              </div>
+
+              <!-- hole cards -->
+              <div style="flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:20px;min-height:0;padding:0 22px">
+                <sc-if value="{{ hasHole }}" hint-placeholder-val="{{ true }}">
+                  <div style="display:flex;gap:16px;align-items:center">
+                    <sc-for list="{{ hole }}" as="c" hint-placeholder-count="2">
+                      <div style="width:150px;height:214px;border-radius:15px;background:linear-gradient(170deg,#fffdf7,#efe7d6);border:1px solid rgba(0,0,0,.2);box-shadow:0 22px 44px -16px rgba(0,0,0,.85);display:flex;flex-direction:column;justify-content:space-between;padding:14px 16px;animation:flipIn .42s cubic-bezier(.2,.8,.2,1) both;{{ c.tiltStyle }}">
+                        <div style="display:flex;align-items:baseline;gap:6px">
+                          <span style="font-family:'IBM Plex Sans',sans-serif;font-weight:700;font-size:60px;line-height:.86;letter-spacing:-.03em;{{ c.colorStyle }}">{{ c.rank }}</span>
+                          <span style="font-size:32px;line-height:1;{{ c.colorStyle }}">{{ c.sym }}</span>
+                        </div>
+                        <div style="text-align:right;font-size:72px;line-height:.78;{{ c.colorStyle }}">{{ c.sym }}</div>
+                      </div>
+                    </sc-for>
+                  </div>
+                  <div style="font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.2em;text-transform:uppercase;color:#8f8270">{{ holeCaption }}</div>
+                </sc-if>
+                <sc-if value="{{ showEmptyState }}" hint-placeholder-val="{{ false }}">
+                  <div style="display:flex;flex-direction:column;align-items:center;gap:18px;text-align:center">
+                    <div style="display:flex;gap:14px">
+                      <div style="width:104px;height:148px;border-radius:13px;border:1px dashed rgba(255,255,255,.16);background:rgba(255,255,255,.03);transform:rotate(-5deg)"></div>
+                      <div style="width:104px;height:148px;border-radius:13px;border:1px dashed rgba(255,255,255,.16);background:rgba(255,255,255,.03);transform:rotate(5deg)"></div>
+                    </div>
+                    <div style="font-size:15px;line-height:1.5;color:#a3977f;max-width:250px">{{ emptyStateText }}</div>
+                  </div>
+                </sc-if>
+                <sc-if value="{{ showWinnerCard }}" hint-placeholder-val="{{ false }}">
+                  <div style="width:100%;border-radius:20px;padding:18px 20px;background:rgba(229,68,60,.1);border:1px solid rgba(229,68,60,.34);display:flex;flex-direction:column;gap:9px">
+                    <span style="font-family:'IBM Plex Mono',monospace;font-size:10px;letter-spacing:.24em;text-transform:uppercase;color:#e5443c">Showdown</span>
+                    <span style="font-family:'Archivo',system-ui,sans-serif;font-weight:800;letter-spacing:-.025em;font-size:26px;line-height:1.2;color:#faeae7">{{ resultText }}</span>
+                    <span style="font-size:14px;color:#b5a894">{{ yourResultText }}</span>
+                  </div>
+                </sc-if>
+              </div>
+
+              <!-- action bar -->
+              <div style="flex:none;padding:0 18px 26px;display:flex;flex-direction:column;gap:11px">
+                <sc-if value="{{ showRejection }}" hint-placeholder-val="{{ false }}">
+                  <div style="padding:11px 15px;border-radius:13px;background:rgba(232,139,125,.13);border:1px solid rgba(232,139,125,.34);font-size:13.5px;color:#f0aa9d">{{ rejectionText }}</div>
+                </sc-if>
+                <div style="display:grid;grid-template-columns:1fr 1fr;gap:11px">
+                  <sc-for list="{{ actions }}" as="a" hint-placeholder-count="4">
+                    <button onClick="{{ a.press }}" disabled="{{ a.disabled }}" style="height:74px;border-radius:18px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:3px;{{ a.style }}">
+                      <span style="font-size:19px;font-weight:700;letter-spacing:.02em">{{ a.label }}</span>
+                      <span style="font-family:'IBM Plex Mono',monospace;font-size:9.5px;letter-spacing:.18em;text-transform:uppercase;opacity:.72">{{ a.sub }}</span>
+                    </button>
+                  </sc-for>
+                </div>
+              </div>
+            </div>
+          </sc-if>
+
+          <!-- ── side menu drawer ── -->
+          <sc-if value="{{ menuOpen }}" hint-placeholder-val="{{ false }}">
+            <div style="position:absolute;inset:0;z-index:20;display:flex;justify-content:flex-end">
+              <button onClick="{{ closeMenu }}" style="position:absolute;inset:0;background:rgba(4,6,5,.62);backdrop-filter:blur(3px)"></button>
+              <div style="position:relative;width:312px;height:100%;padding:30px 24px;display:flex;flex-direction:column;gap:22px;background:linear-gradient(180deg,#241417,#0d0809);border-left:1px solid rgba(229,68,60,.2);box-shadow:-30px 0 70px -20px rgba(0,0,0,.9)">
+                <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:12px">
+                  <div style="display:flex;flex-direction:column;gap:3px">
+                    <span style="font-family:'IBM Plex Mono',monospace;font-size:9.5px;letter-spacing:.24em;text-transform:uppercase;color:#8a7c67">Room</span>
+                    <span style="font-family:'IBM Plex Mono',monospace;font-weight:700;font-size:34px;letter-spacing:.14em;color:#f6dcd8">{{ roomCode }}</span>
+                  </div>
+                  <button onClick="{{ closeMenu }}" style="width:36px;height:36px;border-radius:11px;border:1px solid rgba(255,255,255,.13);color:#cbbfae;font-size:16px">✕</button>
+                </div>
+                <div style="display:flex;align-items:center;gap:9px;padding:12px 14px;border-radius:14px;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.08)">
+                  <span style="width:8px;height:8px;border-radius:50%;background:#7bd88f;box-shadow:0 0 9px #7bd88f"></span>
+                  <span style="font-family:'IBM Plex Mono',monospace;font-size:11px;letter-spacing:.14em;text-transform:uppercase;color:#c0b4a1">{{ phoneConn }} · seat {{ mySeatNo }}</span>
+                </div>
+                <div style="height:1px;background:rgba(255,255,255,.08)"></div>
+                <button onClick="{{ toggleSitOut }}" style="text-align:left;padding:16px;border-radius:16px;border:1px solid rgba(229,68,60,.24);background:rgba(229,68,60,.07);display:flex;flex-direction:column;gap:4px" style-hover="background:rgba(229,68,60,.14)">
+                  <span style="font-size:16px;font-weight:600;color:#f7e6e3">{{ sitOutLabel }}</span>
+                  <span style="font-size:12.5px;color:#a2957f;line-height:1.4">{{ sitOutSub }}</span>
+                </button>
+                <button onClick="{{ changeSeat }}" style="text-align:left;padding:16px;border-radius:16px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.04);display:flex;flex-direction:column;gap:4px" style-hover="background:rgba(255,255,255,.09)">
+                  <span style="font-size:16px;font-weight:600;color:#f2e9d9">Change seat</span>
+                  <span style="font-size:12.5px;color:#a2957f;line-height:1.4">Go back to the seat map and move.</span>
+                </button>
+                <button onClick="{{ leaveTable }}" style="text-align:left;padding:16px;border-radius:16px;border:1px solid rgba(232,139,125,.28);background:rgba(232,139,125,.07);display:flex;flex-direction:column;gap:4px" style-hover="background:rgba(232,139,125,.14)">
+                  <span style="font-size:16px;font-weight:600;color:#f0b3a8">Leave table</span>
+                  <span style="font-size:12.5px;color:#a2957f;line-height:1.4">Frees your seat for someone else.</span>
+                </button>
+                <div style="margin-top:auto;font-family:'IBM Plex Mono',monospace;font-size:10px;letter-spacing:.16em;text-transform:uppercase;color:#6f6455;line-height:1.7">Blinds are posted physically · no chips tracked</div>
+              </div>
+            </div>
+          </sc-if>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1740,&quot;height&quot;:1000},&quot;autoBots&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Prototype behaviour&quot;},&quot;botSpeed&quot;:{&quot;editor&quot;:&quot;range&quot;,&quot;default&quot;:900,&quot;min&quot;:250,&quot;max&quot;:2500,&quot;step&quot;:50,&quot;unit&quot;:&quot;ms&quot;,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Prototype behaviour&quot;},&quot;xray&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:false,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Prototype behaviour&quot;}}">
+const SUITS = { s: "♠", h: "♥", d: "♦", c: "♣" };
+const RANKS = ["2","3","4","5","6","7","8","9","T","J","Q","K","A"];
+const RANK_NAMES = { "2":"Two","3":"Three","4":"Four","5":"Five","6":"Six","7":"Seven","8":"Eight","9":"Nine","T":"Ten","J":"Jack","Q":"Queen","K":"King","A":"Ace" };
+const NAMES = ["Ellis","Mara","Dev","Nina","Tobi","Cass","Reed","Juno"];
+const SEAT_HUES = [22, 22, 22, 22, 22, 22, 22, 22];
+/** Seats sit along the two long edges: 1..k left→right on the bottom, then back right→left on top. */
+function posFor(i, n) {
+  const bottom = Math.ceil(n / 2);
+  if (i < bottom) return { l: 14 + (72 * (bottom === 1 ? 0.5 : i / (bottom - 1))), t: 90 };
+  const topCount = n - bottom, j = i - bottom;
+  return { l: 86 - (72 * (topCount === 1 ? 0.5 : j / (topCount - 1))), t: 10 };
+}
+const seatColor = () => "oklch(0.62 0.17 22)";
+
+function rv(r) { return RANKS.indexOf(r) + 2; }
+function cmp(a, b) { for (let i = 0; i < Math.max(a.length, b.length); i++) { const x = a[i] || 0, y = b[i] || 0; if (x !== y) return x - y; } return 0; }
+
+function score5(cards) {
+  const vals = cards.map((c) => rv(c.r)).sort((a, b) => b - a);
+  const suits = cards.map((c) => c.s);
+  const flush = suits.every((s) => s === suits[0]);
+  const uniq = [...new Set(vals)].sort((a, b) => b - a);
+  let straightHigh = 0;
+  if (uniq.length === 5) {
+    if (uniq[0] - uniq[4] === 4) straightHigh = uniq[0];
+    else if (uniq[0] === 14 && uniq[1] === 5) straightHigh = 5;
+  }
+  const counts = {};
+  vals.forEach((v) => { counts[v] = (counts[v] || 0) + 1; });
+  const groups = Object.keys(counts).map(Number)
+    .sort((a, b) => counts[b] - counts[a] || b - a);
+  const shape = groups.map((g) => counts[g]).join("");
+  if (flush && straightHigh) return [8, straightHigh];
+  if (shape.startsWith("4")) return [7, groups[0], groups[1]];
+  if (shape === "32") return [6, groups[0], groups[1]];
+  if (flush) return [5, ...vals];
+  if (straightHigh) return [4, straightHigh];
+  if (shape.startsWith("3")) return [3, groups[0], ...groups.slice(1)];
+  if (shape.startsWith("22")) return [2, groups[0], groups[1], groups[2]];
+  if (shape.startsWith("2")) return [1, groups[0], ...groups.slice(1)];
+  return [0, ...vals];
+}
+
+function best7(cards) {
+  let best = null, bestC = null;
+  for (let a = 0; a < 3; a++) for (let b = a + 1; b < 4; b++) for (let c = b + 1; c < 5; c++)
+    for (let d = c + 1; d < 6; d++) for (let e = d + 1; e < 7; e++) {
+      const five = [cards[a], cards[b], cards[c], cards[d], cards[e]];
+      const s = score5(five);
+      if (best === null || cmp(s, best) > 0) { best = s; bestC = five; }
+    }
+  return { score: best, cards: bestC };
+}
+
+function describe(score) {
+  const n = (v) => RANK_NAMES[RANKS[v - 2]];
+  switch (score[0]) {
+    case 8: return score[1] === 14 ? "Royal flush" : "Straight flush, " + n(score[1]) + " high";
+    case 7: return "Four " + n(score[1]) + "s";
+    case 6: return "Full house, " + n(score[1]) + "s over " + n(score[2]) + "s";
+    case 5: return "Flush, " + n(score[1]) + " high";
+    case 4: return "Straight, " + n(score[1]) + " high";
+    case 3: return "Three " + n(score[1]) + "s";
+    case 2: return "Two pair, " + n(score[1]) + "s and " + n(score[2]) + "s";
+    case 1: return "Pair of " + n(score[1]) + "s";
+    default: return n(score[1]) + " high";
+  }
+}
+
+function freshDeck() {
+  const d = [];
+  for (const s of ["s", "h", "d", "c"]) for (const r of RANKS) d.push({ r, s });
+  for (let i = d.length - 1; i > 0; i--) { const j = Math.floor(Math.random() * (i + 1)); [d[i], d[j]] = [d[j], d[i]]; }
+  return d;
+}
+const code4 = () => Array.from({ length: 4 }, () => "ACDEFGHJKLMNPQRTUVWXY379"[Math.floor(Math.random() * 24)]).join("");
+
+class Component extends DCLogic {
+  state = {
+    phase: "idle",            // idle | lobby | betting | showdown | foldedout
+    roomCode: null,
+    seats: Array.from({ length: 8 }, (_, i) => ({ id: i, name: NAMES[i], claimed: false, sittingOut: false })),
+    mySeat: null,
+    button: 0,
+    street: "preflop",
+    board: [],
+    deck: [],
+    hole: {},                  // seatId -> [card, card]
+    inHand: [],
+    folded: [],
+    needsAction: [],
+    lastAction: {},            // seatId -> label
+    actor: null,
+    raises: 0,
+    results: [],
+    winners: [],
+    log: [],
+    codeInput: "",
+    joinError: false,
+    menuOpen: false,
+    pending: null,
+    rejection: null,
+    scale: 1,
+    handNo: 0,
+    settingsOpen: false,
+    settings: { seatCount: 8, evictAfter: 3, revealShowdown: true, autoDeal: false, confirmFold: true, sounds: true },
+    sitOutStreak: {}
+  };
+
+  openSettings = () => this.setState({ settingsOpen: true });
+  closeSettings = () => this.setState({ settingsOpen: false });
+  setSetting = (key, value) => this.setState((s) => {
+    const settings = { ...s.settings, [key]: value };
+    if (key === "seatCount") {
+      const seats = s.seats.map((x) => (x.id >= value ? { ...x, claimed: false, sittingOut: false, name: NAMES[x.id] } : x));
+      const mySeat = typeof s.mySeat === "number" && s.mySeat >= value ? "picking" : s.mySeat;
+      return { settings, seats, mySeat };
+    }
+    return { settings };
+  });
+  bump = (key, delta, min, max) => () => {
+    const next = Math.min(max, Math.max(min, this.state.settings[key] + delta));
+    this.setSetting(key, next);
+  };
+  flip = (key) => () => this.setSetting(key, !this.state.settings[key]);
+
+  componentDidMount() {
+    this.fit();
+    this._onResize = () => this.fit();
+    window.addEventListener("resize", this._onResize);
+  }
+  componentWillUnmount() {
+    window.removeEventListener("resize", this._onResize);
+    clearTimeout(this._bot); clearTimeout(this._fill); clearTimeout(this._auto);
+  }
+  fit() {
+    const w = window.innerWidth;
+    this.setState({ scale: Math.min(1, (w - 80) / 1740) });
+  }
+  push(text, gold) {
+    this.setState((s) => ({ log: [...s.log.slice(-4), { text, gold: !!gold }] }));
+  }
+
+  // ── room lifecycle ──
+  createRoom = () => {
+    const code = code4();
+    this.setState({ phase: "lobby", roomCode: code, log: [{ text: "Room " + code + " open — waiting for players", gold: true }] });
+    this._fill = setTimeout(() => this.fillBots(), 2600);
+  };
+  endSession = () => this.resetDemo();
+  resetDemo = () => {
+    clearTimeout(this._bot); clearTimeout(this._fill); clearTimeout(this._auto);
+    this.setState({
+      phase: "idle", roomCode: null, mySeat: null, board: [], hole: {}, inHand: [], folded: [],
+      needsAction: [], lastAction: {}, actor: null, results: [], winners: [], log: [], codeInput: "",
+      joinError: false, menuOpen: false, pending: null, rejection: null, button: 0, handNo: 0,
+      seats: Array.from({ length: 8 }, (_, i) => ({ id: i, name: NAMES[i], claimed: false, sittingOut: false }))
+    });
+  };
+  fillBots = () => {
+    const order = [1, 4, 6, 2, 7].filter((id) => id < this.state.settings.seatCount);
+    let i = 0;
+    const step = () => {
+      if (i >= order.length) return;
+      const id = order[i++];
+      this.setState((s) => ({ seats: s.seats.map((x) => (x.id === id ? { ...x, claimed: true } : x)) }));
+      this.push(NAMES[id] + " sat down in seat " + (id + 1));
+      this._fill = setTimeout(step, 900 + Math.random() * 700);
+    };
+    step();
+  };
+
+  // ── phone join ──
+  pressKey = (ch) => this.setState((s) => {
+    if (ch === "⌫") return { codeInput: s.codeInput.slice(0, -1), joinError: false };
+    if (s.codeInput.length >= 4) return {};
+    return { codeInput: s.codeInput + ch, joinError: false };
+  });
+  joinRoom = () => {
+    const { codeInput, roomCode } = this.state;
+    if (codeInput.length < 4) return;
+    if (roomCode && codeInput === roomCode) this.setState({ joinError: false, mySeat: "picking" });
+    else this.setState({ joinError: true });
+  };
+  claimSeat = (id) => {
+    this.setState((s) => ({
+      mySeat: id, menuOpen: false,
+      seats: s.seats.map((x) => (x.id === id ? { ...x, claimed: true, name: "You" } : x))
+    }));
+    this.push("You sat down in seat " + (id + 1), true);
+  };
+  leaveTable = () => this.setState((s) => ({
+    mySeat: null, menuOpen: false, codeInput: "",
+    seats: s.seats.map((x) => (x.id === s.mySeat ? { ...x, claimed: false, name: NAMES[x.id] } : x))
+  }));
+  toggleSitOut = () => this.setState((s) => ({
+    menuOpen: false,
+    seats: s.seats.map((x) => (x.id === s.mySeat ? { ...x, sittingOut: !x.sittingOut } : x))
+  }));
+  toggleJoin = () => this.setState((s) => ({ joinOpen: !s.joinOpen }));
+  changeSeat = () => this.setState((s) => ({
+    menuOpen: false, mySeat: "picking",
+    seats: s.seats.map((x) => (x.id === s.mySeat ? { ...x, claimed: false, name: NAMES[x.id] } : x))
+  }));
+  openMenu = () => this.setState({ menuOpen: true });
+  closeMenu = () => this.setState({ menuOpen: false });
+
+  // ── hand lifecycle ──
+  startHand = () => {
+    const s = this.state;
+    const n = s.settings.seatCount;
+    // eviction: a seat that sits out this many hands in a row loses its seat
+    const streak = { ...s.sitOutStreak };
+    let seatsNow = s.seats, myGone = false;
+    s.seats.forEach((x) => {
+      if (!x.claimed || x.id >= n) return;
+      if (x.sittingOut) {
+        streak[x.id] = (streak[x.id] || 0) + 1;
+        if (streak[x.id] >= s.settings.evictAfter) {
+          streak[x.id] = 0;
+          if (x.id === s.mySeat) myGone = true;
+          seatsNow = seatsNow.map((y) => (y.id === x.id ? { ...y, claimed: false, sittingOut: false, name: NAMES[y.id] } : y));
+        }
+      } else streak[x.id] = 0;
+    });
+    if (seatsNow !== s.seats || myGone) this.setState({ seats: seatsNow, sitOutStreak: streak, mySeat: myGone ? "picking" : s.mySeat });
+    else this.setState({ sitOutStreak: streak });
+    const dealt = seatsNow.filter((x) => x.claimed && !x.sittingOut && x.id < n).map((x) => x.id);
+    if (dealt.length < 2) return;
+    const deck = freshDeck();
+    const hole = {};
+    dealt.forEach((id) => { hole[id] = [deck.pop(), deck.pop()]; });
+    let button = s.handNo === 0 ? dealt[0] : dealt[(dealt.indexOf(s.button) + 1) % dealt.length];
+    if (!dealt.includes(button)) button = dealt[0];
+    const bb = dealt.length === 2 ? this.nextOf(dealt, button, 1) : this.nextOf(dealt, button, 2);
+    const first = dealt.length === 2 ? button : this.nextOf(dealt, button, 1);
+    this.setState({
+      phase: "betting", street: "preflop", deck, hole, board: [], inHand: dealt, folded: [],
+      needsAction: dealt.slice(), actor: first, button, bbSeat: bb, raises: 0,
+      lastAction: {}, results: [], winners: [], pending: null, rejection: null,
+      handNo: s.handNo + 1, log: [{ text: "Hand " + (s.handNo + 1) + " dealt — button seat " + (button + 1), gold: true }]
+    });
+    this.queueBot();
+  };
+  nextHand = () => this.startHand();
+  nextOf(list, from, k) {
+    const sorted = list.slice().sort((a, b) => a - b);
+    let i = sorted.indexOf(from);
+    if (i < 0) i = 0;
+    return sorted[(i + k) % sorted.length];
+  }
+  liveSeats() { return this.state.inHand.filter((id) => !this.state.folded.includes(id)); }
+  facingBet(seatId) {
+    const s = this.state;
+    if (s.street !== "preflop") return s.raises > 0;
+    return s.raises > 0 || seatId !== s.bbSeat;
+  }
+  legalFor(seatId) {
+    if (this.state.phase !== "betting" || this.state.actor !== seatId) return [];
+    return this.facingBet(seatId) ? ["fold", "call", "raise"] : ["fold", "check", "raise"];
+  }
+
+  act = (seatId, action) => {
+    const s = this.state;
+    if (s.phase !== "betting" || s.actor !== seatId) return;
+    if (!this.legalFor(seatId).includes(action)) {
+      if (seatId === s.mySeat) this.setState({ rejection: "That action isn't available right now." });
+      return;
+    }
+    const live = this.liveSeats();
+    const name = seatId === s.mySeat ? "You" : NAMES[seatId];
+    let folded = s.folded, needs = s.needsAction.filter((x) => x !== seatId), raises = s.raises;
+    if (action === "fold") folded = [...folded, seatId];
+    if (action === "raise") { raises += 1; needs = live.filter((x) => x !== seatId); }
+    const lastAction = { ...s.lastAction, [seatId]: action };
+    this.push(name + (action === "fold" ? " folds" : action === "check" ? " checks" : action === "call" ? " calls" : " raises"), action === "raise");
+    const stillLive = s.inHand.filter((id) => !folded.includes(id));
+    this.setState({ folded, needsAction: needs, raises, lastAction, rejection: null, pending: null }, () => {
+      if (stillLive.length === 1) return this.finishFoldedOut(stillLive[0]);
+      if (needs.filter((x) => stillLive.includes(x)).length === 0) return this.advanceStreet();
+      const order = stillLive;
+      let next = this.nextOf(order, seatId, 1);
+      let guard = 0;
+      while (!needs.includes(next) && guard++ < 10) next = this.nextOf(order, next, 1);
+      this.setState({ actor: next }, this.queueBot);
+    });
+  };
+
+  advanceStreet() {
+    const s = this.state;
+    const deck = s.deck.slice();
+    const live = s.inHand.filter((id) => !s.folded.includes(id));
+    const order = { preflop: "flop", flop: "turn", turn: "river" };
+    const next = order[s.street];
+    if (!next) return this.finishShowdown();
+    const drawn = next === "flop" ? [deck.pop(), deck.pop(), deck.pop()] : [deck.pop()];
+    const board = [...s.board, ...drawn];
+    const first = this.nextOf(live, s.button, 1);
+    this.push(next.toUpperCase() + " — " + drawn.map((c) => c.r + SUITS[c.s]).join(" "), true);
+    this.setState({ street: next, deck, board, needsAction: live.slice(), raises: 0, lastAction: {}, actor: first }, this.queueBot);
+  }
+
+  finishFoldedOut(winner) {
+    clearTimeout(this._bot);
+    this._autoRun = false;
+    this.push((winner === this.state.mySeat ? "You win" : NAMES[winner] + " wins") + " — everyone folded", true);
+    this.setState({ phase: "foldedout", actor: null, winners: [winner], results: [] });
+    if (this.state.settings.autoDeal) this._auto = setTimeout(this.nextHand, 4000);
+  }
+
+  finishShowdown() {
+    clearTimeout(this._bot);
+    this._autoRun = false;
+    const s = this.state;
+    const live = s.inHand.filter((id) => !s.folded.includes(id));
+    const results = live.map((id) => {
+      const b = best7([...s.hole[id], ...s.board]);
+      return { seatId: id, score: b.score, best: b.cards, description: describe(b.score) };
+    });
+    let top = results[0];
+    results.forEach((r) => { if (cmp(r.score, top.score) > 0) top = r; });
+    const winners = results.filter((r) => cmp(r.score, top.score) === 0).map((r) => r.seatId);
+    this.push("Showdown — " + winners.map((id) => (id === s.mySeat ? "You" : NAMES[id])).join(" & ") + " with " + top.description, true);
+    this.setState({ phase: "showdown", actor: null, results, winners });
+    if (this.state.settings.autoDeal) this._auto = setTimeout(this.nextHand, 5000);
+  }
+
+  queueBot = () => {
+    clearTimeout(this._bot);
+    const s = this.state;
+    if (s.phase !== "betting" || s.actor === null) return;
+    if (s.actor === s.mySeat && !this._autoRun) return;
+    if (this.props.autoBots === false && s.actor !== s.mySeat) return;
+    const seatId = s.actor;
+    this._bot = setTimeout(() => {
+      const legal = this.legalFor(seatId);
+      if (!legal.length) return;
+      const r = Math.random();
+      let pick;
+      if (legal.includes("check")) pick = r < 0.68 ? "check" : "raise";
+      else pick = r < 0.68 ? "call" : r < 0.82 ? "raise" : "fold";
+      if (this.state.raises >= 2 && pick === "raise") pick = legal.includes("check") ? "check" : "call";
+      this.act(seatId, pick);
+    }, (this.props.botSpeed ?? 900) * (0.7 + Math.random() * 0.6));
+  };
+
+  autoPlay = () => {
+    this._autoRun = true;
+    const s = this.state;
+    if (typeof s.mySeat === "number") {
+      if (s.phase === "lobby") this.startHand();
+      else if (s.phase === "betting") this.queueBot();
+      else if (s.phase === "showdown" || s.phase === "foldedout") this.nextHand();
+      return;
+    }
+    const step = (fn, ms) => { this._auto = setTimeout(fn, ms); };
+    const seatAndDeal = () => {
+      this.setState({ codeInput: this.state.roomCode }, () => {
+        step(() => {
+          this.joinRoom();
+          step(() => {
+            this.claimSeat(0);
+            const waitForTable = () => {
+              const st = this.state;
+              const n = st.seats.filter((x) => x.claimed && !x.sittingOut && x.id < st.settings.seatCount).length;
+              if (n >= Math.min(4, st.settings.seatCount)) this.startHand();
+              else step(waitForTable, 700);
+            };
+            step(waitForTable, 900);
+          }, 500);
+        }, 600);
+      });
+    };
+    if (s.phase === "idle") { this.createRoom(); step(seatAndDeal, 1200); }
+    else seatAndDeal();
+  };
+
+  renderVals() {
+    const s = this.state;
+    const seated = typeof s.mySeat === "number";
+    const inHand = seated && s.inHand.includes(s.mySeat);
+    const myFolded = seated && s.folded.includes(s.mySeat);
+    const seatCount = s.settings.seatCount;
+    const visible = s.seats.filter((x) => x.id < seatCount);
+    const claimedCount = visible.filter((x) => x.claimed).length;
+    const dealtCount = visible.filter((x) => x.claimed && !x.sittingOut).length;
+    const isBetting = s.phase === "betting";
+    const isComplete = s.phase === "showdown" || s.phase === "foldedout";
+    const bb = s.bbSeat;
+    const sb = s.inHand.length ? (s.inHand.length === 2 ? s.button : this.nextOf(s.inHand, s.button, 1)) : null;
+
+    const cardColor = (c) => "color:" + (c.s === "h" || c.s === "d" ? "#c0392b" : "#151311");
+    const dec = (c) => ({ rank: c.r, sym: SUITS[c.s], colorStyle: cardColor(c) });
+
+    // ── seats around the felt ──
+    const seats = visible.map((seat) => {
+      const isActor = isBetting && s.actor === seat.id;
+      const dealtIn = s.inHand.includes(seat.id);
+      const folded = s.folded.includes(seat.id);
+      const isWinner = isComplete && s.winners.includes(seat.id);
+      const p = posFor(seat.id, seatCount);
+      const topRow = p.t < 50;
+      let pod = "border:1px solid transparent;background:none;";
+      if (folded) pod += "opacity:.34;";
+      if (isWinner) pod = "border:1px solid rgba(250,234,231,.7);background:rgba(250,234,231,.14);box-shadow:0 0 46px -6px rgba(255,255,255,.45);";
+      if (isActor) pod = "border:1px solid rgba(229,68,60,.95);background:rgba(20,7,8,.72);backdrop-filter:blur(6px);animation:actorGlow 1.7s ease-in-out infinite;";
+      let av = "background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.16);color:rgba(250,240,238,.5);";
+      if (seat.claimed) av = "background:rgba(250,240,238,.94);color:#1b0708;box-shadow:0 8px 22px -8px rgba(0,0,0,.9);";
+      if (seat.claimed && seat.id === s.mySeat) av = "background:linear-gradient(180deg,#f27a70,#c22b26);color:#fff;box-shadow:0 8px 24px -8px rgba(229,68,60,.9);";
+      if (folded) av = "background:rgba(255,255,255,.1);border:1px solid rgba(255,255,255,.14);color:rgba(250,240,238,.45);";
+      // hole cards appear on the table only at showdown (or x-ray, for demoing)
+      let cards = [];
+      const reveal = !!s.hole[seat.id] && dealtIn && !folded && ((s.phase === "showdown" && s.settings.revealShowdown) || (this.props.xray && seat.id !== s.mySeat));
+      if (reveal) cards = s.hole[seat.id].map((c, i) => ({
+        rank: c.r, sym: SUITS[c.s],
+        miniStyle: "background:#fdfaf4;border:1px solid rgba(0,0,0,.25);box-shadow:0 8px 18px -7px rgba(0,0,0,.85);" +
+          (topRow ? "top:82px;" : "top:-64px;") + "left:" + (i === 0 ? 4 : 50) + "px;" + cardColor(c)
+      }));
+      const markers = [];
+      const mk = (label, style) => {
+        const n = markers.length;
+        const x = 80 + n * 34;
+        markers.push({ label, style: "left:" + x + "px;top:" + (topRow ? 8 : 22) + "px;" + style });
+      };
+      const headsUp = s.inHand.length === 2;
+      if (dealtIn && seat.id === s.button) mk(headsUp ? "D·SB" : "D", "background:#faf6f0;color:#1b0708;box-shadow:0 6px 16px -4px rgba(0,0,0,.85);");
+      if (dealtIn && seat.id === sb && seat.id !== s.button) mk("SB", "background:#1b1416;color:#f6dcd8;border:1px solid rgba(255,255,255,.28);");
+      if (dealtIn && seat.id === bb) mk("BB", "background:#c22b26;color:#fff;border:1px solid rgba(255,255,255,.24);");
+      return {
+        id: seat.id, badge: String(seat.id + 1), isActor,
+        posStyle: "left:" + p.l.toFixed(2) + "%;top:" + p.t + "%;",
+        podStyle: pod, avatarStyle: av, cards, markers
+      };
+    });
+
+    // ── phone ──
+    const legal = seated ? this.legalFor(s.mySeat) : [];
+    const myTurn = legal.length > 0;
+    const armed = !!s.foldArmed;
+    const actions = ["fold", "check", "call", "raise"].map((a) => {
+      const on = legal.includes(a);
+      const sub = a === "fold" ? (armed ? "tap again" : "muck") : a === "check" ? "no bet" : a === "call" ? "match" : "put in more";
+      let st = "border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.03);color:rgba(243,236,225,.3);cursor:default;";
+      if (on && a === "fold") st = "border:1px solid rgba(232,139,125,.42);background:rgba(232,139,125,.13);color:#f0b3a8;";
+      else if (on && a === "raise") st = "background:linear-gradient(180deg,#fbf6f3,#e0cdc7);color:#1b0708;box-shadow:0 12px 26px -12px rgba(229,68,60,.8);";
+      else if (on) st = "border:1px solid rgba(229,68,60,.4);background:rgba(229,68,60,.12);color:#f8e5e2;";
+      if (on && a === "fold" && armed) st = "background:linear-gradient(180deg,#ef6259,#a81d1c);color:#fff;box-shadow:0 12px 26px -12px rgba(229,68,60,.9);";
+      const label = a === "fold" && armed ? "Confirm" : a[0].toUpperCase() + a.slice(1);
+      const press = () => {
+        if (a === "fold" && s.settings.confirmFold && !this.state.foldArmed) {
+          this.setState({ foldArmed: true });
+          clearTimeout(this._fold);
+          this._fold = setTimeout(() => this.setState({ foldArmed: false }), 3500);
+          return;
+        }
+        this._autoRun = false;
+        this.setState({ foldArmed: false });
+        this.act(s.mySeat, a);
+      };
+      return { label, sub, disabled: !on, style: st, press };
+    });
+
+    const holeCards = seated && s.hole[s.mySeat] && !myFolded ? s.hole[s.mySeat] : null;
+    const oppName = s.actor !== null && s.actor !== s.mySeat ? NAMES[s.actor] : "";
+    let bannerKicker = "Table", bannerText = "Waiting for the next hand", tone = "idle";
+    if (isBetting && myTurn) { bannerKicker = "Your turn"; bannerText = "You're to act — " + s.street; tone = "turn"; }
+    else if (isBetting && myFolded) { bannerKicker = "Folded"; bannerText = "Sitting this one out"; }
+    else if (isBetting && inHand) { bannerKicker = s.street; bannerText = "Waiting on " + oppName; }
+    else if (isBetting) { bannerKicker = "Sitting out"; bannerText = "Dealt back in next hand"; }
+    else if (s.phase === "showdown") { bannerKicker = "Hand complete"; bannerText = s.winners.includes(s.mySeat) ? "You win it" : NAMES[s.winners[0]] + " takes it"; tone = "win"; }
+    else if (s.phase === "foldedout") { bannerKicker = "Hand complete"; bannerText = s.winners[0] === s.mySeat ? "You win — all folded" : NAMES[s.winners[0]] + " wins — all folded"; tone = "win"; }
+    else if (seated && s.seats.find((x) => x.id === s.mySeat).sittingOut) { bannerKicker = "Sitting out"; bannerText = "Tap the menu to sit back in"; }
+
+    const banner = {
+      turn: { box: "background:linear-gradient(120deg,rgba(229,68,60,.22),rgba(229,68,60,.08));border:1px solid rgba(240,120,110,.65);box-shadow:0 0 34px -8px rgba(229,68,60,.55);animation:turnPulse 1.8s ease-in-out infinite;", dot: "background:#ef6259;box-shadow:0 0 12px #ef6259;", kicker: "color:#f6dcd8;", text: "color:#fbf3e2;" },
+      win: { box: "background:rgba(123,216,143,.1);border:1px solid rgba(123,216,143,.4);", dot: "background:#7bd88f;box-shadow:0 0 12px #7bd88f;", kicker: "color:#8fdfa1;", text: "color:#eef7ef;" },
+      idle: { box: "background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.09);", dot: "background:#6f6455;", kicker: "color:#8a7c67;", text: "color:#cbc0ae;" }
+    }[tone];
+
+    const myResult = s.results.find((r) => r.seatId === s.mySeat);
+    const winnerResult = s.results.find((r) => r.seatId === s.winners[0]);
+
+    const keyLabels = [..."ACDEFGHJKLMNPQRTUVWXY379", "⌫"];
+
+    return {
+      stageStyle: "zoom:" + s.scale + ";",
+      roomStyle: "background:#0a0708;",
+      railStyle: "background:linear-gradient(160deg,#3c2b1c,#1d130c 52%,#3a2a1a);box-shadow:inset 0 2px 0 rgba(255,255,255,.09),0 18px 44px -14px rgba(0,0,0,.9);",
+      feltStyle: "background:radial-gradient(120% 150% at 50% 8%,#2f7355 0%,#1a5340 42%,#0d3527 100%);",
+      phoneBgStyle: "background:radial-gradient(520px 380px at 50% -6%,#2a1518,#0b0708 70%);",
+
+      // table
+      isIdle: s.phase === "idle",
+      hasRoom: s.roomCode !== null,
+      roomCode: s.roomCode || "----",
+      joinUrl: "poker.local/join/" + (s.roomCode || ""),
+      tableStatus: s.phase === "idle" ? "Table ready" : isBetting ? "Hand " + s.handNo + " live" : isComplete ? "Hand complete" : claimedCount + " of " + seatCount + " seated",
+      showStreetChip: isBetting,
+      streetLabel: s.street,
+      showJoinPanel: s.phase === "lobby" || !!s.joinOpen,
+      joinPanelDismissable: s.phase !== "lobby",
+      joinToggleLabel: s.joinOpen ? "Hide code" : "Room",
+      joinToggleCode: s.roomCode || "----",
+      toggleJoin: this.toggleJoin,
+      changeSeat: this.changeSeat,
+      lobbyHint: s.phase !== "lobby" ? "New players are dealt in from the next hand" : dealtCount >= 2 ? dealtCount + " seated — deal when ready" : "Waiting for at least two players",
+      showBoard: isBetting || isComplete,
+      board: s.board.map(dec),
+      boardSlots: Array.from({ length: Math.max(0, 5 - s.board.length) }, (_, i) => ({ i })),
+      showResultRibbon: isComplete,
+      resultText: s.phase === "showdown"
+        ? s.winners.map((id) => (id === s.mySeat ? "You" : NAMES[id])).join(" & ") + " — " + (winnerResult ? winnerResult.description : "")
+        : (s.winners[0] === s.mySeat ? "You win" : NAMES[s.winners[0]] + " wins") + " — everyone folded",
+      seats,
+      showQrPill: s.phase !== "idle" && s.phase !== "lobby",
+      canStartHand: s.phase === "lobby" && dealtCount >= 2,
+      isComplete,
+      showLog: s.log.length > 0 && s.phase !== "lobby",
+      log: s.log.map((l) => ({ text: l.text, style: l.gold ? "color:#d9a29b;" : "" })),
+      qr: this.qrNode(s.roomCode, 8),
+      qrSmall: this.qrNode(s.roomCode, 2.1),
+
+      // phone
+      phoneConn: s.roomCode ? "live" : "offline",
+      phoneSeatLabel: seated ? "seat " + (s.mySeat + 1) + " · 390×844" : "390×844",
+      phoneKicker: seated ? "Seat " + (s.mySeat + 1) + (s.roomCode ? " · " + s.roomCode : "") : s.mySeat === "picking" ? "Room " + s.roomCode : "Join a table",
+      phoneTitle: seated ? "You" : s.mySeat === "picking" ? "Take a seat" : "Enter room code",
+      pJoin: s.mySeat === null,
+      pSeatPick: s.mySeat === "picking",
+      seated,
+      codeBoxes: [0, 1, 2, 3].map((i) => ({
+        char: s.codeInput[i] || "",
+        style: "background:rgba(255,255,255,.04);color:#faeae7;border:1px solid " + (s.codeInput.length === i ? "rgba(240,120,110,.8)" : "rgba(255,255,255,.1)") + ";"
+      })),
+      keys: keyLabels.map((k) => ({ label: k, press: () => this.pressKey(k) })),
+      joinBtnLabel: s.codeInput.length === 4 ? "Join room" : "Enter 4 letters",
+      joinBtnStyle: s.codeInput.length === 4
+        ? "background:linear-gradient(180deg,#fbf6f3,#e0cdc7);color:#1b0708;box-shadow:0 14px 30px -14px rgba(229,68,60,.8);"
+        : "background:rgba(255,255,255,.05);color:rgba(243,236,225,.35);border:1px solid rgba(255,255,255,.09);cursor:default;",
+      joinError: s.joinError,
+      seatOptions: visible.map((seat) => ({
+        badge: String(seat.id + 1),
+        title: seat.claimed ? seat.name : "Seat " + (seat.id + 1),
+        sub: seat.claimed ? "Taken" : "Sit here",
+        style: seat.claimed
+          ? "border:1px solid rgba(255,255,255,.07);background:rgba(255,255,255,.02);opacity:.5;cursor:default;"
+          : "border:1px solid rgba(229,68,60,.3);background:rgba(229,68,60,.07);",
+        avatarStyle: "background:linear-gradient(160deg," + seatColor(seat.id) + ",oklch(0.42 0.1 " + SEAT_HUES[seat.id] + "));color:#170708;" + (seat.claimed ? "filter:saturate(.2) brightness(.7);" : ""),
+        claim: seat.claimed ? () => {} : () => this.claimSeat(seat.id)
+      })),
+      bannerKicker, bannerText,
+      bannerStyle: banner.box, bannerDotStyle: banner.dot, bannerKickerStyle: banner.kicker, bannerTextStyle: banner.text,
+      hasHole: !!holeCards,
+      hole: (holeCards || []).map((c, i) => ({ ...dec(c), tiltStyle: "transform:rotate(" + (i === 0 ? -3 : 3) + "deg);" })),
+      holeCaption: myResult ? myResult.description : isBetting ? "Your hole cards · " + s.street : "Your hole cards",
+      showEmptyState: !holeCards && !isComplete,
+      emptyStateText: myFolded ? "You folded — cards are in the muck." : s.phase === "lobby" ? "Seated. The table deals when everyone's in." : "Waiting for the next deal.",
+      showWinnerCard: isComplete,
+      yourResultText: myResult ? "You had " + myResult.description : myFolded ? "You folded earlier in the hand." : "You weren't in this hand.",
+      actions,
+      showRejection: !!s.rejection,
+      rejectionText: s.rejection || "",
+      menuOpen: s.menuOpen,
+      mySeat: s.mySeat,
+      mySeatNo: seated ? s.mySeat + 1 : "-",
+      sitOutLabel: seated && s.seats.find((x) => x.id === s.mySeat).sittingOut ? "Sit back in" : "Sit out next hand",
+      sitOutSub: seated && s.seats.find((x) => x.id === s.mySeat).sittingOut ? "You'll be dealt in from the next hand." : "You keep your seat but skip the deal.",
+      demoHint: s.phase === "idle" ? "Start on the table: create a room" : s.mySeat === null ? "On the phone: type the room code" : s.mySeat === "picking" ? "On the phone: pick a seat" : s.phase === "lobby" ? "On the table: deal the hand" : myTurn ? "Your turn — act on the phone" : "Watching the table",
+
+      seatCountLabel: seatCount,
+      settingsOpen: s.settingsOpen,
+      openSettings: this.openSettings, closeSettings: this.closeSettings,
+      steppers: [
+        { label: "Hands until eviction", desc: "A seat that sits out this many hands in a row is freed for someone else.", value: s.settings.evictAfter, dec: this.bump("evictAfter", -1, 1, 20), inc: this.bump("evictAfter", 1, 1, 20) },
+        { label: "Seats at this table", desc: "Positions shown around the rail — four along each long edge.", value: seatCount, dec: this.bump("seatCount", -1, 2, 8), inc: this.bump("seatCount", 1, 2, 8) }
+      ],
+      toggles: [
+        { key: "revealShowdown", label: "Reveal hands at showdown", desc: "Show every live player's hole cards on the table when the river closes." },
+        { key: "autoDeal", label: "Auto-deal the next hand", desc: "Deal again a few seconds after a hand completes, without tapping." },
+        { key: "confirmFold", label: "Confirm fold on phones", desc: "Folding takes a second tap, so nobody mucks a hand by accident." },
+        { key: "sounds", label: "Table sounds", desc: "Chip clink on each action and a chime when it's someone's turn." }
+      ].map((t) => {
+        const on = !!s.settings[t.key];
+        return {
+          label: t.label, desc: t.desc, toggle: this.flip(t.key),
+          trackStyle: on ? "background:linear-gradient(180deg,#ef6259,#b8302c);border:1px solid rgba(255,255,255,.2);" : "background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.14);",
+          knobStyle: on ? "background:#fff;transform:translateX(28px);box-shadow:0 4px 10px -3px rgba(0,0,0,.7);" : "background:rgba(255,255,255,.55);"
+        };
+      }),
+      createRoom: this.createRoom, endSession: this.endSession, startHand: this.startHand,
+      nextHand: this.nextHand, resetDemo: this.resetDemo, autoPlay: this.autoPlay,
+      joinRoom: this.joinRoom, openMenu: this.openMenu, closeMenu: this.closeMenu,
+      toggleSitOut: this.toggleSitOut, leaveTable: this.leaveTable
+    };
+  }
+
+
+  qrNode(code, cell) {
+    const n = 21;
+    const seed = (code || "TTPK").split("").reduce((a, c) => a + c.charCodeAt(0), 7);
+    const cells = [];
+    const isFinder = (x, y) => (x < 7 && y < 7) || (x > 13 && y < 7) || (x < 7 && y > 13);
+    for (let y = 0; y < n; y++) for (let x = 0; x < n; x++) {
+      let on;
+      if (isFinder(x, y)) {
+        const lx = x > 13 ? x - 14 : x, ly = y > 13 ? y - 14 : y;
+        const d = Math.max(Math.abs(lx - 3), Math.abs(ly - 3));
+        on = d !== 2 && d <= 3;
+      } else {
+        on = ((x * 31 + y * 17 + seed * 7 + ((x * y) % 11)) % 5) < 2;
+      }
+      if (on) cells.push(React.createElement("span", { key: x + "-" + y, style: { gridColumn: x + 1, gridRow: y + 1, background: "#191512", borderRadius: cell > 4 ? 1.5 : 0 } }));
+    }
+    return React.createElement("div", {
+      style: { display: "grid", gridTemplateColumns: "repeat(21," + cell + "px)", gridTemplateRows: "repeat(21," + cell + "px)", width: 21 * cell, height: 21 * cell }
+    }, cells);
+  }
+}
+</script>
+</body>
+</html>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,12 @@ import eslintConfigPrettier from "eslint-config-prettier";
 
 export default tseslint.config(
   {
-    ignores: ["**/dist/**", "**/coverage/**", "**/node_modules/**"],
+    ignores: [
+      "**/dist/**",
+      "**/coverage/**",
+      "**/node_modules/**",
+      "docs/design/**",
+    ],
   },
   eslint.configs.recommended,
   ...tseslint.configs.strictTypeChecked,


### PR DESCRIPTION
## Summary
- Pulls the design team's Claude Design prototype (`Table Top Poker.dc.html` + `support.js`) into `docs/design/` so agents working [Map: visual design pass for the Phase 1 table and player clients](https://github.com/ewanhardingham/table-top-poker/issues/57) can read it locally, without design-MCP access.

## Test plan
- [x] N/A — reference docs only, no code changes