### PR TITLE
ui-shared: design tokens and shared visual primitives

### DIFF
--- a/packages/ui-shared/src/Card.tsx
+++ b/packages/ui-shared/src/Card.tsx
@@ -1,5 +1,6 @@
 import type { Rank, Suit } from "@table-top-poker/protocol";
 import type { CSSProperties } from "react";
+import { color, font, radius, shadow } from "./theme.js";
 
 export type CardProps =
   | { readonly faceDown: true }
@@ -17,14 +18,9 @@ const redSuits: ReadonlySet<Suit> = new Set(["diamonds", "hearts"]);
 const baseStyle: CSSProperties = {
   width: "3.5em",
   height: "5em",
-  borderRadius: "0.3em",
-  border: "1px solid #94a3b8",
+  borderRadius: radius.card,
   boxSizing: "border-box",
-  display: "flex",
-  flexDirection: "column",
-  justifyContent: "center",
-  alignItems: "center",
-  fontFamily: "system-ui, sans-serif",
+  fontFamily: font.body,
   userSelect: "none",
 };
 
@@ -39,7 +35,7 @@ export function Card(props: CardProps) {
       <div
         className="card card-back"
         data-face-down="true"
-        style={{ ...baseStyle, background: "#334155" }}
+        style={{ ...baseStyle, background: color.cardBack }}
       />
     );
   }
@@ -53,12 +49,36 @@ export function Card(props: CardProps) {
       data-suit={suit}
       style={{
         ...baseStyle,
-        background: "#f8fafc",
-        color: redSuits.has(suit) ? "#dc2626" : "#0f172a",
+        background: color.cardFace,
+        border: `1px solid ${color.cardBorder}`,
+        boxShadow: shadow.card,
+        color: redSuits.has(suit) ? color.suitRed : color.suitBlack,
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        padding: "0.15em 0.18em",
       }}
     >
-      <span className="card-rank">{rank}</span>
-      <span className="card-suit">{suitSymbols[suit]}</span>
+      <span
+        className="card-rank"
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: "0.06em",
+          fontWeight: 700,
+          fontSize: "1.1em",
+          lineHeight: 0.9,
+        }}
+      >
+        {rank}
+        <span style={{ fontSize: "0.55em" }}>{suitSymbols[suit]}</span>
+      </span>
+      <span
+        className="card-suit"
+        style={{ textAlign: "right", fontSize: "1.4em", lineHeight: 0.8 }}
+      >
+        {suitSymbols[suit]}
+      </span>
     </div>
   );
 }

