### PR TITLE
fix(server): defer nextHand seat/button mutation until decide succeeds

### DIFF
--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -615,6 +615,23 @@ describe("RoomStore", () => {
           reason: "not-enough-players",
         });
       });
+
+      it("rejects nextHand as stale-next-hand while a hand is still live, leaving seats and button untouched", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 3);
+        store.dispatch(room.code, "table", "startHand");
+        store.setSeatDisconnected(room.code, 2, true);
+
+        const seatsBefore = room.engine?.seats;
+        const buttonBefore = room.engine?.button;
+
+        const result = store.dispatch(room.code, "table", "nextHand");
+
+        expect(result).toMatchObject({ reason: "stale-next-hand" });
+        expect(room.engine?.seats).toBe(seatsBefore);
+        expect(room.engine?.button).toBe(buttonBefore);
+        expect(room.engine?.hand?.status).toBe("betting");
+      });
     });
 
     describe("ADR-0003: manual eviction", () => {

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -484,10 +484,11 @@ export class RoomStore {
     }
 
     let seatMoves: readonly SeatMove[] = [];
+    let candidateEngine = room.engine;
     if (type === "startHand" && room.engine === null) {
       const dealIn = eligibleSeats(room);
       if (dealIn.length < 2) return { reason: "not-enough-players" };
-      room.engine = createInitialState(dealIn);
+      candidateEngine = createInitialState(dealIn);
     } else if (type === "nextHand" && room.engine !== null) {
       if (eligibleSeats(room).length < 2) {
         return { reason: "not-enough-players" };
@@ -499,23 +500,23 @@ export class RoomStore {
       seatMoves = repack.moves;
       const previousButton = remapSeatId(room.engine.button, repack.mapping);
       const dealIn = eligibleSeats(room);
-      room.engine = {
+      candidateEngine = {
         ...room.engine,
         seats: dealIn,
         button: resolveButtonFor(previousButton, dealIn),
       };
     }
 
-    if (room.engine === null) return { reason: "hand-not-in-progress" };
+    if (candidateEngine === null) return { reason: "hand-not-in-progress" };
 
     const command = this.#buildCommand(identity, type);
-    const result = decide(room.engine, command);
+    const result = decide(candidateEngine, command);
     if (!Array.isArray(result)) {
       return { reason: result.reason, command, rejection: result };
     }
 
     const steps: DispatchStep[] = [];
-    let state = room.engine;
+    let state = candidateEngine;
     for (const event of result) {
       state = apply(state, event);
       steps.push({ event, state });


### PR DESCRIPTION
## Summary
- `RoomStore.dispatch()` used to rewrite `room.engine.seats`/`.button` before calling `decide()`. A `nextHand` arriving while a hand is still live is rejected `stale-next-hand`, but the mutation had already landed and was never rolled back — a disconnected or sat-out seat would silently stop receiving `hand-update`/`view-snapshot` broadcasts for the rest of the live hand while still being on the clock, and the next hand's button placement would be corrupted.
- Fix: compute the candidate engine state in a local `candidateEngine` variable and only assign it to `room.engine` once `decide()` returns events on the success path, leaving `room.engine` untouched on rejection.
- Adds a regression test asserting a mid-hand `nextHand` is rejected `stale-next-hand` and that `room.engine.seats`/`.button` stay reference-identical to their pre-dispatch values.

Closes #95

## Test plan
- [x] `npx vitest run packages/server/src/rooms.test.ts` — 48/48 passing, including new regression test
- [x] `npm test` (full suite) — 389/389 passing
- [x] `npm run lint` — clean
- [x] Standards + spec review (via `/code-review`) — no findings on either axis