### PR TITLE
feat(server,deploy): bundle real client apps and add Pi deployment tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ coverage/
 # is a real tracked placeholder, but everything build:release copies under it is generated.
 /packages/server/public/table/
 /packages/server/public/player/
+/.release/
+
+# Local env overrides (e.g. DEV_ALLOWED_HOSTS)
+.env.local
+.env.*.local

--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,6 @@ coverage/
 *.tsbuildinfo
 .DS_Store
 
-# Local env overrides (e.g. DEV_ALLOWED_HOSTS)
-.env.local
-.env.*.local
-
 # Release builds staged by scripts/build-release.sh (ticket 34) — packages/server/public/index.html
 # is a real tracked placeholder, but everything build:release copies under it is generated.
 /packages/server/public/table/

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ coverage/
 # Local env overrides (e.g. DEV_ALLOWED_HOSTS)
 .env.local
 .env.*.local
+
+# Release builds staged by scripts/build-release.sh (ticket 34) — packages/server/public/index.html
+# is a real tracked placeholder, but everything build:release copies under it is generated.
+/packages/server/public/table/
+/packages/server/public/player/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,45 @@ The five canonical triage roles, each using its default label string (`needs-tri
 
 Single-context: one `CONTEXT.md` and one `docs/adr/` at the repo root, both created lazily. See `docs/agents/domain.md`.
 
+## Raspberry Pi deployment
+
+When the human asks to deploy a new app version to the Raspberry Pi, use the
+`raspberrypi` SSH host alias and follow the release workflow in
+`docs/deploy-pi.md`:
+
+1. Work from the checkout containing the requested commit. Inspect `git status`
+   and do not deploy unrelated or uncommitted changes without explicit
+   approval.
+2. Build and verify locally with `npm ci`, `npm run lint`, `npm test`, and
+   `npm run build:release`. The release must be built on the development
+   machine; do not build TypeScript or run `npm install` on the Pi.
+3. Before restarting, warn that the server keeps rooms and hands in memory, so
+   deployment ends active games. Do not restart during an active game unless
+   the human explicitly approves it.
+4. Upload `.release/` to a new timestamped directory and switch the symlink:
+
+   ```bash
+   RELEASE=/opt/poker/releases/$(date +%Y%m%d-%H%M%S)
+   ssh raspberrypi "mkdir -p '$RELEASE'"
+   rsync -az --delete .release/ "raspberrypi:$RELEASE/"
+   ssh raspberrypi "sudo chown -R poker:poker '$RELEASE' && \
+     sudo ln -sfn '$RELEASE' /opt/poker/current && \
+     sudo systemctl restart poker && \
+     sudo systemctl is-active poker"
+   ```
+
+5. Verify the selected release, service status, recent journal output, and LAN
+   HTTP response from `http://192.168.1.116:3000/`.
+6. If `deploy/poker.service` changed, install it into
+   `/etc/systemd/system/poker.service`, run `sudo systemctl daemon-reload`, and
+   restart the service. Do not change `/etc/poker/poker.env` unless requested.
+7. Keep older release directories. To roll back, point
+   `/opt/poker/current` at a known-good release and restart `poker`.
+
+Use `docs/deploy-pi.md` as the source of truth if these instructions and the
+deployment layout diverge. Report the deployed commit/release path and the
+post-deploy verification result to the human.
+
 # Claude for Chrome
 
 - Never invoke unless explicitly asked by the human.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,4 +80,3 @@ post-deploy verification result to the human.
 - Use `find` to locate elements by description
 - Click/interact using `ref`, not coordinates
 - NEVER take screenshots unless explicitly requested by the user
-

--- a/deploy/poker.env.example
+++ b/deploy/poker.env.example
@@ -1,0 +1,13 @@
+# Copy to /etc/poker/poker.env on the Pi (chmod 600, owned by the poker user).
+# Referenced by deploy/poker.service's EnvironmentFile=.
+
+# 0.0.0.0, not 127.0.0.1 (the server's own default) — the whole point is
+# phones on the LAN reaching this box. Binding a specific interface IP before
+# the network is up at boot is a real trap (see docs/deploy-pi.md); 0.0.0.0
+# sidesteps it.
+HOST=0.0.0.0
+
+# 3000 needs no special capability. 80 means a phone doesn't need ":3000" in
+# the URL, but requires uncommenting the AmbientCapabilities lines in
+# poker.service.
+PORT=3000

--- a/deploy/poker.service
+++ b/deploy/poker.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=Table Top Poker server
+Documentation=https://github.com/ewanhardingham/table-top-poker
+# network-online.target is a weaker promise than it looks (systemd's own
+# advice: don't depend on it for correctness) — it's still worth an ordering
+# hint, just not a guarantee the LAN is actually up. See docs/deploy-pi.md.
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=poker
+Group=poker
+WorkingDirectory=/opt/poker/current
+EnvironmentFile=/etc/poker/poker.env
+ExecStart=/usr/bin/node /opt/poker/current/packages/server/dist/server.js
+Restart=always
+RestartSec=2
+# Don't give up after 5 rapid restarts — a poker night is not a production SLO.
+StartLimitIntervalSec=0
+
+# Only needed if poker.env sets PORT=80 (binding <1024 as a non-root user):
+# CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+# AmbientCapabilities=CAP_NET_BIND_SERVICE
+
+# Cheap hardening; all supported on Raspberry Pi OS.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+
+# journald picks up stdout/stderr automatically.
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=poker
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/poker.service
+++ b/deploy/poker.service
@@ -6,6 +6,8 @@ Documentation=https://github.com/ewanhardingham/table-top-poker
 # hint, just not a guarantee the LAN is actually up. See docs/deploy-pi.md.
 After=network-online.target
 Wants=network-online.target
+# Do not let systemd stop retrying after a burst of crashes.
+StartLimitIntervalSec=0
 
 [Service]
 Type=simple
@@ -13,11 +15,9 @@ User=poker
 Group=poker
 WorkingDirectory=/opt/poker/current
 EnvironmentFile=/etc/poker/poker.env
-ExecStart=/usr/bin/node /opt/poker/current/packages/server/dist/server.js
+ExecStart=/usr/local/bin/node /opt/poker/current/packages/server/dist/server.js
 Restart=always
 RestartSec=2
-# Don't give up after 5 rapid restarts — a poker night is not a production SLO.
-StartLimitIntervalSec=0
 
 # Only needed if poker.env sets PORT=80 (binding <1024 as a non-root user):
 # CapabilityBoundingSet=CAP_NET_BIND_SERVICE

--- a/docs/deploy-pi.md
+++ b/docs/deploy-pi.md
@@ -10,39 +10,70 @@ condensed how-to; that doc is the why.
 both bundles under `packages/server/public/` so one Fastify process serves everything
 same-origin — plain HTTP, no certificate (docs/phase-1-spec.md §8).
 
-After it runs, `packages/server/{dist,public,package.json}` plus the workspace's installed
-`node_modules` is the deployable unit.
+After it runs, `.release/` is a self-contained deployable unit. The release
+script copies workspace symlink targets into its `node_modules`, so the Pi does not need a
+source checkout or the development machine's workspace layout.
 
 ## One-time Pi setup
 
 1. **OS**: Raspberry Pi OS Lite, 64-bit.
-2. **Node**: version matching this repo's `engines.node` (`^22.0.0`), arm64 build.
+2. **Node**: install the arm64 Node 22 build matching this repo's `engines.node` (`^22.0.0`).
+   The service uses `/usr/local/bin/node`; this installs the official binary there:
+
+   ```bash
+   sudo apt update
+   sudo apt install -y ca-certificates curl rsync xz-utils iw
+
+   NODE_VERSION=22.22.1
+   NODE_ARCHIVE="node-v${NODE_VERSION}-linux-arm64.tar.xz"
+   NODE_TMP=$(mktemp -d)
+   trap 'rm -rf "$NODE_TMP"' EXIT
+   curl -fsSLo "$NODE_TMP/$NODE_ARCHIVE" \
+     "https://nodejs.org/dist/v${NODE_VERSION}/$NODE_ARCHIVE"
+   curl -fsSLo "$NODE_TMP/SHASUMS256.txt" \
+     "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt"
+   grep " $NODE_ARCHIVE$" "$NODE_TMP/SHASUMS256.txt" | \
+     (cd "$NODE_TMP" && sha256sum -c -)
+   sudo tar -xJf "$NODE_TMP/$NODE_ARCHIVE" -C /opt
+   sudo ln -sfn "/opt/node-v${NODE_VERSION}-linux-arm64" /opt/node
+   for binary in node npm npx corepack; do
+     sudo ln -sfn "/opt/node/bin/$binary" "/usr/local/bin/$binary"
+   done
+   node --version
+   ```
+
 3. **Network**: prefer Ethernet. If Wi-Fi, use the main SSID (not a guest network — see
    below) and disable power save: `sudo iw dev wlan0 set power_save off` (persist this,
    it resets on reboot otherwise).
-4. **A `poker` system user**, matching `deploy/poker.service`'s `User=`/`Group=`.
-5. `sudo mkdir -p /etc/poker /opt/poker/releases`, then copy `deploy/poker.env.example`
-   to `/etc/poker/poker.env` (`chmod 600`, owned by `poker`) and adjust `HOST`/`PORT`.
+4. **A `poker` system user**, matching `deploy/poker.service`'s `User=`/`Group=`:
+
+   ```bash
+   if ! id poker >/dev/null 2>&1; then
+     sudo useradd --system --home-dir /opt/poker --create-home \
+       --shell /usr/sbin/nologin poker
+   fi
+   sudo install -d -o poker -g poker -m 0755 /opt/poker
+   sudo install -d -o "$USER" -g poker -m 0770 /opt/poker/releases
+   sudo install -d -o poker -g poker -m 0750 /etc/poker
+   ```
+
+5. Copy `deploy/poker.env.example` to `/etc/poker/poker.env`, set `HOST`/`PORT`, then
+   run `sudo chown poker:poker /etc/poker/poker.env && sudo chmod 600 /etc/poker/poker.env`.
 
 ## Getting code onto the Pi
 
-Build the release on your dev machine (`npm run build:release`), then `rsync` it into a
-timestamped release directory and flip a `current` symlink:
+Build the release on your dev machine (`npm run build:release`), then `rsync` the
+self-contained directory into a timestamped release and flip a `current` symlink:
 
 ```bash
 RELEASE=/opt/poker/releases/$(date +%Y%m%d%H%M%S)
-rsync -az --relative \
-  packages/server/dist packages/server/public packages/server/package.json \
-  node_modules \
-  pi-host:"$RELEASE/"
-ssh pi-host "ln -sfn $RELEASE /opt/poker/current"
+rsync -az .release/ pi-host:"$RELEASE/"
+ssh pi-host "sudo chown -R poker:poker '$RELEASE' && sudo ln -sfn '$RELEASE' /opt/poker/current"
 ```
 
-(Adjust for however you actually get `node_modules` over — a full workspace `npm ci` on
-the Pi is simplest if disk/time allow; a pruned production install is the smaller-but-
-fussier alternative. Either way, `packages/server`'s own `node_modules` needs the
-workspace's `@table-top-poker/protocol` resolved, which is why the whole tree's
-`node_modules`, not just `packages/server`'s, goes over.)
+The release contains the server's compiled output, both client bundles, `package.json`, and
+a dereferenced runtime `node_modules`. No workspace package symlinks point back to the
+development checkout.
 
 ## systemd
 
@@ -54,8 +85,8 @@ systemctl status poker
 journalctl -u poker -f
 ```
 
-Redeploying is: rsync a new timestamped release, flip the symlink, `sudo systemctl restart
-poker`.
+Redeploying is: rsync a new timestamped release, `sudo chown -R poker:poker` it, flip the
+symlink, and run `sudo systemctl restart poker`.
 
 ## The two things that will actually ruin poker night
 

--- a/docs/deploy-pi.md
+++ b/docs/deploy-pi.md
@@ -1,0 +1,108 @@
+# Deploying to a Pi (ticket 34)
+
+Full research and reasoning: `docs/research/pi-hosting-and-lan-https.md`. This is the
+condensed how-to; that doc is the why.
+
+## What ships
+
+`npm run build:release` (root) builds every package, builds `table-client` and
+`player-client` against their production base paths (`/table/`, `/player/`), and stages
+both bundles under `packages/server/public/` so one Fastify process serves everything
+same-origin — plain HTTP, no certificate (docs/phase-1-spec.md §8).
+
+After it runs, `packages/server/{dist,public,package.json}` plus the workspace's installed
+`node_modules` is the deployable unit.
+
+## One-time Pi setup
+
+1. **OS**: Raspberry Pi OS Lite, 64-bit.
+2. **Node**: version matching this repo's `engines.node` (`^22.0.0`), arm64 build.
+3. **Network**: prefer Ethernet. If Wi-Fi, use the main SSID (not a guest network — see
+   below) and disable power save: `sudo iw dev wlan0 set power_save off` (persist this,
+   it resets on reboot otherwise).
+4. **A `poker` system user**, matching `deploy/poker.service`'s `User=`/`Group=`.
+5. `sudo mkdir -p /etc/poker /opt/poker/releases`, then copy `deploy/poker.env.example`
+   to `/etc/poker/poker.env` (`chmod 600`, owned by `poker`) and adjust `HOST`/`PORT`.
+
+## Getting code onto the Pi
+
+Build the release on your dev machine (`npm run build:release`), then `rsync` it into a
+timestamped release directory and flip a `current` symlink:
+
+```bash
+RELEASE=/opt/poker/releases/$(date +%Y%m%d%H%M%S)
+rsync -az --relative \
+  packages/server/dist packages/server/public packages/server/package.json \
+  node_modules \
+  pi-host:"$RELEASE/"
+ssh pi-host "ln -sfn $RELEASE /opt/poker/current"
+```
+
+(Adjust for however you actually get `node_modules` over — a full workspace `npm ci` on
+the Pi is simplest if disk/time allow; a pruned production install is the smaller-but-
+fussier alternative. Either way, `packages/server`'s own `node_modules` needs the
+workspace's `@table-top-poker/protocol` resolved, which is why the whole tree's
+`node_modules`, not just `packages/server`'s, goes over.)
+
+## systemd
+
+```bash
+sudo cp deploy/poker.service /etc/systemd/system/poker.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now poker
+systemctl status poker
+journalctl -u poker -f
+```
+
+Redeploying is: rsync a new timestamped release, flip the symlink, `sudo systemctl restart
+poker`.
+
+## The two things that will actually ruin poker night
+
+- **Guest Wi-Fi AP client isolation.** If the Pi and the phones aren't on the same SSID
+  with isolation off, phones get a silent, total connection failure that looks exactly
+  like a server bug. Confirm this on the router before the first game — this repo can't
+  verify it for you, it's a setting on hardware this codebase has no access to.
+- **DHCP reassigning the Pi's address.** Set a DHCP reservation (bind the Pi's MAC to a
+  fixed IP) on the router. The QR code is generated live from the request's `Host` header
+  (`packages/server/src/qr.ts`), so it's always correct *for whatever address you're
+  actually on* — a reservation is still what keeps that address the same across a reboot.
+
+Neither of these has a code-level fix; both are router configuration this codebase can't
+reach into. See the verification checklist below.
+
+## Verification checklist
+
+These are ticket 34's acceptance criteria. None of them can be verified by an agent
+working in this repo — they require the physical Pi, the physical router's admin page,
+and a physical phone. Check them off by hand:
+
+- [ ] `systemctl status poker` shows `active (running)` after a fresh `enable --now`.
+- [ ] Reboot the Pi; `poker` comes back on its own with no manual step.
+- [ ] The Pi has a DHCP reservation configured on the router; its LAN IP is unchanged
+      after that reboot.
+- [ ] A phone on the main SSID can create/join a room via the QR code and the raw
+      `http://<pi-ip>:<port>` fallback.
+- [ ] (If a guest network is available to test) a phone on it is confirmed *unable* to
+      reach the server — this documents the AP-isolation constraint rather than working
+      around it.
+
+## Traps (condensed from the research doc's full list)
+
+1. Guest Wi-Fi AP isolation — main SSID only.
+2. A different subnet on a guest/mesh network — check the phone's IP prefix matches.
+3. `.local`/mDNS not resolving on some Android builds — always have the raw IP as a
+   fallback, printed alongside the QR code.
+4. DHCP moved the Pi and the QR code was baked at build time — it isn't; it's generated
+   live from the request `Host` header, so this doesn't apply here, but don't
+   "helpfully" hardcode an origin later.
+5. `localhost` works, the LAN IP doesn't — because `localhost` is a secure context and a
+   LAN IP isn't. Test against the real IP from a real phone, not just from the Pi itself.
+6. Wi-Fi power save on the Pi causing hangs during quiet periods.
+7. Node binding to a specific interface IP before the network is up at boot — this is
+   why `poker.env.example` sets `HOST=0.0.0.0`, not the server's own `127.0.0.1` default.
+8. `systemd` giving up after 5 rapid restarts — `StartLimitIntervalSec=0` in
+   `poker.service` disables that.
+
+Full list (15 items) and reasoning: `docs/research/pi-hosting-and-lan-https.md` §7,
+"Traps list".

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,8 +7,12 @@ export default tseslint.config(
   {
     ignores: [
       "**/dist/**",
+      "**/build/**",
       "**/coverage/**",
       "**/node_modules/**",
+      "**/public/player/**",
+      "**/public/table/**",
+      ".release/**",
       "docs/design/**",
     ],
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   ],
   "scripts": {
     "build": "tsc --build tsconfig.json",
+    "build:release": "bash scripts/build-release.sh",
     "clean": "tsc --build tsconfig.json --clean",
     "test": "vitest run",
     "lint": "eslint . && prettier --check .",

--- a/packages/player-client/vite.config.ts
+++ b/packages/player-client/vite.config.ts
@@ -6,7 +6,10 @@ import { defineConfig, loadEnv } from "vite";
 // server bound to localhost.
 const repoRoot = new URL("../..", import.meta.url).pathname;
 
-export default defineConfig(({ mode }) => {
+// A release build (ticket 34) is staged at packages/server/public/player and
+// served for GET /join/:code — its asset URLs need that prefix baked in. The
+// dev server still serves everything from "/", so only `build` gets it.
+export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, repoRoot, "");
   const allowedHosts = (env.DEV_ALLOWED_HOSTS ?? "")
     .split(",")
@@ -15,6 +18,7 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [react()],
+    base: command === "build" ? "/player/" : "/",
     build: {
       outDir: "build",
     },

--- a/packages/player-client/vite.config.ts
+++ b/packages/player-client/vite.config.ts
@@ -1,14 +1,15 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv } from "vite";
 
+// A release build (ticket 34) is staged at packages/server/public/player and
+// served for GET /join/:code — its asset URLs need that prefix baked in. The
+// dev server still serves everything from "/", so only `build` gets it.
+
 // Hostnames the dev server may be reached by, comma separated. Set it to open
 // the client from another device (e.g. a tailnet name); unset keeps the dev
 // server bound to localhost.
 const repoRoot = new URL("../..", import.meta.url).pathname;
 
-// A release build (ticket 34) is staged at packages/server/public/player and
-// served for GET /join/:code — its asset URLs need that prefix baked in. The
-// dev server still serves everything from "/", so only `build` gets it.
 export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, repoRoot, "");
   const allowedHosts = (env.DEV_ALLOWED_HOSTS ?? "")

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -6,10 +6,25 @@ import {
   type ServerMessage,
 } from "@table-top-poker/protocol";
 import type { FastifyInstance } from "fastify";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import WebSocket from "ws";
 import { buildApp } from "./app.js";
 import { RoomStore, toRoomView } from "./rooms.js";
+
+const publicTableDir = fileURLToPath(
+  new URL("../public/table", import.meta.url),
+);
+const publicPlayerDir = fileURLToPath(
+  new URL("../public/player", import.meta.url),
+);
+
+/** Stages a fake release build (ticket 34) so tests can assert it's served in place of the placeholder. */
+function stageBuiltIndex(dir: string, marker: string): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(`${dir}/index.html`, `<!doctype html><p>${marker}</p>`);
+}
 
 interface RoomCreatedBody {
   readonly code: string;
@@ -233,6 +248,52 @@ describe("GET /join/:code", () => {
     expect(response.headers.location).toBe(
       `http://192.168.1.50:5174/join/${code}`,
     );
+  });
+
+  it("serves a release build staged at public/player over the placeholder", async () => {
+    stageBuiltIndex(publicPlayerDir, "real player client");
+    try {
+      app = await buildApp();
+      const created = await app.inject({ method: "POST", url: "/rooms" });
+      const { code } = created.json<RoomCreatedBody>();
+
+      const response = await app.inject({
+        method: "GET",
+        url: `/join/${code}`,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toContain("real player client");
+    } finally {
+      rmSync(publicPlayerDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("GET /", () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("serves the same-origin placeholder when no table build is staged", async () => {
+    app = await buildApp();
+    const response = await app.inject({ method: "GET", url: "/" });
+    expect(response.statusCode).toBe(200);
+    expect(response.headers["content-type"]).toMatch(/^text\/html/);
+  });
+
+  it("serves a release build staged at public/table over the placeholder", async () => {
+    stageBuiltIndex(publicTableDir, "real table client");
+    try {
+      app = await buildApp();
+      const response = await app.inject({ method: "GET", url: "/" });
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toContain("real table client");
+    } finally {
+      rmSync(publicTableDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -254,7 +254,11 @@ describe("GET /join/:code", () => {
     stageBuiltIndex(publicPlayerDir, "real player client");
     try {
       app = await buildApp();
-      const created = await app.inject({ method: "POST", url: "/rooms" });
+      const created = await app.inject({
+        method: "POST",
+        url: "/rooms",
+        payload: { seatCount: DEFAULT_SEAT_COUNT },
+      });
       const { code } = created.json<RoomCreatedBody>();
 
       const response = await app.inject({

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -18,7 +18,7 @@ import Fastify, {
   type FastifyReply,
   type FastifyRequest,
 } from "fastify";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { WebSocket } from "ws";
 import { ActionClock } from "./action-clock.js";
@@ -35,6 +35,23 @@ const publicDir = fileURLToPath(new URL("../public", import.meta.url));
 const publicIndexPath = fileURLToPath(
   new URL("../public/index.html", import.meta.url),
 );
+/**
+ * A release build (ticket 34's `build:release` script) stages the real
+ * table/player apps here, under their own subpath so each is servable at
+ * its own base URL from the same origin; unstaged (dev, tests, a checkout
+ * that hasn't run the release script), these don't exist and every route
+ * below falls back to `publicIndexPath`'s placeholder.
+ */
+const publicTableIndexPath = fileURLToPath(
+  new URL("../public/table/index.html", import.meta.url),
+);
+const publicPlayerIndexPath = fileURLToPath(
+  new URL("../public/player/index.html", import.meta.url),
+);
+
+function readIndexOr(stagedPath: string): Buffer {
+  return readFileSync(existsSync(stagedPath) ? stagedPath : publicIndexPath);
+}
 
 export interface BuildAppOptions {
   readonly rooms?: RoomStore;
@@ -365,8 +382,16 @@ export async function buildApp(
     });
   }
 
-  await app.register(fastifyStatic, { root: publicDir });
+  // `index: false` — the explicit "/" route below owns index resolution
+  // (placeholder vs. a staged table build), so the static plugin only ever
+  // serves fingerprinted assets (`/table/assets/*`, `/player/assets/*`),
+  // never racing its own directory-index behaviour against that route.
+  await app.register(fastifyStatic, { root: publicDir, index: false });
   await app.register(fastifyWebsocket);
+
+  app.get("/", (_request, reply) => {
+    return reply.type("text/html").send(readIndexOr(publicTableIndexPath));
+  });
 
   app.post("/rooms", async (request, reply) => {
     // The table client picks a seat count (issue #74); this is the trust
@@ -444,8 +469,9 @@ export async function buildApp(
 
   /**
    * Where the QR code's join URL lands. `PLAYER_CLIENT_ORIGIN` points dev at
-   * the player-client's own Vite server; unset, it serves the (currently
-   * placeholder) same-origin index — ticket 34 bundles the real app there.
+   * the player-client's own Vite server; unset, it serves a release build
+   * staged at `public/player` (ticket 34's `build:release`), or the
+   * placeholder if none has been staged.
    */
   app.get<RoomCodeRoute>("/join/:code", (request, reply) => {
     const room = findRoomOrReject(rooms, request.params.code, reply);
@@ -454,7 +480,7 @@ export async function buildApp(
     if (playerOrigin) {
       return reply.redirect(`${playerOrigin}/join/${room.code}`);
     }
-    return reply.type("text/html").send(readFileSync(publicIndexPath));
+    return reply.type("text/html").send(readIndexOr(publicPlayerIndexPath));
   });
 
   app.post<RoomSeatRoute>(

--- a/packages/table-client/vite.config.ts
+++ b/packages/table-client/vite.config.ts
@@ -1,14 +1,15 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv } from "vite";
 
+// A release build (ticket 34) is staged at packages/server/public/table and
+// served for GET / — its asset URLs need that prefix baked in. The dev
+// server still serves everything from "/", so only `build` gets it.
+
 // Hostnames the dev server may be reached by, comma separated. Set it to open
 // the client from another device (e.g. a tailnet name); unset keeps the dev
 // server bound to localhost.
 const repoRoot = new URL("../..", import.meta.url).pathname;
 
-// A release build (ticket 34) is staged at packages/server/public/table and
-// served for GET / — its asset URLs need that prefix baked in. The dev
-// server still serves everything from "/", so only `build` gets it.
 export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, repoRoot, "");
   const allowedHosts = (env.DEV_ALLOWED_HOSTS ?? "")

--- a/packages/table-client/vite.config.ts
+++ b/packages/table-client/vite.config.ts
@@ -6,7 +6,10 @@ import { defineConfig, loadEnv } from "vite";
 // server bound to localhost.
 const repoRoot = new URL("../..", import.meta.url).pathname;
 
-export default defineConfig(({ mode }) => {
+// A release build (ticket 34) is staged at packages/server/public/table and
+// served for GET / — its asset URLs need that prefix baked in. The dev
+// server still serves everything from "/", so only `build` gets it.
+export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, repoRoot, "");
   const allowedHosts = (env.DEV_ALLOWED_HOSTS ?? "")
     .split(",")
@@ -15,6 +18,7 @@ export default defineConfig(({ mode }) => {
 
   return {
     plugins: [react()],
+    base: command === "build" ? "/table/" : "/",
     build: {
       outDir: "build",
     },

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Builds a deployable release: compiles every package, builds both client
+# SPAs against their production base path (/table/, /player/ — see each
+# vite.config.ts), and stages the client bundles under packages/server/public
+# so the running server can serve them same-origin (docs/research/pi-hosting-and-lan-https.md
+# §3.4 "build TS locally, ship JS"; ticket 34).
+#
+# Usage: npm run build:release
+#
+# Afterwards, packages/server/{dist,public,package.json} plus the workspace's
+# node_modules is what you rsync to the Pi — see docs/deploy-pi.md.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+echo "==> Building every package (tsc)"
+npm run build
+
+echo "==> Building table-client (base: /table/)"
+npm run -w @table-top-poker/table-client build:app
+
+echo "==> Building player-client (base: /player/)"
+npm run -w @table-top-poker/player-client build:app
+
+echo "==> Staging client builds into packages/server/public"
+rm -rf packages/server/public/table packages/server/public/player
+mkdir -p packages/server/public/table packages/server/public/player
+cp -r packages/table-client/build/. packages/server/public/table/
+cp -r packages/player-client/build/. packages/server/public/player/
+
+echo "==> Release staged. packages/server/{dist,public,package.json} is what to deploy."

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -7,8 +7,8 @@
 #
 # Usage: npm run build:release
 #
-# Afterwards, packages/server/{dist,public,package.json} plus the workspace's
-# node_modules is what you rsync to the Pi — see docs/deploy-pi.md.
+# Afterwards, .release/ is the self-contained deployable unit —
+# see docs/deploy-pi.md.
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
@@ -27,4 +27,17 @@ mkdir -p packages/server/public/table packages/server/public/player
 cp -r packages/table-client/build/. packages/server/public/table/
 cp -r packages/player-client/build/. packages/server/public/player/
 
-echo "==> Release staged. packages/server/{dist,public,package.json} is what to deploy."
+echo "==> Staging self-contained server release"
+release_dir=.release
+rm -rf "$release_dir"
+mkdir -p "$release_dir/packages/server"
+cp -a packages/server/dist packages/server/public packages/server/package.json "$release_dir/packages/server/"
+# npm workspaces represent local packages as symlinks. Dereference them so
+# the release does not depend on the source checkout existing on the Pi.
+rsync -aL node_modules/ "$release_dir/node_modules/"
+
+echo "==> Verifying deployable runtime imports"
+node --input-type=module -e \
+  'await import("./.release/packages/server/dist/app.js")'
+
+echo "==> Release staged at .release/"


### PR DESCRIPTION
## Summary

Part of #34 (Pi deployment). Issue #34's acceptance criteria are mostly physical/network verification (systemd survives a reboot, a DHCP reservation holds, a phone on the main SSID can reach the server, a guest-isolated phone can't) — none of that is verifiable from inside this coding environment, which has no Raspberry Pi, no router admin access, and no phone. This PR does the part that is: the one concrete code-level gap the ticket's acceptance criteria depend on, plus the deployment tooling/docs, with the physical steps documented as a checklist for the human to run and check off themselves rather than silently skipped or fabricated.

- **Closes the placeholder gap**: `packages/server/src/app.ts` had its own comment saying "ticket 34 bundles the real app there" — `GET /` and `GET /join/:code` were serving a static "Client not built yet" placeholder instead of the real `table-client`/`player-client` apps. Both routes now serve a release build staged at `public/table`/`public/player` when present, falling back to the placeholder otherwise (dev, tests, an unreleased checkout).
- **`scripts/build-release.sh`** (`npm run build:release`): builds every package, builds both SPAs against a production base path (`/table/`, `/player/` — each `vite.config.ts` only in `build` mode, dev server unaffected), and stages the bundles into `packages/server/public`. Verified end-to-end against the running server: root, `/join/:code`, and both apps' fingerprinted static assets all resolve correctly.
- **`deploy/poker.service`, `deploy/poker.env.example`**: a systemd unit and env-file template adapted from `docs/research/pi-hosting-and-lan-https.md`'s findings, matching this repo's actual entrypoint and Node version (not blindly copied from the research doc's example).
- **`docs/deploy-pi.md`**: the how-to (Pi setup, `rsync`+symlink release flow, systemd install), the two things most likely to actually break the night (guest Wi-Fi AP isolation, DHCP), and a verification checklist mapped 1:1 to the ticket's acceptance criteria for the human to complete.

## Test plan
- [x] TDD on the server route seam: wrote failing tests for the staged-build fallback first (`app.test.ts`), then implemented `app.ts` to turn them green
- [x] `npm run -w @table-top-poker/server test` — all pass except 2 pre-existing timing-sensitive reconnection tests, confirmed flaky on unmodified `main` too (reproduced via `git stash`), not caused by this change
- [x] `npm run build:release` run for real; manually staged output served by the running server, verified via `curl` against `/`, `/join/:code`, and both apps' asset paths
- [x] `npm run build` (full workspace typecheck), `npm test` (full suite, same pre-existing flake only)
- [x] `eslint`/`prettier --check` on all changed files
- [x] `/code-review` (Standards + Spec) — both clean, no hard violations, no scope creep, no inaccuracies

## What this PR does *not* claim to have verified
Issue #34's acceptance criteria around physical hardware/network — systemd surviving an actual reboot, the DHCP reservation holding, a real phone reaching the server on the main SSID, a real phone on a guest-isolated network being confirmed unreachable — are left as an unchecked checklist in `docs/deploy-pi.md` for the person with the actual Pi and router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018YUEZNYmpGERDmbDJz2wdq