### PR TITLE
fix(server): auto-fold evicted current actor

### DIFF
--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -1525,12 +1525,12 @@ describe("action clock", () => {
     const actor = rooms.currentActor(room.code);
     if (actor === undefined) throw new Error("expected a current actor");
 
-    await settle(120);
+    await settle(150);
     const evicted = await app.inject({
       method: "POST",
       url: `/rooms/${room.code}/seats/${String((actor + 1) % 3)}/evict`,
     });
-    await settle(130);
+    await settle(120);
 
     expect(evicted.statusCode).toBe(204);
     expect(actionsSeen(table.messages)).toContainEqual(

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -1173,6 +1173,47 @@ describe("hand command dispatch over WebSocket", () => {
     expect(lastView.view.seats[1]).toMatchObject({ claimed: false });
   });
 
+  it("auto-folds an evicted current actor and broadcasts the turn advance", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const seatSockets = [
+      await claimAndConnect(room.code, 0),
+      await claimAndConnect(room.code, 1),
+      await claimAndConnect(room.code, 2),
+    ];
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    const actor = rooms.currentActor(room.code);
+    if (actor === undefined) throw new Error("expected a current actor");
+
+    const closed = new Promise<void>((resolve) => {
+      seatSockets[actor]?.socket.once("close", () => {
+        resolve();
+      });
+    });
+    const evicted = await app.inject({
+      method: "POST",
+      url: `/rooms/${room.code}/seats/${String(actor)}/evict`,
+    });
+    await closed;
+    await settle();
+
+    expect(evicted.statusCode).toBe(204);
+    expect(rooms.get(room.code)?.seats[actor]).toMatchObject({
+      claimed: false,
+    });
+    expect(rooms.currentActor(room.code)).not.toBe(actor);
+    expect(table.messages).toContainEqual(
+      expect.objectContaining({
+        type: "hand-update",
+        event: { type: "ActionTaken", seatId: actor, action: "fold" },
+      }),
+    );
+  });
+
   it("rejects an out-of-turn action, visible only to the sender", async () => {
     const room = rooms.create();
     const table = connect(`room=${room.code}&role=table`);
@@ -1470,6 +1511,31 @@ describe("action clock", () => {
         action: "fold",
       }),
     ]);
+  });
+
+  it("does not reset the current actor's clock for a different seat's eviction", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    for (const seatId of [0, 1, 2]) rooms.claimSeat(room.code, seatId);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    const actor = rooms.currentActor(room.code);
+    if (actor === undefined) throw new Error("expected a current actor");
+
+    await settle(120);
+    const evicted = await app.inject({
+      method: "POST",
+      url: `/rooms/${room.code}/seats/${String((actor + 1) % 3)}/evict`,
+    });
+    await settle(130);
+
+    expect(evicted.statusCode).toBe(204);
+    expect(actionsSeen(table.messages)).toContainEqual(
+      expect.objectContaining({ seatId: actor, action: "fold" }),
+    );
   });
 
   it("does not auto-fold a seat that acts before the clock elapses", async () => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -406,19 +406,21 @@ export async function buildApp(
       // `actor` was read as the live current actor at schedule time, and
       // any real action in between would have rescheduled (and thus
       // replaced) this very timer — so `dispatch` rejecting the
-      // synthesized fold isn't expected to happen. `for` runs zero times
-      // if it somehow does, and the clock still re-arms below.
+      // synthesized fold isn't expected to happen. If it somehow does, the
+      // clock still re-arms below.
       if ("steps" in result) {
-        for (const step of result.steps) {
-          fanOutHandUpdate(code, step);
-        }
+        publishDispatch(code, result);
+        return;
       }
       rescheduleActionClock(code);
     });
   }
 
-  /** Publishes an accepted engine dispatch and moves the room's action clock. */
+  /** Publishes an accepted dispatch, including any positional seat moves. */
   function publishDispatch(code: string, result: DispatchSuccess): void {
+    if (result.seatMoves !== undefined) {
+      applySeatMoves(code, result.seatMoves);
+    }
     logDispatch(code, result);
     for (const step of result.steps) {
       fanOutHandUpdate(code, step);
@@ -720,9 +722,6 @@ export async function buildApp(
             return;
           }
 
-          if (dispatchResult.seatMoves !== undefined) {
-            applySeatMoves(code, dispatchResult.seatMoves);
-          }
           publishDispatch(code, dispatchResult);
           // A fresh deal-in (new join, reconnect) changes seat state the
           // routine hand-update fan-out above doesn't cover.

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -417,6 +417,15 @@ export async function buildApp(
     });
   }
 
+  /** Publishes an accepted engine dispatch and moves the room's action clock. */
+  function publishDispatch(code: string, result: DispatchSuccess): void {
+    logDispatch(code, result);
+    for (const step of result.steps) {
+      fanOutHandUpdate(code, step);
+    }
+    rescheduleActionClock(code);
+  }
+
   // `index: false` — the explicit "/" route below owns index resolution
   // (placeholder vs. a staged table build), so the static plugin only ever
   // serves fingerprinted assets (`/table/assets/*`, `/player/assets/*`),
@@ -550,7 +559,10 @@ export async function buildApp(
       }
       const room = findRoomOrReject(rooms, request.params.code, reply);
       if (!room) return;
