### PR TITLE
fix(server): persist hand logs and repair release harness

### DIFF
--- a/deploy/poker.env.example
+++ b/deploy/poker.env.example
@@ -11,3 +11,7 @@ HOST=0.0.0.0
 # the URL, but requires uncommenting the AmbientCapabilities lines in
 # poker.service.
 PORT=3000
+
+# Append-as-you-go command/event logs for completed and in-progress hands.
+# The service unit grants poker write access to this state directory.
+HAND_LOG_DIR=/var/lib/poker/hands

--- a/deploy/poker.service
+++ b/deploy/poker.service
@@ -15,6 +15,9 @@ User=poker
 Group=poker
 WorkingDirectory=/opt/poker/current
 EnvironmentFile=/etc/poker/poker.env
+# Keep hand logs outside versioned releases; an EnvironmentFile value can
+# override this default for a different persistent volume.
+Environment=HAND_LOG_DIR=/var/lib/poker/hands
 ExecStart=/usr/local/bin/node /opt/poker/current/packages/server/dist/server.js
 Restart=always
 RestartSec=2
@@ -28,6 +31,8 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
+StateDirectory=poker
+ReadWritePaths=/var/lib/poker
 
 # journald picks up stdout/stderr automatically.
 StandardOutput=journal

--- a/docs/deploy-pi.md
+++ b/docs/deploy-pi.md
@@ -54,11 +54,13 @@ source checkout or the development machine's workspace layout.
    fi
    sudo install -d -o poker -g poker -m 0755 /opt/poker
    sudo install -d -o "$USER" -g poker -m 0770 /opt/poker/releases
