### PR TITLE
feat(server,table,protocol): seat eviction — manual table action (ADR-0002+0003, closes #56)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,7 +28,16 @@ Room — across hands, and across a Device disconnecting and reconnecting.
 A position at the table (tracked positionally for the Button and blinds),
 occupied by a Player for as long as they remain seated. Persists across
 hands within a Room; a Player keeps their Seat through a Device disconnect.
-A Room has at most 8 Seats.
+A Room has at most 8 Seats. A Seat is always in one of four states: Active,
+Sitting-out, Disconnected, or Evicted (see ADR-0002).
+
+**Sitting-out**:
+A Seat state the Player toggles themselves — not dealt in, and never
+accrues eviction risk no matter how long it lasts, even alongside a Device
+disconnect. Distinct from Disconnected, which is involuntary and does
+accrue eviction risk.
+_Avoid_: Conflating with Disconnected — sitting-out is a choice, not a
+connection failure.
 
 **Device**:
 A Player's current live connection (their phone's socket). Ephemeral — can

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,15 +29,18 @@ A position at the table (tracked positionally for the Button and blinds),
 occupied by a Player for as long as they remain seated. Persists across
 hands within a Room; a Player keeps their Seat through a Device disconnect.
 A Room has at most 8 Seats. A Seat is always in one of four states: Active,
-Sitting-out, Disconnected, or Evicted (see ADR-0002).
+Sitting-out, Disconnected, or Evicted (see ADR-0002, ADR-0003).
 
 **Sitting-out**:
-A Seat state the Player toggles themselves — not dealt in, and never
-accrues eviction risk no matter how long it lasts, even alongside a Device
-disconnect. Distinct from Disconnected, which is involuntary and does
-accrue eviction risk.
+A Seat state the Player toggles themselves — not dealt in. Distinct from
+Disconnected, which is involuntary.
 _Avoid_: Conflating with Disconnected — sitting-out is a choice, not a
 connection failure.
+
+**Evicted**:
+The table device manually freeing a claimed Seat — its token is
+invalidated and it returns to the join picker. Not automatic and not tied
+to any counter; the table decides when (see ADR-0003).
 
 **Device**:
 A Player's current live connection (their phone's socket). Ephemeral — can