-      rooms.evictSeat(request.params.code, seatId);
+      const eviction = rooms.evictSeat(request.params.code, seatId);
+      if (eviction.dispatch !== undefined) {
+        publishDispatch(request.params.code, eviction.dispatch);
+      }
       broadcastRoomView(request.params.code);
       closeSeatSockets(request.params.code, seatId);
       return reply.code(204).send();
@@ -711,11 +723,7 @@ export async function buildApp(
           if (dispatchResult.seatMoves !== undefined) {
             applySeatMoves(code, dispatchResult.seatMoves);
           }
-          logDispatch(code, dispatchResult);
-          for (const step of dispatchResult.steps) {
-            fanOutHandUpdate(code, step);
-          }
-          rescheduleActionClock(code);
+          publishDispatch(code, dispatchResult);
           // A fresh deal-in (new join, reconnect) changes seat state the
           // routine hand-update fan-out above doesn't cover.
           if (

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -652,6 +652,28 @@ describe("RoomStore", () => {
         expect(room.engine.hand.players.get(actor)?.folded).toBe(true);
       });
 
+      it("completes a heads-up hand when evicting the current actor", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 2);
+        store.dispatch(room.code, "table", "startHand");
+        const actor = store.currentActor(room.code);
+        if (actor === undefined) throw new Error("expected a current actor");
+
+        const result = store.evictSeat(room.code, actor);
+
+        if (result.dispatch === undefined) {
+          throw new Error("expected the eviction fold to dispatch");
+        }
+        expect(result.dispatch.steps.map((step) => step.event.type)).toEqual([
+          "ActionTaken",
+          "HandFoldedOut",
+          "HandComplete",
+        ]);
+        expect(room.seats[actor]).toMatchObject({ claimed: false });
+        expect(store.currentActor(room.code)).toBeUndefined();
+        expect(room.engine?.hand?.status).toBe("complete");
+      });
+
       it("frees a claimed seat via evictSeat regardless of connection status", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 3);

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -635,6 +635,23 @@ describe("RoomStore", () => {
     });
 
     describe("ADR-0003: manual eviction", () => {
+      it("auto-folds the current actor before freeing the evicted seat", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 3);
+        store.dispatch(room.code, "table", "startHand");
+        const actor = store.currentActor(room.code);
+        if (actor === undefined) throw new Error("expected a current actor");
+
+        store.evictSeat(room.code, actor);
+
+        expect(room.seats[actor]).toMatchObject({ claimed: false });
+        expect(store.currentActor(room.code)).not.toBe(actor);
+        if (room.engine?.hand?.status !== "betting") {
+          throw new Error("expected the hand to continue");
+        }
+        expect(room.engine.hand.players.get(actor)?.folded).toBe(true);
+      });
+
       it("frees a claimed seat via evictSeat regardless of connection status", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 3);

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -62,6 +62,11 @@ export type ClaimSeatError =
 
 export type ClaimSeatResult = { seat: Seat } | { error: ClaimSeatError };
 
+/** The engine fold, when evicting the seat currently owed a decision. */
+export interface EvictSeatResult {
+  readonly dispatch?: DispatchSuccess;
+}
+
 export type ChangeSeatCountError = Exclude<
   SeatCountChangeError,
   "invalid-request-body"
@@ -367,14 +372,22 @@ export class RoomStore {
   /**
    * Frees any claimed seat — active, sitting-out, or disconnected alike —
    * back into the join picker and invalidates its token. The table
-   * device's manual "evict" action (ADR-0003); there is no automatic
-   * trigger.
+   * device's manual "evict" action (ADR-0003); there is no automatic trigger.
+   * An actor evicted during a live hand is folded first so the engine can
+   * advance to the next decision.
    */
-  evictSeat(code: string, seatId: SeatId): void {
+  evictSeat(code: string, seatId: SeatId): EvictSeatResult {
     const room = this.#rooms.get(code);
     const seat = room?.seats[seatId];
-    if (!seat) return;
+    if (!seat) return {};
+
+    let fold: DispatchSuccess | undefined;
+    if (this.currentActor(code) === seatId) {
+      const result = this.dispatch(code, seatId, "fold");
+      if ("steps" in result) fold = result;
+    }
     freeSeat(seat);
+    return fold === undefined ? {} : { dispatch: fold };
   }
 
   /**

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -381,13 +381,20 @@ export class RoomStore {
     const seat = room?.seats[seatId];
     if (!seat) return {};
 
-    let fold: DispatchSuccess | undefined;
-    if (this.currentActor(code) === seatId) {
-      const result = this.dispatch(code, seatId, "fold");
-      if ("steps" in result) fold = result;
+    if (this.currentActor(code) !== seatId) {
+      freeSeat(seat);
+      return {};
     }
+
+    const result = this.dispatch(code, seatId, "fold");
+    // `currentActor` was read as the live actor, and fold is unconditionally
+    // legal for that seat. If that invariant ever breaks, leave the seat
+    // claimed so the action clock can recover instead of freeing an actor the
+    // engine is still waiting on.
+    if (!("steps" in result)) return {};
+
     freeSeat(seat);
-    return fold === undefined ? {} : { dispatch: fold };
+    return { dispatch: result };
   }
 
   /**


### PR DESCRIPTION
Closes #90

## Summary

- auto-fold the current actor before freeing an evicted seat
- broadcast the synthesized fold and advance the action clock
- preserve the current actor's timeout when another seat is evicted
- add RoomStore, WebSocket, and action-clock regression coverage

## Verification

- `npm run build`
- `npm run lint`
- `npm test` — 66 files, 393 tests