--- a/packages/ui-shared/src/Card.tsx
+++ b/packages/ui-shared/src/Card.tsx
@@ -28,6 +28,10 @@ const baseStyle: CSSProperties = {
  * Renders a card as DOM elements, branching on `faceDown` rather than
  * swapping an `<img>` src — required so Phase 3's flip animation can
  * cross-fade between the two branches instead of a network image swap.
+ *
+ * Face styling matches the prototype's hole card (the larger of its two
+ * card treatments); the board card differs slightly (radius, border,
+ * shadow) but the two aren't different enough to justify a second component.
  */
 export function Card(props: CardProps) {
   if (props.faceDown) {

--- a/packages/ui-shared/src/Panel.test.tsx
+++ b/packages/ui-shared/src/Panel.test.tsx
@@ -15,7 +15,7 @@ describe("Panel", () => {
 
   it("blurs its background so content behind it reads as backdrop, not overlay", () => {
     const html = renderToStaticMarkup(<Panel>content</Panel>);
-    expect(html).toContain("backdrop-filter:blur(6px)");
+    expect(html).toContain("backdrop-filter:blur(3px)");
   });
 
   it("lets a caller override style, for shapes that diverge from the base card (e.g. the side-menu drawer)", () => {

--- a/packages/ui-shared/src/Panel.test.tsx
+++ b/packages/ui-shared/src/Panel.test.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { Panel } from "./Panel.js";
+
+describe("Panel", () => {
+  it("renders its children", () => {
+    const html = renderToStaticMarkup(
+      <Panel>
+        <span>Table settings</span>
+      </Panel>,
+    );
+    expect(html).toContain("Table settings");
+  });
+
+  it("blurs its background so content behind it reads as backdrop, not overlay", () => {
+    const html = renderToStaticMarkup(<Panel>content</Panel>);
+    expect(html).toContain("backdrop-filter:blur(6px)");
+  });
+
+  it("lets a caller override style, for shapes that diverge from the base card (e.g. the side-menu drawer)", () => {
+    const html = renderToStaticMarkup(
+      <Panel style={{ borderRadius: 0 }}>content</Panel>,
+    );
+    expect(html).toContain("border-radius:0");
+  });
+
+  it("passes through standard div attributes", () => {
+    const html = renderToStaticMarkup(
+      <Panel data-testid="settings-panel">content</Panel>,
+    );
+    expect(html).toContain('data-testid="settings-panel"');
+  });
+});

--- a/packages/ui-shared/src/Panel.tsx
+++ b/packages/ui-shared/src/Panel.tsx
@@ -8,14 +8,15 @@ const baseStyle: CSSProperties = {
   background: color.surface,
   border: `1px solid ${color.border}`,
   boxShadow: shadow.panel,
-  backdropFilter: "blur(6px)",
-  WebkitBackdropFilter: "blur(6px)",
+  backdropFilter: "blur(3px)",
+  WebkitBackdropFilter: "blur(3px)",
 };
 
 /**
  * The blurred dark card container behind the settings sheet, join panel, and
- * side menu. Consumers override `style` for layout that diverges from this
- * base (the side menu's drawer shape, the settings sheet's fixed width).
+ * side menu. Defaults match the join panel exactly; the settings sheet
+ * (opaque gradient, no self-blur) and the side menu (drawer shape, no
+ * radius) diverge, so those consumers override `background`/`style`.
  */
 export function Panel({ style, ...rest }: PanelProps) {
   return <div {...rest} style={{ ...baseStyle, ...style }} />;

--- a/packages/ui-shared/src/Panel.tsx
+++ b/packages/ui-shared/src/Panel.tsx
@@ -1,0 +1,22 @@
+import type { CSSProperties, HTMLAttributes } from "react";
+import { color, radius, shadow } from "./theme.js";
+
+export type PanelProps = HTMLAttributes<HTMLDivElement>;
+
+const baseStyle: CSSProperties = {
+  borderRadius: radius.panel,
+  background: color.surface,
+  border: `1px solid ${color.border}`,
+  boxShadow: shadow.panel,
+  backdropFilter: "blur(6px)",
+  WebkitBackdropFilter: "blur(6px)",
+};
+
+/**
+ * The blurred dark card container behind the settings sheet, join panel, and
+ * side menu. Consumers override `style` for layout that diverges from this
+ * base (the side menu's drawer shape, the settings sheet's fixed width).
+ */
+export function Panel({ style, ...rest }: PanelProps) {
+  return <div {...rest} style={{ ...baseStyle, ...style }} />;
+}

--- a/packages/ui-shared/src/PillButton.test.tsx
+++ b/packages/ui-shared/src/PillButton.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { PillButton } from "./PillButton.js";
+
+describe("PillButton", () => {
+  it("renders its label", () => {
+    const html = renderToStaticMarkup(<PillButton>Deal hand</PillButton>);
+    expect(html).toContain("Deal hand");
+  });
+
+  it("defaults to a button type, so it never submits an enclosing form", () => {
+    const html = renderToStaticMarkup(<PillButton>Create room</PillButton>);
+    expect(html).toContain('type="button"');
+  });
+
+  it("applies the larger size's padding when size is lg", () => {
+    const md = renderToStaticMarkup(<PillButton>Deal hand</PillButton>);
+    const lg = renderToStaticMarkup(
+      <PillButton size="lg">Create room</PillButton>,
+    );
+    expect(md).toContain("padding:17px 34px");
+    expect(lg).toContain("padding:20px 44px");
+  });
+
+  it("lets a caller pass through standard button attributes", () => {
+    const html = renderToStaticMarkup(
+      <PillButton disabled>End session</PillButton>,
+    );
+    expect(html).toContain("disabled");
+  });
+});

--- a/packages/ui-shared/src/PillButton.tsx
+++ b/packages/ui-shared/src/PillButton.tsx
@@ -1,0 +1,38 @@
+import type { ButtonHTMLAttributes, CSSProperties } from "react";
+import { color, font, radius, shadow } from "./theme.js";
+
+export type PillButtonSize = "md" | "lg";
+
+export interface PillButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  readonly size?: PillButtonSize;
+}
+
+const sizeStyle: Record<PillButtonSize, CSSProperties> = {
+  md: { padding: "17px 34px", fontSize: "16px" },
+  lg: { padding: "20px 44px", fontSize: "19px" },
+};
+
+/**
+ * The rounded gradient pill used for primary actions ("Deal hand", "Create
+ * room"). Matches the prototype's cream-on-felt button, not a generic button.
+ */
+export function PillButton({ size = "md", style, ...rest }: PillButtonProps) {
+  return (
+    <button
+      type="button"
+      {...rest}
+      style={{
+        border: 0,
+        borderRadius: radius.pill,
+        background: color.pillGradient,
+        color: color.pillInk,
+        fontFamily: font.body,
+        fontWeight: 700,
+        letterSpacing: "0.04em",
+        boxShadow: shadow.pill,
+        ...sizeStyle[size],
+        ...style,
+      }}
+    />
+  );
+}

--- a/packages/ui-shared/src/index.ts
+++ b/packages/ui-shared/src/index.ts
@@ -4,4 +4,4 @@ export { PillButton } from "./PillButton.js";
 export type { PillButtonProps, PillButtonSize } from "./PillButton.js";
 export { Panel } from "./Panel.js";
 export type { PanelProps } from "./Panel.js";
-export { color, font, radius, shadow } from "./theme.js";
+export { color, font, fontSize, radius, shadow } from "./theme.js";

--- a/packages/ui-shared/src/index.ts
+++ b/packages/ui-shared/src/index.ts
@@ -1,2 +1,7 @@
 export { Card } from "./Card.js";
 export type { CardProps } from "./Card.js";
+export { PillButton } from "./PillButton.js";
+export type { PillButtonProps, PillButtonSize } from "./PillButton.js";
+export { Panel } from "./Panel.js";
+export type { PanelProps } from "./Panel.js";
+export { color, font, radius, shadow } from "./theme.js";

--- a/packages/ui-shared/src/theme.ts
+++ b/packages/ui-shared/src/theme.ts
@@ -1,0 +1,53 @@
+/**
+ * Design tokens for the felt/night palette used by the design prototype
+ * (`docs/design/table-top-poker-prototype.dc.html`). `table-client` and
+ * `player-client` both style against these rather than hard-coding values.
+ */
+
+export const color = {
+  background: "#0b0a09",
+  felt: "linear-gradient(180deg,#6a1a1f 0%,#4b1317 42%,#2c0c0f 100%)",
+
+  surface: "rgba(6,9,8,.62)",
+  surfaceStrong: "rgba(12,7,8,.62)",
+  surfaceGradient: "linear-gradient(180deg,#1d1214,#100a0b)",
+  border: "rgba(255,255,255,.1)",
+  borderStrong: "rgba(255,255,255,.16)",
+
+  accent: "#e5443c",
+  accentBright: "#ef6259",
+  accentDeep: "#a81d1c",
+
+  pillGradient: "linear-gradient(180deg,#fbf6f3,#e0cdc7)",
+  pillInk: "#1b0708",
+
+  text: "#f3ece1",
+  textMuted: "#cdbfa6",
+  textDim: "#a2957f",
+  textFaint: "#7d6a68",
+
+  cardFace: "linear-gradient(170deg,#fffdf7,#efe7d6)",
+  cardBack: "linear-gradient(180deg,#6a1a1f 0%,#4b1317 42%,#2c0c0f 100%)",
+  cardBorder: "rgba(0,0,0,.2)",
+  suitRed: "#c0392b",
+  suitBlack: "#151311",
+} as const;
+
+export const font = {
+  display: "'Archivo', system-ui, sans-serif",
+  body: "'IBM Plex Sans', system-ui, sans-serif",
+  mono: "'IBM Plex Mono', monospace",
+} as const;
+
+export const radius = {
+  pill: "999px",
+  panel: "22px",
+  card: "15px",
+  control: "16px",
+} as const;
+
+export const shadow = {
+  panel: "0 44px 90px -30px rgba(0,0,0,.95)",
+  pill: "0 16px 40px -14px rgba(229,68,60,.6), inset 0 1px 0 rgba(255,255,255,.5)",
+  card: "0 22px 44px -16px rgba(0,0,0,.85)",
+} as const;

--- a/packages/ui-shared/src/theme.ts
+++ b/packages/ui-shared/src/theme.ts
@@ -4,13 +4,17 @@
  * `player-client` both style against these rather than hard-coding values.
  */
 
+const feltGradient =
+  "linear-gradient(180deg,#6a1a1f 0%,#4b1317 42%,#2c0c0f 100%)";
+
 export const color = {
   background: "#0b0a09",
-  felt: "linear-gradient(180deg,#6a1a1f 0%,#4b1317 42%,#2c0c0f 100%)",
+  felt: feltGradient,
 
   surface: "rgba(6,9,8,.62)",
-  surfaceStrong: "rgba(12,7,8,.62)",
   surfaceGradient: "linear-gradient(180deg,#1d1214,#100a0b)",
+  sideMenuGradient: "linear-gradient(180deg,#241417,#0d0809)",
+  control: "rgba(12,7,8,.62)",
   border: "rgba(255,255,255,.1)",
   borderStrong: "rgba(255,255,255,.16)",
 
@@ -27,7 +31,7 @@ export const color = {
   textFaint: "#7d6a68",
 
   cardFace: "linear-gradient(170deg,#fffdf7,#efe7d6)",
-  cardBack: "linear-gradient(180deg,#6a1a1f 0%,#4b1317 42%,#2c0c0f 100%)",
+  cardBack: feltGradient,
   cardBorder: "rgba(0,0,0,.2)",
   suitRed: "#c0392b",
   suitBlack: "#151311",
@@ -37,6 +41,17 @@ export const font = {
   display: "'Archivo', system-ui, sans-serif",
   body: "'IBM Plex Sans', system-ui, sans-serif",
   mono: "'IBM Plex Mono', monospace",
+} as const;
+
+/** Named rungs of the type scale, from mono kicker labels up to the room-code display. */
+export const fontSize = {
+  xs: "10px",
+  sm: "12px",
+  md: "15px",
+  lg: "19px",
+  xl: "26px",
+  display: "34px",
+  jumbo: "104px",
 } as const;
 
 export const radius = {


### PR DESCRIPTION
## Summary
- Adds a theme/design-token module to `packages/ui-shared` (felt/night palette, Archivo/IBM Plex Sans/IBM Plex Mono family + size scale, radii, shadows) matching the design prototype.
- Adds `PillButton` (rounded gradient buttons for primary actions like "Deal hand"/"Create room") and `Panel` (blurred dark card container used by the settings sheet, join panel, and side menu).
- Restyles the existing `Card` component's face to match the prototype's card (gradient, corner radius, suit color, rank/suit layout) — no second card component introduced.
- No breaking changes: `Card`'s props are unchanged; everything else is additive.

Closes #58

## Test plan
- [x] `npx tsc --build` (full workspace)
- [x] `npx eslint packages/ui-shared/src`
- [x] `npx prettier --check packages/ui-shared/src`
- [x] `npx vitest run` (full workspace, 297 tests passing)
- [x] `/code-review` against the pre-work tip of `design`; findings addressed in a follow-up commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Q1EEG1cbMjHRnFBTzG5nQ