--- a/docs/adr/0002-seat-eviction-clocks-on-missed-hands.md
+++ b/docs/adr/0002-seat-eviction-clocks-on-missed-hands.md
@@ -1,0 +1,59 @@
+# 0002 — Seat eviction clocks on consecutive missed hands, not wall-clock time; sitting-out is an explicit state
+
+## Status
+
+Accepted
+
+## Context
+
+`docs/phase-1-spec.md` §7 (from issue #13) covers disconnect detection and
+the cosmetic "disconnected" badge, but leaves no path to free a seat that
+never reconnects — it stays occupied, dealt in, clock-timed-out, and folded
+every hand, indefinitely. Issue #56 proposed closing that gap with a fourth
+seat state (eviction after N consecutive missed hands) and splitting
+voluntary sit-out from disconnection, leaving three open questions:
+hand-count vs. wall-clock as the eviction timer, whether N is a room
+setting or a fixed constant, and whether an evicted seat's in-progress hand
+needs special handling.
+
+## Decision
+
+**Sitting-out** becomes an explicit, player-toggled seat state, independent
+of connection status. A sitting-out seat is never dealt in and **never
+accrues eviction risk**, even if it's also disconnected for the entire
+duration.
+
+**Disconnected** seats keep the existing §7 behaviour unchanged: a hand
+already in progress still times out and folds via the action clock, never
+the socket. From the *next* hand onward while still disconnected, the seat
+is skipped like a sit-out (no wasted deals or timeouts), and a per-seat
+"hands missed" counter increments once per skipped hand.
+
+**Eviction** fires when that counter reaches **N = 3 consecutive missed
+hands**, fixed as a constant for Phase 1, not a room-level setting — no
+other room-level config exists yet (§7's room lifecycle has none), and
+introducing one just for this is premature until a real table proves 3
+wrong. On eviction: the seat's token is invalidated server-side, the seat
+is freed back into the join picker, and the eviction is broadcast to the
+table.
+
+The counter is **hand-count**, not wall-clock: deterministic, replayable
+from the JSONL hand log the same way the rest of hand state is (§5), and
+needs no timer running against room state between hands.
+
+Reconnecting at any point while disconnected resets the counter to 0 and
+returns the seat to active for the next hand.
+
+## Consequences
+
+- Eviction can only fire on the boundary between hands, after a skipped
+  hand's counter increments — never while a seat is mid-hand. The issue's
+  third open question (does an evicted seat's in-progress hand need special
+  handling) resolves to: not reachable, by construction. No such handling
+  is needed.
+- New per-seat state: a voluntary sitting-out flag and an involuntary
+  missed-hand counter, both independent of the existing §7 disconnected
+  presence signal.
+- N = 3 ships as a constant. Making it configurable later is a small,
+  reversible follow-up if a real table proves it wrong — not blocking this
+  decision.

--- a/docs/adr/0002-seat-eviction-clocks-on-missed-hands.md
+++ b/docs/adr/0002-seat-eviction-clocks-on-missed-hands.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-Accepted
+Partially superseded by [ADR-0003](0003-eviction-is-a-manual-table-action.md):
+the "Eviction" section below (automatic, threshold-triggered) no longer
+applies — eviction is now a manual table action. The rest of this ADR
+(sitting-out as an explicit state, disconnected seats skipped from deal-in)
+still stands.
 
 ## Context
 

--- a/docs/adr/0003-eviction-is-a-manual-table-action.md
+++ b/docs/adr/0003-eviction-is-a-manual-table-action.md
@@ -1,0 +1,52 @@
+# 0003 — Seat eviction is a manual table action, not automatic on missed hands
+
+## Status
+
+Accepted. Supersedes the eviction *trigger* in [ADR-0002](0002-seat-eviction-clocks-on-missed-hands.md)
+(its "Eviction" section and the associated "hand-count vs. wall-clock" and
+"N = 3" decisions). ADR-0002's other decisions — sitting-out as an explicit,
+player-toggled state exempt from eviction, and disconnected seats being
+skipped from deal-in from the next hand onward — stand unchanged.
+
+## Context
+
+ADR-0002 had a disconnected seat evict itself automatically once its
+missed-hands counter reached a fixed threshold (N = 3). Building it
+surfaced a real usability problem: the app has no in-progress way for a
+table operator to see *why* a seat is still occupied versus free, and an
+automatic timer removes the one person actually at the table — the
+host — from a decision that's theirs to make (a player who's stepped away
+to answer the door is not the same situation as one who's genuinely gone).
+
+## Decision
+
+Eviction is now a manual action the table device takes on any claimed
+seat — active, sitting-out, or disconnected alike — via "click a seat,
+select Evict." There is no automatic threshold and no missed-hands
+counter; the disconnected badge (§7) is the only signal, and the human at
+the table decides when it's been long enough.
+
+Mechanically this reuses the same free-the-seat operation ADR-0002 already
+had for eviction: invalidate the seat's token, clear its claim, and
+broadcast the freed seat to the table — now exposed as
+`POST /rooms/:code/seats/:seatId/evict` (renamed from the prior,
+UI-unwired `/clear` admin route) rather than fired by `dispatch`.
+
+Disconnected seats are still skipped from deal-in from the next hand
+onward — that part of ADR-0002 wasn't the problem and stays as-is. Only
+the automatic *eviction* is gone; a disconnected seat now stays occupied
+(sitting out every hand) until either it reconnects or the table evicts it.
+
+## Consequences
+
+- `missedHands` and the `EVICTION_THRESHOLD` constant are removed —
+  nothing tracks how long a seat has been disconnected. If a table
+  operator wants that surfaced later (e.g. "missed 4 hands" on the seat
+  pod), that's new scope, not a revival of the old counter.
+- `dispatch`'s `nextHand` branch no longer needs to report evictions —
+  the only thing that can free a seat now is the explicit evict action,
+  which happens outside `dispatch` entirely.
+- The table client needs a seat-click affordance it didn't have before;
+  this ADR doesn't specify its visual design, only that the action exists
+  and is scoped to the table device (never available to a player's own
+  client).

--- a/docs/phase-1-spec.md
+++ b/docs/phase-1-spec.md
@@ -325,18 +325,18 @@ network round trip.
   model. The real perimeter is keeping strangers off the network at all.
 - **Seat eviction** ([Seat lifecycle: disconnected sit-out and eviction
   after missed hands](https://github.com/ewanhardingham/table-top-poker/issues/56),
-  [ADR-0002](adr/0002-seat-eviction-clocks-on-missed-hands.md)): a seat has
+  [ADR-0002](adr/0002-seat-eviction-clocks-on-missed-hands.md),
+  [ADR-0003](adr/0003-eviction-is-a-manual-table-action.md)): a seat has
   four states — **active**, **sitting-out** (voluntary, player-toggled,
-  never dealt in, never accrues eviction risk regardless of connection
-  status), **disconnected** (the existing presence signal above, unchanged
-  — a hand already in progress still folds via the action clock, never the
-  socket), and **evicted**. From the hand *after* a seat goes disconnected,
-  it's skipped like a sit-out and a per-seat "hands missed" counter
-  increments each skipped hand; reconnecting at any point resets the
-  counter to 0 and returns the seat to active next hand. At **N = 3**
-  consecutive missed hands (a fixed Phase 1 constant, not a room setting),
-  the seat is evicted: its token is invalidated server-side, the seat is
-  freed into the join picker, and the eviction is broadcast to the table.
+  never dealt in), **disconnected** (the existing presence signal above,
+  unchanged — a hand already in progress still folds via the action clock,
+  never the socket; from the *next* hand onward, a disconnected seat is
+  skipped like a sit-out), and **evicted**. Eviction is a manual table
+  action, not automatic — the table device can evict any claimed seat
+  (active, sitting-out, or disconnected) at any time; there is no
+  missed-hands counter or threshold. On eviction: the seat's token is
+  invalidated server-side, the seat is freed into the join picker, and the
+  eviction is broadcast to the table.
 
 ## 8. Deployment
 ([Research: hosting on a Pi](https://github.com/ewanhardingham/table-top-poker/issues/7),

--- a/docs/phase-1-spec.md
+++ b/docs/phase-1-spec.md
@@ -323,6 +323,20 @@ network round trip.
 - **Security model**: no auth, no rate-limiting — room codes and seat
   tokens are accepted bearer secrets, consistent with the trusted-home-LAN
   model. The real perimeter is keeping strangers off the network at all.
+- **Seat eviction** ([Seat lifecycle: disconnected sit-out and eviction
+  after missed hands](https://github.com/ewanhardingham/table-top-poker/issues/56),
+  [ADR-0002](adr/0002-seat-eviction-clocks-on-missed-hands.md)): a seat has
+  four states — **active**, **sitting-out** (voluntary, player-toggled,
+  never dealt in, never accrues eviction risk regardless of connection
+  status), **disconnected** (the existing presence signal above, unchanged
+  — a hand already in progress still folds via the action clock, never the
+  socket), and **evicted**. From the hand *after* a seat goes disconnected,
+  it's skipped like a sit-out and a per-seat "hands missed" counter
+  increments each skipped hand; reconnecting at any point resets the
+  counter to 0 and returns the seat to active next hand. At **N = 3**
+  consecutive missed hands (a fixed Phase 1 constant, not a room setting),
+  the seat is evicted: its token is invalidated server-side, the seat is
+  freed into the join picker, and the eviction is broadcast to the table.
 
 ## 8. Deployment
 ([Research: hosting on a Pi](https://github.com/ewanhardingham/table-top-poker/issues/7),

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -35,6 +35,7 @@ export function App() {
   );
   const [claimError, setClaimError] = useState<string | null>(null);
   const [seatToken, setSeatToken] = useState<string | null>(null);
+  const [evictionMessage, setEvictionMessage] = useState<string | null>(null);
 
   useEffect(() => {
     // Silently reclaim a stored seat on mount (docs/phase-1-spec.md §7) — a
@@ -43,6 +44,7 @@ export function App() {
     if (stored === null) return;
     joinRoom(stored.roomCode)
       .then((view) => {
+        setEvictionMessage(null);
         setRoomView(view);
         const seat = view.seats.find((s) => s.id === stored.seatId);
         setSeat({
@@ -62,6 +64,13 @@ export function App() {
     clearSeat();
   }, [clearSeat]);
 
+  const handleEvicted = useCallback(() => {
+    clearSeatToken(window.localStorage);
+    setSeatToken(null);
+    clearSeat();
+    setEvictionMessage("You have been evicted from the room");
+  }, [clearSeat]);
+
   const handleRoomEnded = useCallback(() => {
     clearSeatToken(window.localStorage);
     setSeatToken(null);
@@ -77,6 +86,7 @@ export function App() {
   }, [roomCode, seatId, seatToken]);
   const { send } = useWebSocket(wsParams, {
     onRejected: handleRejected,
+    onEvicted: handleEvicted,
     onRoomEnded: handleRoomEnded,
   });
   const playerSeat =
@@ -90,7 +100,10 @@ export function App() {
   const handleJoin = useCallback(
     (code: string) => {
       joinRoom(code)
-        .then(setRoomView)
+        .then((view) => {
+          setEvictionMessage(null);
+          setRoomView(view);
+        })
         .catch(() => {
           setJoinError("room-not-found");
         });
@@ -104,6 +117,7 @@ export function App() {
       claimSeat(roomCode, seat)
         .then((claim) => {
           setClaimError(null);
+          setEvictionMessage(null);
           setSeat({ seatId: claim.seatId, sittingOut: claim.sittingOut });
           setSeatToken(claim.token);
           saveSeatToken(window.localStorage, {
@@ -130,7 +144,12 @@ export function App() {
     );
   } else if (seatId === null) {
     content = (
-      <SeatPicker seats={seats} error={claimError} onClaim={handleClaim} />
+      <SeatPicker
+        seats={seats}
+        error={claimError}
+        evictionMessage={evictionMessage}
+        onClaim={handleClaim}
+      />
     );
   } else {
     content = (

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -20,7 +20,6 @@ export function App() {
   const seats = usePlayerStore((state) => state.seats);
   const joinError = usePlayerStore((state) => state.joinError);
   const seatId = usePlayerStore((state) => state.seatId);
-  const sittingOut = usePlayerStore((state) => state.sittingOut);
   const connectionStatus = usePlayerStore((state) => state.connectionStatus);
   const handView = usePlayerStore((state) => state.handView);
   const setRoomView = usePlayerStore((state) => state.setRoomView);
@@ -80,6 +79,12 @@ export function App() {
     onRejected: handleRejected,
     onRoomEnded: handleRoomEnded,
   });
+  const playerSeat =
+    seatId === null ? undefined : seats.find((seat) => seat.id === seatId);
+  const handleToggleSittingOut = useCallback(() => {
+    if (!playerSeat) return;
+    send({ type: playerSeat.sittingOut ? "sitIn" : "sitOut" });
+  }, [playerSeat, send]);
   const intent = useActionIntent(send);
 
   const handleJoin = useCallback(
@@ -157,7 +162,12 @@ export function App() {
       <StatusBar
         showBadge={wsParams !== null}
         connectionStatus={connectionStatus}
-        seat={seatId !== null ? { seatId, sittingOut } : null}
+        onToggleSittingOut={handleToggleSittingOut}
+        seat={
+          playerSeat
+            ? { seatId: playerSeat.id, sittingOut: playerSeat.sittingOut }
+            : null
+        }
       />
       <main className="hand">{content}</main>
     </div>

--- a/packages/player-client/src/SeatPanel.test.tsx
+++ b/packages/player-client/src/SeatPanel.test.tsx
@@ -3,10 +3,17 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { SeatPanel } from "./SeatPanel.js";
 
+const noop = () => undefined;
+
 describe("SeatPanel", () => {
   it("shows the claimed seat", () => {
     const html = renderToStaticMarkup(
-      <SeatPanel seatId={2} sittingOut={false} />,
+      <SeatPanel
+        seatId={2}
+        sittingOut={false}
+        toggleDisabled={false}
+        onToggleSittingOut={noop}
+      />,
     );
     expect(html).toContain('data-testid="claimed-seat"');
     expect(html).toContain("Seat 3");
@@ -15,8 +22,49 @@ describe("SeatPanel", () => {
 
   it("shows a sitting-out badge when joined mid-hand", () => {
     const html = renderToStaticMarkup(
-      <SeatPanel seatId={2} sittingOut={true} />,
+      <SeatPanel
+        seatId={2}
+        sittingOut={true}
+        toggleDisabled={false}
+        onToggleSittingOut={noop}
+      />,
     );
     expect(html).toContain('data-testid="sitting-out-badge"');
+  });
+
+  it("offers sit out while active and sit in while sitting out", () => {
+    const active = renderToStaticMarkup(
+      <SeatPanel
+        seatId={0}
+        sittingOut={false}
+        toggleDisabled={false}
+        onToggleSittingOut={noop}
+      />,
+    );
+    const sittingOut = renderToStaticMarkup(
+      <SeatPanel
+        seatId={0}
+        sittingOut={true}
+        toggleDisabled={false}
+        onToggleSittingOut={noop}
+      />,
+    );
+
+    expect(active).toContain('data-testid="sitting-out-toggle"');
+    expect(active).toContain("Sit out");
+    expect(sittingOut).toContain("Sit in");
+  });
+
+  it("disables the toggle while the socket is reconnecting", () => {
+    const html = renderToStaticMarkup(
+      <SeatPanel
+        seatId={0}
+        sittingOut={false}
+        toggleDisabled={true}
+        onToggleSittingOut={noop}
+      />,
+    );
+
+    expect(html).toMatch(/data-testid="sitting-out-toggle"[^>]*disabled/);
   });
 });

--- a/packages/player-client/src/SeatPanel.tsx
+++ b/packages/player-client/src/SeatPanel.tsx
@@ -1,11 +1,24 @@
-import { color, font, fontSize, radius } from "@table-top-poker/ui-shared";
+import {
+  PillButton,
+  color,
+  font,
+  fontSize,
+  radius,
+} from "@table-top-poker/ui-shared";
 
 export interface SeatPanelProps {
   readonly seatId: number;
   readonly sittingOut: boolean;
+  readonly toggleDisabled: boolean;
+  readonly onToggleSittingOut: () => void;
 }
 
-export function SeatPanel({ seatId, sittingOut }: SeatPanelProps) {
+export function SeatPanel({
+  seatId,
+  sittingOut,
+  toggleDisabled,
+  onToggleSittingOut,
+}: SeatPanelProps) {
   return (
     <div
       data-testid="seat-panel"
@@ -55,6 +68,16 @@ export function SeatPanel({ seatId, sittingOut }: SeatPanelProps) {
           Sitting out
         </div>
       )}
+      <PillButton
+        size="md"
+        tone="outline"
+        data-testid="sitting-out-toggle"
+        disabled={toggleDisabled}
+        onClick={onToggleSittingOut}
+        style={{ padding: "8px 12px", fontSize: fontSize.xs }}
+      >
+        {sittingOut ? "Sit in" : "Sit out"}
+      </PillButton>
     </div>
   );
 }

--- a/packages/player-client/src/SeatPicker.test.tsx
+++ b/packages/player-client/src/SeatPicker.test.tsx
@@ -40,4 +40,21 @@ describe("SeatPicker", () => {
     );
     expect(html).not.toContain('data-testid="claim-error"');
   });
+
+  it("shows the eviction message above the seat choices", () => {
+    const html = renderToStaticMarkup(
+      <SeatPicker
+        error={null}
+        evictionMessage="You have been evicted from the room"
+        onClaim={() => undefined}
+        seats={[]}
+      />,
+    );
+
+    expect(html).toContain('data-testid="eviction-message"');
+    expect(html).toContain("You have been evicted from the room");
+    expect(html).toMatch(
+      /data-testid="eviction-message"[^>]*font-size:19px[^>]*font-weight:800/,
+    );
+  });
 });

--- a/packages/player-client/src/SeatPicker.tsx
+++ b/packages/player-client/src/SeatPicker.tsx
@@ -6,6 +6,7 @@ import { InlineError } from "./InlineError.js";
 export interface SeatPickerProps {
   readonly seats: readonly SeatView[];
   readonly error: string | null;
+  readonly evictionMessage?: string | null;
   readonly onClaim: (seatId: number) => void;
 }
 
@@ -95,7 +96,12 @@ const subStyle: CSSProperties = {
   color: color.textDim,
 };
 
-export function SeatPicker({ seats, error, onClaim }: SeatPickerProps) {
+export function SeatPicker({
+  seats,
+  error,
+  evictionMessage,
+  onClaim,
+}: SeatPickerProps) {
   return (
     <div
       data-testid="seat-picker"
@@ -148,6 +154,25 @@ export function SeatPicker({ seats, error, onClaim }: SeatPickerProps) {
           );
         })}
       </div>
+      {evictionMessage && (
+        <div
+          data-testid="eviction-message"
+          style={{
+            padding: "14px 16px",
+            border: `1px solid ${color.accent}`,
+            borderRadius: radius.control,
+            background: color.lossBackground,
+            color: color.textBright,
+            fontFamily: font.display,
+            fontSize: fontSize.lg,
+            fontWeight: 800,
+            lineHeight: 1.25,
+            textAlign: "center",
+          }}
+        >
+          {evictionMessage}
+        </div>
+      )}
       {error && (
         <InlineError
           testId="claim-error"

--- a/packages/player-client/src/StatusBar.test.tsx
+++ b/packages/player-client/src/StatusBar.test.tsx
@@ -3,12 +3,15 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { StatusBar } from "./StatusBar.js";
 
+const noop = () => undefined;
+
 describe("StatusBar", () => {
   it("hides the connection badge before a seat is claimed", () => {
     const html = renderToStaticMarkup(
       <StatusBar
         showBadge={false}
         connectionStatus="disconnected"
+        onToggleSittingOut={noop}
         seat={null}
       />,
     );
@@ -17,7 +20,12 @@ describe("StatusBar", () => {
 
   it("shows the connection badge once connecting begins", () => {
     const html = renderToStaticMarkup(
-      <StatusBar showBadge={true} connectionStatus="connected" seat={null} />,
+      <StatusBar
+        showBadge={true}
+        connectionStatus="connected"
+        onToggleSittingOut={noop}
+        seat={null}
+      />,
     );
     expect(html).toContain('data-testid="connection-status"');
     expect(html).toContain("connected");
@@ -28,6 +36,7 @@ describe("StatusBar", () => {
       <StatusBar
         showBadge={true}
         connectionStatus="connected"
+        onToggleSittingOut={noop}
         seat={{ seatId: 0, sittingOut: false }}
       />,
     );
@@ -46,6 +55,7 @@ describe("StatusBar", () => {
       <StatusBar
         showBadge={false}
         connectionStatus="disconnected"
+        onToggleSittingOut={noop}
         seat={null}
       />,
     );

--- a/packages/player-client/src/StatusBar.tsx
+++ b/packages/player-client/src/StatusBar.tsx
@@ -6,6 +6,7 @@ import type { ConnectionStatus } from "./store/connectionSlice.js";
 export interface StatusBarProps {
   readonly showBadge: boolean;
   readonly connectionStatus: ConnectionStatus;
+  readonly onToggleSittingOut: () => void;
   readonly seat: {
     readonly seatId: number;
     readonly sittingOut: boolean;
@@ -35,6 +36,7 @@ const badgeStyle: CSSProperties = {
 export function StatusBar({
   showBadge,
   connectionStatus,
+  onToggleSittingOut,
   seat,
 }: StatusBarProps) {
   const tone = badgeTone[connectionStatus];
@@ -48,7 +50,14 @@ export function StatusBar({
         padding: "16px 18px 0",
       }}
     >
-      {seat && <SeatPanel seatId={seat.seatId} sittingOut={seat.sittingOut} />}
+      {seat && (
+        <SeatPanel
+          seatId={seat.seatId}
+          sittingOut={seat.sittingOut}
+          toggleDisabled={connectionStatus !== "connected"}
+          onToggleSittingOut={onToggleSittingOut}
+        />
+      )}
       {showBadge && (
         <span
           data-testid="connection-status"

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -58,6 +58,7 @@ export function useWebSocket(
     (state) => state.setConnectionStatus,
   );
   const setRoomView = usePlayerStore((state) => state.setRoomView);
+  const setSeat = usePlayerStore((state) => state.setSeat);
   const setHandView = usePlayerStore((state) => state.setHandView);
   const viewSnapshotReceived = usePlayerStore(
     (state) => state.viewSnapshotReceived,
@@ -109,6 +110,14 @@ export function useWebSocket(
         switch (message.type) {
           case "room-view":
             setRoomView(message.view);
+            {
+              const seat = message.view.seats.find(
+                (candidate) => candidate.id === seatParams.seatId,
+              );
+              if (seat?.claimed) {
+                setSeat({ seatId: seat.id, sittingOut: seat.sittingOut });
+              }
+            }
             break;
           case "hand-update":
             // The server only ever sends a seat's socket its own `view(state, seatId)`.
@@ -141,6 +150,7 @@ export function useWebSocket(
     params,
     setConnectionStatus,
     setRoomView,
+    setSeat,
     setHandView,
     viewSnapshotReceived,
     commandRejected,

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -24,6 +24,8 @@ export interface UseWebSocketOptions {
   readonly onRejected?: () => void;
   /** The room ended — manual "End session" or the table's grace window elapsing. */
   readonly onRoomEnded?: () => void;
+  /** The seat was evicted by the table device. */
+  readonly onEvicted?: () => void;
 }
 
 export interface SeatSocket {
@@ -133,6 +135,10 @@ export function useWebSocket(
             break;
           case "room-ended":
             optionsRef.current.onRoomEnded?.();
+            break;
+          case "player-evicted":
+            active = false;
+            optionsRef.current.onEvicted?.();
             break;
         }
       });

--- a/packages/protocol/src/command-schema.test.ts
+++ b/packages/protocol/src/command-schema.test.ts
@@ -2,13 +2,19 @@ import { describe, expect, it } from "vitest";
 import { ClientCommandSchema } from "./command-schema.js";
 
 describe("ClientCommandSchema", () => {
-  it.each(["startHand", "fold", "check", "call", "raise", "nextHand"])(
-    "accepts a bare %s command",
-    (type) => {
-      const result = ClientCommandSchema.safeParse({ type });
-      expect(result.success).toBe(true);
-    },
-  );
+  it.each([
+    "startHand",
+    "fold",
+    "check",
+    "call",
+    "raise",
+    "nextHand",
+    "sitOut",
+    "sitIn",
+  ])("accepts a bare %s command", (type) => {
+    const result = ClientCommandSchema.safeParse({ type });
+    expect(result.success).toBe(true);
+  });
 
   it("rejects an unknown command type", () => {
     const result = ClientCommandSchema.safeParse({ type: "advance" });

--- a/packages/protocol/src/command-schema.ts
+++ b/packages/protocol/src/command-schema.ts
@@ -16,6 +16,9 @@ export const ClientCommandSchema = z.discriminatedUnion("type", [
   z.strictObject({ type: z.literal("call") }),
   z.strictObject({ type: z.literal("raise") }),
   z.strictObject({ type: z.literal("nextHand") }),
+  /** Voluntary seat state (ADR-0002) — never reaches the engine, handled at the room-store layer only. */
+  z.strictObject({ type: z.literal("sitOut") }),
+  z.strictObject({ type: z.literal("sitIn") }),
 ]);
 
 export type ClientCommand = z.infer<typeof ClientCommandSchema>;

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -21,6 +21,11 @@ export interface RoomViewMessage {
   readonly view: RoomView;
 }
 
+/** Sent to a player's socket immediately before the server closes it after eviction. */
+export interface PlayerEvictedMessage {
+  readonly type: "player-evicted";
+}
+
 /**
  * Pushed once, right after a socket opens (fresh join or reconnect), when a
  * hand is already in progress — a snapshot only, never replayed events
@@ -42,6 +47,7 @@ export interface RoomEndedMessage {
 
 export type ServerMessage =
   | RoomViewMessage
+  | PlayerEvictedMessage
   | HandUpdateMessage
   | CommandRejectedMessage
   | ViewSnapshotMessage

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -152,7 +152,7 @@ describe("GET /join/:code", () => {
   });
 });
 
-describe("seat claim/clear routes", () => {
+describe("seat claim/evict routes", () => {
   let app: FastifyInstance;
   let rooms: RoomStore;
 
@@ -237,15 +237,15 @@ describe("seat claim/clear routes", () => {
     expect(response.json<SeatClaimBody>().sittingOut).toBe(true);
   });
 
-  it("force-clears a seat so it can be reclaimed", async () => {
+  it("evicts a seat so it can be reclaimed (ADR-0003)", async () => {
     const code = await createRoom();
     await app.inject({ method: "POST", url: `/rooms/${code}/seats/0/claim` });
 
-    const cleared = await app.inject({
+    const evicted = await app.inject({
       method: "POST",
-      url: `/rooms/${code}/seats/0/clear`,
+      url: `/rooms/${code}/seats/0/evict`,
     });
-    expect(cleared.statusCode).toBe(204);
+    expect(evicted.statusCode).toBe(204);
 
     const reclaimed = await app.inject({
       method: "POST",
@@ -662,7 +662,7 @@ describe("hand command dispatch over WebSocket", () => {
     }
   });
 
-  it("evicts a seat after 3 hands disconnected and broadcasts the freed seat (ADR-0002)", async () => {
+  it("has no automatic eviction — a disconnected seat stays occupied across repeated nextHands (ADR-0003)", async () => {
     const room = rooms.create();
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
@@ -692,57 +692,33 @@ describe("hand command dispatch over WebSocket", () => {
     seat2.socket.close();
     await settle();
 
-    for (let i = 0; i < 2; i++) {
+    for (let i = 0; i < 3; i++) {
       table.socket.send(JSON.stringify({ type: "nextHand" }));
       await settle();
       await completeHandOverWs();
     }
-    table.socket.send(JSON.stringify({ type: "nextHand" }));
-    await settle();
 
-    expect(rooms.get(room.code)?.seats[2]).toMatchObject({
-      claimed: false,
-      missedHands: 0,
-    });
-    const roomViews = table.messages.filter((m) => m.type === "room-view");
-    const lastView = roomViews.at(-1);
-    if (lastView?.type !== "room-view") throw new Error("expected a view");
-    expect(lastView.view.seats[2]).toMatchObject({
-      claimed: false,
-      sittingOut: false,
-    });
+    expect(rooms.get(room.code)?.seats[2]).toMatchObject({ claimed: true });
   });
 
-  it("still broadcasts an eviction that happens on a nextHand rejected as not-enough-players", async () => {
+  it("evicting a seat via the REST route broadcasts the freed seat over the room's sockets (ADR-0003)", async () => {
     const room = rooms.create();
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
     await claimAndConnect(room.code, 0);
-    const seat1 = await claimAndConnect(room.code, 1);
-    const seat2 = await claimAndConnect(room.code, 2);
+    await claimAndConnect(room.code, 1);
     await settle();
 
-    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await app.inject({
+      method: "POST",
+      url: `/rooms/${room.code}/seats/1/evict`,
+    });
     await settle();
-
-    // Seats 1 and 2 stay disconnected for every subsequent nextHand — only
-    // seat 0 stays eligible, so every nextHand rejects as not-enough-players,
-    // but the eviction bookkeeping still runs and still needs broadcasting.
-    seat1.socket.close();
-    seat2.socket.close();
-    await settle();
-
-    for (let i = 0; i < 3; i++) {
-      table.socket.send(JSON.stringify({ type: "nextHand" }));
-      await settle();
-    }
 
     expect(rooms.get(room.code)?.seats[1]).toMatchObject({ claimed: false });
-    expect(rooms.get(room.code)?.seats[2]).toMatchObject({ claimed: false });
     const lastView = table.messages.findLast((m) => m.type === "room-view");
     if (lastView?.type !== "room-view") throw new Error("expected a view");
     expect(lastView.view.seats[1]).toMatchObject({ claimed: false });
-    expect(lastView.view.seats[2]).toMatchObject({ claimed: false });
   });
 
   it("rejects an out-of-turn action, visible only to the sender", async () => {
@@ -1222,12 +1198,12 @@ describe("presence and reconnection", () => {
     expect(view.yourHoleCards).toBeNull();
   });
 
-  it("rejects a WS connect with a stale token after the seat is cleared", async () => {
+  it("rejects a WS connect with a stale token after the seat is evicted", async () => {
     const room = rooms.create();
     const claim = rooms.claimSeat(room.code, 0);
     if (!("seat" in claim)) throw new Error("expected a claimed seat");
     const token = claim.seat.token ?? "";
-    rooms.clearSeat(room.code, 0);
+    rooms.evictSeat(room.code, 0);
 
     const socket = new WebSocket(
       `ws://127.0.0.1:${String(port)}/ws?room=${room.code}&seat=0&token=${token}`,

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -3,7 +3,7 @@ import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import WebSocket from "ws";
 import { buildApp } from "./app.js";
-import { RoomStore, SEAT_COUNT } from "./rooms.js";
+import { RoomStore, SEAT_COUNT, toRoomView } from "./rooms.js";
 
 interface RoomCreatedBody {
   readonly code: string;
@@ -511,7 +511,48 @@ describe("hand command dispatch over WebSocket", () => {
     );
     expect(handUpdates).toHaveLength(0);
 
-    expect(rooms.get(room.code)?.seats[2]?.sittingOut).toBe(true);
+    const view = rooms.get(room.code);
+    expect(view && toRoomView(view).seats[2]?.sittingOut).toBe(true);
+  });
+
+  it("lets a seat voluntarily sit out and back in over the WebSocket (ADR-0002)", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const seat0 = await claimAndConnect(room.code, 0);
+    await settle();
+
+    seat0.socket.send(JSON.stringify({ type: "sitOut" }));
+    await settle();
+
+    expect(rooms.get(room.code)?.seats[0]).toMatchObject({
+      sittingOut: true,
+    });
+    const roomView = table.messages.findLast((m) => m.type === "room-view");
+    if (roomView?.type !== "room-view") throw new Error("expected a view");
+    expect(roomView.view.seats[0]).toMatchObject({ sittingOut: true });
+
+    seat0.socket.send(JSON.stringify({ type: "sitIn" }));
+    await settle();
+
+    expect(rooms.get(room.code)?.seats[0]).toMatchObject({
+      sittingOut: false,
+    });
+  });
+
+  it("rejects sitOut/sitIn from the table role", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "sitOut" }));
+    await settle();
+
+    expect(table.messages).toContainEqual({
+      type: "command-rejected",
+      reason: "not-permitted",
+    });
   });
 
   it("rejects a malformed command via Zod before it reaches the engine", async () => {
@@ -619,6 +660,89 @@ describe("hand command dispatch over WebSocket", () => {
         false,
       );
     }
+  });
+
+  it("evicts a seat after 3 hands disconnected and broadcasts the freed seat (ADR-0002)", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const seat2 = await claimAndConnect(room.code, 2);
+    const seatSockets: Record<number, { socket: WebSocket }> = {
+      0: await claimAndConnect(room.code, 0),
+      1: await claimAndConnect(room.code, 1),
+      2: seat2,
+    };
+    await settle();
+
+    async function completeHandOverWs(): Promise<void> {
+      for (let i = 0; i < 5; i++) {
+        if (rooms.get(room.code)?.engine?.hand?.status === "complete") return;
+        const actor = rooms.currentActor(room.code);
+        if (actor === undefined) throw new Error("expected a current actor");
+        seatSockets[actor]?.socket.send(JSON.stringify({ type: "fold" }));
+        await settle();
+      }
+      throw new Error("hand did not complete");
+    }
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    await completeHandOverWs();
+
+    seat2.socket.close();
+    await settle();
+
+    for (let i = 0; i < 2; i++) {
+      table.socket.send(JSON.stringify({ type: "nextHand" }));
+      await settle();
+      await completeHandOverWs();
+    }
+    table.socket.send(JSON.stringify({ type: "nextHand" }));
+    await settle();
+
+    expect(rooms.get(room.code)?.seats[2]).toMatchObject({
+      claimed: false,
+      missedHands: 0,
+    });
+    const roomViews = table.messages.filter((m) => m.type === "room-view");
+    const lastView = roomViews.at(-1);
+    if (lastView?.type !== "room-view") throw new Error("expected a view");
+    expect(lastView.view.seats[2]).toMatchObject({
+      claimed: false,
+      sittingOut: false,
+    });
+  });
+
+  it("still broadcasts an eviction that happens on a nextHand rejected as not-enough-players", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    await claimAndConnect(room.code, 0);
+    const seat1 = await claimAndConnect(room.code, 1);
+    const seat2 = await claimAndConnect(room.code, 2);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    // Seats 1 and 2 stay disconnected for every subsequent nextHand — only
+    // seat 0 stays eligible, so every nextHand rejects as not-enough-players,
+    // but the eviction bookkeeping still runs and still needs broadcasting.
+    seat1.socket.close();
+    seat2.socket.close();
+    await settle();
+
+    for (let i = 0; i < 3; i++) {
+      table.socket.send(JSON.stringify({ type: "nextHand" }));
+      await settle();
+    }
+
+    expect(rooms.get(room.code)?.seats[1]).toMatchObject({ claimed: false });
+    expect(rooms.get(room.code)?.seats[2]).toMatchObject({ claimed: false });
+    const lastView = table.messages.findLast((m) => m.type === "room-view");
+    if (lastView?.type !== "room-view") throw new Error("expected a view");
+    expect(lastView.view.seats[1]).toMatchObject({ claimed: false });
+    expect(lastView.view.seats[2]).toMatchObject({ claimed: false });
   });
 
   it("rejects an out-of-turn action, visible only to the sender", async () => {

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -416,6 +416,7 @@ describe("hand command dispatch over WebSocket", () => {
   }
 
   async function opened(socket: WebSocket): Promise<void> {
+    if (socket.readyState === WebSocket.OPEN) return;
     await new Promise<void>((resolve, reject) => {
       socket.on("open", resolve);
       socket.on("error", reject);
@@ -706,16 +707,23 @@ describe("hand command dispatch over WebSocket", () => {
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
     await claimAndConnect(room.code, 0);
-    await claimAndConnect(room.code, 1);
+    const seat1 = await claimAndConnect(room.code, 1);
     await settle();
 
+    const closed = new Promise<void>((resolve) => {
+      seat1.socket.once("close", () => {
+        resolve();
+      });
+    });
     await app.inject({
       method: "POST",
       url: `/rooms/${room.code}/seats/1/evict`,
     });
+    await closed;
     await settle();
 
     expect(rooms.get(room.code)?.seats[1]).toMatchObject({ claimed: false });
+    expect(seat1.socket.readyState).toBe(WebSocket.CLOSED);
     const lastView = table.messages.findLast((m) => m.type === "room-view");
     if (lastView?.type !== "room-view") throw new Error("expected a view");
     expect(lastView.view.seats[1]).toMatchObject({ claimed: false });
@@ -835,6 +843,7 @@ describe("action clock", () => {
   }
 
   async function opened(socket: WebSocket): Promise<void> {
+    if (socket.readyState === WebSocket.OPEN) return;
     await new Promise<void>((resolve, reject) => {
       socket.on("open", resolve);
       socket.on("error", reject);
@@ -1037,6 +1046,7 @@ describe("presence and reconnection", () => {
   }
 
   async function opened(socket: WebSocket): Promise<void> {
+    if (socket.readyState === WebSocket.OPEN) return;
     await new Promise<void>((resolve, reject) => {
       socket.on("open", resolve);
       socket.on("error", reject);

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -724,6 +724,7 @@ describe("hand command dispatch over WebSocket", () => {
 
     expect(rooms.get(room.code)?.seats[1]).toMatchObject({ claimed: false });
     expect(seat1.socket.readyState).toBe(WebSocket.CLOSED);
+    expect(seat1.messages).toContainEqual({ type: "player-evicted" });
     const lastView = table.messages.findLast((m) => m.type === "room-view");
     if (lastView?.type !== "room-view") throw new Error("expected a view");
     expect(lastView.view.seats[1]).toMatchObject({ claimed: false });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -329,8 +329,9 @@ export async function buildApp(
     },
   );
 
+  /** The table device's manual evict action (ADR-0003) — no automatic trigger. */
   app.post<RoomSeatRoute>(
-    "/rooms/:code/seats/:seatId/clear",
+    "/rooms/:code/seats/:seatId/evict",
     (request, reply) => {
       const seatId = parseSeatId(request.params.seatId);
       if (seatId === undefined) {
@@ -338,7 +339,7 @@ export async function buildApp(
       }
       const room = findRoomOrReject(rooms, request.params.code, reply);
       if (!room) return;
-      rooms.clearSeat(request.params.code, seatId);
+      rooms.evictSeat(request.params.code, seatId);
       broadcastRoomView(request.params.code);
       return reply.code(204).send();
     },
@@ -483,12 +484,6 @@ export async function buildApp(
           }
           if ("reason" in dispatchResult) {
             sendRejection(socket, dispatchResult.reason);
-            // A rejected nextHand can still have evicted seats (ADR-0002) —
-            // eviction runs before the eligible-seat-count check, so it
-            // isn't undone by the rejection.
-            if ((dispatchResult.evicted?.length ?? 0) > 0) {
-              broadcastRoomView(code);
-            }
             return;
           }
 
@@ -496,13 +491,11 @@ export async function buildApp(
             fanOutHandUpdate(code, step);
           }
           rescheduleActionClock(code);
-          // A fresh deal-in (new join, eviction, reconnect) or an eviction
-          // on its own (ADR-0002) all change seat state the routine
-          // hand-update fan-out above doesn't cover.
+          // A fresh deal-in (new join, reconnect) changes seat state the
+          // routine hand-update fan-out above doesn't cover.
           if (
             parseResult.data.type === "startHand" ||
-            parseResult.data.type === "nextHand" ||
-            (dispatchResult.evicted?.length ?? 0) > 0
+            parseResult.data.type === "nextHand"
           ) {
             broadcastRoomView(code);
           }

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -115,6 +115,7 @@ export async function buildApp(
   const actionClock = new ActionClock(options.actionClockMs);
   const socketRoomCode = new Map<WebSocket, string>();
   const pingMissed = new Map<WebSocket, number>();
+  const evictedSockets = new WeakSet<WebSocket>();
   /** One timer per room, armed the moment its table-role socket closes. */
   const tableGraceTimers = new Map<string, NodeJS.Timeout>();
   const app = Fastify();
@@ -154,6 +155,8 @@ export async function buildApp(
 
     for (const socket of [...sockets]) {
       if (socketIdentity.get(socket) !== seatId) continue;
+      evictedSockets.add(socket);
+      send(socket, { type: "player-evicted" });
       sockets.delete(socket);
       socketIdentity.delete(socket);
       socketRoomCode.delete(socket);
@@ -359,8 +362,8 @@ export async function buildApp(
       const room = findRoomOrReject(rooms, request.params.code, reply);
       if (!room) return;
       rooms.evictSeat(request.params.code, seatId);
-      closeSeatSockets(request.params.code, seatId);
       broadcastRoomView(request.params.code);
+      closeSeatSockets(request.params.code, seatId);
       return reply.code(204).send();
     },
   );
@@ -526,6 +529,8 @@ export async function buildApp(
           socketIdentity.delete(socket);
           socketRoomCode.delete(socket);
           pingMissed.delete(socket);
+
+          if (evictedSockets.delete(socket)) return;
 
           if (identity === "table") {
             // Room may already be gone (this close came from `endRoom` itself

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -143,6 +143,25 @@ export async function buildApp(
     }
   }
 
+  /**
+   * A seat token only protects the next connection attempt. Remove all
+   * currently open sockets for an evicted seat too, otherwise that socket
+   * could keep issuing commands until it disconnected on its own.
+   */
+  function closeSeatSockets(code: string, seatId: SeatId): void {
+    const sockets = roomSockets.get(code);
+    if (!sockets) return;
+
+    for (const socket of [...sockets]) {
+      if (socketIdentity.get(socket) !== seatId) continue;
+      sockets.delete(socket);
+      socketIdentity.delete(socket);
+      socketRoomCode.delete(socket);
+      pingMissed.delete(socket);
+      socket.close();
+    }
+  }
+
   /** Cosmetic presence toggle for a seat's socket — never touches `rooms.dispatch`. */
   function markPresence(socket: WebSocket, disconnected: boolean): void {
     const identity = socketIdentity.get(socket);
@@ -340,6 +359,7 @@ export async function buildApp(
       const room = findRoomOrReject(rooms, request.params.code, reply);
       if (!room) return;
       rooms.evictSeat(request.params.code, seatId);
+      closeSeatSockets(request.params.code, seatId);
       broadcastRoomView(request.params.code);
       return reply.code(204).send();
     },

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -324,7 +324,7 @@ export async function buildApp(
       return {
         seatId: result.seat.id,
         token: result.seat.token,
-        sittingOut: result.seat.sittingOut,
+        sittingOut: rooms.isSittingOut(request.params.code, result.seat.id),
       };
     },
   );
@@ -453,6 +453,25 @@ export async function buildApp(
             return;
           }
 
+          // Voluntary sit-out/in (ADR-0002) never reaches the engine — it's
+          // a seat-only room-store mutation, not a hand command.
+          if (
+            parseResult.data.type === "sitOut" ||
+            parseResult.data.type === "sitIn"
+          ) {
+            if (identity === "table") {
+              sendRejection(socket, "not-permitted");
+              return;
+            }
+            rooms.setSittingOut(
+              code,
+              identity,
+              parseResult.data.type === "sitOut",
+            );
+            broadcastRoomView(code);
+            return;
+          }
+
           const dispatchResult = rooms.dispatch(
             code,
             identity,
@@ -464,6 +483,12 @@ export async function buildApp(
           }
           if ("reason" in dispatchResult) {
             sendRejection(socket, dispatchResult.reason);
+            // A rejected nextHand can still have evicted seats (ADR-0002) —
+            // eviction runs before the eligible-seat-count check, so it
+            // isn't undone by the rejection.
+            if ((dispatchResult.evicted?.length ?? 0) > 0) {
+              broadcastRoomView(code);
+            }
             return;
           }
 
@@ -471,7 +496,14 @@ export async function buildApp(
             fanOutHandUpdate(code, step);
           }
           rescheduleActionClock(code);
-          if (parseResult.data.type === "startHand") {
+          // A fresh deal-in (new join, eviction, reconnect) or an eviction
+          // on its own (ADR-0002) all change seat state the routine
+          // hand-update fan-out above doesn't cover.
+          if (
+            parseResult.data.type === "startHand" ||
+            parseResult.data.type === "nextHand" ||
+            (dispatchResult.evicted?.length ?? 0) > 0
+          ) {
             broadcastRoomView(code);
           }
         });

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { RoomStore, SEAT_COUNT, toRoomView } from "./rooms.js";
+import { type Room, RoomStore, SEAT_COUNT, toRoomView } from "./rooms.js";
 
 describe("RoomStore", () => {
   it("creates a room with a fresh code", () => {
@@ -70,6 +70,7 @@ describe("RoomStore", () => {
           token: "token-0",
           sittingOut: false,
           disconnected: false,
+          missedHands: 0,
         },
       });
       expect(room.seats[0]).toEqual({
@@ -78,6 +79,7 @@ describe("RoomStore", () => {
         token: "token-0",
         sittingOut: false,
         disconnected: false,
+        missedHands: 0,
       });
     });
 
@@ -107,7 +109,7 @@ describe("RoomStore", () => {
       });
     });
 
-    it("marks a seat claimed while a hand is in progress as sitting out", () => {
+    it("claims a seat mid-hand with sittingOut false internally, shown as sitting out in the room view", () => {
       const store = new RoomStore();
       const room = store.create();
       store.claimSeat(room.code, 0);
@@ -121,8 +123,9 @@ describe("RoomStore", () => {
       expect(result.seat).toMatchObject({
         id: 2,
         claimed: true,
-        sittingOut: true,
+        sittingOut: false,
       });
+      expect(toRoomView(room).seats[2]).toMatchObject({ sittingOut: true });
     });
 
     it("force-clears a claimed seat so it can be reclaimed", () => {
@@ -138,6 +141,7 @@ describe("RoomStore", () => {
         token: null,
         sittingOut: false,
         disconnected: false,
+        missedHands: 0,
       });
       const reclaimed = store.claimSeat(room.code, 0);
       if (!("seat" in reclaimed)) throw new Error("expected a claimed seat");
@@ -231,18 +235,17 @@ describe("RoomStore", () => {
       expect(room.engine?.hand?.status).toBe("betting");
     });
 
-    it("excludes a sitting-out seat from the deal and leaves it sitting out", () => {
+    it("excludes a mid-hand joiner from the deal, showing it sitting out", () => {
       const store = new RoomStore();
       const room = roomWithClaimedSeats(store, 2);
       store.dispatch(room.code, "table", "startHand");
       const midHandJoin = store.claimSeat(room.code, 2);
       if (!("seat" in midHandJoin)) throw new Error("expected a claim");
-      expect(midHandJoin.seat.sittingOut).toBe(true);
 
       const foldResult = store.dispatch(room.code, 2, "fold");
 
       expect(foldResult).toEqual({ reason: "not-your-turn" });
-      expect(room.seats[2]?.sittingOut).toBe(true);
+      expect(toRoomView(room).seats[2]).toMatchObject({ sittingOut: true });
     });
 
     it("clears sittingOut on every seat dealt into a hand", () => {
@@ -281,6 +284,187 @@ describe("RoomStore", () => {
 
       expect(store.dispatch(room.code, outOfTurnSeat.id, "fold")).toEqual({
         reason: "not-your-turn",
+      });
+    });
+
+    /** Folds every actor in turn until only one live player remains (fold-out). */
+    function completeHand(store: RoomStore, room: Room): void {
+      for (let i = 0; i < SEAT_COUNT; i++) {
+        if (room.engine?.hand?.status === "complete") return;
+        const actor = store.currentActor(room.code);
+        if (actor === undefined) throw new Error("expected a current actor");
+        const result = store.dispatch(room.code, actor, "fold");
+        if (!("steps" in result)) throw new Error("expected dispatch steps");
+      }
+      throw new Error("hand did not complete");
+    }
+
+    describe("ADR-0002: seat eviction", () => {
+      it("deals a mid-hand joiner into the next hand", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 2);
+        store.dispatch(room.code, "table", "startHand");
+        store.claimSeat(room.code, 2);
+        completeHand(store, room);
+
+        const result = store.dispatch(room.code, "table", "nextHand");
+
+        if (!("steps" in result)) throw new Error("expected dispatch steps");
+        const holeCardsDealt = result.steps.find(
+          (step) => step.event.type === "HoleCardsDealt",
+        )?.event;
+        if (holeCardsDealt?.type !== "HoleCardsDealt") {
+          throw new Error("expected HoleCardsDealt");
+        }
+        expect(holeCardsDealt.deals.map((d) => d.seatId).sort()).toEqual([
+          0, 1, 2,
+        ]);
+        expect(toRoomView(room).seats[2]).toMatchObject({ sittingOut: false });
+      });
+
+      it("excludes a disconnected seat from the next hand and increments its missed-hands counter", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 3);
+        store.dispatch(room.code, "table", "startHand");
+        completeHand(store, room);
+        store.setSeatDisconnected(room.code, 2, true);
+
+        const result = store.dispatch(room.code, "table", "nextHand");
+
+        if (!("steps" in result)) throw new Error("expected dispatch steps");
+        expect(room.engine?.seats).not.toContain(2);
+        expect(room.seats[2]?.missedHands).toBe(1);
+      });
+
+      it("never accrues missed hands for a voluntarily sitting-out seat, even while disconnected", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 3);
+        store.dispatch(room.code, "table", "startHand");
+        completeHand(store, room);
+        store.setSittingOut(room.code, 2, true);
+        store.setSeatDisconnected(room.code, 2, true);
+
+        store.dispatch(room.code, "table", "nextHand");
+        completeHand(store, room);
+        store.dispatch(room.code, "table", "nextHand");
+        completeHand(store, room);
+        store.dispatch(room.code, "table", "nextHand");
+
+        expect(room.seats[2]?.missedHands).toBe(0);
+        expect(room.seats[2]?.claimed).toBe(true);
+      });
+
+      it("resets the missed-hands counter to 0 on reconnect", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 3);
+        store.dispatch(room.code, "table", "startHand");
+        completeHand(store, room);
+        store.setSeatDisconnected(room.code, 2, true);
+        store.dispatch(room.code, "table", "nextHand");
+        expect(room.seats[2]?.missedHands).toBe(1);
+
+        store.setSeatDisconnected(room.code, 2, false);
+
+        expect(room.seats[2]?.missedHands).toBe(0);
+      });
+
+      it("evicts a seat once it misses 3 consecutive hands, freeing it and reporting the eviction", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 3);
+        store.dispatch(room.code, "table", "startHand");
+        completeHand(store, room);
+        store.setSeatDisconnected(room.code, 2, true);
+
+        store.dispatch(room.code, "table", "nextHand");
+        completeHand(store, room);
+        store.dispatch(room.code, "table", "nextHand");
+        completeHand(store, room);
+        const result = store.dispatch(room.code, "table", "nextHand");
+
+        if (!("steps" in result)) throw new Error("expected dispatch steps");
+        expect(result.evicted).toEqual([2]);
+        expect(room.seats[2]).toMatchObject({
+          claimed: false,
+          token: null,
+          missedHands: 0,
+        });
+      });
+
+      it("rejects nextHand once too few seats remain eligible, without dealing anyone in", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 2);
+        store.dispatch(room.code, "table", "startHand");
+        completeHand(store, room);
+        store.setSeatDisconnected(room.code, 1, true);
+
+        expect(store.dispatch(room.code, "table", "nextHand")).toEqual({
+          reason: "not-enough-players",
+        });
+        expect(room.seats[1]?.missedHands).toBe(1);
+      });
+
+      it("reports evicted seats on a rejected nextHand, since eviction isn't undone by the rejection", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 3);
+        store.dispatch(room.code, "table", "startHand");
+        completeHand(store, room);
+        store.setSeatDisconnected(room.code, 1, true);
+        store.setSeatDisconnected(room.code, 2, true);
+
+        // Only seat 0 stays eligible throughout, so every nextHand rejects —
+        // but seats 1 and 2 still miss hands and reach eviction on the 3rd.
+        expect(store.dispatch(room.code, "table", "nextHand")).toEqual({
+          reason: "not-enough-players",
+        });
+        expect(store.dispatch(room.code, "table", "nextHand")).toEqual({
+          reason: "not-enough-players",
+        });
+        expect(store.dispatch(room.code, "table", "nextHand")).toEqual({
+          reason: "not-enough-players",
+          evicted: [1, 2],
+        });
+        expect(room.seats[1]).toMatchObject({ claimed: false });
+        expect(room.seats[2]).toMatchObject({ claimed: false });
+      });
+    });
+
+    describe("ADR-0002: sitOut/sitIn", () => {
+      it("excludes a voluntarily sitting-out seat from deal-in and never marks it disconnected", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 3);
+        store.setSittingOut(room.code, 2, true);
+
+        const result = store.dispatch(room.code, "table", "startHand");
+
+        if (!("steps" in result)) throw new Error("expected dispatch steps");
+        expect(room.engine?.seats).not.toContain(2);
+        expect(toRoomView(room).seats[2]).toMatchObject({
+          sittingOut: true,
+          disconnected: false,
+        });
+      });
+
+      it("deals a seat back in once it sits back in", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 3);
+        store.setSittingOut(room.code, 2, true);
+        store.dispatch(room.code, "table", "startHand");
+        completeHand(store, room);
+
+        store.setSittingOut(room.code, 2, false);
+        const result = store.dispatch(room.code, "table", "nextHand");
+
+        if (!("steps" in result)) throw new Error("expected dispatch steps");
+        expect(room.engine?.seats).toContain(2);
+      });
+
+      it("is a no-op on an unclaimed seat", () => {
+        const store = new RoomStore();
+        const room = store.create();
+
+        store.setSittingOut(room.code, 0, true);
+
+        expect(room.seats[0]?.sittingOut).toBe(false);
       });
     });
   });

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -70,7 +70,6 @@ describe("RoomStore", () => {
           token: "token-0",
           sittingOut: false,
           disconnected: false,
-          missedHands: 0,
         },
       });
       expect(room.seats[0]).toEqual({
@@ -79,7 +78,6 @@ describe("RoomStore", () => {
         token: "token-0",
         sittingOut: false,
         disconnected: false,
-        missedHands: 0,
       });
     });
 
@@ -128,12 +126,12 @@ describe("RoomStore", () => {
       expect(toRoomView(room).seats[2]).toMatchObject({ sittingOut: true });
     });
 
-    it("force-clears a claimed seat so it can be reclaimed", () => {
+    it("evicts a claimed seat so it can be reclaimed (ADR-0003)", () => {
       const store = new RoomStore();
       const room = store.create();
       store.claimSeat(room.code, 0);
 
-      store.clearSeat(room.code, 0);
+      store.evictSeat(room.code, 0);
 
       expect(room.seats[0]).toEqual({
         id: 0,
@@ -141,7 +139,6 @@ describe("RoomStore", () => {
         token: null,
         sittingOut: false,
         disconnected: false,
-        missedHands: 0,
       });
       const reclaimed = store.claimSeat(room.code, 0);
       if (!("seat" in reclaimed)) throw new Error("expected a claimed seat");
@@ -153,10 +150,10 @@ describe("RoomStore", () => {
       });
     });
 
-    it("clearing a seat in an unknown room is a no-op", () => {
+    it("evicting a seat in an unknown room is a no-op", () => {
       const store = new RoomStore();
       expect(() => {
-        store.clearSeat("ZZZZ", 0);
+        store.evictSeat("ZZZZ", 0);
       }).not.toThrow();
     });
   });
@@ -299,7 +296,7 @@ describe("RoomStore", () => {
       throw new Error("hand did not complete");
     }
 
-    describe("ADR-0002: seat eviction", () => {
+    describe("ADR-0002: per-hand deal-in recompute", () => {
       it("deals a mid-hand joiner into the next hand", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 2);
@@ -322,7 +319,7 @@ describe("RoomStore", () => {
         expect(toRoomView(room).seats[2]).toMatchObject({ sittingOut: false });
       });
 
-      it("excludes a disconnected seat from the next hand and increments its missed-hands counter", () => {
+      it("excludes a disconnected seat from the next hand's deal-in", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 3);
         store.dispatch(room.code, "table", "startHand");
@@ -333,61 +330,6 @@ describe("RoomStore", () => {
 
         if (!("steps" in result)) throw new Error("expected dispatch steps");
         expect(room.engine?.seats).not.toContain(2);
-        expect(room.seats[2]?.missedHands).toBe(1);
-      });
-
-      it("never accrues missed hands for a voluntarily sitting-out seat, even while disconnected", () => {
-        const store = new RoomStore();
-        const room = roomWithClaimedSeats(store, 3);
-        store.dispatch(room.code, "table", "startHand");
-        completeHand(store, room);
-        store.setSittingOut(room.code, 2, true);
-        store.setSeatDisconnected(room.code, 2, true);
-
-        store.dispatch(room.code, "table", "nextHand");
-        completeHand(store, room);
-        store.dispatch(room.code, "table", "nextHand");
-        completeHand(store, room);
-        store.dispatch(room.code, "table", "nextHand");
-
-        expect(room.seats[2]?.missedHands).toBe(0);
-        expect(room.seats[2]?.claimed).toBe(true);
-      });
-
-      it("resets the missed-hands counter to 0 on reconnect", () => {
-        const store = new RoomStore();
-        const room = roomWithClaimedSeats(store, 3);
-        store.dispatch(room.code, "table", "startHand");
-        completeHand(store, room);
-        store.setSeatDisconnected(room.code, 2, true);
-        store.dispatch(room.code, "table", "nextHand");
-        expect(room.seats[2]?.missedHands).toBe(1);
-
-        store.setSeatDisconnected(room.code, 2, false);
-
-        expect(room.seats[2]?.missedHands).toBe(0);
-      });
-
-      it("evicts a seat once it misses 3 consecutive hands, freeing it and reporting the eviction", () => {
-        const store = new RoomStore();
-        const room = roomWithClaimedSeats(store, 3);
-        store.dispatch(room.code, "table", "startHand");
-        completeHand(store, room);
-        store.setSeatDisconnected(room.code, 2, true);
-
-        store.dispatch(room.code, "table", "nextHand");
-        completeHand(store, room);
-        store.dispatch(room.code, "table", "nextHand");
-        completeHand(store, room);
-        const result = store.dispatch(room.code, "table", "nextHand");
-
-        if (!("steps" in result)) throw new Error("expected dispatch steps");
-        expect(result.evicted).toEqual([2]);
-        expect(room.seats[2]).toMatchObject({
-          claimed: false,
-          token: null,
-          missedHands: 0,
-        });
       });
 
       it("rejects nextHand once too few seats remain eligible, without dealing anyone in", () => {
@@ -400,31 +342,44 @@ describe("RoomStore", () => {
         expect(store.dispatch(room.code, "table", "nextHand")).toEqual({
           reason: "not-enough-players",
         });
-        expect(room.seats[1]?.missedHands).toBe(1);
       });
+    });
 
-      it("reports evicted seats on a rejected nextHand, since eviction isn't undone by the rejection", () => {
+    describe("ADR-0003: manual eviction", () => {
+      it("frees a claimed seat via evictSeat regardless of connection status", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 3);
         store.dispatch(room.code, "table", "startHand");
         completeHand(store, room);
-        store.setSeatDisconnected(room.code, 1, true);
         store.setSeatDisconnected(room.code, 2, true);
 
-        // Only seat 0 stays eligible throughout, so every nextHand rejects —
-        // but seats 1 and 2 still miss hands and reach eviction on the 3rd.
-        expect(store.dispatch(room.code, "table", "nextHand")).toEqual({
-          reason: "not-enough-players",
-        });
-        expect(store.dispatch(room.code, "table", "nextHand")).toEqual({
-          reason: "not-enough-players",
-        });
-        expect(store.dispatch(room.code, "table", "nextHand")).toEqual({
-          reason: "not-enough-players",
-          evicted: [1, 2],
-        });
+        store.evictSeat(room.code, 2);
+
+        expect(room.seats[2]).toMatchObject({ claimed: false, token: null });
+      });
+
+      it("has no automatic eviction — a disconnected seat stays occupied across any number of hands", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 3);
+        store.dispatch(room.code, "table", "startHand");
+        completeHand(store, room);
+        store.setSeatDisconnected(room.code, 2, true);
+
+        for (let i = 0; i < 5; i++) {
+          store.dispatch(room.code, "table", "nextHand");
+          completeHand(store, room);
+        }
+
+        expect(room.seats[2]).toMatchObject({ claimed: true });
+      });
+
+      it("evicts an active (non-disconnected) seat just as freely", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 2);
+
+        store.evictSeat(room.code, 1);
+
         expect(room.seats[1]).toMatchObject({ claimed: false });
-        expect(room.seats[2]).toMatchObject({ claimed: false });
       });
     });
 

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -15,6 +15,9 @@ import { generateRoomCode } from "./room-code.js";
 
 export const SEAT_COUNT = 8;
 
+/** Consecutive missed hands before a still-disconnected seat is evicted (ADR-0002). */
+const EVICTION_THRESHOLD = 3;
+
 /**
  * `Seat` and `Room` are `RoomStore`'s internal mutable aggregate state, not
  * wire DTOs — mutated in place by the store rather than replaced, unlike
@@ -26,9 +29,21 @@ export interface Seat {
   readonly id: SeatId;
   claimed: boolean;
   token: string | null;
+  /**
+   * Voluntary opt-out only (ADR-0002) — set solely by the `sitOut`/`sitIn`
+   * commands via `setSittingOut`. Excludes the seat from deal-in and, unlike
+   * `disconnected`, never accrues `missedHands` no matter how long it lasts.
+   */
   sittingOut: boolean;
-  /** Cosmetic presence badge only (ticket 33) — never consulted by `dispatch`/`decide`. */
+  /**
+   * Presence badge (ticket 33 §7): missed pongs or a closed socket flip it
+   * on, a reconnect flips it off. Beyond the cosmetic badge, ADR-0002 also
+   * has it gate deal-in and drive `missedHands` — `dispatch`'s own
+   * fold/check/call/raise legality still never consults it directly.
+   */
   disconnected: boolean;
+  /** Consecutive hands skipped while disconnected (ADR-0002); reset to 0 on reconnect. */
+  missedHands: number;
 }
 
 export interface Room {
@@ -52,11 +67,30 @@ export interface DispatchStep {
 export type DispatchRejectionReason = RejectionReason | "not-enough-players";
 
 export type DispatchResult =
-  | { readonly steps: readonly DispatchStep[] }
+  | {
+      readonly steps: readonly DispatchStep[];
+      /** Seats evicted (ADR-0002) as a side effect of this dispatch, if any. */
+      readonly evicted?: readonly SeatId[];
+    }
   | { readonly error: "room-not-found" | "not-permitted" }
-  | { readonly reason: DispatchRejectionReason };
+  | {
+      readonly reason: DispatchRejectionReason;
+      /**
+       * A rejected `nextHand` can still have evicted seats: eviction runs
+       * before the eligible-seat-count check, so a `not-enough-players`
+       * rejection doesn't undo it (ADR-0002) — surfaced here so the caller
+       * still broadcasts the freed seats.
+       */
+      readonly evicted?: readonly SeatId[];
+    };
 
-const TABLE_ONLY_COMMANDS: ReadonlySet<ClientCommandType> = new Set([
+/**
+ * `sitOut`/`sitIn` are seat commands that never reach the engine (ADR-0002)
+ * — `dispatch` only ever runs the commands the engine understands.
+ */
+export type SeatCommandType = Exclude<ClientCommandType, "sitOut" | "sitIn">;
+
+const TABLE_ONLY_COMMANDS: ReadonlySet<SeatCommandType> = new Set([
   "startHand",
   "nextHand",
 ]);
@@ -68,18 +102,84 @@ function makeSeats(): Seat[] {
     token: null,
     sittingOut: false,
     disconnected: false,
+    missedHands: 0,
   }));
 }
 
+/** Seats eligible for the next deal-in: claimed, connected, not voluntarily sitting out. */
+function eligibleSeats(room: Room): SeatId[] {
+  return room.seats
+    .filter((seat) => seat.claimed && !seat.disconnected && !seat.sittingOut)
+    .map((seat) => seat.id);
+}
+
 /**
- * True once the room's first hand has ever started. `nextHand` reuses the
- * same `EngineState` for the room's whole life (its `seats` are fixed at
- * creation, per `createInitialState`), so there's no later point at which a
- * seat that missed the deal-in is automatically un-sat-out — that's future
- * scope, not this ticket's.
+ * Runs the ADR-0002 hand-boundary bookkeeping before a `nextHand` deal-in is
+ * computed: every still-claimed, still-disconnected, not-sitting-out seat
+ * just missed the hand about to start, so its counter advances; a seat that
+ * reaches `EVICTION_THRESHOLD` is freed back into the join picker instead.
+ * Returns the seat ids evicted this call, for the caller to broadcast.
  */
-function isHandInProgress(room: Room): boolean {
-  return room.engine !== null;
+function advanceMissedHandsAndEvict(room: Room): SeatId[] {
+  const evicted: SeatId[] = [];
+  for (const seat of room.seats) {
+    if (!seat.claimed || seat.sittingOut || !seat.disconnected) continue;
+
+    seat.missedHands += 1;
+    if (seat.missedHands >= EVICTION_THRESHOLD) {
+      freeSeat(seat);
+      evicted.push(seat.id);
+    }
+  }
+  return evicted;
+}
+
+/** Resets a seat to its unclaimed default — shared by `clearSeat` and eviction. */
+function freeSeat(seat: Seat): void {
+  seat.claimed = false;
+  seat.token = null;
+  seat.sittingOut = false;
+  seat.disconnected = false;
+  seat.missedHands = 0;
+}
+
+/**
+ * Whether `seatId` reads as "sitting out" to a client: a voluntary opt-out,
+ * or a claim that arrived after the room's current ring was fixed and
+ * hasn't been swept into a deal-in recompute yet (issue #13). Shared by
+ * `toRoomView` and any single-seat lookup that needs the same derivation.
+ */
+function isSittingOut(room: Room, seatId: SeatId): boolean {
+  const seat = room.seats[seatId];
+  if (!seat) return false;
+  const ring = room.engine?.seats;
+  return (
+    seat.sittingOut ||
+    (seat.claimed &&
+      !seat.disconnected &&
+      ring !== undefined &&
+      !ring.includes(seatId))
+  );
+}
+
+/**
+ * Carries the button forward into a freshly recomputed deal-in list: stays
+ * put if the previous button is still eligible, otherwise advances to the
+ * next eligible seat in physical (ascending id) order, wrapping around —
+ * the button skipping an empty/sitting-out/disconnected seat, same as at a
+ * real table.
+ */
+function resolveButtonFor(
+  previousButton: SeatId,
+  dealIn: readonly SeatId[],
+): SeatId {
+  if (dealIn.includes(previousButton)) return previousButton;
+  const ordered = [...dealIn].sort((a, b) => a - b);
+  const first = ordered[0];
+  if (first === undefined) {
+    throw new Error("resolveButtonFor requires a non-empty deal-in list");
+  }
+  return ordered.find((id) => id > previousButton) ?? first;
 }
 
 /** In-memory room registry, with the engine wired in behind `dispatch`. */
@@ -131,8 +231,9 @@ export class RoomStore {
 
     seat.claimed = true;
     seat.token = this.#generateToken();
-    seat.sittingOut = isHandInProgress(room);
+    seat.sittingOut = false;
     seat.disconnected = false;
+    seat.missedHands = 0;
     return { seat };
   }
 
@@ -141,17 +242,35 @@ export class RoomStore {
     const room = this.#rooms.get(code);
     const seat = room?.seats[seatId];
     if (!seat) return;
+    freeSeat(seat);
+  }
 
-    seat.claimed = false;
-    seat.token = null;
-    seat.sittingOut = false;
-    seat.disconnected = false;
+  /** Whether `seatId` reads as "sitting out" in the room's public view — see `isSittingOut`. */
+  isSittingOut(code: string, seatId: SeatId): boolean {
+    const room = this.#rooms.get(code);
+    return room ? isSittingOut(room, seatId) : false;
+  }
+
+  /**
+   * Voluntary seat-state toggle (ADR-0002), driven by the `sitOut`/`sitIn`
+   * commands. Never reaches the engine — a sitting-out seat is simply
+   * excluded the next time deal-in is recomputed, and never accrues
+   * `missedHands` regardless of how long it lasts, even if also
+   * disconnected the whole time.
+   */
+  setSittingOut(code: string, seatId: SeatId, sittingOut: boolean): void {
+    const room = this.#rooms.get(code);
+    const seat = room?.seats[seatId];
+    if (!seat?.claimed) return;
+    seat.sittingOut = sittingOut;
   }
 
   /**
    * Presence-only badge toggle (ticket 33 §7): missed pongs or a socket
-   * closing flip it on, a reconnect or fresh pong flips it off. Purely
-   * cosmetic — never read by `dispatch`, so it can never cause a fold.
+   * closing flip it on, a reconnect or fresh pong flips it off. Cosmetic to
+   * `dispatch`'s fold/check/call/raise legality, which never consults it —
+   * but ADR-0002 has it gate deal-in, so reconnecting also resets
+   * `missedHands` to 0 here, before any hand-boundary bookkeeping runs.
    */
   setSeatDisconnected(
     code: string,
@@ -161,6 +280,7 @@ export class RoomStore {
     const room = this.#rooms.get(code);
     const seat = room?.seats[seatId];
     if (!seat) return;
+    if (seat.disconnected && !disconnected) seat.missedHands = 0;
     seat.disconnected = disconnected;
   }
 
@@ -169,14 +289,16 @@ export class RoomStore {
    * socket. `identity` is derived server-side from the WS connection, never
    * from the message payload — see docs/phase-1-spec.md §6. `startHand` and
    * `nextHand` are table-only at this layer (the engine itself places no
-   * such restriction); everything else is seat-only. A room's first
-   * `startHand` builds its `EngineState` from the seats currently claimed
-   * and not sitting out — every other seat stays sitting out for that hand.
+   * such restriction); everything else is seat-only. Every `startHand`/
+   * `nextHand` recomputes deal-in from the seats currently claimed,
+   * connected, and not sitting out (ADR-0002) — `nextHand` additionally
+   * runs the missed-hands/eviction bookkeeping first, and carries the
+   * button forward into whatever that recompute leaves eligible.
    */
   dispatch(
     code: string,
     identity: SeatId | "table",
-    type: ClientCommandType,
+    type: SeatCommandType,
   ): DispatchResult {
     const room = this.#rooms.get(code);
     if (!room) return { error: "room-not-found" };
@@ -186,12 +308,25 @@ export class RoomStore {
       return { error: "not-permitted" };
     }
 
+    let evicted: readonly SeatId[] = [];
+
     if (type === "startHand" && room.engine === null) {
-      const dealIn = room.seats
-        .filter((seat) => seat.claimed && !seat.sittingOut)
-        .map((seat) => seat.id);
+      const dealIn = eligibleSeats(room);
       if (dealIn.length < 2) return { reason: "not-enough-players" };
       room.engine = createInitialState(dealIn);
+    } else if (type === "nextHand" && room.engine !== null) {
+      evicted = advanceMissedHandsAndEvict(room);
+      const dealIn = eligibleSeats(room);
+      if (dealIn.length < 2) {
+        return evicted.length > 0
+          ? { reason: "not-enough-players", evicted }
+          : { reason: "not-enough-players" };
+      }
+      room.engine = {
+        ...room.engine,
+        seats: dealIn,
+        button: resolveButtonFor(room.engine.button, dealIn),
+      };
     }
 
     if (room.engine === null) return { reason: "hand-not-in-progress" };
@@ -208,14 +343,7 @@ export class RoomStore {
     }
     room.engine = state;
 
-    if (type === "startHand") {
-      for (const seatId of room.engine.seats) {
-        const seat = room.seats[seatId];
-        if (seat) seat.sittingOut = false;
-      }
-    }
-
-    return { steps };
+    return evicted.length > 0 ? { steps, evicted } : { steps };
   }
 
   /**
@@ -224,7 +352,7 @@ export class RoomStore {
    * table isn't a seat, so there's no meaningful id to supply; `0` is an
    * arbitrary placeholder.
    */
-  #buildCommand(identity: SeatId | "table", type: ClientCommandType): Command {
+  #buildCommand(identity: SeatId | "table", type: SeatCommandType): Command {
     if (type === "startHand" || type === "nextHand") {
       return { type, playerId: 0, seed: this.#generateSeed() };
     }
@@ -239,7 +367,7 @@ export function toRoomView(room: Room): RoomView {
     seats: room.seats.map((seat) => ({
       id: seat.id,
       claimed: seat.claimed,
-      sittingOut: seat.sittingOut,
+      sittingOut: isSittingOut(room, seat.id),
       disconnected: seat.disconnected,
     })),
   };

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -238,7 +238,7 @@ export class RoomStore {
   ): void {
     const room = this.#rooms.get(code);
     const seat = room?.seats[seatId];
-    if (!seat) return;
+    if (!seat?.claimed) return;
     seat.disconnected = disconnected;
   }
 

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -15,9 +15,6 @@ import { generateRoomCode } from "./room-code.js";
 
 export const SEAT_COUNT = 8;
 
-/** Consecutive missed hands before a still-disconnected seat is evicted (ADR-0002). */
-const EVICTION_THRESHOLD = 3;
-
 /**
  * `Seat` and `Room` are `RoomStore`'s internal mutable aggregate state, not
  * wire DTOs — mutated in place by the store rather than replaced, unlike
@@ -31,19 +28,16 @@ export interface Seat {
   token: string | null;
   /**
    * Voluntary opt-out only (ADR-0002) — set solely by the `sitOut`/`sitIn`
-   * commands via `setSittingOut`. Excludes the seat from deal-in and, unlike
-   * `disconnected`, never accrues `missedHands` no matter how long it lasts.
+   * commands via `setSittingOut`. Excludes the seat from deal-in.
    */
   sittingOut: boolean;
   /**
    * Presence badge (ticket 33 §7): missed pongs or a closed socket flip it
-   * on, a reconnect flips it off. Beyond the cosmetic badge, ADR-0002 also
-   * has it gate deal-in and drive `missedHands` — `dispatch`'s own
-   * fold/check/call/raise legality still never consults it directly.
+   * on, a reconnect flips it off. Beyond the cosmetic badge, it also gates
+   * deal-in (ADR-0002) — `dispatch`'s own fold/check/call/raise legality
+   * still never consults it directly.
    */
   disconnected: boolean;
-  /** Consecutive hands skipped while disconnected (ADR-0002); reset to 0 on reconnect. */
-  missedHands: number;
 }
 
 export interface Room {
@@ -67,22 +61,9 @@ export interface DispatchStep {
 export type DispatchRejectionReason = RejectionReason | "not-enough-players";
 
 export type DispatchResult =
-  | {
-      readonly steps: readonly DispatchStep[];
-      /** Seats evicted (ADR-0002) as a side effect of this dispatch, if any. */
-      readonly evicted?: readonly SeatId[];
-    }
+  | { readonly steps: readonly DispatchStep[] }
   | { readonly error: "room-not-found" | "not-permitted" }
-  | {
-      readonly reason: DispatchRejectionReason;
-      /**
-       * A rejected `nextHand` can still have evicted seats: eviction runs
-       * before the eligible-seat-count check, so a `not-enough-players`
-       * rejection doesn't undo it (ADR-0002) — surfaced here so the caller
-       * still broadcasts the freed seats.
-       */
-      readonly evicted?: readonly SeatId[];
-    };
+  | { readonly reason: DispatchRejectionReason };
 
 /**
  * `sitOut`/`sitIn` are seat commands that never reach the engine (ADR-0002)
@@ -102,7 +83,6 @@ function makeSeats(): Seat[] {
     token: null,
     sittingOut: false,
     disconnected: false,
-    missedHands: 0,
   }));
 }
 
@@ -113,34 +93,12 @@ function eligibleSeats(room: Room): SeatId[] {
     .map((seat) => seat.id);
 }
 
-/**
- * Runs the ADR-0002 hand-boundary bookkeeping before a `nextHand` deal-in is
- * computed: every still-claimed, still-disconnected, not-sitting-out seat
- * just missed the hand about to start, so its counter advances; a seat that
- * reaches `EVICTION_THRESHOLD` is freed back into the join picker instead.
- * Returns the seat ids evicted this call, for the caller to broadcast.
- */
-function advanceMissedHandsAndEvict(room: Room): SeatId[] {
-  const evicted: SeatId[] = [];
-  for (const seat of room.seats) {
-    if (!seat.claimed || seat.sittingOut || !seat.disconnected) continue;
-
-    seat.missedHands += 1;
-    if (seat.missedHands >= EVICTION_THRESHOLD) {
-      freeSeat(seat);
-      evicted.push(seat.id);
-    }
-  }
-  return evicted;
-}
-
-/** Resets a seat to its unclaimed default — shared by `clearSeat` and eviction. */
+/** Resets a seat to its unclaimed default — used by the manual evict action. */
 function freeSeat(seat: Seat): void {
   seat.claimed = false;
   seat.token = null;
   seat.sittingOut = false;
   seat.disconnected = false;
-  seat.missedHands = 0;
 }
 
 /**
@@ -233,12 +191,16 @@ export class RoomStore {
     seat.token = this.#generateToken();
     seat.sittingOut = false;
     seat.disconnected = false;
-    seat.missedHands = 0;
     return { seat };
   }
 
-  /** Force-clears a claimed seat — used by the manual "clear seat" admin action. */
-  clearSeat(code: string, seatId: SeatId): void {
+  /**
+   * Frees any claimed seat — active, sitting-out, or disconnected alike —
+   * back into the join picker and invalidates its token. The table
+   * device's manual "evict" action (ADR-0003); there is no automatic
+   * trigger.
+   */
+  evictSeat(code: string, seatId: SeatId): void {
     const room = this.#rooms.get(code);
     const seat = room?.seats[seatId];
     if (!seat) return;
@@ -254,9 +216,7 @@ export class RoomStore {
   /**
    * Voluntary seat-state toggle (ADR-0002), driven by the `sitOut`/`sitIn`
    * commands. Never reaches the engine — a sitting-out seat is simply
-   * excluded the next time deal-in is recomputed, and never accrues
-   * `missedHands` regardless of how long it lasts, even if also
-   * disconnected the whole time.
+   * excluded the next time deal-in is recomputed.
    */
   setSittingOut(code: string, seatId: SeatId, sittingOut: boolean): void {
     const room = this.#rooms.get(code);
@@ -269,8 +229,7 @@ export class RoomStore {
    * Presence-only badge toggle (ticket 33 §7): missed pongs or a socket
    * closing flip it on, a reconnect or fresh pong flips it off. Cosmetic to
    * `dispatch`'s fold/check/call/raise legality, which never consults it —
-   * but ADR-0002 has it gate deal-in, so reconnecting also resets
-   * `missedHands` to 0 here, before any hand-boundary bookkeeping runs.
+   * but ADR-0002 has it gate deal-in.
    */
   setSeatDisconnected(
     code: string,
@@ -280,7 +239,6 @@ export class RoomStore {
     const room = this.#rooms.get(code);
     const seat = room?.seats[seatId];
     if (!seat) return;
-    if (seat.disconnected && !disconnected) seat.missedHands = 0;
     seat.disconnected = disconnected;
   }
 
@@ -291,9 +249,8 @@ export class RoomStore {
    * `nextHand` are table-only at this layer (the engine itself places no
    * such restriction); everything else is seat-only. Every `startHand`/
    * `nextHand` recomputes deal-in from the seats currently claimed,
-   * connected, and not sitting out (ADR-0002) — `nextHand` additionally
-   * runs the missed-hands/eviction bookkeeping first, and carries the
-   * button forward into whatever that recompute leaves eligible.
+   * connected, and not sitting out (ADR-0002), carrying the button forward
+   * into whatever that recompute leaves eligible.
    */
   dispatch(
     code: string,
@@ -308,20 +265,13 @@ export class RoomStore {
       return { error: "not-permitted" };
     }
 
-    let evicted: readonly SeatId[] = [];
-
     if (type === "startHand" && room.engine === null) {
       const dealIn = eligibleSeats(room);
       if (dealIn.length < 2) return { reason: "not-enough-players" };
       room.engine = createInitialState(dealIn);
     } else if (type === "nextHand" && room.engine !== null) {
-      evicted = advanceMissedHandsAndEvict(room);
       const dealIn = eligibleSeats(room);
-      if (dealIn.length < 2) {
-        return evicted.length > 0
-          ? { reason: "not-enough-players", evicted }
-          : { reason: "not-enough-players" };
-      }
+      if (dealIn.length < 2) return { reason: "not-enough-players" };
       room.engine = {
         ...room.engine,
         seats: dealIn,
@@ -343,7 +293,7 @@ export class RoomStore {
     }
     room.engine = state;
 
-    return evicted.length > 0 ? { steps, evicted } : { steps };
+    return { steps };
   }
 
   /**

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -1,10 +1,11 @@
 import { PillButton, color } from "@table-top-poker/ui-shared";
 import { useCallback, useState } from "react";
-import { createRoom, endSession } from "./api/rooms.js";
+import { createRoom, endSession, evictSeat } from "./api/rooms.js";
 import { Board } from "./Board.js";
 import { isHandComplete } from "./handComplete.js";
 import { JoinCodeToggle } from "./JoinCodeToggle.js";
 import { JoinPanel } from "./JoinPanel.js";
+import { SeatMenu } from "./SeatMenu.js";
 import { Seats } from "./Seats.js";
 import { StatusBar } from "./StatusBar.js";
 import { TableControls } from "./TableControls.js";
@@ -25,6 +26,21 @@ export function App() {
   const toggleJoin = useCallback(() => {
     setJoinOpen((open) => !open);
   }, []);
+
+  const [menuSeatId, setMenuSeatId] = useState<number | null>(null);
+  const handleSeatClick = useCallback((seatId: number) => {
+    setMenuSeatId((current) => (current === seatId ? null : seatId));
+  }, []);
+  const dismissSeatMenu = useCallback(() => {
+    setMenuSeatId(null);
+  }, []);
+  const handleEvictSeat = useCallback(() => {
+    if (roomCode === null || menuSeatId === null) return;
+    evictSeat(roomCode, menuSeatId).catch((error: unknown) => {
+      console.error(error);
+    });
+    setMenuSeatId(null);
+  }, [roomCode, menuSeatId]);
 
   const { send } = useWebSocket(roomCode, {
     onRoomEnded: clearRoom,
@@ -89,7 +105,19 @@ export function App() {
                 "inset 0 0 12em 4em rgba(0,0,0,.62), inset 0 2px 0 rgba(255,255,255,.08)",
             }}
           >
-            <Seats seats={seats} view={handView} />
+            <Seats
+              seats={seats}
+              view={handView}
+              onSeatClick={handleSeatClick}
+            />
+            {menuSeatId !== null && (
+              <SeatMenu
+                seatId={menuSeatId}
+                seatCount={seats.length}
+                onEvict={handleEvictSeat}
+                onDismiss={dismissSeatMenu}
+              />
+            )}
             {handView !== null && (
               <div
                 style={{

--- a/packages/table-client/src/SeatMenu.test.tsx
+++ b/packages/table-client/src/SeatMenu.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { SeatMenu } from "./SeatMenu.js";
+
+const noop = () => {
+  /* unused in these tests */
+};
+
+describe("SeatMenu", () => {
+  it("shows the seat number and an Evict action", () => {
+    const html = renderToStaticMarkup(
+      <SeatMenu seatId={2} seatCount={8} onEvict={noop} onDismiss={noop} />,
+    );
+    expect(html).toContain('data-testid="seat-menu-2"');
+    expect(html).toContain("Seat 3");
+    expect(html).toContain('data-testid="evict-seat-2-button"');
+    expect(html).toContain("Evict");
+  });
+
+  it("renders a full-screen backdrop for dismissal", () => {
+    const html = renderToStaticMarkup(
+      <SeatMenu seatId={0} seatCount={8} onEvict={noop} onDismiss={noop} />,
+    );
+    expect(html).toContain('data-testid="seat-menu-backdrop"');
+  });
+});

--- a/packages/table-client/src/SeatMenu.tsx
+++ b/packages/table-client/src/SeatMenu.tsx
@@ -1,0 +1,82 @@
+import {
+  Panel,
+  PillButton,
+  color,
+  font,
+  fontSize,
+} from "@table-top-poker/ui-shared";
+import { posFor } from "./table/posFor.js";
+
+export interface SeatMenuProps {
+  readonly seatId: number;
+  readonly seatCount: number;
+  readonly onEvict: () => void;
+  readonly onDismiss: () => void;
+}
+
+/**
+ * The table device's manual seat action (ADR-0003) — click a claimed seat,
+ * this pops up next to it with the one action currently available: Evict.
+ * A full-screen backdrop dismisses it without acting, same as the join
+ * panel's own dismiss pattern.
+ */
+export function SeatMenu({
+  seatId,
+  seatCount,
+  onEvict,
+  onDismiss,
+}: SeatMenuProps) {
+  const pos = posFor(seatId, seatCount);
+  const isTopRow = pos.top < 50;
+
+  return (
+    <>
+      <div
+        data-testid="seat-menu-backdrop"
+        onClick={onDismiss}
+        style={{ position: "absolute", inset: 0, zIndex: 9 }}
+      />
+      <Panel
+        data-testid={`seat-menu-${String(seatId)}`}
+        style={{
+          position: "absolute",
+          left: `${String(pos.left)}%`,
+          top: `${String(isTopRow ? pos.top + 16 : pos.top - 16)}%`,
+          transform: "translate(-50%, -50%)",
+          padding: "0.7em",
+          display: "flex",
+          flexDirection: "column",
+          gap: "0.5em",
+          zIndex: 10,
+        }}
+      >
+        <div
+          style={{
+            fontFamily: font.mono,
+            fontSize: fontSize.xs,
+            letterSpacing: "0.1em",
+            textTransform: "uppercase",
+            color: color.textMuted,
+            padding: "0 0.2em",
+          }}
+        >
+          Seat {seatId + 1}
+        </div>
+        <PillButton
+          data-testid={`evict-seat-${String(seatId)}-button`}
+          tone="outline"
+          onClick={onEvict}
+          style={{
+            padding: "10px 20px",
+            fontSize: fontSize.xs,
+            color: color.accentBright,
+            borderColor: color.lossBorder,
+            background: color.lossBackground,
+          }}
+        >
+          Evict
+        </PillButton>
+      </Panel>
+    </>
+  );
+}

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -137,4 +137,16 @@ describe("Seats", () => {
     expect(html).toMatch(/data-testid="seat-pod-0"[^>]*data-winner="false"/);
     expect(html).not.toContain("hole-cards");
   });
+
+  it("marks only claimed seats as clickable when onSeatClick is provided (ADR-0003)", () => {
+    const html = renderToStaticMarkup(
+      <Seats seats={seats} view={null} onSeatClick={() => undefined} />,
+    );
+    expect(html).toMatch(
+      /data-testid="seat-pod-0"[^>]*style="[^"]*cursor:pointer/,
+    );
+    expect(html).toMatch(
+      /data-testid="seat-pod-3"[^>]*style="(?:(?!cursor).)*"/,
+    );
+  });
 });

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -10,6 +10,8 @@ import { posFor } from "./table/posFor.js";
 export interface SeatsProps {
   readonly seats: readonly SeatView[];
   readonly view: TableView | null;
+  /** Called with a claimed seat's id when its pod is clicked — table-only, see ADR-0003. */
+  readonly onSeatClick?: (seatId: number) => void;
 }
 
 type SeatStatus = "open" | "sitting-out" | "folded" | "in-hand";
@@ -90,7 +92,7 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
  * is the only place `seats` and the in-progress `view` are merged into a
  * single per-seat picture — `Board` only ever renders the centre content.
  */
-export function Seats({ seats, view }: SeatsProps) {
+export function Seats({ seats, view, onSeatClick }: SeatsProps) {
   return (
     <div data-testid="seats" style={{ position: "absolute", inset: 0 }}>
       {seats.map((seat) => {
@@ -207,6 +209,13 @@ export function Seats({ seats, view }: SeatsProps) {
             data-turn={visual.isActor}
             data-winner={visual.isWinner}
             data-disconnected={seat.disconnected}
+            onClick={
+              seat.claimed && onSeatClick
+                ? () => {
+                    onSeatClick(seat.id);
+                  }
+                : undefined
+            }
             style={{
               position: "absolute",
               left: `${String(pos.left)}%`,
@@ -216,6 +225,7 @@ export function Seats({ seats, view }: SeatsProps) {
               flexDirection: "column",
               alignItems: "center",
               gap: "0.5em",
+              cursor: seat.claimed && onSeatClick ? "pointer" : undefined,
             }}
           >
             <motion.div

--- a/packages/table-client/src/api/rooms.ts
+++ b/packages/table-client/src/api/rooms.ts
@@ -18,3 +18,13 @@ export async function endSession(code: string): Promise<void> {
     throw new Error(`failed to end session: ${String(response.status)}`);
   }
 }
+
+/** The table device's manual evict action (ADR-0003) — no automatic trigger. */
+export async function evictSeat(code: string, seatId: number): Promise<void> {
+  const response = await fetch(`/rooms/${code}/seats/${String(seatId)}/evict`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    throw new Error(`failed to evict seat: ${String(response.status)}`);
+  }
+}


### PR DESCRIPTION
## Summary

- ADR-0002 resolves #56's original open questions.
- ADR-0003 supersedes ADR-0002's eviction trigger: eviction is a manual table action — click a claimed seat and select Evict.
- Server: POST /rooms/:code/seats/:seatId/evict frees the seat, invalidates its token, broadcasts the freed seat, and notifies/closes every socket belonging to that seat.
- Player client: handles the player-evicted message, clears the stored seat token, returns to seat selection, and shows the prominent message You have been evicted from the room.
- Table client: clicking a claimed seat opens the SeatMenu with the Evict action.

## Test plan

- [x] Server regression test verifies eviction sends player-evicted, closes the player socket, broadcasts the freed seat, and allows the seat to be reclaimed.
- [x] Player-client regression test verifies the eviction message is rendered with prominent typography.
- [x] packages/server rooms and eviction tests pass.
- [x] TypeScript build, targeted ESLint, Prettier, and diff checks pass.
- [x] The pre-existing reconnection timing failure was reproduced on an unchanged main worktree and is unrelated to this follow-up.

Follow-up implementation: 6a37bda.