### PR TITLE
chore(table,player): expose dev servers on the tailnet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ build/
 coverage/
 *.tsbuildinfo
 .DS_Store
+
+# Local env overrides (e.g. DEV_ALLOWED_HOSTS)
+.env.local
+.env.*.local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,3 +33,12 @@ The five canonical triage roles, each using its default label string (`needs-tri
 ### Domain docs
 
 Single-context: one `CONTEXT.md` and one `docs/adr/` at the repo root, both created lazily. See `docs/agents/domain.md`.
+
+# Claude for Chrome
+
+- Never invoke unless explicitly asked by the human.
+- Use `read_page` to get element refs from the accessibility tree
+- Use `find` to locate elements by description
+- Click/interact using `ref`, not coordinates
+- NEVER take screenshots unless explicitly requested by the user
+

--- a/packages/player-client/vite.config.ts
+++ b/packages/player-client/vite.config.ts
@@ -1,19 +1,34 @@
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 
-export default defineConfig({
-  plugins: [react()],
-  build: {
-    outDir: "build",
-  },
-  server: {
-    port: 5174,
-    proxy: {
-      "/ws": {
-        target: "ws://localhost:3000",
-        ws: true,
-      },
-      "/rooms": "http://localhost:3000",
+// Hostnames the dev server may be reached by, comma separated. Set it to open
+// the client from another device (e.g. a tailnet name); unset keeps the dev
+// server bound to localhost.
+const repoRoot = new URL("../..", import.meta.url).pathname;
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, repoRoot, "");
+  const allowedHosts = (env.DEV_ALLOWED_HOSTS ?? "")
+    .split(",")
+    .map((host) => host.trim())
+    .filter(Boolean);
+
+  return {
+    plugins: [react()],
+    build: {
+      outDir: "build",
     },
-  },
+    server: {
+      port: 5174,
+      host: allowedHosts.length > 0,
+      allowedHosts,
+      proxy: {
+        "/ws": {
+          target: "ws://localhost:3000",
+          ws: true,
+        },
+        "/rooms": "http://localhost:3000",
+      },
+    },
+  };
 });

--- a/packages/table-client/vite.config.ts
+++ b/packages/table-client/vite.config.ts
@@ -1,19 +1,34 @@
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 
-export default defineConfig({
-  plugins: [react()],
-  build: {
-    outDir: "build",
-  },
-  server: {
-    port: 5173,
-    proxy: {
-      "/ws": {
-        target: "ws://localhost:3000",
-        ws: true,
-      },
-      "/rooms": "http://localhost:3000",
+// Hostnames the dev server may be reached by, comma separated. Set it to open
+// the client from another device (e.g. a tailnet name); unset keeps the dev
+// server bound to localhost.
+const repoRoot = new URL("../..", import.meta.url).pathname;
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, repoRoot, "");
+  const allowedHosts = (env.DEV_ALLOWED_HOSTS ?? "")
+    .split(",")
+    .map((host) => host.trim())
+    .filter(Boolean);
+
+  return {
+    plugins: [react()],
+    build: {
+      outDir: "build",
     },
-  },
+    server: {
+      port: 5173,
+      host: allowedHosts.length > 0,
+      allowedHosts,
+      proxy: {
+        "/ws": {
+          target: "ws://localhost:3000",
+          ws: true,
+        },
+        "/rooms": "http://localhost:3000",
+      },
+    },
+  };
 });


### PR DESCRIPTION
Lets the table and player clients be opened from another device (a phone, a tablet) during development, instead of only from the machine running Vite.

## What changed

Both dev servers read a `DEV_ALLOWED_HOSTS` environment variable — a comma-separated list of hostnames the server may be reached by. It is loaded with Vite's `loadEnv` from the repo root, so a single gitignored `.env.local` configures both clients:

```
DEV_ALLOWED_HOSTS=my-machine.example.ts.net
```

`server.host` is tied to the same variable (`host: allowedHosts.length > 0`), so there is one switch rather than two:

- **unset** — the dev server binds to localhost only, unchanged from today. This is what a fresh clone gets.
- **set** — it binds to all interfaces and accepts the listed hostnames.

No hostname is committed; `.env.local` is added to `.gitignore`.

## Why the host allowlist is needed

Vite rejects requests whose `Host` header it does not recognise (`Blocked request. This host … is not allowed`). Raw IPs are always permitted, so `http://<ip>:5173` worked already — it is reaching the server by name that needs the allowlist.

## Verification

Exercised both paths against a real remote device:

- with the variable set, `:5173` and `:5174` both return 200 for a request carrying the configured hostname;
- with it unset, localhost returns 200 and the non-loopback address refuses the connection.

The server on `:3000` is untouched and stays on loopback — the clients reach it through the existing Vite proxy.

Also records the repo's Claude for Chrome usage rules in `CLAUDE.md`, in a second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177qhfGw1T3Grrh9CVqzKBz