### PR TITLE
feat(player): rebuild the join screen and seat picker to match the prototype

### DIFF
--- a/packages/player-client/src/InlineError.tsx
+++ b/packages/player-client/src/InlineError.tsx
@@ -1,0 +1,22 @@
+import { color, fontSize } from "@table-top-poker/ui-shared";
+import type { CSSProperties } from "react";
+
+export interface InlineErrorProps {
+  readonly testId: string;
+  readonly message: string;
+}
+
+const style: CSSProperties = {
+  fontSize: fontSize.caption,
+  color: color.accentBright,
+  textAlign: "center",
+};
+
+/** The centred inline error line shown below the join form and seat picker. */
+export function InlineError({ testId, message }: InlineErrorProps) {
+  return (
+    <div data-testid={testId} style={style}>
+      {message}
+    </div>
+  );
+}

--- a/packages/player-client/src/JoinForm.test.tsx
+++ b/packages/player-client/src/JoinForm.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { JoinForm } from "./JoinForm.js";
 
 describe("JoinForm", () => {
-  it("prefills the room code input", () => {
+  it("prefills the code boxes from the default room code", () => {
     const html = renderToStaticMarkup(
       <JoinForm
         defaultRoomCode="ABCD"
@@ -12,11 +12,43 @@ describe("JoinForm", () => {
         onSubmit={() => undefined}
       />,
     );
-    expect(html).toContain('data-testid="room-code-input"');
-    expect(html).toContain('value="ABCD"');
+    expect(html).toContain('data-testid="join-code-box-0"');
+    expect(html).toContain(">A<");
+    expect(html).toContain(">B<");
+    expect(html).toContain(">C<");
+    expect(html).toContain(">D<");
   });
 
-  it("shows a join error when present", () => {
+  it("disables the join button until four characters are entered", () => {
+    const html = renderToStaticMarkup(
+      <JoinForm defaultRoomCode="AB" error={null} onSubmit={() => undefined} />,
+    );
+    expect(html).toContain("Enter 4 letters");
+    expect(html).toMatch(/data-testid="join-room-button"[^>]*disabled/);
+  });
+
+  it("enables the join button once four characters are entered", () => {
+    const html = renderToStaticMarkup(
+      <JoinForm
+        defaultRoomCode="ABCD"
+        error={null}
+        onSubmit={() => undefined}
+      />,
+    );
+    expect(html).toContain("Join room");
+    expect(html).not.toMatch(/data-testid="join-room-button"[^>]*disabled/);
+  });
+
+  it("renders a key for every character in the room-code alphabet", () => {
+    const html = renderToStaticMarkup(
+      <JoinForm defaultRoomCode="" error={null} onSubmit={() => undefined} />,
+    );
+    expect(html).toContain('data-testid="join-key-A"');
+    expect(html).toContain('data-testid="join-key-9"');
+    expect(html).toContain('data-testid="join-key-backspace"');
+  });
+
+  it("shows a friendly message for a known join error", () => {
     const html = renderToStaticMarkup(
       <JoinForm
         defaultRoomCode=""
@@ -25,7 +57,7 @@ describe("JoinForm", () => {
       />,
     );
     expect(html).toContain('data-testid="join-error"');
-    expect(html).toContain("room-not-found");
+    expect(html).toContain("check the table screen");
   });
 
   it("omits the error element when there is none", () => {

--- a/packages/player-client/src/JoinForm.tsx
+++ b/packages/player-client/src/JoinForm.tsx
@@ -7,6 +7,7 @@ import {
 } from "@table-top-poker/ui-shared";
 import type { CSSProperties } from "react";
 import { useState } from "react";
+import { InlineError } from "./InlineError.js";
 
 export interface JoinFormProps {
   readonly defaultRoomCode: string;
@@ -74,10 +75,10 @@ function boxStyle(active: boolean): CSSProperties {
     justifyContent: "center",
     fontFamily: font.mono,
     fontWeight: 700,
-    fontSize: "42px",
-    background: "rgba(255,255,255,.04)",
+    fontSize: fontSize.codeDigit,
+    background: color.controlFill,
     color: color.textBright,
-    border: `1px solid ${active ? "rgba(240,120,110,.8)" : color.border}`,
+    border: `1px solid ${active ? color.focusBorder : color.border}`,
   };
 }
 
@@ -90,26 +91,20 @@ const keypadStyle: CSSProperties = {
 const keyStyle: CSSProperties = {
   height: 52,
   borderRadius: radius.control,
-  border: "1px solid rgba(255,255,255,.09)",
-  background: "rgba(255,255,255,.04)",
+  border: `1px solid ${color.border}`,
+  background: color.controlFill,
   fontFamily: font.mono,
-  fontSize: "18px",
+  fontSize: fontSize.lg,
   fontWeight: 600,
   color: color.text,
 };
 
 const disabledJoinStyle: CSSProperties = {
-  background: "rgba(255,255,255,.05)",
-  color: "rgba(243,236,225,.35)",
-  border: "1px solid rgba(255,255,255,.09)",
+  background: color.controlFill,
+  color: color.disabledText,
+  border: `1px solid ${color.border}`,
   boxShadow: "none",
   cursor: "default",
-};
-
-const errorStyle: CSSProperties = {
-  fontSize: "13.5px",
-  color: color.accentBright,
-  textAlign: "center",
 };
 
 export function JoinForm({ defaultRoomCode, error, onSubmit }: JoinFormProps) {
@@ -186,9 +181,7 @@ export function JoinForm({ defaultRoomCode, error, onSubmit }: JoinFormProps) {
         {complete ? "Join room" : "Enter 4 letters"}
       </PillButton>
       {error && (
-        <div data-testid="join-error" style={errorStyle}>
-          {errorCopy[error] ?? error}
-        </div>
+        <InlineError testId="join-error" message={errorCopy[error] ?? error} />
       )}
     </div>
   );

--- a/packages/player-client/src/JoinForm.tsx
+++ b/packages/player-client/src/JoinForm.tsx
@@ -1,3 +1,11 @@
+import {
+  PillButton,
+  color,
+  font,
+  fontSize,
+  radius,
+} from "@table-top-poker/ui-shared";
+import type { CSSProperties } from "react";
 import { useState } from "react";
 
 export interface JoinFormProps {
@@ -6,29 +14,182 @@ export interface JoinFormProps {
   readonly onSubmit: (roomCode: string) => void;
 }
 
+const CODE_LENGTH = 4;
+
+/**
+ * Digits + uppercase letters, excluding characters easily confused on a
+ * phone screen (0/O, 1/I/L, 2/Z, 5/S, 8/B) — mirrors the server's
+ * `ROOM_CODE_ALPHABET` (packages/server/src/room-code.ts).
+ */
+const KEYS = [
+  "3",
+  "4",
+  "6",
+  "7",
+  "9",
+  "A",
+  "C",
+  "D",
+  "E",
+  "F",
+  "G",
+  "H",
+  "J",
+  "K",
+  "M",
+  "N",
+  "P",
+  "Q",
+  "R",
+  "T",
+  "U",
+  "V",
+  "W",
+  "X",
+  "Y",
+];
+
+const errorCopy: Record<string, string> = {
+  "room-not-found": "That room code doesn't exist — check the table screen.",
+};
+
+const descriptionStyle: CSSProperties = {
+  fontSize: fontSize.md,
+  lineHeight: 1.5,
+  color: color.textMuted,
+};
+
+const boxRowStyle: CSSProperties = {
+  display: "flex",
+  gap: 10,
+};
+
+function boxStyle(active: boolean): CSSProperties {
+  return {
+    flex: 1,
+    aspectRatio: "1 / 1.15",
+    borderRadius: radius.control,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontFamily: font.mono,
+    fontWeight: 700,
+    fontSize: "42px",
+    background: "rgba(255,255,255,.04)",
+    color: color.textBright,
+    border: `1px solid ${active ? "rgba(240,120,110,.8)" : color.border}`,
+  };
+}
+
+const keypadStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(5, 1fr)",
+  gap: 8,
+};
+
+const keyStyle: CSSProperties = {
+  height: 52,
+  borderRadius: radius.control,
+  border: "1px solid rgba(255,255,255,.09)",
+  background: "rgba(255,255,255,.04)",
+  fontFamily: font.mono,
+  fontSize: "18px",
+  fontWeight: 600,
+  color: color.text,
+};
+
+const disabledJoinStyle: CSSProperties = {
+  background: "rgba(255,255,255,.05)",
+  color: "rgba(243,236,225,.35)",
+  border: "1px solid rgba(255,255,255,.09)",
+  boxShadow: "none",
+  cursor: "default",
+};
+
+const errorStyle: CSSProperties = {
+  fontSize: "13.5px",
+  color: color.accentBright,
+  textAlign: "center",
+};
+
 export function JoinForm({ defaultRoomCode, error, onSubmit }: JoinFormProps) {
   const [roomCode, setRoomCode] = useState(defaultRoomCode);
+  const complete = roomCode.length === CODE_LENGTH;
+
+  const press = (key: string) => {
+    setRoomCode((code) => (code.length < CODE_LENGTH ? code + key : code));
+  };
+  const backspace = () => {
+    setRoomCode((code) => code.slice(0, -1));
+  };
 
   return (
-    <form
+    <div
       data-testid="join-form"
-      onSubmit={(event) => {
-        event.preventDefault();
-        onSubmit(roomCode.trim().toUpperCase());
+      style={{
+        flex: 1,
+        minHeight: 0,
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        gap: 20,
+        padding: "0 26px 34px",
       }}
     >
-      <input
-        data-testid="room-code-input"
-        value={roomCode}
-        maxLength={4}
-        onChange={(event) => {
-          setRoomCode(event.target.value);
+      <div style={descriptionStyle}>
+        Enter the four letters shown in the middle of the table, or scan its
+        code.
+      </div>
+      <div style={boxRowStyle}>
+        {Array.from({ length: CODE_LENGTH }, (_, i) => (
+          <div
+            key={i}
+            data-testid={`join-code-box-${String(i)}`}
+            style={boxStyle(roomCode.length === i)}
+          >
+            {roomCode[i] ?? ""}
+          </div>
+        ))}
+      </div>
+      <div style={keypadStyle}>
+        {KEYS.map((key) => (
+          <button
+            key={key}
+            type="button"
+            data-testid={`join-key-${key}`}
+            onClick={() => {
+              press(key);
+            }}
+            style={keyStyle}
+          >
+            {key}
+          </button>
+        ))}
+        <button
+          type="button"
+          data-testid="join-key-backspace"
+          onClick={backspace}
+          style={keyStyle}
+        >
+          ⌫
+        </button>
+      </div>
+      <PillButton
+        size="lg"
+        data-testid="join-room-button"
+        disabled={!complete}
+        onClick={() => {
+          onSubmit(roomCode);
         }}
-      />
-      <button type="submit" data-testid="join-room-button">
-        Join room
-      </button>
-      {error && <div data-testid="join-error">{error}</div>}
-    </form>
+        style={complete ? undefined : disabledJoinStyle}
+      >
+        {complete ? "Join room" : "Enter 4 letters"}
+      </PillButton>
+      {error && (
+        <div data-testid="join-error" style={errorStyle}>
+          {errorCopy[error] ?? error}
+        </div>
+      )}
+    </div>
   );
 }

--- a/packages/player-client/src/SeatPicker.test.tsx
+++ b/packages/player-client/src/SeatPicker.test.tsx
@@ -16,12 +16,13 @@ describe("SeatPicker", () => {
       />,
     );
 
+    expect(html).toContain('data-testid="seat-option-0"');
     expect(html).toContain('data-testid="claim-seat-0"');
     expect(html).not.toContain('data-testid="claim-seat-1"');
-    expect(html).toContain("taken");
+    expect(html).toContain("Taken");
   });
 
-  it("shows a claim error when present", () => {
+  it("shows a friendly message for a known claim error", () => {
     const html = renderToStaticMarkup(
       <SeatPicker
         error="seat-already-claimed"
@@ -30,6 +31,13 @@ describe("SeatPicker", () => {
       />,
     );
     expect(html).toContain('data-testid="claim-error"');
-    expect(html).toContain("seat-already-claimed");
+    expect(html).toContain("pick another");
+  });
+
+  it("omits the error element when there is none", () => {
+    const html = renderToStaticMarkup(
+      <SeatPicker error={null} onClaim={() => undefined} seats={[]} />,
+    );
+    expect(html).not.toContain('data-testid="claim-error"');
   });
 });

--- a/packages/player-client/src/SeatPicker.tsx
+++ b/packages/player-client/src/SeatPicker.tsx
@@ -1,6 +1,7 @@
 import type { SeatView } from "@table-top-poker/protocol";
 import { color, font, fontSize, radius } from "@table-top-poker/ui-shared";
 import type { CSSProperties } from "react";
+import { InlineError } from "./InlineError.js";
 
 export interface SeatPickerProps {
   readonly seats: readonly SeatView[];
@@ -31,12 +32,12 @@ function seatStyle(claimed: boolean): CSSProperties {
     ...(claimed
       ? {
           border: `1px solid ${color.border}`,
-          background: "rgba(255,255,255,.02)",
+          background: color.mutedSurface,
           opacity: 0.5,
         }
       : {
           border: `1px solid ${color.accentBorder}`,
-          background: "rgba(229,68,60,.07)",
+          background: color.accentWash,
         }),
   };
 }
@@ -67,8 +68,8 @@ function avatarStyle(claimed: boolean): CSSProperties {
     fontFamily: font.mono,
     fontWeight: 700,
     fontSize: fontSize.xs,
-    background: "linear-gradient(160deg,#e9a89f,#a13a2e)",
-    color: "#170708",
+    background: color.avatarGradient,
+    color: color.pillInk,
     filter: claimed ? "saturate(.2) brightness(.7)" : undefined,
   };
 }
@@ -88,16 +89,10 @@ const titleStyle: CSSProperties = {
 
 const subStyle: CSSProperties = {
   fontFamily: font.mono,
-  fontSize: "9.5px",
+  fontSize: fontSize.xs,
   letterSpacing: "0.14em",
   textTransform: "uppercase",
   color: color.textDim,
-};
-
-const errorStyle: CSSProperties = {
-  fontSize: "13.5px",
-  color: color.accentBright,
-  textAlign: "center",
 };
 
 export function SeatPicker({ seats, error, onClaim }: SeatPickerProps) {
@@ -154,9 +149,10 @@ export function SeatPicker({ seats, error, onClaim }: SeatPickerProps) {
         })}
       </div>
       {error && (
-        <div data-testid="claim-error" style={errorStyle}>
-          {seatErrorCopy[error] ?? error}
-        </div>
+        <InlineError
+          testId="claim-error"
+          message={seatErrorCopy[error] ?? error}
+        />
       )}
     </div>
   );

--- a/packages/player-client/src/SeatPicker.tsx
+++ b/packages/player-client/src/SeatPicker.tsx
@@ -1,4 +1,6 @@
 import type { SeatView } from "@table-top-poker/protocol";
+import { color, font, fontSize, radius } from "@table-top-poker/ui-shared";
+import type { CSSProperties } from "react";
 
 export interface SeatPickerProps {
   readonly seats: readonly SeatView[];
@@ -6,30 +8,156 @@ export interface SeatPickerProps {
   readonly onClaim: (seatId: number) => void;
 }
 
+const seatErrorCopy: Record<string, string> = {
+  "seat-already-claimed": "Someone just took that seat — pick another.",
+};
+
+const descriptionStyle: CSSProperties = {
+  fontSize: fontSize.md,
+  lineHeight: 1.5,
+  color: color.textMuted,
+};
+
+const gridStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "1fr 1fr",
+  gap: 10,
+};
+
+function seatStyle(claimed: boolean): CSSProperties {
+  return {
+    borderRadius: radius.control,
+    padding: "14px 13px",
+    ...(claimed
+      ? {
+          border: `1px solid ${color.border}`,
+          background: "rgba(255,255,255,.02)",
+          opacity: 0.5,
+        }
+      : {
+          border: `1px solid ${color.accentBorder}`,
+          background: "rgba(229,68,60,.07)",
+        }),
+  };
+}
+
+const rowStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 11,
+  width: "100%",
+  textAlign: "left",
+  background: "none",
+  border: 0,
+  padding: 0,
+  font: "inherit",
+  color: "inherit",
+  cursor: "pointer",
+};
+
+function avatarStyle(claimed: boolean): CSSProperties {
+  return {
+    width: 34,
+    height: 34,
+    borderRadius: radius.pill,
+    flex: "none",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    fontFamily: font.mono,
+    fontWeight: 700,
+    fontSize: fontSize.xs,
+    background: "linear-gradient(160deg,#e9a89f,#a13a2e)",
+    color: "#170708",
+    filter: claimed ? "saturate(.2) brightness(.7)" : undefined,
+  };
+}
+
+const textColStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 2,
+  minWidth: 0,
+};
+
+const titleStyle: CSSProperties = {
+  fontSize: fontSize.md,
+  fontWeight: 600,
+  color: color.text,
+};
+
+const subStyle: CSSProperties = {
+  fontFamily: font.mono,
+  fontSize: "9.5px",
+  letterSpacing: "0.14em",
+  textTransform: "uppercase",
+  color: color.textDim,
+};
+
+const errorStyle: CSSProperties = {
+  fontSize: "13.5px",
+  color: color.accentBright,
+  textAlign: "center",
+};
+
 export function SeatPicker({ seats, error, onClaim }: SeatPickerProps) {
   return (
-    <div data-testid="seat-picker">
-      <ul>
-        {seats.map((seat) => (
-          <li key={seat.id} data-testid={`seat-option-${String(seat.id)}`}>
-            Seat {seat.id + 1}
-            {seat.claimed ? (
-              " — taken"
-            ) : (
-              <button
-                type="button"
-                data-testid={`claim-seat-${String(seat.id)}`}
-                onClick={() => {
-                  onClaim(seat.id);
-                }}
-              >
-                Sit here
-              </button>
-            )}
-          </li>
-        ))}
-      </ul>
-      {error && <div data-testid="claim-error">{error}</div>}
+    <div
+      data-testid="seat-picker"
+      style={{
+        flex: 1,
+        overflow: "hidden",
+        display: "flex",
+        flexDirection: "column",
+        gap: 14,
+        padding: "0 22px 26px",
+      }}
+    >
+      <div style={descriptionStyle}>
+        Pick where you're sitting. Seat order sets the button and blinds.
+      </div>
+      <div style={gridStyle}>
+        {seats.map((seat) => {
+          const content = (
+            <>
+              <span style={avatarStyle(seat.claimed)}>{seat.id + 1}</span>
+              <span style={textColStyle}>
+                <span style={titleStyle}>Seat {seat.id + 1}</span>
+                <span style={subStyle}>
+                  {seat.claimed ? "Taken" : "Sit here"}
+                </span>
+              </span>
+            </>
+          );
+          return (
+            <div
+              key={seat.id}
+              data-testid={`seat-option-${String(seat.id)}`}
+              style={seatStyle(seat.claimed)}
+            >
+              {seat.claimed ? (
+                <div style={rowStyle}>{content}</div>
+              ) : (
+                <button
+                  type="button"
+                  data-testid={`claim-seat-${String(seat.id)}`}
+                  onClick={() => {
+                    onClaim(seat.id);
+                  }}
+                  style={rowStyle}
+                >
+                  {content}
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      {error && (
+        <div data-testid="claim-error" style={errorStyle}>
+          {seatErrorCopy[error] ?? error}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/player-client/src/app-shell.css
+++ b/packages/player-client/src/app-shell.css
@@ -7,16 +7,25 @@ body {
   margin: 0;
   padding: 0;
   touch-action: manipulation;
+  background: #050403;
 }
 
+/*
+ * player-client is a phone experience even when opened in a wide desktop
+ * tab (no phone in hand for testing/demoing) — #root centres a
+ * phone-width column instead of letting the shell stretch full-bleed.
+ */
 #root {
   width: 100%;
   height: 100svh;
   overflow: hidden;
+  display: flex;
+  justify-content: center;
 }
 
 .app-shell {
   width: 100%;
+  max-width: 480px;
   height: 100%;
   overflow: hidden;
   display: flex;
@@ -24,6 +33,7 @@ body {
   background: radial-gradient(520px 380px at 50% -6%, #2a1518, #0b0708 70%);
   color: #f8fafc;
   font-family: "IBM Plex Sans", system-ui, sans-serif;
+  box-shadow: 0 0 80px rgba(0, 0, 0, 0.6);
   padding: env(safe-area-inset-top) env(safe-area-inset-right)
     env(safe-area-inset-bottom) env(safe-area-inset-left);
 }

--- a/packages/player-client/src/app-shell.css
+++ b/packages/player-client/src/app-shell.css
@@ -21,9 +21,9 @@ body {
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  background: #1e293b;
+  background: radial-gradient(520px 380px at 50% -6%, #2a1518, #0b0708 70%);
   color: #f8fafc;
-  font-family: system-ui, sans-serif;
+  font-family: "IBM Plex Sans", system-ui, sans-serif;
   padding: env(safe-area-inset-top) env(safe-area-inset-right)
     env(safe-area-inset-bottom) env(safe-area-inset-left);
 }
@@ -37,8 +37,7 @@ body {
 
 .hand {
   flex: 1;
+  min-height: 0;
   display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 12px;
+  flex-direction: column;
 }

--- a/packages/ui-shared/src/theme.ts
+++ b/packages/ui-shared/src/theme.ts
@@ -15,14 +15,21 @@ export const color = {
   surfaceGradient: "linear-gradient(180deg,#1d1214,#100a0b)",
   sideMenuGradient: "linear-gradient(180deg,#241417,#0d0809)",
   control: "rgba(12,7,8,.62)",
+  controlFill: "rgba(255,255,255,.04)",
   overlay: "rgba(5,8,7,.5)",
   border: "rgba(255,255,255,.1)",
   borderStrong: "rgba(255,255,255,.16)",
   accentBorder: "rgba(229,68,60,.32)",
+  accentWash: "rgba(229,68,60,.07)",
+  mutedSurface: "rgba(255,255,255,.02)",
+  focusBorder: "rgba(240,120,110,.8)",
 
   accent: "#e5443c",
   accentBright: "#ef6259",
   accentDeep: "#a81d1c",
+  disabledText: "rgba(243,236,225,.35)",
+
+  avatarGradient: "linear-gradient(160deg,#e9a89f,#a13a2e)",
 
   pillGradient: "linear-gradient(180deg,#fbf6f3,#e0cdc7)",
   pillInk: "#1b0708",
@@ -55,6 +62,8 @@ export const fontSize = {
   md: "15px",
   lg: "19px",
   xl: "26px",
+  caption: "13.5px",
+  codeDigit: "42px",
   display: "34px",
   jumbo: "104px",
 } as const;


### PR DESCRIPTION
## Summary
- Rebuilds `player-client`'s `JoinForm` (four-character code boxes + tap keypad) and `SeatPicker` (two-column seat grid with avatar badges) to match `docs/design/table-top-poker-prototype.dc.html`'s join screen and seat-picker sections.
- Keeps the existing join/seat-claim logic unchanged: `JoinForm`/`SeatPicker`'s prop contracts and `parseRoomCodeFromPath` are untouched — this is a visual/layout rebuild only.
- Styles from `ui-shared`'s design tokens, extending `theme.ts` with the few rungs (`controlFill`, `accentWash`, `mutedSurface`, `focusBorder`, `disabledText`, `avatarGradient`, `caption`, `codeDigit`) the prototype's join/seat screens needed, and adds a small shared `InlineError` component to avoid duplicating the inline error styling across the two screens.

Closes #61

## Test plan
- [x] `npm run -w @table-top-poker/player-client test` — 59 passed
- [x] `npm run -w @table-top-poker/ui-shared test` — 11 passed
- [x] `npm run -w @table-top-poker/player-client build` / `ui-shared build` / `table-client build` — typecheck clean
- [x] `npm run lint` — clean
- [x] `npm run build && npm test` (full workspace) — clean except one pre-existing flaky WS reconnection timeout in `packages/server/src/app.test.ts`, confirmed to fail identically on `design` with none of this branch's changes applied (unrelated infra flakiness, not touched by this diff)
- [x] Ran `/code-review` (Standards + Spec sub-agents against `origin/design`); addressed the token-hygiene and duplication findings in a follow-up commit