### PR TITLE
feat(table): show sitting-out seats as quiet pods (#92)

### DIFF
--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -21,6 +21,15 @@ describe("Seats", () => {
     expect(html).toMatch(/data-testid="seat-pod-3"[^>]*data-status="open"/);
   });
 
+  it("gives a sitting-out seat a quiet local treatment and next-hand copy", () => {
+    const html = renderToStaticMarkup(<Seats seats={seats} view={null} />);
+
+    expect(html).toContain('data-testid="seat-pod-2-sitting-out"');
+    expect(html).toContain("Sitting out");
+    expect(html).toContain("Next hand");
+    expect(html).not.toContain('data-testid="seat-pod-0-sitting-out"');
+  });
+
   it("marks the button seat once a hand exists, even with no active betting", () => {
     const view: TableView = { phase: "no-hand", button: 1 };
     const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -21,12 +21,40 @@ describe("Seats", () => {
     expect(html).toMatch(/data-testid="seat-pod-3"[^>]*data-status="open"/);
   });
 
-  it("gives a sitting-out seat a quiet local treatment and next-hand copy", () => {
+  it("gives a sitting-out seat a quiet local treatment and neutral copy", () => {
     const html = renderToStaticMarkup(<Seats seats={seats} view={null} />);
 
-    expect(html).toContain('data-testid="seat-pod-2-sitting-out"');
-    expect(html).toContain("Sitting out");
-    expect(html).toContain("Next hand");
+    expect(html).toMatch(
+      /data-testid="seat-pod-2-sitting-out"[^>]*>[\s\S]*Sitting out[\s\S]*Not in hand[\s\S]*<\/div>/,
+    );
+    expect(html).toContain('data-testid="seat-pod-2-sitting-out-marker"');
+    expect(html).toMatch(
+      /data-testid="seat-pod-2-avatar"[^>]*style="[^"]*border:1px dashed/,
+    );
+    expect(html).not.toContain('data-testid="seat-pod-0-sitting-out"');
+  });
+
+  it("shows a claimed seat absent from a live hand as sitting out", () => {
+    const view: TableView = {
+      phase: "betting",
+      button: 0,
+      street: "flop",
+      board: [],
+      toAct: [0],
+      seats: [
+        { seatId: 0, folded: false },
+        { seatId: 1, folded: false },
+      ],
+    };
+    const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
+
+    expect(html).toMatch(
+      /data-testid="seat-pod-2"[^>]*data-status="sitting-out"/,
+    );
+    expect(html).toMatch(
+      /data-testid="seat-pod-2-sitting-out"[^>]*>[\s\S]*Sitting out[\s\S]*Not in hand[\s\S]*<\/div>/,
+    );
+    expect(html).toContain('data-testid="seat-pod-2-sitting-out-marker"');
     expect(html).not.toContain('data-testid="seat-pod-0-sitting-out"');
   });
 

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -167,11 +167,66 @@ describe("Seats", () => {
     expect(html).not.toContain("Winner");
   });
 
+  it("keeps a revealed player in-hand when they sit out for the next hand", () => {
+    const view: TableView = {
+      phase: "showdown",
+      button: 0,
+      board: [
+        { rank: "A", suit: "spades" },
+        { rank: "K", suit: "hearts" },
+        { rank: "2", suit: "clubs" },
+        { rank: "7", suit: "diamonds" },
+        { rank: "9", suit: "clubs" },
+      ],
+      winners: [2],
+      results: [
+        {
+          seatId: 2,
+          rank: 1,
+          description: "Pair of Aces",
+          holeCards: [
+            { rank: "A", suit: "clubs" },
+            { rank: "3", suit: "hearts" },
+          ],
+          bestHand: [
+            { rank: "A", suit: "spades" },
+            { rank: "A", suit: "clubs" },
+            { rank: "K", suit: "hearts" },
+            { rank: "9", suit: "clubs" },
+            { rank: "7", suit: "diamonds" },
+          ],
+        },
+      ],
+    };
+    const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
+
+    expect(html).toMatch(
+      /data-testid="seat-pod-2"[^>]*data-status="in-hand"[^>]*data-winner="true"/,
+    );
+    expect(html).toContain('data-testid="seat-pod-2-hole-cards"');
+    expect(html).not.toContain('data-testid="seat-pod-2-sitting-out"');
+    expect(html).not.toContain('data-testid="seat-pod-2-sitting-out-marker"');
+    expect(html).not.toMatch(
+      /data-testid="seat-pod-2-avatar"[^>]*style="[^"]*border:1px dashed/,
+    );
+    expect(html).toMatch(
+      /data-testid="seat-pod-2-surface"[^>]*style="[^"]*opacity:1/,
+    );
+  });
+
   it("marks the sole winner at a fold-out completion, with no reveal", () => {
     const view: TableView = { phase: "folded-out", button: 0, winner: 1 };
-    const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
+    const sittingOutWinnerSeats = seats.map((seat) =>
+      seat.id === 1 ? { ...seat, sittingOut: true } : seat,
+    );
+    const html = renderToStaticMarkup(
+      <Seats seats={sittingOutWinnerSeats} view={view} />,
+    );
     expect(html).toMatch(/data-testid="seat-pod-1"[^>]*data-winner="true"/);
+    expect(html).toMatch(/data-testid="seat-pod-1"[^>]*data-status="in-hand"/);
     expect(html).toMatch(/data-testid="seat-pod-0"[^>]*data-winner="false"/);
+    expect(html).not.toContain('data-testid="seat-pod-1-sitting-out"');
+    expect(html).not.toContain('data-testid="seat-pod-1-sitting-out-marker"');
     expect(html).not.toContain("hole-cards");
   });
 

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -37,6 +37,18 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
     view?.phase === "betting"
       ? view.seats.find((s) => s.seatId === seat.id)
       : undefined;
+  const showdownResult =
+    view?.phase === "showdown"
+      ? view.results.find((r) => r.seatId === seat.id)
+      : undefined;
+  const participatedInCurrentHand =
+    view?.phase === "betting"
+      ? handSeat !== undefined
+      : view?.phase === "showdown"
+        ? showdownResult !== undefined
+        : view?.phase === "folded-out"
+          ? view.winner === seat.id
+          : false;
 
   let status: SeatStatus = "open";
   if (seat.claimed) {
@@ -46,6 +58,10 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
         : handSeat.folded
           ? "folded"
           : "in-hand";
+    } else if (participatedInCurrentHand) {
+      // `SeatView.sittingOut` may change during a hand, but the hand view is
+      // authoritative about whether this seat is still in that hand.
+      status = "in-hand";
     } else {
       status = seat.sittingOut ? "sitting-out" : "in-hand";
     }
@@ -72,11 +88,6 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
       : status === "sitting-out"
         ? color.seatAvatarSittingOutText
         : color.pillInk;
-
-  const showdownResult =
-    view?.phase === "showdown"
-      ? view.results.find((r) => r.seatId === seat.id)
-      : undefined;
 
   return {
     status,
@@ -283,6 +294,7 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
             }}
           >
             <motion.div
+              data-testid={`seat-pod-${String(seat.id)}-surface`}
               animate={{
                 boxShadow: visual.isActor
                   ? [...shadow.seatActorGlow]

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -110,6 +110,7 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
         const avatarBlock = (
           <div key="avatar" style={{ position: "relative" }}>
             <div
+              data-testid={`seat-pod-${String(seat.id)}-avatar`}
               style={{
                 width: "3em",
                 height: "3em",
@@ -133,6 +134,7 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
             {visual.status === "sitting-out" && (
               <span
                 aria-hidden="true"
+                data-testid={`seat-pod-${String(seat.id)}-sitting-out-marker`}
                 style={{
                   position: "absolute",
                   left: "0.1em",
@@ -237,7 +239,7 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
               Sitting out
             </span>
             <span style={{ fontSize: "0.6em", color: color.textFaint }}>
-              Next hand
+              Not in hand
             </span>
           </div>
         );

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -62,12 +62,16 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
     ? color.seatAvatarOpen
     : status === "folded"
       ? color.seatAvatarFolded
-      : color.text;
+      : status === "sitting-out"
+        ? color.seatAvatarSittingOut
+        : color.text;
   const avatarColor = !seat.claimed
     ? color.seatAvatarOpenText
     : status === "folded"
       ? color.seatAvatarFoldedText
-      : color.pillInk;
+      : status === "sitting-out"
+        ? color.seatAvatarSittingOutText
+        : color.pillInk;
 
   const showdownResult =
     view?.phase === "showdown"
@@ -118,10 +122,28 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
                 fontSize: "1.1em",
                 background: visual.avatarBackground,
                 color: visual.avatarColor,
+                border:
+                  visual.status === "sitting-out"
+                    ? `1px dashed ${color.seatSittingOutBorder}`
+                    : undefined,
               }}
             >
               {seat.id + 1}
             </div>
+            {visual.status === "sitting-out" && (
+              <span
+                aria-hidden="true"
+                style={{
+                  position: "absolute",
+                  left: "0.1em",
+                  right: "0.1em",
+                  top: "50%",
+                  height: "1px",
+                  transform: "rotate(-34deg)",
+                  background: color.textFaint,
+                }}
+              />
+            )}
             {visual.isButton && (
               <span
                 data-testid={`seat-pod-${String(seat.id)}-button`}
@@ -190,6 +212,36 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
           </div>
         );
 
+        const sittingOutBlock = visual.status === "sitting-out" && (
+          <div
+            key="sitting-out"
+            data-testid={`seat-pod-${String(seat.id)}-sitting-out`}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "0.15em",
+              whiteSpace: "nowrap",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: font.mono,
+                fontSize: "0.6em",
+                fontWeight: 700,
+                letterSpacing: "0.16em",
+                textTransform: "uppercase",
+                color: color.textMuted,
+              }}
+            >
+              Sitting out
+            </span>
+            <span style={{ fontSize: "0.6em", color: color.textFaint }}>
+              Next hand
+            </span>
+          </div>
+        );
+
         // Boundary rule: the avatar is the fixed anchor `posFor` placed —
         // cards and the hand-description caption only ever grow inward,
         // toward the felt's centre, never past the seat toward the rail.
@@ -197,8 +249,8 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
         // is the mirror, so the caption always ends up on the table-facing
         // side, closest to the centre everyone's looking at.
         const stack = isTopRow
-          ? [avatarBlock, holeCardsBlock, captionBlock]
-          : [captionBlock, holeCardsBlock, avatarBlock];
+          ? [avatarBlock, holeCardsBlock, sittingOutBlock, captionBlock]
+          : [captionBlock, holeCardsBlock, sittingOutBlock, avatarBlock];
 
         return (
           <div
@@ -251,15 +303,24 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
                   ? color.seatWinnerBackground
                   : visual.isActor
                     ? color.seatActorBackground
-                    : "transparent",
+                    : visual.status === "sitting-out"
+                      ? color.seatSittingOutBackground
+                      : "transparent",
                 border: `1px solid ${
                   visual.isWinner
                     ? color.seatWinnerBorder
                     : visual.isActor
                       ? color.accent
-                      : "transparent"
+                      : visual.status === "sitting-out"
+                        ? color.seatSittingOutBorder
+                        : "transparent"
                 }`,
-                opacity: visual.status === "folded" ? 0.34 : 1,
+                opacity:
+                  visual.status === "folded"
+                    ? 0.34
+                    : visual.status === "sitting-out"
+                      ? 0.82
+                      : 1,
               }}
             >
               {stack}

--- a/packages/ui-shared/src/theme.ts
+++ b/packages/ui-shared/src/theme.ts
@@ -57,8 +57,12 @@ export const color = {
 
   seatAvatarOpen: "rgba(255,255,255,.06)",
   seatAvatarOpenText: "rgba(250,240,238,.5)",
+  seatAvatarSittingOut: "rgba(255,255,255,.035)",
+  seatAvatarSittingOutText: "rgba(250,240,238,.45)",
   seatAvatarFolded: "rgba(255,255,255,.1)",
   seatAvatarFoldedText: "rgba(250,240,238,.45)",
+  seatSittingOutBackground: "rgba(10,6,7,.32)",
+  seatSittingOutBorder: "rgba(125,106,104,.8)",
   seatWinnerBorder: "rgba(250,234,231,.7)",
   seatWinnerBackground: "rgba(250,234,231,.14)",
   seatActorBackground: "rgba(20,7,8,.72)",


### PR DESCRIPTION
## Summary

- promote Option A (Quiet pod) from the sat-out prototype into the production table UI
- keep the seat in its normal position, but mute it with a dashed pod/avatar, strike-through marker, and `Sitting out` / `Not in hand` copy
- add focused rendering coverage and shared theme tokens

## Design decision

Option A keeps the player easy to locate without making a non-participant compete with the active seats. The seat remains claimed and visually distinct from a folded or disconnected player.

Prototype source: `prototype/issue-92-sat-out` (`ccfa83d`)

Closes #92

## Validation

- `npm run build`
- `npm run lint`
- `npm run test --workspace @table-top-poker/table-client -- --run` — 57 tests passed
- `npm run build:app --workspace @table-top-poker/table-client`