### PR TITLE
table-client: board, seats, actor-glow and hand controls

### DIFF
--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -1,11 +1,13 @@
-import { PillButton } from "@table-top-poker/ui-shared";
+import { PillButton, color } from "@table-top-poker/ui-shared";
 import { useCallback, useState } from "react";
 import { createRoom, endSession } from "./api/rooms.js";
 import { Board } from "./Board.js";
 import { isHandComplete } from "./handComplete.js";
 import { JoinCodeToggle } from "./JoinCodeToggle.js";
 import { JoinPanel } from "./JoinPanel.js";
+import { Seats } from "./Seats.js";
 import { StatusBar } from "./StatusBar.js";
+import { TableControls } from "./TableControls.js";
 import { useTableStore } from "./store/store.js";
 import { useWebSocket } from "./ws/useWebSocket.js";
 
@@ -77,7 +79,31 @@ export function App() {
             Create room
           </PillButton>
         ) : (
-          <>
+          <div
+            style={{
+              position: "absolute",
+              inset: "1em",
+              borderRadius: "0.7em",
+              background: color.felt,
+              boxShadow:
+                "inset 0 0 12em 4em rgba(0,0,0,.62), inset 0 2px 0 rgba(255,255,255,.08)",
+            }}
+          >
+            <Seats seats={seats} view={handView} />
+            {handView !== null && (
+              <div
+                style={{
+                  position: "absolute",
+                  inset: 0,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  pointerEvents: "none",
+                }}
+              >
+                <Board view={handView} />
+              </div>
+            )}
             <JoinCodeToggle
               roomCode={roomCode}
               open={joinOpen}
@@ -93,33 +119,14 @@ export function App() {
                 onDismiss={toggleJoin}
               />
             )}
-            {canStartHand && (
-              <button
-                type="button"
-                data-testid="start-hand-button"
-                onClick={handleStartHand}
-              >
-                Start hand
-              </button>
-            )}
-            {handComplete && (
-              <button
-                type="button"
-                data-testid="next-hand-button"
-                onClick={handleNextHand}
-              >
-                Next hand
-              </button>
-            )}
-            {handView !== null && <Board view={handView} seats={seats} />}
-            <button
-              type="button"
-              data-testid="end-session-button"
-              onClick={handleEndSession}
-            >
-              End session
-            </button>
-          </>
+            <TableControls
+              canStartHand={canStartHand}
+              handComplete={handComplete}
+              onStartHand={handleStartHand}
+              onNextHand={handleNextHand}
+              onEndSession={handleEndSession}
+            />
+          </div>
         )}
       </main>
     </div>

--- a/packages/table-client/src/Board.test.tsx
+++ b/packages/table-client/src/Board.test.tsx
@@ -1,24 +1,17 @@
-import type { SeatView, TableView } from "@table-top-poker/protocol";
+import type { TableView } from "@table-top-poker/protocol";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { Board } from "./Board.js";
 
