### PR TITLE
fix(table,ui-shared): land Phase 1 rail and pill fixes

### DIFF
--- a/packages/table-client/src/TableControls.tsx
+++ b/packages/table-client/src/TableControls.tsx
@@ -1,4 +1,4 @@
-import { PillButton } from "@table-top-poker/ui-shared";
+import { PillButton, color } from "@table-top-poker/ui-shared";
 
 export interface TableControlsProps {
   readonly canStartHand: boolean;
@@ -6,12 +6,26 @@ export interface TableControlsProps {
   readonly onStartHand: () => void;
   readonly onNextHand: () => void;
   readonly onEndSession: () => void;
+  /**
+   * PROTOTYPE (wayfinder #81) — opens the session hand picker. Optional so
+   * the live `App` is unaffected; Phase 2 makes it a peer of the other rail
+   * actions. Review is reachable exactly when this rail offers a Deal/Next
+   * hand button, i.e. between hands (map #79).
+   */
+  readonly onReviewHands?: () => void;
 }
 
 /**
- * The bottom-right control rail — Deal hand / Next hand are mutually
- * exclusive with the felt's hand state, End session is always available
- * once a room exists (this component is only mounted then).
+ * The right-hand control rail — every table action the device offers, as one
+ * group. Deal hand / Next hand are mutually exclusive with the felt's hand
+ * state; Review hands and End session are always available once a room exists
+ * (this component is only mounted then).
+ *
+ * The rail is a fixed-width column and every button fills it, so the actions
+ * share one left and right edge instead of ragging off the right margin at
+ * whatever width each label happens to be. Sizing comes from `PillButton`'s
+ * size token for all of them — an ad-hoc smaller `End session` made the rail
+ * read as two unrelated controls rather than one group.
  */
 export function TableControls({
   canStartHand,
@@ -19,6 +33,7 @@ export function TableControls({
   onStartHand,
   onNextHand,
   onEndSession,
+  onReviewHands,
 }: TableControlsProps) {
   return (
     <div
@@ -29,25 +44,47 @@ export function TableControls({
         transform: "translateY(-50%)",
         display: "flex",
         flexDirection: "column",
-        alignItems: "flex-end",
-        gap: "0.75em",
+        width: "13em",
+        gap: "0.6em",
       }}
     >
       {canStartHand && (
-        <PillButton data-testid="start-hand-button" onClick={onStartHand}>
+        <PillButton
+          data-testid="start-hand-button"
+          onClick={onStartHand}
+          style={{ width: "100%" }}
+        >
           Deal hand
         </PillButton>
       )}
       {handComplete && (
-        <PillButton data-testid="next-hand-button" onClick={onNextHand}>
+        <PillButton
+          data-testid="next-hand-button"
+          onClick={onNextHand}
+          style={{ width: "100%" }}
+        >
           Next hand
+        </PillButton>
+      )}
+      {onReviewHands && (
+        <PillButton
+          tone="outline"
+          data-testid="review-hands-button"
+          onClick={onReviewHands}
+          style={{ width: "100%" }}
+        >
+          Review hands
         </PillButton>
       )}
       <PillButton
         tone="outline"
         data-testid="end-session-button"
         onClick={onEndSession}
-        style={{ padding: "15px 22px", fontSize: "11px" }}
+        style={{
+          width: "100%",
+          borderColor: color.accentBorder,
+          color: color.textBright,
+        }}
       >
         End session
       </PillButton>

--- a/packages/table-client/src/TableControls.tsx
+++ b/packages/table-client/src/TableControls.tsx
@@ -1,4 +1,4 @@
-import { PillButton, color } from "@table-top-poker/ui-shared";
+import { PillButton } from "@table-top-poker/ui-shared";
 
 export interface TableControlsProps {
   readonly canStartHand: boolean;
@@ -26,6 +26,10 @@ export interface TableControlsProps {
  * whatever width each label happens to be. Sizing comes from `PillButton`'s
  * size token for all of them — an ad-hoc smaller `End session` made the rail
  * read as two unrelated controls rather than one group.
+ *
+ * The two secondary actions take the plain outline tone with no per-call
+ * colour of their own, so the rail's only visual hierarchy is solid (deal the
+ * next hand) against outline (everything else).
  */
 export function TableControls({
   canStartHand,
@@ -80,11 +84,7 @@ export function TableControls({
         tone="outline"
         data-testid="end-session-button"
         onClick={onEndSession}
-        style={{
-          width: "100%",
-          borderColor: color.accentBorder,
-          color: color.textBright,
-        }}
+        style={{ width: "100%" }}
       >
         End session
       </PillButton>

--- a/packages/ui-shared/src/PillButton.test.tsx
+++ b/packages/ui-shared/src/PillButton.test.tsx
@@ -35,7 +35,16 @@ describe("PillButton", () => {
     const outline = renderToStaticMarkup(
       <PillButton tone="outline">End session</PillButton>,
     );
+    expect(solid).not.toContain("IBM Plex Mono");
+    expect(outline).toContain("IBM Plex Mono");
+  });
+
+  it("renders both tones' labels as written, so a mixed rail reads as one group", () => {
+    const solid = renderToStaticMarkup(<PillButton>Deal hand</PillButton>);
+    const outline = renderToStaticMarkup(
+      <PillButton tone="outline">End session</PillButton>,
+    );
     expect(solid).not.toContain("text-transform");
-    expect(outline).toContain("text-transform:uppercase");
+    expect(outline).not.toContain("text-transform");
   });
 });

--- a/packages/ui-shared/src/PillButton.tsx
+++ b/packages/ui-shared/src/PillButton.tsx
@@ -29,8 +29,10 @@ const toneStyle: Record<PillButtonTone, CSSProperties> = {
     color: color.textMuted,
     fontFamily: font.mono,
     fontWeight: 600,
-    letterSpacing: "0.14em",
-    textTransform: "uppercase",
+    // No `textTransform` and normal tracking: every pill reads in the sentence
+    // case its label is written in, so a rail of mixed tones doesn't look like
+    // two different vocabularies. Primary vs secondary is carried by the fill.
+    letterSpacing: "0.04em",
   },
 };
 
@@ -38,6 +40,9 @@ const toneStyle: Record<PillButtonTone, CSSProperties> = {
  * The rounded pill used for table/player actions. `tone="solid"` is the
  * cream gradient for primary actions ("Deal hand", "Create room"); `tone="outline"`
  * is the muted mono-label pill used for secondary actions ("End session").
+ *
+ * Both tones render their label as written — the distinction is the fill, not
+ * the casing. Labels are therefore authored in sentence case at the call site.
  */
 export function PillButton({
   size = "md",


### PR DESCRIPTION
## Summary
- Cherry-pick the three Phase 1 rail/pill fixes stranded on `prototype/*` branches: the rail is now grouped into one fixed-width column, both pill tones render labels as written, and the two secondary rail actions share a plain outline.
- Drop the `HandPickerPrototype.tsx` hunk from `aad3d5c` during the pick since that file doesn't exist on `main`.

## Test plan
- [x] `npm run lint`
- [x] `npm test` (390/390 passing)
- [x] No `prototype/` files added (verified via diff)

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVBhKq2Kxdsc5Mj77VhfS3