+   sudo install -d -o poker -g poker -m 0750 /var/lib/poker/hands
    sudo install -d -o poker -g poker -m 0750 /etc/poker
    ```
 
-5. Copy `deploy/poker.env.example` to `/etc/poker/poker.env`, set `HOST`/`PORT`, then
-   run `sudo chown poker:poker /etc/poker/poker.env && sudo chmod 600 /etc/poker/poker.env`.
+5. Copy `deploy/poker.env.example` to `/etc/poker/poker.env`, set `HOST`/`PORT` and
+   `HAND_LOG_DIR`, then run
+   `sudo chown poker:poker /etc/poker/poker.env && sudo chmod 600 /etc/poker/poker.env`.
 
 ## Getting code onto the Pi
 
@@ -74,6 +76,11 @@ ssh pi-host "sudo chown -R poker:poker '$RELEASE' && sudo ln -sfn '$RELEASE' /op
 The release contains the server's compiled output, both client bundles, `package.json`, and
 a dereferenced runtime `node_modules`. No workspace package symlinks point back to the
 development checkout.
+
+When `poker.service` is installed, completed and in-progress hands are logged under
+`/var/lib/poker/hands/<room-code>/` as `game.jsonl`, `hand-NNNN.commands.jsonl`, and
+`hand-NNNN.events.jsonl`. The command file is the replay input; the event file is the
+version-tagged audit stream.
 
 ## systemd
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "workspaces": [
         "packages/engine",
+        "packages/persistence",
         "packages/harness",
         "packages/protocol",
         "packages/server",
@@ -829,6 +830,10 @@
     },
     "node_modules/@table-top-poker/harness": {
       "resolved": "packages/harness",
+      "link": true
+    },
+    "node_modules/@table-top-poker/persistence": {
+      "resolved": "packages/persistence",
       "link": true
     },
     "node_modules/@table-top-poker/player-client": {
@@ -4055,10 +4060,18 @@
       "name": "@table-top-poker/harness",
       "version": "0.0.0",
       "dependencies": {
-        "@table-top-poker/engine": "*"
+        "@table-top-poker/engine": "*",
+        "@table-top-poker/persistence": "*"
       },
       "bin": {
         "harness": "dist/cli.js"
+      }
+    },
+    "packages/persistence": {
+      "name": "@table-top-poker/persistence",
+      "version": "0.0.0",
+      "dependencies": {
+        "@table-top-poker/engine": "*"
       }
     },
     "packages/player-client": {
@@ -4094,6 +4107,7 @@
       "dependencies": {
         "@fastify/static": "^10.1.2",
         "@fastify/websocket": "^11.3.0",
+        "@table-top-poker/persistence": "*",
         "@table-top-poker/protocol": "*",
         "fastify": "^5.10.0",
         "qrcode": "^1.5.4"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "workspaces": [
     "packages/engine",
+    "packages/persistence",
     "packages/harness",
     "packages/protocol",
     "packages/server",

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@table-top-poker/engine": "*"
+    "@table-top-poker/engine": "*",
+    "@table-top-poker/persistence": "*"
   }
 }

--- a/packages/harness/src/persistence.ts
+++ b/packages/harness/src/persistence.ts
@@ -1,94 +1,11 @@
-import { appendFileSync, existsSync, mkdirSync } from "node:fs";
-import path from "node:path";
-import { ENGINE_LOG_VERSION } from "@table-top-poker/engine";
-import type {
-  Command,
-  HandEvent,
-  Rejection,
-  SeatId,
-} from "@table-top-poker/engine";
-
-const GAME_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
-
-export function assertValidGameId(gameId: string): void {
-  if (!GAME_ID_PATTERN.test(gameId)) {
-    throw new Error(
-      `--game-id: "${gameId}" must match ${GAME_ID_PATTERN.source} (it becomes a directory name)`,
-    );
-  }
-}
-
-/** A logged command line is the bare `Command` plus a version tag — the exact shape the harness reads on stdin, so a logged file re-pipes through it unmodified. */
-export type LoggedCommand = Command & { readonly v: number };
-
-/** A logged event line is the bare `HandEvent`/`Rejection` plus a version tag — the exact shape the harness writes on stdout. */
-export type LoggedEvent = (HandEvent | Rejection) & { readonly v: number };
-
-export interface GameManifest {
-  readonly v: number;
-  readonly seats: readonly SeatId[];
-}
-
-export interface HandLogPaths {
-  readonly commandsPath: string;
-  readonly eventsPath: string;
-}
-
-function handBase(handIndex: number): string {
-  return `hand-${String(handIndex).padStart(4, "0")}`;
-}
-
-export function handLogPaths(gameDir: string, handIndex: number): HandLogPaths {
-  const base = handBase(handIndex);
-  return {
-    commandsPath: path.join(gameDir, `${base}.commands.jsonl`),
-    eventsPath: path.join(gameDir, `${base}.events.jsonl`),
-  };
-}
-
-/**
- * Append-as-you-go JSONL logger for one game: a seats manifest written once,
- * plus a command/event log file pair per hand, partitioned by game and by
- * hand as required by docs/phase-1-spec.md §5. Every write is a single
- * synchronous fs call — no in-process buffering — so a killed process loses
- * at most the record it was mid-write on, never a batch of completed ones.
- *
- * A command/event received before the first `startHand`/`nextHand` belongs
- * to no hand yet, so it isn't logged — there's nothing to partition it
- * into.
- */
-export class HandLog {
-  readonly gameDir: string;
-  #handIndex = 0;
-  #paths: HandLogPaths | null = null;
-
-  constructor(logDir: string, gameId: string, seats: readonly SeatId[]) {
-    assertValidGameId(gameId);
-    this.gameDir = path.join(logDir, gameId);
-    mkdirSync(this.gameDir, { recursive: true });
-
-    const manifestPath = path.join(this.gameDir, "game.jsonl");
-    if (!existsSync(manifestPath)) {
-      const manifest: GameManifest = { v: ENGINE_LOG_VERSION, seats };
-      appendFileSync(manifestPath, JSON.stringify(manifest) + "\n");
-    }
-  }
-
-  logCommand(command: Command): void {
-    if (command.type === "startHand" || command.type === "nextHand") {
-      this.#handIndex += 1;
-      this.#paths = handLogPaths(this.gameDir, this.#handIndex);
-    }
-    if (this.#paths === null) return;
-
-    const record: LoggedCommand = { ...command, v: ENGINE_LOG_VERSION };
-    appendFileSync(this.#paths.commandsPath, JSON.stringify(record) + "\n");
-  }
-
-  logEvent(event: HandEvent | Rejection): void {
-    if (this.#paths === null) return;
-
-    const record: LoggedEvent = { ...event, v: ENGINE_LOG_VERSION };
-    appendFileSync(this.#paths.eventsPath, JSON.stringify(record) + "\n");
-  }
-}
+export {
+  assertValidGameId,
+  HandLog,
+  handLogPaths,
+} from "@table-top-poker/persistence";
+export type {
+  GameManifest,
+  HandLogPaths,
+  LoggedCommand,
+  LoggedEvent,
+} from "@table-top-poker/persistence";

--- a/packages/persistence/package.json
+++ b/packages/persistence/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@table-top-poker/persistence",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --build"
+  },
+  "dependencies": {
+    "@table-top-poker/engine": "*"
+  }
+}

--- a/packages/persistence/src/index.ts
+++ b/packages/persistence/src/index.ts
@@ -1,0 +1,7 @@
+export { assertValidGameId, HandLog, handLogPaths } from "./persistence.js";
+export type {
+  GameManifest,
+  HandLogPaths,
+  LoggedCommand,
+  LoggedEvent,
+} from "./persistence.js";

--- a/packages/persistence/src/persistence.ts
+++ b/packages/persistence/src/persistence.ts
@@ -1,0 +1,92 @@
+import { appendFileSync, existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { ENGINE_LOG_VERSION } from "@table-top-poker/engine";
+import type {
+  Command,
+  HandEvent,
+  Rejection,
+  SeatId,
+} from "@table-top-poker/engine";
+
+const GAME_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
+
+export function assertValidGameId(gameId: string): void {
+  if (!GAME_ID_PATTERN.test(gameId)) {
+    throw new Error(
+      `--game-id: "${gameId}" must match ${GAME_ID_PATTERN.source} (it becomes a directory name)`,
+    );
+  }
+}
+
+/** A logged command line is the bare `Command` plus a version tag. */
+export type LoggedCommand = Command & { readonly v: number };
+
+/** A logged event line is the bare `HandEvent`/`Rejection` plus a version tag. */
+export type LoggedEvent = (HandEvent | Rejection) & { readonly v: number };
+
+export interface GameManifest {
+  readonly v: number;
+  readonly seats: readonly SeatId[];
+}
+
+export interface HandLogPaths {
+  readonly commandsPath: string;
+  readonly eventsPath: string;
+}
+
+function handBase(handIndex: number): string {
+  return `hand-${String(handIndex).padStart(4, "0")}`;
+}
+
+export function handLogPaths(gameDir: string, handIndex: number): HandLogPaths {
+  const base = handBase(handIndex);
+  return {
+    commandsPath: path.join(gameDir, `${base}.commands.jsonl`),
+    eventsPath: path.join(gameDir, `${base}.events.jsonl`),
+  };
+}
+
+/**
+ * Append-as-you-go JSONL logger for one game: a seats manifest written once,
+ * plus a command/event log file pair per hand. Every write is a single
+ * synchronous fs call, so a killed process loses at most the record it was
+ * mid-write on, never a batch of completed records.
+ */
+export class HandLog {
+  readonly gameDir: string;
+  #handIndex = 0;
+  #paths: HandLogPaths | null = null;
+
+  constructor(logDir: string, gameId: string, seats: readonly SeatId[]) {
+    assertValidGameId(gameId);
+    this.gameDir = path.join(logDir, gameId);
+    mkdirSync(this.gameDir, { recursive: true });
+
+    const manifestPath = path.join(this.gameDir, "game.jsonl");
+    if (!existsSync(manifestPath)) {
+      const manifest: GameManifest = { v: ENGINE_LOG_VERSION, seats };
+      appendFileSync(manifestPath, JSON.stringify(manifest) + "\n");
+    }
+  }
+
+  logCommand(
+    command: Command,
+    startsHand = command.type === "startHand" || command.type === "nextHand",
+  ): void {
+    if (startsHand) {
+      this.#handIndex += 1;
+      this.#paths = handLogPaths(this.gameDir, this.#handIndex);
+    }
+    if (this.#paths === null) return;
+
+    const record: LoggedCommand = { ...command, v: ENGINE_LOG_VERSION };
+    appendFileSync(this.#paths.commandsPath, JSON.stringify(record) + "\n");
+  }
+
+  logEvent(event: HandEvent | Rejection): void {
+    if (this.#paths === null) return;
+
+    const record: LoggedEvent = { ...event, v: ENGINE_LOG_VERSION };
+    appendFileSync(this.#paths.eventsPath, JSON.stringify(record) + "\n");
+  }
+}

--- a/packages/persistence/tsconfig.json
+++ b/packages/persistence/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "references": [{ "path": "../engine" }, { "path": "../persistence" }]
+  "references": [{ "path": "../engine" }]
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@fastify/static": "^10.1.2",
     "@fastify/websocket": "^11.3.0",
+    "@table-top-poker/persistence": "*",
     "@table-top-poker/protocol": "*",
     "fastify": "^5.10.0",
     "qrcode": "^1.5.4"

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -6,7 +6,15 @@ import {
   type ServerMessage,
 } from "@table-top-poker/protocol";
 import type { FastifyInstance } from "fastify";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import WebSocket from "ws";
@@ -1242,6 +1250,133 @@ describe("hand command dispatch over WebSocket", () => {
     expect(table.messages).not.toContainEqual(
       expect.objectContaining({ type: "command-rejected" }),
     );
+  });
+});
+
+describe("hand persistence", () => {
+  it("writes a completed hand's commands and events as replayable JSONL", async () => {
+    const handLogDir = mkdtempSync(path.join(tmpdir(), "server-hands-"));
+    const rooms = new RoomStore();
+    const app = await buildApp({ rooms, handLogDir });
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected a bound TCP address");
+    }
+
+    const room = rooms.create(2);
+    const table = new WebSocket(
+      `ws://127.0.0.1:${String(address.port)}/ws?room=${room.code}&role=table`,
+    );
+    const seat0Claim = rooms.claimSeat(room.code, 0);
+    const seat1Claim = rooms.claimSeat(room.code, 1);
+    if (!("seat" in seat0Claim) || !("seat" in seat1Claim)) {
+      throw new Error("expected both seats to be claimed");
+    }
+    const seat1 = new WebSocket(
+      `ws://127.0.0.1:${String(address.port)}/ws?room=${room.code}&seat=1&token=${seat1Claim.seat.token ?? ""}`,
+    );
+    const seat0 = new WebSocket(
+      `ws://127.0.0.1:${String(address.port)}/ws?room=${room.code}&seat=0&token=${seat0Claim.seat.token ?? ""}`,
+    );
+    const tableMessages: ServerMessage[] = [];
+    const seat1Messages: ServerMessage[] = [];
+    table.on("message", (data: Buffer) => {
+      tableMessages.push(JSON.parse(data.toString()) as ServerMessage);
+    });
+    seat1.on("message", (data: Buffer) => {
+      seat1Messages.push(JSON.parse(data.toString()) as ServerMessage);
+    });
+
+    async function waitForEvent(eventType: string): Promise<void> {
+      for (let attempt = 0; attempt < 100; attempt++) {
+        if (
+          tableMessages.some(
+            (message) =>
+              message.type === "hand-update" &&
+              message.event.type === eventType,
+          )
+        ) {
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      throw new Error(`timed out waiting for ${eventType}`);
+    }
+
+    async function waitForRejection(): Promise<void> {
+      for (let attempt = 0; attempt < 100; attempt++) {
+        if (
+          seat1Messages.some((message) => message.type === "command-rejected")
+        ) {
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      throw new Error("timed out waiting for command rejection");
+    }
+
+    try {
+      await Promise.all(
+        [table, seat0, seat1].map(
+          (socket) =>
+            new Promise<void>((resolve, reject) => {
+              socket.once("open", () => {
+                resolve();
+              });
+              socket.once("error", reject);
+            }),
+        ),
+      );
+
+      table.send(JSON.stringify({ type: "startHand" }));
+      await waitForEvent("StreetStarted");
+      seat1.send(JSON.stringify({ type: "fold" }));
+      await waitForRejection();
+      seat0.send(JSON.stringify({ type: "fold" }));
+      await waitForEvent("HandComplete");
+
+      const gameDir = path.join(handLogDir, room.code);
+      const commandsPath = path.join(gameDir, "hand-0001.commands.jsonl");
+      const eventsPath = path.join(gameDir, "hand-0001.events.jsonl");
+      const readJsonLines = (filePath: string): unknown[] =>
+        readFileSync(filePath, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line) as unknown);
+      const commands = readJsonLines(commandsPath) as {
+        type: string;
+        playerId: number;
+        seed?: string;
+        v: number;
+      }[];
+      const events = readJsonLines(eventsPath) as {
+        type: string;
+        seed?: string;
+        v: number;
+      }[];
+
+      expect(commands.map((command) => command.type)).toEqual([
+        "startHand",
+        "fold",
+        "fold",
+      ]);
+      expect(commands[0]?.type).toBe("startHand");
+      expect(commands[0]?.playerId).toBe(0);
+      expect(typeof commands[0]?.seed).toBe("string");
+      expect(Number.isInteger(commands[0]?.v)).toBe(true);
+      expect(events.at(-1)?.type).toBe("HandComplete");
+      expect(Number.isInteger(events.at(-1)?.v)).toBe(true);
+      expect(events.some((event) => event.type === "Rejection")).toBe(true);
+      expect(events[0]?.seed).toBe(commands[0]?.seed);
+      expect(events.every((event) => Number.isInteger(event.v))).toBe(true);
+    } finally {
+      table.close();
+      seat0.close();
+      seat1.close();
+      await app.close();
+      rmSync(handLogDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -13,6 +13,7 @@ import {
   type SeatMove,
   type ServerMessage,
 } from "@table-top-poker/protocol";
+import { HandLog } from "@table-top-poker/persistence";
 import Fastify, {
   type FastifyInstance,
   type FastifyReply,
@@ -25,7 +26,9 @@ import { ActionClock } from "./action-clock.js";
 import { joinUrl, roomQrCodeDataUrl } from "./qr.js";
 import {
   type ClaimSeatError,
+  type DispatchRejection,
   type DispatchStep,
+  type DispatchSuccess,
   type Room,
   RoomStore,
   toRoomView,
@@ -55,6 +58,8 @@ function readIndexOr(stagedPath: string): Buffer {
 
 export interface BuildAppOptions {
   readonly rooms?: RoomStore;
+  /** Root directory for append-as-you-go per-game hand logs. */
+  readonly handLogDir?: string;
   /** Overridable for tests only; production runs `ActionClock`'s 90s default. */
   readonly actionClockMs?: number;
   /** How often the server pings every open socket (docs/phase-1-spec.md §7). */
@@ -167,6 +172,7 @@ export async function buildApp(
   options: BuildAppOptions = {},
 ): Promise<FastifyInstance> {
   const rooms = options.rooms ?? new RoomStore();
+  const handLogs = new Map<string, HandLog>();
   const pingIntervalMs = options.pingIntervalMs ?? 10_000;
   const missedPongLimit = options.missedPongLimit ?? 2;
   const graceWindowMs = options.graceWindowMs ?? 60_000;
@@ -300,7 +306,36 @@ export async function buildApp(
       tableGraceTimers.delete(code);
     }
     actionClock.clear(code);
+    handLogs.delete(code);
     rooms.end(code);
+  }
+
+  /** Persists the exact engine command and resulting events for replay/audit. */
+  function logDispatch(
+    code: string,
+    result: DispatchRejection | DispatchSuccess,
+  ): void {
+    if (options.handLogDir === undefined) return;
+    if (result.command === undefined) return;
+    const room = rooms.get(code);
+    const seats = room?.engine?.seats;
+    if (room === undefined || seats === undefined) return;
+
+    let log = handLogs.get(code);
+    if (log === undefined) {
+      log = new HandLog(options.handLogDir, code, seats);
+      handLogs.set(code, log);
+    }
+    if ("steps" in result) {
+      const startsHand = result.steps.some(
+        (step) => step.event.type === "HandStarted",
+      );
+      log.logCommand(result.command, startsHand);
+      for (const step of result.steps) log.logEvent(step.event);
+    } else if (result.rejection !== undefined) {
+      log.logCommand(result.command, false);
+      log.logEvent(result.rejection);
+    }
   }
 
   const pingTimer = setInterval(() => {
@@ -668,6 +703,7 @@ export async function buildApp(
             return;
           }
           if ("reason" in dispatchResult) {
+            logDispatch(code, dispatchResult);
             sendRejection(socket, dispatchResult.reason);
             return;
           }
@@ -675,6 +711,7 @@ export async function buildApp(
           if (dispatchResult.seatMoves !== undefined) {
             applySeatMoves(code, dispatchResult.seatMoves);
           }
+          logDispatch(code, dispatchResult);
           for (const step of dispatchResult.steps) {
             fanOutHandUpdate(code, step);
           }

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -476,7 +476,11 @@ describe("RoomStore", () => {
 
       const foldResult = store.dispatch(room.code, 2, "fold");
 
-      expect(foldResult).toEqual({ reason: "not-your-turn" });
+      expect(foldResult).toMatchObject({
+        reason: "not-your-turn",
+        command: { type: "fold", playerId: 2 },
+        rejection: { type: "Rejection", reason: "not-your-turn" },
+      });
       expect(toRoomView(room).seats[2]).toMatchObject({ sittingOut: true });
     });
 
@@ -495,9 +499,23 @@ describe("RoomStore", () => {
       const room = roomWithClaimedSeats(store, 2);
       store.dispatch(room.code, "table", "startHand");
 
-      expect(store.dispatch(room.code, "table", "startHand")).toEqual({
+      const result = store.dispatch(room.code, "table", "startHand");
+      expect(result).toMatchObject({
         reason: "hand-already-in-progress",
+        command: {
+          type: "startHand",
+          playerId: 0,
+        },
+        rejection: {
+          type: "Rejection",
+          reason: "hand-already-in-progress",
+        },
       });
+      if (!("command" in result)) throw new Error("expected a command");
+      if (result.command.type !== "startHand") {
+        throw new Error("expected a startHand command");
+      }
+      expect(typeof result.command.seed).toBe("string");
     });
 
     it("rejects an out-of-turn fold", () => {
@@ -514,9 +532,13 @@ describe("RoomStore", () => {
       );
       if (!outOfTurnSeat) throw new Error("expected an out-of-turn seat");
 
-      expect(store.dispatch(room.code, outOfTurnSeat.id, "fold")).toEqual({
-        reason: "not-your-turn",
-      });
+      expect(store.dispatch(room.code, outOfTurnSeat.id, "fold")).toMatchObject(
+        {
+          reason: "not-your-turn",
+          command: { type: "fold", playerId: outOfTurnSeat.id },
+          rejection: { type: "Rejection", reason: "not-your-turn" },
+        },
+      );
     });
 
     /** Folds every actor in turn until only one live player remains (fold-out). */

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -13,6 +13,7 @@ import {
   type HandEvent,
   isHandComplete,
   isHandLive,
+  type Rejection,
   type RejectionReason,
   type RoomView,
   type SeatId,
@@ -78,13 +79,22 @@ export interface DispatchStep {
 
 export type DispatchRejectionReason = RejectionReason | "not-enough-players";
 
+export interface DispatchSuccess {
+  readonly command: Command;
+  readonly steps: readonly DispatchStep[];
+  readonly seatMoves?: readonly SeatMove[];
+}
+
+export interface DispatchRejection {
+  readonly reason: DispatchRejectionReason;
+  readonly command?: Command;
+  readonly rejection?: Rejection;
+}
+
 export type DispatchResult =
-  | {
-      readonly steps: readonly DispatchStep[];
-      readonly seatMoves?: readonly SeatMove[];
-    }
+  | DispatchSuccess
   | { readonly error: "room-not-found" | "not-permitted" }
-  | { readonly reason: DispatchRejectionReason };
+  | DispatchRejection;
 
 /**
  * `sitOut`/`sitIn` are seat commands that never reach the engine (ADR-0002)
@@ -500,7 +510,9 @@ export class RoomStore {
 
     const command = this.#buildCommand(identity, type);
     const result = decide(room.engine, command);
-    if (!Array.isArray(result)) return { reason: result.reason };
+    if (!Array.isArray(result)) {
+      return { reason: result.reason, command, rejection: result };
+    }
 
     const steps: DispatchStep[] = [];
     let state = room.engine;
@@ -510,7 +522,9 @@ export class RoomStore {
     }
     room.engine = state;
 
-    return seatMoves.length > 0 ? { steps, seatMoves } : { steps };
+    return seatMoves.length > 0
+      ? { command, steps, seatMoves }
+      : { command, steps };
   }
 
   /**

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,7 +1,8 @@
 import { buildApp } from "./app.js";
 
 async function main(): Promise<void> {
-  const app = await buildApp();
+  const handLogDir = process.env.HAND_LOG_DIR;
+  const app = await buildApp(handLogDir === undefined ? {} : { handLogDir });
   const port = Number(process.env.PORT ?? 3000);
   const host = process.env.HOST ?? "127.0.0.1";
   await app.listen({ port, host });

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "references": [{ "path": "../protocol" }]
+  "references": [{ "path": "../persistence" }, { "path": "../protocol" }]
 }

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -35,9 +35,19 @@ cp -a packages/server/dist packages/server/public packages/server/package.json "
 # npm workspaces represent local packages as symlinks. Dereference them so
 # the release does not depend on the source checkout existing on the Pi.
 rsync -aL node_modules/ "$release_dir/node_modules/"
+# `.bin` entries are symlinks to files beside the package entrypoint. The
+# dereferenced copy above turns them into standalone files, so their relative
+# imports resolve from `.bin` and fail. Restore the symlink directory after
+# copying the package contents.
+rm -rf "$release_dir/node_modules/.bin"
+rsync -a node_modules/.bin "$release_dir/node_modules/"
 
 echo "==> Verifying deployable runtime imports"
 node --input-type=module -e \
   'await import("./.release/packages/server/dist/app.js")'
+
+echo "==> Verifying the packaged harness entrypoint"
+cat "$release_dir/node_modules/@table-top-poker/harness/fixtures/hand-1.commands.jsonl" |
+  "$release_dir/node_modules/.bin/harness" >/dev/null
 
 echo "==> Release staged at .release/"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "packages/engine" },
+    { "path": "packages/persistence" },
     { "path": "packages/harness" },
     { "path": "packages/protocol" },
     { "path": "packages/server" },


### PR DESCRIPTION
## Summary

- persist each server-hand command and resulting event/rejection stream as versioned JSONL under the configured hand-log directory
- share the logger between the server and harness, preserving the generated seed and replay format
- configure the Pi service to keep logs in /var/lib/poker/hands with systemd-managed writable state
- preserve node_modules/.bin symlinks in release builds so the packaged harness runs on the Pi
- add end-to-end server persistence coverage for a completed hand and replay-relevant rejection records

## Verification

- npm run build
- npm test -w @table-top-poker/server (120 tests)
- npm test -w @table-top-poker/harness (26 tests)
- protocol, UI, client, and non-exhaustive engine suites pass
- npm run build:release
- npx eslint .
- scoped Prettier check

The root test command was not completed within 180 seconds because the existing exhaustive engine suite enumerates 133,784,560 seven-card hands; the changed packages and all non-exhaustive engine tests pass.

Fixes #35