-const seats: SeatView[] = [
-  { id: 0, claimed: true, sittingOut: false, disconnected: false },
-  { id: 1, claimed: true, sittingOut: false, disconnected: false },
-  { id: 2, claimed: true, sittingOut: true, disconnected: false },
-  { id: 3, claimed: false, sittingOut: false, disconnected: false },
-];
-
 describe("Board", () => {
   it("renders a waiting state before any hand has started", () => {
     const view: TableView = { phase: "no-hand", button: 0 };
-    const html = renderToStaticMarkup(<Board view={view} seats={seats} />);
+    const html = renderToStaticMarkup(<Board view={view} />);
     expect(html).toMatch(/data-testid="board"[^>]*data-phase="no-hand"/);
   });
 
-  it("renders community cards, seat status, button and current actor", () => {
+  it("renders the community cards for a live betting street", () => {
     const view: TableView = {
       phase: "betting",
       button: 0,
@@ -34,70 +27,16 @@ describe("Board", () => {
         { seatId: 1, folded: false },
       ],
     };
-    const html = renderToStaticMarkup(<Board view={view} seats={seats} />);
+    const html = renderToStaticMarkup(<Board view={view} />);
 
+    expect(html).toMatch(/data-testid="board"[^>]*data-phase="betting"/);
     expect(html).toMatch(/data-testid="community-cards"/);
     expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(3);
-    expect(html).toMatch(
-      /data-testid="board-seat-0"[^>]*data-status="in-hand"[^>]*data-button="true"/,
-    );
-    expect(html).toMatch(
-      /data-testid="board-seat-1"[^>]*data-status="in-hand"[^>]*data-turn="true"/,
-    );
-    expect(html).toMatch(
-      /data-testid="board-seat-2"[^>]*data-status="sitting-out"/,
-    );
-    expect(html).toMatch(/data-testid="board-seat-3"[^>]*data-status="open"/);
-    expect(html).not.toContain("yourHoleCards");
-  });
-
-  it("marks a folded seat", () => {
-    const view: TableView = {
-      phase: "betting",
-      button: 0,
-      street: "preflop",
-      board: [],
-      toAct: [0],
-      seats: [
-        { seatId: 0, folded: false },
-        { seatId: 1, folded: true },
-      ],
-    };
-    const html = renderToStaticMarkup(
-      <Board view={view} seats={seats.slice(0, 2)} />,
-    );
-    expect(html).toMatch(/data-testid="board-seat-1"[^>]*data-status="folded"/);
-  });
-
-  it("shows a disconnected badge for a presence-dropped seat", () => {
-    const view: TableView = {
-      phase: "betting",
-      button: 0,
-      street: "preflop",
-      board: [],
-      toAct: [0],
-      seats: [
-        { seatId: 0, folded: false },
-        { seatId: 1, folded: false },
-      ],
-    };
-    const disconnectedSeats: SeatView[] = [
-      { id: 0, claimed: true, sittingOut: false, disconnected: false },
-      { id: 1, claimed: true, sittingOut: false, disconnected: true },
-    ];
-    const html = renderToStaticMarkup(
-      <Board view={view} seats={disconnectedSeats} />,
-    );
-    expect(html).toMatch(
-      /data-testid="board-seat-1"[^>]*data-disconnected="true"/,
-    );
-    expect(html).toContain('data-testid="board-seat-1-disconnected"');
-    expect(html).not.toContain('data-testid="board-seat-0-disconnected"');
   });
 
   it("renders a fold-out completion with no reveal", () => {
     const view: TableView = { phase: "folded-out", button: 0, winner: 1 };
-    const html = renderToStaticMarkup(<Board view={view} seats={seats} />);
+    const html = renderToStaticMarkup(<Board view={view} />);
     expect(html).toMatch(/data-testid="board"[^>]*data-phase="folded-out"/);
     expect(html).not.toContain('data-testid="showdown-results"');
   });
@@ -149,7 +88,7 @@ describe("Board", () => {
         },
       ],
     };
-    const html = renderToStaticMarkup(<Board view={view} seats={seats} />);
+    const html = renderToStaticMarkup(<Board view={view} />);
 
     expect(html).toMatch(/data-testid="board"[^>]*data-phase="showdown"/);
     expect(html).toContain('data-testid="winners"');

--- a/packages/table-client/src/Board.tsx
+++ b/packages/table-client/src/Board.tsx
@@ -1,33 +1,17 @@
-import type { SeatView, TableView } from "@table-top-poker/protocol";
-import { Card } from "@table-top-poker/ui-shared";
+import type { TableView } from "@table-top-poker/protocol";
+import { Card, font } from "@table-top-poker/ui-shared";
+import { motion } from "motion/react";
 
 export interface BoardProps {
   readonly view: TableView;
-  readonly seats: readonly SeatView[];
-}
-
-type SeatStatus = "open" | "sitting-out" | "folded" | "in-hand";
-
-/** The per-seat slice of a betting-phase `TableView`. */
-interface HandSeat {
-  readonly seatId: number;
-  readonly folded: boolean;
 }
 
 /**
- * Cross-references the room's full seat list against this hand's dealt-in
- * seats: a claimed seat absent from `handSeats` was excluded from the deal
- * (sitting out), never a leak — `handSeats` only ever lists seats actually
- * dealt into the running hand (docs/phase-1-spec.md §4).
+ * The felt's centre content — community cards and, at showdown, every live
+ * seat's revealed hand. Seat pods themselves (including button/actor state
+ * and each winner's hole cards) are `Seats`' job, not this component's.
  */
-function statusOf(seat: SeatView, handSeats: readonly HandSeat[]): SeatStatus {
-  if (!seat.claimed) return "open";
-  const handSeat = handSeats.find((s) => s.seatId === seat.id);
-  if (!handSeat) return "sitting-out";
-  return handSeat.folded ? "folded" : "in-hand";
-}
-
-export function Board({ view, seats }: BoardProps) {
+export function Board({ view }: BoardProps) {
   if (view.phase === "no-hand") {
     return (
       <div data-testid="board" data-phase="no-hand">
@@ -47,7 +31,22 @@ export function Board({ view, seats }: BoardProps) {
   if (view.phase === "showdown") {
     return (
       <div data-testid="board" data-phase="showdown">
-        <span data-testid="winners">
+        <div
+          data-testid="community-cards"
+          style={{ display: "flex", gap: "0.4em", fontSize: "2em" }}
+        >
+          {view.board.map((card, i) => (
+            <motion.div
+              key={i}
+              initial={{ opacity: 0, y: -18, rotate: -6, scale: 0.9 }}
+              animate={{ opacity: 1, y: 0, rotate: 0, scale: 1 }}
+              transition={{ duration: 0.4, delay: i * 0.08 }}
+            >
+              <Card rank={card.rank} suit={card.suit} />
+            </motion.div>
+          ))}
+        </div>
+        <span data-testid="winners" style={{ fontFamily: font.display }}>
           Winner{view.winners.length > 1 ? "s" : ""}: seat
           {view.winners.length > 1 ? "s" : ""}{" "}
           {view.winners.map((seatId) => seatId + 1).join(", ")}
@@ -71,44 +70,23 @@ export function Board({ view, seats }: BoardProps) {
     );
   }
 
-  const actor = view.toAct[0];
-
   return (
     <div data-testid="board" data-phase="betting" data-street={view.street}>
-      <div data-testid="community-cards">
+      <div
+        data-testid="community-cards"
+        style={{ display: "flex", gap: "0.4em", fontSize: "2em" }}
+      >
         {view.board.map((card, i) => (
-          <Card key={i} rank={card.rank} suit={card.suit} />
+          <motion.div
+            key={i}
+            initial={{ opacity: 0, y: -18, rotate: -6, scale: 0.9 }}
+            animate={{ opacity: 1, y: 0, rotate: 0, scale: 1 }}
+            transition={{ duration: 0.4, delay: i * 0.08 }}
+          >
+            <Card rank={card.rank} suit={card.suit} />
+          </motion.div>
         ))}
       </div>
-      <ul data-testid="board-seats">
-        {seats.map((seat) => {
-          const status = statusOf(seat, view.seats);
-          const isButton = seat.id === view.button;
-          const isActor = seat.id === actor;
-          return (
-            <li
-              key={seat.id}
-              data-testid={`board-seat-${String(seat.id)}`}
-              data-status={status}
-              data-button={isButton}
-              data-turn={isActor}
-              data-disconnected={seat.disconnected}
-            >
-              Seat {seat.id + 1} — {status}
-              {isButton ? " (button)" : ""}
-              {isActor ? " (to act)" : ""}
-              {seat.disconnected && (
-                <span
-                  data-testid={`board-seat-${String(seat.id)}-disconnected`}
-                >
-                  {" "}
-                  — disconnected
-                </span>
-              )}
-            </li>
-          );
-        })}
-      </ul>
     </div>
   );
 }

--- a/packages/table-client/src/Board.tsx
+++ b/packages/table-client/src/Board.tsx
@@ -51,21 +51,54 @@ export function Board({ view }: BoardProps) {
 
   if (view.phase === "showdown") {
     return (
-      <div data-testid="board" data-phase="showdown">
+      <div
+        data-testid="board"
+        data-phase="showdown"
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "0.6em",
+        }}
+      >
         <CommunityCards board={view.board} />
-        <span data-testid="winners" style={{ fontFamily: font.display }}>
+        <span
+          data-testid="winners"
+          style={{ fontFamily: font.display, fontSize: "1.2em" }}
+        >
           Winner{view.winners.length > 1 ? "s" : ""}: seat
           {view.winners.length > 1 ? "s" : ""}{" "}
           {view.winners.map((seatId) => seatId + 1).join(", ")}
         </span>
-        <ul data-testid="showdown-results">
+        <ul
+          data-testid="showdown-results"
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            justifyContent: "center",
+            gap: "1.2em",
+            listStyle: "none",
+            margin: 0,
+            padding: 0,
+          }}
+        >
           {view.results.map((result) => (
             <li
               key={result.seatId}
               data-testid={`result-${String(result.seatId)}`}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: "0.3em",
+                fontSize: "0.85em",
+              }}
             >
               Seat {result.seatId + 1}: {result.description}
-              <div data-testid={`best-hand-${String(result.seatId)}`}>
+              <div
+                data-testid={`best-hand-${String(result.seatId)}`}
+                style={{ display: "flex", gap: "0.2em", fontSize: "0.6em" }}
+              >
                 {result.bestHand.map((card, i) => (
                   <Card key={i} rank={card.rank} suit={card.suit} />
                 ))}

--- a/packages/table-client/src/Board.tsx
+++ b/packages/table-client/src/Board.tsx
@@ -1,9 +1,30 @@
-import type { TableView } from "@table-top-poker/protocol";
+import type { Card as CardType, TableView } from "@table-top-poker/protocol";
 import { Card, font } from "@table-top-poker/ui-shared";
 import { motion } from "motion/react";
 
 export interface BoardProps {
   readonly view: TableView;
+}
+
+/** The community cards, dealt in one at a time via Motion rather than CSS keyframes. */
+function CommunityCards({ board }: { readonly board: readonly CardType[] }) {
+  return (
+    <div
+      data-testid="community-cards"
+      style={{ display: "flex", gap: "0.4em", fontSize: "2em" }}
+    >
+      {board.map((card, i) => (
+        <motion.div
+          key={i}
+          initial={{ opacity: 0, y: -18, rotate: -6, scale: 0.9 }}
+          animate={{ opacity: 1, y: 0, rotate: 0, scale: 1 }}
+          transition={{ duration: 0.4, delay: i * 0.08 }}
+        >
+          <Card rank={card.rank} suit={card.suit} />
+        </motion.div>
+      ))}
+    </div>
+  );
 }
 
 /**
@@ -31,21 +52,7 @@ export function Board({ view }: BoardProps) {
   if (view.phase === "showdown") {
     return (
       <div data-testid="board" data-phase="showdown">
-        <div
-          data-testid="community-cards"
-          style={{ display: "flex", gap: "0.4em", fontSize: "2em" }}
-        >
-          {view.board.map((card, i) => (
-            <motion.div
-              key={i}
-              initial={{ opacity: 0, y: -18, rotate: -6, scale: 0.9 }}
-              animate={{ opacity: 1, y: 0, rotate: 0, scale: 1 }}
-              transition={{ duration: 0.4, delay: i * 0.08 }}
-            >
-              <Card rank={card.rank} suit={card.suit} />
-            </motion.div>
-          ))}
-        </div>
+        <CommunityCards board={view.board} />
         <span data-testid="winners" style={{ fontFamily: font.display }}>
           Winner{view.winners.length > 1 ? "s" : ""}: seat
           {view.winners.length > 1 ? "s" : ""}{" "}
@@ -72,21 +79,7 @@ export function Board({ view }: BoardProps) {
 
   return (
     <div data-testid="board" data-phase="betting" data-street={view.street}>
-      <div
-        data-testid="community-cards"
-        style={{ display: "flex", gap: "0.4em", fontSize: "2em" }}
-      >
-        {view.board.map((card, i) => (
-          <motion.div
-            key={i}
-            initial={{ opacity: 0, y: -18, rotate: -6, scale: 0.9 }}
-            animate={{ opacity: 1, y: 0, rotate: 0, scale: 1 }}
-            transition={{ duration: 0.4, delay: i * 0.08 }}
-          >
-            <Card rank={card.rank} suit={card.suit} />
-          </motion.div>
-        ))}
-      </div>
+      <CommunityCards board={view.board} />
     </div>
   );
 }

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -1,0 +1,136 @@
+import type { SeatView, TableView } from "@table-top-poker/protocol";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { Seats } from "./Seats.js";
+
+const seats: SeatView[] = [
+  { id: 0, claimed: true, sittingOut: false, disconnected: false },
+  { id: 1, claimed: true, sittingOut: false, disconnected: false },
+  { id: 2, claimed: true, sittingOut: true, disconnected: false },
+  { id: 3, claimed: false, sittingOut: false, disconnected: false },
+];
+
+describe("Seats", () => {
+  it("shows every seat as open or sitting-out before any hand exists", () => {
+    const html = renderToStaticMarkup(<Seats seats={seats} view={null} />);
+    expect(html).toMatch(/data-testid="seat-pod-0"[^>]*data-status="in-hand"/);
+    expect(html).toMatch(
+      /data-testid="seat-pod-2"[^>]*data-status="sitting-out"/,
+    );
+    expect(html).toMatch(/data-testid="seat-pod-3"[^>]*data-status="open"/);
+  });
+
+  it("marks the button seat once a hand exists, even with no active betting", () => {
+    const view: TableView = { phase: "no-hand", button: 1 };
+    const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
+    expect(html).toMatch(/data-testid="seat-pod-1"[^>]*data-button="true"/);
+    expect(html).toMatch(/data-testid="seat-pod-0"[^>]*data-button="false"/);
+  });
+
+  it("marks status, button and the current actor during betting", () => {
+    const view: TableView = {
+      phase: "betting",
+      button: 0,
+      street: "flop",
+      board: [],
+      toAct: [1],
+      seats: [
+        { seatId: 0, folded: false },
+        { seatId: 1, folded: false },
+      ],
+    };
+    const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
+
+    expect(html).toMatch(
+      /data-testid="seat-pod-0"[^>]*data-status="in-hand"[^>]*data-button="true"/,
+    );
+    expect(html).toMatch(
+      /data-testid="seat-pod-1"[^>]*data-status="in-hand"[^>]*data-turn="true"/,
+    );
+    expect(html).toContain('data-testid="seat-pod-1-to-act"');
+    expect(html).not.toContain('data-testid="seat-pod-0-to-act"');
+    expect(html).toMatch(
+      /data-testid="seat-pod-2"[^>]*data-status="sitting-out"/,
+    );
+    expect(html).toMatch(/data-testid="seat-pod-3"[^>]*data-status="open"/);
+  });
+
+  it("marks a folded seat", () => {
+    const view: TableView = {
+      phase: "betting",
+      button: 0,
+      street: "preflop",
+      board: [],
+      toAct: [0],
+      seats: [
+        { seatId: 0, folded: false },
+        { seatId: 1, folded: true },
+      ],
+    };
+    const html = renderToStaticMarkup(
+      <Seats seats={seats.slice(0, 2)} view={view} />,
+    );
+    expect(html).toMatch(/data-testid="seat-pod-1"[^>]*data-status="folded"/);
+  });
+
+  it("shows a disconnected badge for a presence-dropped seat", () => {
+    const disconnectedSeats: SeatView[] = [
+      { id: 0, claimed: true, sittingOut: false, disconnected: false },
+      { id: 1, claimed: true, sittingOut: false, disconnected: true },
+    ];
+    const html = renderToStaticMarkup(
+      <Seats seats={disconnectedSeats} view={null} />,
+    );
+    expect(html).toMatch(
+      /data-testid="seat-pod-1"[^>]*data-disconnected="true"/,
+    );
+    expect(html).toContain('data-testid="seat-pod-1-disconnected"');
+    expect(html).not.toContain('data-testid="seat-pod-0-disconnected"');
+  });
+
+  it("marks the winning seat at showdown and reveals its hole cards", () => {
+    const view: TableView = {
+      phase: "showdown",
+      button: 0,
+      board: [
+        { rank: "A", suit: "spades" },
+        { rank: "K", suit: "hearts" },
+        { rank: "2", suit: "clubs" },
+        { rank: "7", suit: "diamonds" },
+        { rank: "9", suit: "clubs" },
+      ],
+      winners: [0],
+      results: [
+        {
+          seatId: 0,
+          rank: 1,
+          description: "Pair of Aces",
+          holeCards: [
+            { rank: "A", suit: "clubs" },
+            { rank: "3", suit: "hearts" },
+          ],
+          bestHand: [
+            { rank: "A", suit: "spades" },
+            { rank: "A", suit: "clubs" },
+            { rank: "K", suit: "hearts" },
+            { rank: "9", suit: "clubs" },
+            { rank: "7", suit: "diamonds" },
+          ],
+        },
+      ],
+    };
+    const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
+    expect(html).toMatch(/data-testid="seat-pod-0"[^>]*data-winner="true"/);
+    expect(html).toContain('data-testid="seat-pod-0-hole-cards"');
+    expect(html).not.toContain('data-testid="seat-pod-1-hole-cards"');
+  });
+
+  it("marks the sole winner at a fold-out completion, with no reveal", () => {
+    const view: TableView = { phase: "folded-out", button: 0, winner: 1 };
+    const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
+    expect(html).toMatch(/data-testid="seat-pod-1"[^>]*data-winner="true"/);
+    expect(html).toMatch(/data-testid="seat-pod-0"[^>]*data-winner="false"/);
+    expect(html).not.toContain("hole-cards");
+  });
+});

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -3,7 +3,7 @@ import type {
   SeatView,
   TableView,
 } from "@table-top-poker/protocol";
-import { Card, color, font } from "@table-top-poker/ui-shared";
+import { Card, color, font, shadow } from "@table-top-poker/ui-shared";
 import { AnimatePresence, motion } from "motion/react";
 import { posFor } from "./table/posFor.js";
 
@@ -14,37 +14,71 @@ export interface SeatsProps {
 
 type SeatStatus = "open" | "sitting-out" | "folded" | "in-hand";
 
-function statusOf(seat: SeatView, view: TableView | null): SeatStatus {
-  if (!seat.claimed) return "open";
-  if (view !== null && view.phase === "betting") {
-    const handSeat = view.seats.find((s) => s.seatId === seat.id);
-    if (!handSeat) return "sitting-out";
-    return handSeat.folded ? "folded" : "in-hand";
+interface SeatVisual {
+  readonly status: SeatStatus;
+  readonly isButton: boolean;
+  readonly isActor: boolean;
+  readonly isWinner: boolean;
+  readonly holeCards: readonly [CardType, CardType] | null;
+  readonly avatarBackground: string;
+  readonly avatarColor: string;
+}
+
+/**
+ * Merges one seat's static room membership with whatever the in-progress
+ * `view` knows about it — the single place `Seats` reasons about `TableView`'s
+ * per-phase shape, so the render below stays a plain lookup.
+ */
+function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
+  const handSeat =
+    view?.phase === "betting"
+      ? view.seats.find((s) => s.seatId === seat.id)
+      : undefined;
+
+  let status: SeatStatus = "open";
+  if (seat.claimed) {
+    if (view?.phase === "betting") {
+      status = !handSeat
+        ? "sitting-out"
+        : handSeat.folded
+          ? "folded"
+          : "in-hand";
+    } else {
+      status = seat.sittingOut ? "sitting-out" : "in-hand";
+    }
   }
-  return seat.sittingOut ? "sitting-out" : "in-hand";
-}
 
-function isWinnerSeat(seatId: number, view: TableView | null): boolean {
-  if (view === null) return false;
-  if (view.phase === "showdown") return view.winners.includes(seatId);
-  if (view.phase === "folded-out") return view.winner === seatId;
-  return false;
-}
+  const isWinner =
+    view?.phase === "showdown"
+      ? view.winners.includes(seat.id)
+      : view?.phase === "folded-out"
+        ? view.winner === seat.id
+        : false;
 
-function holeCardsFor(
-  seatId: number,
-  view: TableView | null,
-): readonly [CardType, CardType] | null {
-  if (view?.phase !== "showdown") return null;
-  return view.results.find((r) => r.seatId === seatId)?.holeCards ?? null;
-}
+  const avatarBackground = !seat.claimed
+    ? color.seatAvatarOpen
+    : status === "folded"
+      ? color.seatAvatarFolded
+      : color.text;
+  const avatarColor = !seat.claimed
+    ? color.seatAvatarOpenText
+    : status === "folded"
+      ? color.seatAvatarFoldedText
+      : color.pillInk;
 
-const restingGlow = "0 0 0 1px rgba(255,255,255,.1)";
-const actorGlowFrames = [
-  "0 0 0 2px rgba(229,68,60,.95), 0 0 34px 6px rgba(229,68,60,.3)",
-  "0 0 0 3px rgba(255,120,110,1), 0 0 54px 14px rgba(229,68,60,.5)",
-  "0 0 0 2px rgba(229,68,60,.95), 0 0 34px 6px rgba(229,68,60,.3)",
-];
+  return {
+    status,
+    isButton: view !== null && seat.id === view.button,
+    isActor: view?.phase === "betting" && view.toAct[0] === seat.id,
+    isWinner,
+    holeCards:
+      view?.phase === "showdown"
+        ? (view.results.find((r) => r.seatId === seat.id)?.holeCards ?? null)
+        : null,
+    avatarBackground,
+    avatarColor,
+  };
+}
 
 /**
  * The seat pods ringing the felt's two long edges, percentage-positioned via
@@ -56,35 +90,17 @@ export function Seats({ seats, view }: SeatsProps) {
   return (
     <div data-testid="seats" style={{ position: "absolute", inset: 0 }}>
       {seats.map((seat) => {
-        const status = statusOf(seat, view);
-        const isButton = view !== null && seat.id === view.button;
-        const isActor =
-          view !== null &&
-          view.phase === "betting" &&
-          view.toAct[0] === seat.id;
-        const isWinner = isWinnerSeat(seat.id, view);
-        const holeCards = holeCardsFor(seat.id, view);
+        const visual = deriveSeat(seat, view);
         const pos = posFor(seat.id, seats.length);
-
-        let avatarBackground = "rgba(255,255,255,.06)";
-        let avatarColor = "rgba(250,240,238,.5)";
-        if (seat.claimed) {
-          avatarBackground = color.text;
-          avatarColor = color.pillInk;
-        }
-        if (status === "folded") {
-          avatarBackground = "rgba(255,255,255,.1)";
-          avatarColor = "rgba(250,240,238,.45)";
-        }
 
         return (
           <div
             key={seat.id}
             data-testid={`seat-pod-${String(seat.id)}`}
-            data-status={status}
-            data-button={isButton}
-            data-turn={isActor}
-            data-winner={isWinner}
+            data-status={visual.status}
+            data-button={visual.isButton}
+            data-turn={visual.isActor}
+            data-winner={visual.isWinner}
             data-disconnected={seat.disconnected}
             style={{
               position: "absolute",
@@ -98,9 +114,13 @@ export function Seats({ seats, view }: SeatsProps) {
             }}
           >
             <motion.div
-              animate={{ boxShadow: isActor ? actorGlowFrames : restingGlow }}
+              animate={{
+                boxShadow: visual.isActor
+                  ? [...shadow.seatActorGlow]
+                  : shadow.seatResting,
+              }}
               transition={
-                isActor
+                visual.isActor
                   ? { duration: 1.7, repeat: Infinity, ease: "easeInOut" }
                   : { duration: 0.3 }
               }
@@ -112,19 +132,19 @@ export function Seats({ seats, view }: SeatsProps) {
                 flexDirection: "column",
                 alignItems: "center",
                 gap: "0.4em",
-                background: isWinner
-                  ? "rgba(250,234,231,.14)"
-                  : isActor
-                    ? "rgba(20,7,8,.72)"
+                background: visual.isWinner
+                  ? color.seatWinnerBackground
+                  : visual.isActor
+                    ? color.seatActorBackground
                     : "transparent",
                 border: `1px solid ${
-                  isWinner
-                    ? "rgba(250,234,231,.7)"
-                    : isActor
-                      ? "rgba(229,68,60,.95)"
+                  visual.isWinner
+                    ? color.seatWinnerBorder
+                    : visual.isActor
+                      ? color.accent
                       : "transparent"
                 }`,
-                opacity: status === "folded" ? 0.34 : 1,
+                opacity: visual.status === "folded" ? 0.34 : 1,
               }}
             >
               <div
@@ -138,13 +158,13 @@ export function Seats({ seats, view }: SeatsProps) {
                   fontFamily: font.display,
                   fontWeight: 800,
                   fontSize: "1.1em",
-                  background: avatarBackground,
-                  color: avatarColor,
+                  background: visual.avatarBackground,
+                  color: visual.avatarColor,
                 }}
               >
                 {seat.id + 1}
               </div>
-              {isButton && (
+              {visual.isButton && (
                 <span
                   data-testid={`seat-pod-${String(seat.id)}-button`}
                   style={{
@@ -160,20 +180,20 @@ export function Seats({ seats, view }: SeatsProps) {
                     fontFamily: font.mono,
                     fontSize: "0.6em",
                     fontWeight: 700,
-                    background: "#faf6f0",
+                    background: color.buttonMarker,
                     color: color.pillInk,
-                    boxShadow: "0 6px 16px -4px rgba(0,0,0,.85)",
+                    boxShadow: shadow.card,
                   }}
                 >
                   D
                 </span>
               )}
-              {holeCards && (
+              {visual.holeCards && (
                 <div
                   data-testid={`seat-pod-${String(seat.id)}-hole-cards`}
                   style={{ display: "flex", gap: "0.2em", fontSize: "0.5em" }}
                 >
-                  {holeCards.map((c, i) => (
+                  {visual.holeCards.map((c, i) => (
                     <motion.div
                       key={i}
                       initial={{ opacity: 0, rotateY: -92 }}
@@ -187,7 +207,7 @@ export function Seats({ seats, view }: SeatsProps) {
               )}
             </motion.div>
             <AnimatePresence>
-              {isActor && (
+              {visual.isActor && (
                 <motion.div
                   data-testid={`seat-pod-${String(seat.id)}-to-act`}
                   initial={{ opacity: 0, y: 6, scale: 0.9 }}

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -1,0 +1,224 @@
+import type {
+  Card as CardType,
+  SeatView,
+  TableView,
+} from "@table-top-poker/protocol";
+import { Card, color, font } from "@table-top-poker/ui-shared";
+import { AnimatePresence, motion } from "motion/react";
+import { posFor } from "./table/posFor.js";
+
+export interface SeatsProps {
+  readonly seats: readonly SeatView[];
+  readonly view: TableView | null;
+}
+
+type SeatStatus = "open" | "sitting-out" | "folded" | "in-hand";
+
+function statusOf(seat: SeatView, view: TableView | null): SeatStatus {
+  if (!seat.claimed) return "open";
+  if (view !== null && view.phase === "betting") {
+    const handSeat = view.seats.find((s) => s.seatId === seat.id);
+    if (!handSeat) return "sitting-out";
+    return handSeat.folded ? "folded" : "in-hand";
+  }
+  return seat.sittingOut ? "sitting-out" : "in-hand";
+}
+
+function isWinnerSeat(seatId: number, view: TableView | null): boolean {
+  if (view === null) return false;
+  if (view.phase === "showdown") return view.winners.includes(seatId);
+  if (view.phase === "folded-out") return view.winner === seatId;
+  return false;
+}
+
+function holeCardsFor(
+  seatId: number,
+  view: TableView | null,
+): readonly [CardType, CardType] | null {
+  if (view?.phase !== "showdown") return null;
+  return view.results.find((r) => r.seatId === seatId)?.holeCards ?? null;
+}
+
+const restingGlow = "0 0 0 1px rgba(255,255,255,.1)";
+const actorGlowFrames = [
+  "0 0 0 2px rgba(229,68,60,.95), 0 0 34px 6px rgba(229,68,60,.3)",
+  "0 0 0 3px rgba(255,120,110,1), 0 0 54px 14px rgba(229,68,60,.5)",
+  "0 0 0 2px rgba(229,68,60,.95), 0 0 34px 6px rgba(229,68,60,.3)",
+];
+
+/**
+ * The seat pods ringing the felt's two long edges, percentage-positioned via
+ * `posFor` so the layout holds across the table device's real viewport. This
+ * is the only place `seats` and the in-progress `view` are merged into a
+ * single per-seat picture — `Board` only ever renders the centre content.
+ */
+export function Seats({ seats, view }: SeatsProps) {
+  return (
+    <div data-testid="seats" style={{ position: "absolute", inset: 0 }}>
+      {seats.map((seat) => {
+        const status = statusOf(seat, view);
+        const isButton = view !== null && seat.id === view.button;
+        const isActor =
+          view !== null &&
+          view.phase === "betting" &&
+          view.toAct[0] === seat.id;
+        const isWinner = isWinnerSeat(seat.id, view);
+        const holeCards = holeCardsFor(seat.id, view);
+        const pos = posFor(seat.id, seats.length);
+
+        let avatarBackground = "rgba(255,255,255,.06)";
+        let avatarColor = "rgba(250,240,238,.5)";
+        if (seat.claimed) {
+          avatarBackground = color.text;
+          avatarColor = color.pillInk;
+        }
+        if (status === "folded") {
+          avatarBackground = "rgba(255,255,255,.1)";
+          avatarColor = "rgba(250,240,238,.45)";
+        }
+
+        return (
+          <div
+            key={seat.id}
+            data-testid={`seat-pod-${String(seat.id)}`}
+            data-status={status}
+            data-button={isButton}
+            data-turn={isActor}
+            data-winner={isWinner}
+            data-disconnected={seat.disconnected}
+            style={{
+              position: "absolute",
+              left: `${String(pos.left)}%`,
+              top: `${String(pos.top)}%`,
+              transform: "translate(-50%, -50%)",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "0.5em",
+            }}
+          >
+            <motion.div
+              animate={{ boxShadow: isActor ? actorGlowFrames : restingGlow }}
+              transition={
+                isActor
+                  ? { duration: 1.7, repeat: Infinity, ease: "easeInOut" }
+                  : { duration: 0.3 }
+              }
+              style={{
+                position: "relative",
+                borderRadius: "1em",
+                padding: "0.5em",
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: "0.4em",
+                background: isWinner
+                  ? "rgba(250,234,231,.14)"
+                  : isActor
+                    ? "rgba(20,7,8,.72)"
+                    : "transparent",
+                border: `1px solid ${
+                  isWinner
+                    ? "rgba(250,234,231,.7)"
+                    : isActor
+                      ? "rgba(229,68,60,.95)"
+                      : "transparent"
+                }`,
+                opacity: status === "folded" ? 0.34 : 1,
+              }}
+            >
+              <div
+                style={{
+                  width: "3em",
+                  height: "3em",
+                  borderRadius: "50%",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontFamily: font.display,
+                  fontWeight: 800,
+                  fontSize: "1.1em",
+                  background: avatarBackground,
+                  color: avatarColor,
+                }}
+              >
+                {seat.id + 1}
+              </div>
+              {isButton && (
+                <span
+                  data-testid={`seat-pod-${String(seat.id)}-button`}
+                  style={{
+                    position: "absolute",
+                    top: "-0.4em",
+                    right: "-0.4em",
+                    width: "1.6em",
+                    height: "1.6em",
+                    borderRadius: "50%",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontFamily: font.mono,
+                    fontSize: "0.6em",
+                    fontWeight: 700,
+                    background: "#faf6f0",
+                    color: color.pillInk,
+                    boxShadow: "0 6px 16px -4px rgba(0,0,0,.85)",
+                  }}
+                >
+                  D
+                </span>
+              )}
+              {holeCards && (
+                <div
+                  data-testid={`seat-pod-${String(seat.id)}-hole-cards`}
+                  style={{ display: "flex", gap: "0.2em", fontSize: "0.5em" }}
+                >
+                  {holeCards.map((c, i) => (
+                    <motion.div
+                      key={i}
+                      initial={{ opacity: 0, rotateY: -92 }}
+                      animate={{ opacity: 1, rotateY: 0 }}
+                      transition={{ duration: 0.35, delay: i * 0.08 }}
+                    >
+                      <Card rank={c.rank} suit={c.suit} />
+                    </motion.div>
+                  ))}
+                </div>
+              )}
+            </motion.div>
+            <AnimatePresence>
+              {isActor && (
+                <motion.div
+                  data-testid={`seat-pod-${String(seat.id)}-to-act`}
+                  initial={{ opacity: 0, y: 6, scale: 0.9 }}
+                  animate={{ opacity: 1, y: 0, scale: 1 }}
+                  exit={{ opacity: 0, y: 6, scale: 0.9 }}
+                  transition={{ duration: 0.2 }}
+                  style={{
+                    padding: "0.35em 0.9em",
+                    borderRadius: "999px",
+                    background: color.accent,
+                    color: "#fff",
+                    fontFamily: font.mono,
+                    fontSize: "0.7em",
+                    fontWeight: 700,
+                    letterSpacing: "0.2em",
+                    textTransform: "uppercase",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  To act
+                </motion.div>
+              )}
+            </AnimatePresence>
+            {seat.disconnected && (
+              <span data-testid={`seat-pod-${String(seat.id)}-disconnected`}>
+                Disconnected
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/table-client/src/TableControls.test.tsx
+++ b/packages/table-client/src/TableControls.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { TableControls } from "./TableControls.js";
+
+const noop = () => {
+  /* unused in these tests */
+};
+
+describe("TableControls", () => {
+  it("shows Deal hand when a hand can start, and always shows End session", () => {
+    const html = renderToStaticMarkup(
+      <TableControls
+        canStartHand
+        handComplete={false}
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+      />,
+    );
+    expect(html).toContain('data-testid="start-hand-button"');
+    expect(html).not.toContain('data-testid="next-hand-button"');
+    expect(html).toContain('data-testid="end-session-button"');
+  });
+
+  it("shows Next hand once the hand is complete, not Deal hand", () => {
+    const html = renderToStaticMarkup(
+      <TableControls
+        canStartHand={false}
+        handComplete
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+      />,
+    );
+    expect(html).not.toContain('data-testid="start-hand-button"');
+    expect(html).toContain('data-testid="next-hand-button"');
+  });
+
+  it("shows neither deal control mid-hand", () => {
+    const html = renderToStaticMarkup(
+      <TableControls
+        canStartHand={false}
+        handComplete={false}
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+      />,
+    );
+    expect(html).not.toContain('data-testid="start-hand-button"');
+    expect(html).not.toContain('data-testid="next-hand-button"');
+    expect(html).toContain('data-testid="end-session-button"');
+  });
+});

--- a/packages/table-client/src/TableControls.tsx
+++ b/packages/table-client/src/TableControls.tsx
@@ -1,4 +1,4 @@
-import { PillButton, color, font } from "@table-top-poker/ui-shared";
+import { PillButton } from "@table-top-poker/ui-shared";
 
 export interface TableControlsProps {
   readonly canStartHand: boolean;
@@ -43,24 +43,14 @@ export function TableControls({
           Next hand
         </PillButton>
       )}
-      <button
-        type="button"
+      <PillButton
+        tone="outline"
         data-testid="end-session-button"
         onClick={onEndSession}
-        style={{
-          padding: "0.9em 1.3em",
-          borderRadius: "999px",
-          border: `1px solid ${color.border}`,
-          background: "rgba(0,0,0,.28)",
-          color: color.textMuted,
-          fontFamily: font.mono,
-          fontSize: "0.7em",
-          letterSpacing: "0.14em",
-          textTransform: "uppercase",
-        }}
+        style={{ padding: "15px 22px", fontSize: "11px" }}
       >
         End session
-      </button>
+      </PillButton>
     </div>
   );
 }

--- a/packages/table-client/src/TableControls.tsx
+++ b/packages/table-client/src/TableControls.tsx
@@ -1,0 +1,66 @@
+import { PillButton, color, font } from "@table-top-poker/ui-shared";
+
+export interface TableControlsProps {
+  readonly canStartHand: boolean;
+  readonly handComplete: boolean;
+  readonly onStartHand: () => void;
+  readonly onNextHand: () => void;
+  readonly onEndSession: () => void;
+}
+
+/**
+ * The bottom-right control rail — Deal hand / Next hand are mutually
+ * exclusive with the felt's hand state, End session is always available
+ * once a room exists (this component is only mounted then).
+ */
+export function TableControls({
+  canStartHand,
+  handComplete,
+  onStartHand,
+  onNextHand,
+  onEndSession,
+}: TableControlsProps) {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        right: "1.5em",
+        top: "50%",
+        transform: "translateY(-50%)",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "flex-end",
+        gap: "0.75em",
+      }}
+    >
+      {canStartHand && (
+        <PillButton data-testid="start-hand-button" onClick={onStartHand}>
+          Deal hand
+        </PillButton>
+      )}
+      {handComplete && (
+        <PillButton data-testid="next-hand-button" onClick={onNextHand}>
+          Next hand
+        </PillButton>
+      )}
+      <button
+        type="button"
+        data-testid="end-session-button"
+        onClick={onEndSession}
+        style={{
+          padding: "0.9em 1.3em",
+          borderRadius: "999px",
+          border: `1px solid ${color.border}`,
+          background: "rgba(0,0,0,.28)",
+          color: color.textMuted,
+          fontFamily: font.mono,
+          fontSize: "0.7em",
+          letterSpacing: "0.14em",
+          textTransform: "uppercase",
+        }}
+      >
+        End session
+      </button>
+    </div>
+  );
+}

--- a/packages/table-client/src/app-shell.css
+++ b/packages/table-client/src/app-shell.css
@@ -21,9 +21,9 @@ body {
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  background: #0f172a;
-  color: #f8fafc;
-  font-family: system-ui, sans-serif;
+  background: #0b0a09;
+  color: #f3ece1;
+  font-family: "IBM Plex Sans", system-ui, sans-serif;
   padding: env(safe-area-inset-top) env(safe-area-inset-right)
     env(safe-area-inset-bottom) env(safe-area-inset-left);
 }
@@ -36,9 +36,12 @@ body {
 }
 
 .felt {
+  position: relative;
   flex: 1;
+  overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 12px;
+  background: linear-gradient(160deg, #1a1516, #0a0708 60%, #161011);
 }

--- a/packages/table-client/src/table/posFor.test.ts
+++ b/packages/table-client/src/table/posFor.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { posFor } from "./posFor.js";
+
+describe("posFor", () => {
+  it("spreads an 8-seat table across the bottom edge first, then the top", () => {
+    expect(posFor(0, 8)).toEqual({ left: 14, top: 90 });
+    expect(posFor(3, 8)).toEqual({ left: 86, top: 90 });
+    expect(posFor(4, 8)).toEqual({ left: 86, top: 10 });
+    expect(posFor(7, 8)).toEqual({ left: 14, top: 10 });
+  });
+
+  it("centres a single seat on each edge instead of dividing by zero", () => {
+    expect(posFor(0, 1)).toEqual({ left: 50, top: 90 });
+    expect(posFor(0, 2)).toEqual({ left: 50, top: 90 });
+    expect(posFor(1, 2)).toEqual({ left: 50, top: 10 });
+  });
+
+  it("splits an odd seat count with the extra seat on the bottom edge", () => {
+    expect(posFor(0, 3)).toEqual({ left: 14, top: 90 });
+    expect(posFor(1, 3)).toEqual({ left: 86, top: 90 });
+    expect(posFor(2, 3)).toEqual({ left: 50, top: 10 });
+  });
+});

--- a/packages/table-client/src/table/posFor.ts
+++ b/packages/table-client/src/table/posFor.ts
@@ -1,0 +1,25 @@
+export interface SeatPosition {
+  /** Percent from the felt's left edge. */
+  readonly left: number;
+  /** Percent from the felt's top edge. */
+  readonly top: number;
+}
+
+/**
+ * Lays seats out along the two long edges of the felt — 1..k left to right
+ * along the bottom, then back right to left along the top — matching the
+ * design prototype's `posFor()` so the layout holds up across the table
+ * device's actual viewport rather than the prototype's mocked one.
+ */
+export function posFor(seatId: number, seatCount: number): SeatPosition {
+  const bottomCount = Math.ceil(seatCount / 2);
+  if (seatId < bottomCount) {
+    const fraction = bottomCount === 1 ? 0.5 : seatId / (bottomCount - 1);
+    return { left: 14 + 72 * fraction, top: 90 };
+  }
+
+  const topCount = seatCount - bottomCount;
+  const j = seatId - bottomCount;
+  const fraction = topCount === 1 ? 0.5 : j / (topCount - 1);
+  return { left: 86 - 72 * fraction, top: 10 };
+}

--- a/packages/ui-shared/src/PillButton.test.tsx
+++ b/packages/ui-shared/src/PillButton.test.tsx
@@ -29,4 +29,13 @@ describe("PillButton", () => {
     );
     expect(html).toContain("disabled");
   });
+
+  it("switches to the muted mono-label style when tone is outline", () => {
+    const solid = renderToStaticMarkup(<PillButton>Deal hand</PillButton>);
+    const outline = renderToStaticMarkup(
+      <PillButton tone="outline">End session</PillButton>,
+    );
+    expect(solid).not.toContain("text-transform");
+    expect(outline).toContain("text-transform:uppercase");
+  });
 });

--- a/packages/ui-shared/src/PillButton.tsx
+++ b/packages/ui-shared/src/PillButton.tsx
@@ -2,9 +2,11 @@ import type { ButtonHTMLAttributes, CSSProperties } from "react";
 import { color, font, radius, shadow } from "./theme.js";
 
 export type PillButtonSize = "md" | "lg";
+export type PillButtonTone = "solid" | "outline";
 
 export interface PillButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   readonly size?: PillButtonSize;
+  readonly tone?: PillButtonTone;
 }
 
 const sizeStyle: Record<PillButtonSize, CSSProperties> = {
@@ -12,24 +14,45 @@ const sizeStyle: Record<PillButtonSize, CSSProperties> = {
   lg: { padding: "20px 44px", fontSize: "19px" },
 };
 
+const toneStyle: Record<PillButtonTone, CSSProperties> = {
+  solid: {
+    border: 0,
+    background: color.pillGradient,
+    color: color.pillInk,
+    fontWeight: 700,
+    letterSpacing: "0.04em",
+    boxShadow: shadow.pill,
+  },
+  outline: {
+    border: `1px solid ${color.border}`,
+    background: "rgba(0,0,0,.28)",
+    color: color.textMuted,
+    fontFamily: font.mono,
+    fontWeight: 600,
+    letterSpacing: "0.14em",
+    textTransform: "uppercase",
+  },
+};
+
 /**
- * The rounded gradient pill used for primary actions ("Deal hand", "Create
- * room"). Matches the prototype's cream-on-felt button, not a generic button.
+ * The rounded pill used for table/player actions. `tone="solid"` is the
+ * cream gradient for primary actions ("Deal hand", "Create room"); `tone="outline"`
+ * is the muted mono-label pill used for secondary actions ("End session").
  */
-export function PillButton({ size = "md", style, ...rest }: PillButtonProps) {
+export function PillButton({
+  size = "md",
+  tone = "solid",
+  style,
+  ...rest
+}: PillButtonProps) {
   return (
     <button
       type="button"
       {...rest}
       style={{
-        border: 0,
         borderRadius: radius.pill,
-        background: color.pillGradient,
-        color: color.pillInk,
         fontFamily: font.body,
-        fontWeight: 700,
-        letterSpacing: "0.04em",
-        boxShadow: shadow.pill,
+        ...toneStyle[tone],
         ...sizeStyle[size],
         ...style,
       }}

--- a/packages/ui-shared/src/index.ts
+++ b/packages/ui-shared/src/index.ts
@@ -1,7 +1,11 @@
 export { Card } from "./Card.js";
 export type { CardProps } from "./Card.js";
 export { PillButton } from "./PillButton.js";
-export type { PillButtonProps, PillButtonSize } from "./PillButton.js";
+export type {
+  PillButtonProps,
+  PillButtonSize,
+  PillButtonTone,
+} from "./PillButton.js";
 export { Panel } from "./Panel.js";
 export type { PanelProps } from "./Panel.js";
 export { color, font, fontSize, radius, shadow } from "./theme.js";

--- a/packages/ui-shared/src/theme.ts
+++ b/packages/ui-shared/src/theme.ts
@@ -40,6 +40,15 @@ export const color = {
   cardBorder: "rgba(0,0,0,.2)",
   suitRed: "#c0392b",
   suitBlack: "#151311",
+
+  seatAvatarOpen: "rgba(255,255,255,.06)",
+  seatAvatarOpenText: "rgba(250,240,238,.5)",
+  seatAvatarFolded: "rgba(255,255,255,.1)",
+  seatAvatarFoldedText: "rgba(250,240,238,.45)",
+  seatWinnerBorder: "rgba(250,234,231,.7)",
+  seatWinnerBackground: "rgba(250,234,231,.14)",
+  seatActorBackground: "rgba(20,7,8,.72)",
+  buttonMarker: "#faf6f0",
 } as const;
 
 export const font = {
@@ -70,4 +79,11 @@ export const shadow = {
   panel: "0 44px 90px -30px rgba(0,0,0,.95)",
   pill: "0 16px 40px -14px rgba(229,68,60,.6), inset 0 1px 0 rgba(255,255,255,.5)",
   card: "0 22px 44px -16px rgba(0,0,0,.85)",
+  seatResting: "0 0 0 1px rgba(255,255,255,.1)",
+  /** The actor-glow pulse's three keyframes, driven by Motion's `animate`. */
+  seatActorGlow: [
+    "0 0 0 2px rgba(229,68,60,.95), 0 0 34px 6px rgba(229,68,60,.3)",
+    "0 0 0 3px rgba(255,120,110,1), 0 0 54px 14px rgba(229,68,60,.5)",
+    "0 0 0 2px rgba(229,68,60,.95), 0 0 34px 6px rgba(229,68,60,.3)",
+  ],
 } as const;


### PR DESCRIPTION
## Summary
- Adds a `Seats` layer — seat pods percentage-positioned via a ported `posFor()`, actor-glow pulse and "to act" badge driven by Motion (not CSS keyframes), button marker, and showdown hole-card reveal per seat.
- Restyles `Board` to own only the felt's centre content (community-card deal-in via Motion, showdown results) now that seat rendering lives in `Seats`.
- Adds a bottom-right `TableControls` rail (Deal hand / Next hand / End session), pulling End session out of `RoomPanel` to match the prototype's control rail.
- Gives the felt a real surface (rail + felt gradient) instead of the placeholder flex column.
- Extends `ui-shared`'s theme with seat/actor-glow tokens and a `PillButton` `tone="outline"` variant, so `TableControls` reuses the shared pill shape instead of a bespoke button.

Closes #60.

**Known gap:** the prototype's "seats" section also shows small/big-blind markers (`SB`/`BB`), but the engine's `TableView` doesn't currently expose which seat holds each blind (that logic — `bigBlindSeat()` — is internal to the engine's `HandState`). Adding blind markers needs a `view.ts` change (new engine-exposed fields) under the engine's normal TDD process, which is out of this ticket's table-client-only scope — flagging for a follow-up.

## Test plan
- [x] `npm run -w packages/table-client test` — 41/41 passing
- [x] `npm run -w packages/ui-shared test` — 12/12 passing
- [x] `npm run build` — typechecks clean across the workspace
- [x] `npm run lint` — eslint + prettier clean
- [x] Full workspace `npm test` — only 2 pre-existing, unrelated timing flakes in `packages/server`'s reconnection tests (untouched by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Ho7vKfyBmbNavG3pZYeaQ