### PR TITLE
feat: add required player names to seats

### DIFF
--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { ActionBar } from "./ActionBar.js";
 import { claimSeat, joinRoom } from "./api/rooms.js";
 import { useActionIntent } from "./actions/useActionIntent.js";
+import { claimErrorCode } from "./claimError.js";
 import { Hand } from "./Hand.js";
 import { JoinForm } from "./JoinForm.js";
 import { parseRoomCodeFromPath } from "./join/parseRoomCodeFromPath.js";
@@ -15,6 +16,7 @@ import {
   saveSeatToken,
 } from "./storage/seatToken.js";
 import { usePlayerStore } from "./store/store.js";
+import { useLobbyWebSocket } from "./ws/useLobbyWebSocket.js";
 import { useWebSocket } from "./ws/useWebSocket.js";
 
 export function App() {
@@ -22,6 +24,7 @@ export function App() {
   const seats = usePlayerStore((state) => state.seats);
   const joinError = usePlayerStore((state) => state.joinError);
   const seatId = usePlayerStore((state) => state.seatId);
+  const displayName = usePlayerStore((state) => state.displayName);
   const connectionStatus = usePlayerStore((state) => state.connectionStatus);
   const handView = usePlayerStore((state) => state.handView);
   const setRoomView = usePlayerStore((state) => state.setRoomView);
@@ -54,6 +57,7 @@ export function App() {
         setSeat({
           seatId: stored.seatId,
           sittingOut: seat?.sittingOut ?? false,
+          displayName: seat?.displayName ?? stored.displayName ?? null,
         });
         setSeatToken(stored.token);
       })
@@ -96,10 +100,11 @@ export function App() {
           roomCode,
           seatId: to,
           token: seatToken,
+          ...(displayName === null ? {} : { displayName }),
         });
       }
     },
-    [moveSeat, roomCode, seatToken],
+    [displayName, moveSeat, roomCode, seatToken],
   );
 
   const wsParams = useMemo(() => {
@@ -108,6 +113,9 @@ export function App() {
     }
     return { roomCode, seatId, token: seatToken };
   }, [roomCode, seatId, seatToken]);
+  useLobbyWebSocket(roomCode !== null && seatId === null ? roomCode : null, {
+    onRoomEnded: handleRoomEnded,
+  });
   const { send } = useWebSocket(wsParams, {
     onRejected: handleRejected,
     onEvicted: handleEvicted,
@@ -138,23 +146,28 @@ export function App() {
   );
 
   const handleClaim = useCallback(
-    (seat: number) => {
+    (seat: number, name: string) => {
       if (roomCode === null) return;
-      claimSeat(roomCode, seat)
+      claimSeat(roomCode, seat, name)
         .then((claim) => {
           setClaimError(null);
           setEvictionMessage(null);
           setSeatMoveMessage(null);
-          setSeat({ seatId: claim.seatId, sittingOut: claim.sittingOut });
+          setSeat({
+            seatId: claim.seatId,
+            sittingOut: claim.sittingOut,
+            displayName: claim.displayName,
+          });
           setSeatToken(claim.token);
           saveSeatToken(window.localStorage, {
             roomCode,
             seatId: claim.seatId,
             token: claim.token,
+            displayName: claim.displayName,
           });
         })
-        .catch(() => {
-          setClaimError("seat-already-claimed");
+        .catch((error: unknown) => {
+          setClaimError(claimErrorCode(error));
         });
     },
     [roomCode, setSeat],
@@ -185,6 +198,7 @@ export function App() {
           <Hand
             view={handView}
             seatId={seatId}
+            seats={seats}
             connectionStatus={connectionStatus}
           />
         )}
@@ -211,7 +225,11 @@ export function App() {
         onToggleSittingOut={handleToggleSittingOut}
         seat={
           playerSeat
-            ? { seatId: playerSeat.id, sittingOut: playerSeat.sittingOut }
+            ? {
+                seatId: playerSeat.id,
+                displayName: playerSeat.displayName ?? null,
+                sittingOut: playerSeat.sittingOut,
+              }
             : null
         }
       />

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -11,6 +11,47 @@ describe("Hand", () => {
     expect(html).toMatch(/data-testid="hand"[^>]*data-phase="no-hand"/);
   });
 
+  it("uses the named seat in waiting copy", () => {
+    const view: PlayerView = {
+      phase: "betting",
+      button: 0,
+      street: "flop",
+      board: [],
+      toAct: [1],
+      seats: [{ seatId: 0, folded: false }],
+      yourSeatId: 0,
+      yourHoleCards: [
+        { rank: "Q", suit: "diamonds" },
+        { rank: "J", suit: "clubs" },
+      ],
+      legalActions: [],
+    };
+    const html = renderToStaticMarkup(
+      <Hand
+        view={view}
+        seatId={0}
+        seats={[
+          {
+            id: 0,
+            claimed: true,
+            displayName: "Blair",
+            sittingOut: false,
+            disconnected: false,
+          },
+          {
+            id: 1,
+            claimed: true,
+            displayName: "Avery",
+            sittingOut: false,
+            disconnected: false,
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("Waiting on Avery");
+  });
+
   it("reveals own hole cards but never the shared board mid-hand", () => {
     const view: PlayerView = {
       phase: "betting",

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -1,4 +1,8 @@
-import type { Card as CardType, PlayerView } from "@table-top-poker/protocol";
+import type {
+  Card as CardType,
+  PlayerView,
+  SeatView,
+} from "@table-top-poker/protocol";
 import {
   Card,
   color,
@@ -13,6 +17,7 @@ import type { ConnectionStatus } from "./store/connectionSlice.js";
 export interface HandProps {
   readonly view: PlayerView;
   readonly seatId: number;
+  readonly seats?: readonly SeatView[];
   readonly connectionStatus?: ConnectionStatus;
 }
 
@@ -83,8 +88,11 @@ function isDealtIn(view: PlayerViewBetting): boolean {
   return view.seats.some((s) => s.seatId === view.yourSeatId);
 }
 
-function seatLabel(seatId: number): string {
-  return `Seat ${String(seatId + 1)}`;
+function seatLabel(seatId: number, seats: readonly SeatView[]): string {
+  return (
+    seats.find((seat) => seat.id === seatId)?.displayName ??
+    `Seat ${String(seatId + 1)}`
+  );
 }
 
 /**
@@ -99,6 +107,7 @@ function bannerFor(
   view: PlayerView,
   connectionStatus: ConnectionStatus,
   seatId: number,
+  seats: readonly SeatView[],
 ): Banner {
   if (connectionStatus !== "connected") {
     return {
@@ -127,7 +136,9 @@ function bannerFor(
         tone: "win",
       };
     }
-    const winnerNames = view.winners.map(seatLabel).join(" & ");
+    const winnerNames = view.winners
+      .map((winner) => seatLabel(winner, seats))
+      .join(" & ");
     const winClause = winnerResult
       ? `${winnerNames} wins with ${winnerResult.description}`
       : `${winnerNames} wins`;
@@ -148,7 +159,7 @@ function bannerFor(
       kicker: "Hand complete",
       text: iWon
         ? "You win — everyone folded"
-        : `${seatLabel(view.winner)} wins — everyone folded`,
+        : `${seatLabel(view.winner, seats)} wins — everyone folded`,
       tone: iWon ? "win" : "loss",
     };
   }
@@ -174,7 +185,7 @@ function bannerFor(
       kicker: view.street,
       text:
         waitingOn !== undefined
-          ? `Waiting on Seat ${String(waitingOn + 1)}`
+          ? `Waiting on ${seatLabel(waitingOn, seats)}`
           : "Waiting on other players",
       tone: "idle",
     };
@@ -371,6 +382,7 @@ function EmptyHoleCards({ text }: { readonly text: string }) {
 export function Hand({
   view,
   seatId,
+  seats = [],
   connectionStatus = "connected",
 }: HandProps) {
   if (view.phase === "no-hand") {
@@ -386,7 +398,7 @@ export function Hand({
           gap: "1em",
         }}
       >
-        <TurnBanner banner={bannerFor(view, connectionStatus, seatId)} />
+        <TurnBanner banner={bannerFor(view, connectionStatus, seatId, seats)} />
         <EmptyHoleCards text="Waiting for the next hand." />
       </div>
     );
@@ -406,7 +418,7 @@ export function Hand({
           gap: "1em",
         }}
       >
-        <TurnBanner banner={bannerFor(view, connectionStatus, seatId)} />
+        <TurnBanner banner={bannerFor(view, connectionStatus, seatId, seats)} />
         <EmptyHoleCards
           text={
             iWon
@@ -432,7 +444,7 @@ export function Hand({
           gap: "1em",
         }}
       >
-        <TurnBanner banner={bannerFor(view, connectionStatus, seatId)} />
+        <TurnBanner banner={bannerFor(view, connectionStatus, seatId, seats)} />
         {myResult ? (
           <HoleCards
             cards={myResult.holeCards}
@@ -458,7 +470,7 @@ export function Hand({
         gap: "1em",
       }}
     >
-      <TurnBanner banner={bannerFor(view, connectionStatus, seatId)} />
+      <TurnBanner banner={bannerFor(view, connectionStatus, seatId, seats)} />
       {view.yourHoleCards ? (
         <HoleCards
           cards={view.yourHoleCards}

--- a/packages/player-client/src/SeatPanel.test.tsx
+++ b/packages/player-client/src/SeatPanel.test.tsx
@@ -6,6 +6,20 @@ import { SeatPanel } from "./SeatPanel.js";
 const noop = () => undefined;
 
 describe("SeatPanel", () => {
+  it("shows the player's name while retaining the seat number", () => {
+    const html = renderToStaticMarkup(
+      <SeatPanel
+        seatId={2}
+        displayName="Avery"
+        sittingOut={false}
+        toggleDisabled={false}
+        onToggleSittingOut={noop}
+      />,
+    );
+
+    expect(html).toContain("Avery · Seat 3");
+  });
+
   it("shows the claimed seat", () => {
     const html = renderToStaticMarkup(
       <SeatPanel

--- a/packages/player-client/src/SeatPanel.tsx
+++ b/packages/player-client/src/SeatPanel.tsx
@@ -8,6 +8,7 @@ import {
 
 export interface SeatPanelProps {
   readonly seatId: number;
+  readonly displayName?: string | null;
   readonly sittingOut: boolean;
   readonly toggleDisabled: boolean;
   readonly onToggleSittingOut: () => void;
@@ -15,6 +16,7 @@ export interface SeatPanelProps {
 
 export function SeatPanel({
   seatId,
+  displayName,
   sittingOut,
   toggleDisabled,
   onToggleSittingOut,
@@ -47,7 +49,7 @@ export function SeatPanel({
           color: color.textMuted,
         }}
       >
-        Seat {seatId + 1}
+        {displayName ? `${displayName} · ` : ""}Seat {seatId + 1}
       </div>
       {sittingOut && (
         <div

--- a/packages/player-client/src/SeatPicker.test.tsx
+++ b/packages/player-client/src/SeatPicker.test.tsx
@@ -1,7 +1,32 @@
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { SeatPicker } from "./SeatPicker.js";
+import { SeatPicker, selectionLostMessage } from "./SeatPicker.js";
+
+describe("selectionLostMessage", () => {
+  const free = {
+    id: 2,
+    claimed: false,
+    sittingOut: false,
+    disconnected: false,
+  } as const;
+
+  it("keeps a still-free selection", () => {
+    expect(selectionLostMessage(2, free)).toBeNull();
+  });
+
+  it("explains a selection another player claimed first", () => {
+    expect(selectionLostMessage(2, { ...free, claimed: true })).toContain(
+      "Seat 3 was just taken",
+    );
+  });
+
+  it("explains a selection a seat-count change removed", () => {
+    expect(selectionLostMessage(5, undefined)).toContain(
+      "Seat 6 is no longer at this table",
+    );
+  });
+});
 
 describe("SeatPicker", () => {
   it("offers a claim button for each free seat and marks taken seats", () => {
@@ -22,6 +47,26 @@ describe("SeatPicker", () => {
     expect(html).toContain("Taken");
   });
 
+  it("sizes the seat grid rows to the number of seats", () => {
+    const html = renderToStaticMarkup(
+      <SeatPicker
+        error={null}
+        onClaim={() => undefined}
+        seats={Array.from({ length: 6 }, (_, id) => ({
+          id,
+          claimed: false,
+          sittingOut: false,
+          disconnected: false,
+        }))}
+      />,
+    );
+
+    expect(html).toContain('data-testid="seat-grid"');
+    expect(html).toContain('data-seat-count="6"');
+    expect(html).toContain("grid-template-columns:repeat(2, minmax(0, 1fr));");
+    expect(html).toContain("grid-template-rows:repeat(3, minmax(0, 1fr));");
+  });
+
   it("shows a friendly message for a known claim error", () => {
     const html = renderToStaticMarkup(
       <SeatPicker
@@ -32,6 +77,30 @@ describe("SeatPicker", () => {
     );
     expect(html).toContain('data-testid="claim-error"');
     expect(html).toContain("pick another");
+  });
+
+  it("explains when a seat disappeared while the picker was open", () => {
+    const html = renderToStaticMarkup(
+      <SeatPicker
+        error="seat-not-found"
+        onClaim={() => undefined}
+        seats={[]}
+      />,
+    );
+
+    expect(html).toContain("seat is no longer available");
+  });
+
+  it("shows a friendly message for a duplicate display name", () => {
+    const html = renderToStaticMarkup(
+      <SeatPicker
+        error="duplicate-display-name"
+        onClaim={() => undefined}
+        seats={[]}
+      />,
+    );
+
+    expect(html).toContain("name is already taken");
   });
 
   it("omits the error element when there is none", () => {

--- a/packages/player-client/src/SeatPicker.tsx
+++ b/packages/player-client/src/SeatPicker.tsx
@@ -1,18 +1,45 @@
-import type { SeatView } from "@table-top-poker/protocol";
+import {
+  MAX_DISPLAY_NAME_LENGTH,
+  type SeatView,
+} from "@table-top-poker/protocol";
 import { color, font, fontSize, radius } from "@table-top-poker/ui-shared";
-import type { CSSProperties } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 import { InlineError } from "./InlineError.js";
 
 export interface SeatPickerProps {
   readonly seats: readonly SeatView[];
   readonly error: string | null;
   readonly evictionMessage?: string | null;
-  readonly onClaim: (seatId: number) => void;
+  readonly onClaim: (seatId: number, displayName: string) => void;
 }
 
 const seatErrorCopy: Record<string, string> = {
+  "room-not-found":
+    "That room is no longer available — return to the join screen.",
+  "seat-not-found": "That seat is no longer available — pick another.",
   "seat-already-claimed": "Someone just took that seat — pick another.",
+  "duplicate-display-name": "That name is already taken — choose another.",
+  "invalid-display-name": "Enter a name with 1–10 characters.",
+  "claim-failed": "Couldn't reach the table — try that seat again.",
 };
+
+/**
+ * Why a pending seat selection can no longer be claimed, or null while it
+ * still can. A live room view can take the seat or repack it out of the table
+ * between selecting it and claiming it.
+ */
+export function selectionLostMessage(
+  seatId: number,
+  seat: SeatView | undefined,
+): string | null {
+  if (seat === undefined) {
+    return `Seat ${String(seatId + 1)} is no longer at this table — pick another.`;
+  }
+  if (seat.claimed) {
+    return `Seat ${String(seatId + 1)} was just taken — pick another.`;
+  }
+  return null;
+}
 
 const descriptionStyle: CSSProperties = {
   fontSize: fontSize.md,
@@ -20,16 +47,26 @@ const descriptionStyle: CSSProperties = {
   color: color.textMuted,
 };
 
-const gridStyle: CSSProperties = {
-  display: "grid",
-  gridTemplateColumns: "1fr 1fr",
-  gap: 10,
-};
+function seatGridStyle(seatCount: number): CSSProperties {
+  const rowCount = Math.max(1, Math.ceil(seatCount / 2));
 
-function seatStyle(claimed: boolean): CSSProperties {
   return {
+    display: "grid",
+    gridTemplateColumns: seatCount <= 1 ? "1fr" : "repeat(2, minmax(0, 1fr))",
+    gridTemplateRows: `repeat(${String(rowCount)}, minmax(0, 1fr))`,
+    gap: 12,
+    flex: "1 1 0",
+    minHeight: 0,
+  };
+}
+
+function seatStyle(claimed: boolean, selected: boolean): CSSProperties {
+  return {
+    display: "flex",
+    minHeight: 108,
+    height: "100%",
     borderRadius: radius.control,
-    padding: "14px 13px",
+    padding: 16,
     ...(claimed
       ? {
           border: `1px solid ${color.border}`,
@@ -37,17 +74,27 @@ function seatStyle(claimed: boolean): CSSProperties {
           opacity: 0.5,
         }
       : {
-          border: `1px solid ${color.accentBorder}`,
+          border: `1px solid ${
+            selected ? color.accentBright : color.accentBorder
+          }`,
+          // Selection is carried by the brighter border and the ring, not by
+          // a fill: `lossBackground` is the error surface this same screen
+          // uses below, and a selected seat is not an error.
           background: color.accentWash,
+          boxShadow: selected ? `0 0 0 2px ${color.accentBorder}` : undefined,
         }),
   };
 }
 
 const rowStyle: CSSProperties = {
   display: "flex",
-  alignItems: "center",
-  gap: 11,
+  flexDirection: "column",
+  alignItems: "flex-start",
+  justifyContent: "space-between",
+  gap: 12,
   width: "100%",
+  height: "100%",
+  minHeight: 0,
   textAlign: "left",
   background: "none",
   border: 0,
@@ -59,8 +106,8 @@ const rowStyle: CSSProperties = {
 
 function avatarStyle(claimed: boolean): CSSProperties {
   return {
-    width: 34,
-    height: 34,
+    width: 44,
+    height: 44,
     borderRadius: radius.pill,
     flex: "none",
     display: "flex",
@@ -68,7 +115,7 @@ function avatarStyle(claimed: boolean): CSSProperties {
     justifyContent: "center",
     fontFamily: font.mono,
     fontWeight: 700,
-    fontSize: fontSize.xs,
+    fontSize: fontSize.sm,
     background: color.avatarGradient,
     color: color.pillInk,
     filter: claimed ? "saturate(.2) brightness(.7)" : undefined,
@@ -79,6 +126,7 @@ const textColStyle: CSSProperties = {
   display: "flex",
   flexDirection: "column",
   gap: 2,
+  width: "100%",
   minWidth: 0,
 };
 
@@ -88,12 +136,54 @@ const titleStyle: CSSProperties = {
   color: color.text,
 };
 
+const seatTitleStyle: CSSProperties = {
+  ...titleStyle,
+  fontSize: fontSize.lg,
+  lineHeight: 1.15,
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
 const subStyle: CSSProperties = {
   fontFamily: font.mono,
   fontSize: fontSize.xs,
   letterSpacing: "0.14em",
   textTransform: "uppercase",
   color: color.textDim,
+  lineHeight: 1.1,
+};
+
+const nameEntryStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: 12,
+  padding: "15px 16px 16px",
+  border: `1px solid ${color.accentBorder}`,
+  borderRadius: radius.control,
+  background: color.accentWash,
+};
+
+const inputStyle: CSSProperties = {
+  width: "100%",
+  padding: "11px 12px",
+  border: `1px solid ${color.borderStrong}`,
+  borderRadius: radius.control,
+  outline: "none",
+  color: color.text,
+  font: "inherit",
+  fontSize: fontSize.md,
+  background: color.control,
+};
+
+const claimButtonStyle: CSSProperties = {
+  border: 0,
+  borderRadius: radius.pill,
+  padding: "13px 17px",
+  color: color.pillInk,
+  font: "inherit",
+  fontWeight: 700,
+  background: color.pillGradient,
 };
 
 export function SeatPicker({
@@ -102,30 +192,64 @@ export function SeatPicker({
   evictionMessage,
   onClaim,
 }: SeatPickerProps) {
+  const [selectedSeatId, setSelectedSeatId] = useState<number | null>(null);
+  const [displayName, setDisplayName] = useState("");
+  const [selectionLost, setSelectionLost] = useState<string | null>(null);
+  const selectedSeat =
+    selectedSeatId === null
+      ? undefined
+      : seats.find((seat) => seat.id === selectedSeatId);
+  const canClaim =
+    selectedSeat !== undefined &&
+    !selectedSeat.claimed &&
+    displayName.trim() !== "";
+
+  // Room views now arrive live over the lobby socket, so the selected seat can
+  // be claimed by someone else or repacked away while this player is still
+  // typing. Drop the selection and say why — the typed name is deliberately
+  // kept, so picking another seat doesn't mean typing it again.
+  useEffect(() => {
+    if (selectedSeatId === null) return;
+    const lost = selectionLostMessage(selectedSeatId, selectedSeat);
+    if (lost === null) return;
+    setSelectionLost(lost);
+    setSelectedSeatId(null);
+  }, [selectedSeat, selectedSeatId]);
+
   return (
     <div
       data-testid="seat-picker"
       style={{
         flex: 1,
-        overflow: "hidden",
+        minHeight: 0,
+        overflow: "auto",
         display: "flex",
         flexDirection: "column",
-        gap: 14,
+        gap: 12,
         padding: "0 22px 26px",
       }}
     >
       <div style={descriptionStyle}>
         Pick where you're sitting. Seat order sets the button and blinds.
       </div>
-      <div style={gridStyle}>
+      <div
+        data-testid="seat-grid"
+        data-seat-count={seats.length}
+        style={seatGridStyle(seats.length)}
+      >
         {seats.map((seat) => {
+          const selected = selectedSeatId === seat.id;
           const content = (
             <>
               <span style={avatarStyle(seat.claimed)}>{seat.id + 1}</span>
               <span style={textColStyle}>
-                <span style={titleStyle}>Seat {seat.id + 1}</span>
+                <span style={seatTitleStyle}>
+                  {seat.claimed
+                    ? (seat.displayName ?? `Seat ${String(seat.id + 1)}`)
+                    : `Seat ${String(seat.id + 1)}`}
+                </span>
                 <span style={subStyle}>
-                  {seat.claimed ? "Taken" : "Sit here"}
+                  {seat.claimed ? "Taken" : selected ? "Selected" : "Sit here"}
                 </span>
               </span>
             </>
@@ -134,7 +258,7 @@ export function SeatPicker({
             <div
               key={seat.id}
               data-testid={`seat-option-${String(seat.id)}`}
-              style={seatStyle(seat.claimed)}
+              style={seatStyle(seat.claimed, selected)}
             >
               {seat.claimed ? (
                 <div style={rowStyle}>{content}</div>
@@ -143,9 +267,11 @@ export function SeatPicker({
                   type="button"
                   data-testid={`claim-seat-${String(seat.id)}`}
                   onClick={() => {
-                    onClaim(seat.id);
+                    setSelectionLost(null);
+                    setSelectedSeatId(seat.id);
                   }}
                   style={rowStyle}
+                  aria-pressed={selected}
                 >
                   {content}
                 </button>
@@ -154,6 +280,56 @@ export function SeatPicker({
           );
         })}
       </div>
+      {selectedSeat !== undefined && !selectedSeat.claimed && (
+        <div data-testid="name-entry" style={nameEntryStyle}>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              gap: 12,
+            }}
+          >
+            <div style={textColStyle}>
+              <span style={subStyle}>Seat selected</span>
+              <strong style={titleStyle}>Seat {selectedSeat.id + 1}</strong>
+            </div>
+            <span style={subStyle}>Name required</span>
+          </div>
+          <label style={{ ...textColStyle, gap: 6 }}>
+            <span style={{ ...subStyle, letterSpacing: "0.12em" }}>
+              Display name
+            </span>
+            <input
+              data-testid="display-name-input"
+              value={displayName}
+              required
+              aria-required="true"
+              maxLength={MAX_DISPLAY_NAME_LENGTH}
+              placeholder="e.g. Avery"
+              onChange={(event) => {
+                setDisplayName(event.target.value);
+              }}
+              style={inputStyle}
+            />
+          </label>
+          <button
+            type="button"
+            data-testid="confirm-claim-seat"
+            disabled={!canClaim}
+            onClick={() => {
+              if (!canClaim) return;
+              onClaim(selectedSeat.id, displayName.trim());
+            }}
+            style={{
+              ...claimButtonStyle,
+              opacity: canClaim ? 1 : 0.45,
+              cursor: canClaim ? "pointer" : "not-allowed",
+            }}
+          >
+            Claim Seat {selectedSeat.id + 1}
+          </button>
+        </div>
+      )}
       {evictionMessage && (
         <div
           data-testid="eviction-message"
@@ -172,6 +348,9 @@ export function SeatPicker({
         >
           {evictionMessage}
         </div>
+      )}
+      {selectionLost !== null && (
+        <InlineError testId="selection-lost" message={selectionLost} />
       )}
       {error && (
         <InlineError

--- a/packages/player-client/src/StatusBar.tsx
+++ b/packages/player-client/src/StatusBar.tsx
@@ -9,6 +9,7 @@ export interface StatusBarProps {
   readonly onToggleSittingOut: () => void;
   readonly seat: {
     readonly seatId: number;
+    readonly displayName?: string | null;
     readonly sittingOut: boolean;
   } | null;
 }
@@ -53,6 +54,7 @@ export function StatusBar({
       {seat && (
         <SeatPanel
           seatId={seat.seatId}
+          displayName={seat.displayName ?? null}
           sittingOut={seat.sittingOut}
           toggleDisabled={connectionStatus !== "connected"}
           onToggleSittingOut={onToggleSittingOut}

--- a/packages/player-client/src/api/rooms.test.ts
+++ b/packages/player-client/src/api/rooms.test.ts
@@ -38,23 +38,42 @@ describe("claimSeat", () => {
   });
 
   it("posts to /rooms/:code/seats/:seatId/claim and returns the claim", async () => {
-    const body = { seatId: 2, token: "tok", sittingOut: false };
+    const body = {
+      seatId: 2,
+      token: "tok",
+      displayName: "Avery",
+      sittingOut: false,
+    };
     vi.mocked(fetch).mockResolvedValue(
       new Response(JSON.stringify(body), { status: 200 }),
     );
 
-    const claim = await claimSeat("ABCD", 2);
+    const claim = await claimSeat("ABCD", 2, "Avery");
 
     expect(fetch).toHaveBeenCalledWith("/rooms/ABCD/seats/2/claim", {
       method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ displayName: "Avery" }),
     });
     expect(claim).toEqual(body);
   });
 
   it("throws when the seat is already claimed", async () => {
     vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 409 }));
-    await expect(claimSeat("ABCD", 2)).rejects.toThrow(
+    await expect(claimSeat("ABCD", 2, "Avery")).rejects.toThrow(
       "failed to claim seat: 409",
+    );
+  });
+
+  it("preserves the server error code for a duplicate display name", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ error: "duplicate-display-name" }), {
+        status: 409,
+      }),
+    );
+
+    await expect(claimSeat("ABCD", 2, "Avery")).rejects.toThrow(
+      "duplicate-display-name",
     );
   });
 });

--- a/packages/player-client/src/api/rooms.ts
+++ b/packages/player-client/src/api/rooms.ts
@@ -11,17 +11,30 @@ export async function joinRoom(code: string): Promise<RoomView> {
 export interface SeatClaim {
   readonly seatId: number;
   readonly token: string;
+  readonly displayName: string;
   readonly sittingOut: boolean;
 }
 
 export async function claimSeat(
   code: string,
   seatId: number,
+  displayName: string,
 ): Promise<SeatClaim> {
   const response = await fetch(`/rooms/${code}/seats/${String(seatId)}/claim`, {
     method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ displayName }),
   });
   if (!response.ok) {
+    const body = (await response.json().catch(() => null)) as unknown;
+    if (
+      typeof body === "object" &&
+      body !== null &&
+      "error" in body &&
+      typeof body.error === "string"
+    ) {
+      throw new Error(body.error);
+    }
     throw new Error(`failed to claim seat: ${String(response.status)}`);
   }
   return (await response.json()) as SeatClaim;

--- a/packages/player-client/src/claimError.test.ts
+++ b/packages/player-client/src/claimError.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { claimErrorCode } from "./claimError.js";
+
+describe("claimErrorCode", () => {
+  it("preserves a seat-not-found race from the server", () => {
+    expect(claimErrorCode(new Error("seat-not-found"))).toBe("seat-not-found");
+  });
+
+  it("keeps an occupied seat distinct from a failure the server never named", () => {
+    expect(claimErrorCode(new Error("seat-already-claimed"))).toBe(
+      "seat-already-claimed",
+    );
+    expect(claimErrorCode(new Error("network-failure"))).toBe("claim-failed");
+    expect(claimErrorCode(new Error("failed to claim seat: 500"))).toBe(
+      "claim-failed",
+    );
+    expect(claimErrorCode("not an error")).toBe("claim-failed");
+  });
+});

--- a/packages/player-client/src/claimError.ts
+++ b/packages/player-client/src/claimError.ts
@@ -1,0 +1,27 @@
+export type ClaimErrorCode =
+  | "room-not-found"
+  | "seat-not-found"
+  | "seat-already-claimed"
+  | "invalid-display-name"
+  | "duplicate-display-name"
+  | "claim-failed";
+
+/**
+ * Keep server claim errors specific when a claim races a room update. Anything
+ * the server did not name — a network failure, a 500 — falls back to
+ * `claim-failed` rather than to an occupied seat: telling a player someone
+ * took the seat sends them hunting for another one when the seat was fine.
+ */
+export function claimErrorCode(error: unknown): ClaimErrorCode {
+  const code = error instanceof Error ? error.message : "";
+  if (
+    code === "room-not-found" ||
+    code === "seat-not-found" ||
+    code === "seat-already-claimed" ||
+    code === "invalid-display-name" ||
+    code === "duplicate-display-name"
+  ) {
+    return code;
+  }
+  return "claim-failed";
+}

--- a/packages/player-client/src/storage/seatToken.test.ts
+++ b/packages/player-client/src/storage/seatToken.test.ts
@@ -46,6 +46,23 @@ describe("loadSeatToken", () => {
     });
   });
 
+  it("persists a display name alongside the reconnect token", () => {
+    const storage = fakeStorage(() => undefined);
+    saveSeatToken(storage, {
+      roomCode: "ABCD",
+      seatId: 3,
+      token: "tok-1",
+      displayName: "Avery",
+    });
+
+    expect(loadSeatToken(storage)).toEqual({
+      roomCode: "ABCD",
+      seatId: 3,
+      token: "tok-1",
+      displayName: "Avery",
+    });
+  });
+
   it("returns null when nothing is stored", () => {
     const storage = fakeStorage(() => undefined);
     expect(loadSeatToken(storage)).toBeNull();

--- a/packages/player-client/src/storage/seatToken.ts
+++ b/packages/player-client/src/storage/seatToken.ts
@@ -4,6 +4,8 @@ export interface StoredSeatToken {
   readonly roomCode: string;
   readonly seatId: number;
   readonly token: string;
+  /** Added with named claims; absent tokens still reconnect for migration. */
+  readonly displayName?: string;
 }
 
 /**
@@ -33,15 +35,23 @@ export function loadSeatToken(storage: Storage): StoredSeatToken | null {
       parsed !== null &&
       "roomCode" in parsed &&
       "seatId" in parsed &&
-      "token" in parsed &&
-      typeof parsed.roomCode === "string" &&
-      typeof parsed.seatId === "number" &&
-      typeof parsed.token === "string"
+      "token" in parsed
     ) {
+      const record = parsed as Record<string, unknown>;
+      if (
+        typeof record.roomCode !== "string" ||
+        typeof record.seatId !== "number" ||
+        typeof record.token !== "string"
+      ) {
+        return null;
+      }
       return {
-        roomCode: parsed.roomCode,
-        seatId: parsed.seatId,
-        token: parsed.token,
+        roomCode: record.roomCode,
+        seatId: record.seatId,
+        token: record.token,
+        ...(typeof record.displayName === "string"
+          ? { displayName: record.displayName }
+          : {}),
       };
     }
     return null;

--- a/packages/player-client/src/store/seatSlice.ts
+++ b/packages/player-client/src/store/seatSlice.ts
@@ -3,22 +3,28 @@ import type { StateCreator } from "zustand";
 
 export interface SeatSlice {
   readonly seatId: SeatId | null;
+  readonly displayName: string | null;
   readonly sittingOut: boolean;
-  readonly setSeat: (seat: { seatId: SeatId; sittingOut: boolean }) => void;
+  readonly setSeat: (seat: {
+    seatId: SeatId;
+    sittingOut: boolean;
+    displayName?: string | null;
+  }) => void;
   readonly moveSeat: (seatId: SeatId) => void;
   readonly clearSeat: () => void;
 }
 
 export const createSeatSlice: StateCreator<SeatSlice> = (set) => ({
   seatId: null,
+  displayName: null,
   sittingOut: false,
-  setSeat: ({ seatId, sittingOut }) => {
-    set({ seatId, sittingOut });
+  setSeat: ({ seatId, sittingOut, displayName = null }) => {
+    set({ seatId, sittingOut, displayName });
   },
   moveSeat: (seatId) => {
     set({ seatId });
   },
   clearSeat: () => {
-    set({ seatId: null, sittingOut: false });
+    set({ seatId: null, displayName: null, sittingOut: false });
   },
 });

--- a/packages/player-client/src/ws/getWebSocketUrl.test.ts
+++ b/packages/player-client/src/ws/getWebSocketUrl.test.ts
@@ -22,4 +22,13 @@ describe("getWebSocketUrl", () => {
       ),
     ).toBe("ws://localhost:3000/ws?room=ABCD&seat=2&token=tok");
   });
+
+  it("appends the lobby role for an unclaimed player connection", () => {
+    expect(
+      getWebSocketUrl(
+        { protocol: "http:", host: "localhost:3000" },
+        { room: "ABCD", role: "lobby" },
+      ),
+    ).toBe("ws://localhost:3000/ws?room=ABCD&role=lobby");
+  });
 });

--- a/packages/player-client/src/ws/useLobbyWebSocket.ts
+++ b/packages/player-client/src/ws/useLobbyWebSocket.ts
@@ -1,0 +1,93 @@
+import type { ServerMessage } from "@table-top-poker/protocol";
+import { useEffect, useRef } from "react";
+import { usePlayerStore } from "../store/store.js";
+import { getWebSocketUrl } from "./getWebSocketUrl.js";
+
+export interface LobbyWebSocketOptions {
+  readonly onRoomEnded?: () => void;
+}
+
+const RETRY_DELAY_MS = 1500;
+/**
+ * A lobby socket has no token that can go stale, so a refused upgrade means
+ * either the room is gone or the server is briefly unreachable. Only after
+ * this many consecutive refusals is the room declared gone — a single failed
+ * connect is far more often a restart or a dropped link than an ended room.
+ */
+const MAX_REFUSED_CONNECTS = 3;
+
+/**
+ * Keeps the unclaimed seat picker subscribed to room-level changes. A lobby
+ * socket receives room views only; it has no seat identity and cannot issue
+ * table or player commands.
+ *
+ * Unlike a seat socket, this one retries a close that never opened: there is
+ * no equivalent of a stale seat token to spin against, and a room that really
+ * has ended says so on the wire (`room-ended`) before closing.
+ */
+export function useLobbyWebSocket(
+  roomCode: string | null,
+  options: LobbyWebSocketOptions = {},
+): void {
+  const setRoomView = usePlayerStore((state) => state.setRoomView);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  useEffect(() => {
+    if (roomCode === null) return;
+
+    const code = roomCode;
+    let active = true;
+    let ended = false;
+    let refusedConnects = 0;
+    let retryTimer: ReturnType<typeof setTimeout> | undefined;
+    let socketRef: WebSocket | null = null;
+
+    function connect(): void {
+      if (!active) return;
+
+      let openedOnce = false;
+      const socket = new WebSocket(
+        getWebSocketUrl(window.location, { room: code, role: "lobby" }),
+      );
+      socketRef = socket;
+
+      socket.addEventListener("open", () => {
+        openedOnce = true;
+        refusedConnects = 0;
+      });
+      socket.addEventListener("close", () => {
+        if (!active || ended) return;
+        if (!openedOnce) {
+          refusedConnects += 1;
+          if (refusedConnects >= MAX_REFUSED_CONNECTS) {
+            optionsRef.current.onRoomEnded?.();
+            return;
+          }
+        }
+        retryTimer = setTimeout(connect, RETRY_DELAY_MS);
+      });
+      socket.addEventListener("message", (event: MessageEvent<string>) => {
+        if (!active) return;
+        const message: ServerMessage = JSON.parse(event.data) as ServerMessage;
+        if (message.type === "room-view") {
+          setRoomView(message.view);
+        } else if (message.type === "room-ended") {
+          // The room said so itself — the close that follows is expected and
+          // must not restart the retry loop.
+          ended = true;
+          optionsRef.current.onRoomEnded?.();
+        }
+      });
+    }
+
+    connect();
+
+    return () => {
+      active = false;
+      if (retryTimer !== undefined) clearTimeout(retryTimer);
+      socketRef?.close();
+      socketRef = null;
+    };
+  }, [roomCode, setRoomView]);
+}

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -147,7 +147,11 @@ export function useWebSocket(
                 (candidate) => candidate.id === activeConnection.seatId,
               );
               if (seat?.claimed) {
-                setSeat({ seatId: seat.id, sittingOut: seat.sittingOut });
+                setSeat({
+                  seatId: seat.id,
+                  displayName: seat.displayName ?? null,
+                  sittingOut: seat.sittingOut,
+                });
               }
             }
             break;

--- a/packages/player-client/vite.config.ts
+++ b/packages/player-client/vite.config.ts
@@ -16,6 +16,8 @@ export default defineConfig(({ command, mode }) => {
     .split(",")
     .map((host) => host.trim())
     .filter(Boolean);
+  const backendOrigin = env.BACKEND_ORIGIN ?? "http://localhost:3000";
+  const backendWebSocketOrigin = backendOrigin.replace(/^http/, "ws");
 
   return {
     plugins: [react()],
@@ -29,10 +31,10 @@ export default defineConfig(({ command, mode }) => {
       allowedHosts,
       proxy: {
         "/ws": {
-          target: "ws://localhost:3000",
+          target: backendWebSocketOrigin,
           ws: true,
         },
-        "/rooms": "http://localhost:3000",
+        "/rooms": backendOrigin,
       },
     },
   };

--- a/packages/protocol/src/room.test.ts
+++ b/packages/protocol/src/room.test.ts
@@ -1,11 +1,42 @@
 import { describe, expect, it } from "vitest";
 import {
   ChangeSeatCountRequestSchema,
+  ClaimSeatRequestSchema,
   CreateRoomRequestSchema,
   DEFAULT_SEAT_COUNT,
+  MAX_DISPLAY_NAME_LENGTH,
   MAX_SEAT_COUNT,
   MIN_SEAT_COUNT,
 } from "./room.js";
+
+describe("ClaimSeatRequestSchema", () => {
+  it("requires and trims a non-empty display name", () => {
+    expect(ClaimSeatRequestSchema.parse({ displayName: " Avery " })).toEqual({
+      displayName: "Avery",
+    });
+    expect(
+      ClaimSeatRequestSchema.safeParse({
+        displayName: "1234567890",
+      }).success,
+    ).toBe(true);
+    expect(
+      ClaimSeatRequestSchema.safeParse({
+        displayName: "1".repeat(MAX_DISPLAY_NAME_LENGTH + 1),
+      }).success,
+    ).toBe(false);
+    expect(ClaimSeatRequestSchema.safeParse({}).success).toBe(false);
+    expect(
+      ClaimSeatRequestSchema.safeParse({ displayName: "   " }).success,
+    ).toBe(false);
+  });
+
+  it("rejects extra fields", () => {
+    expect(
+      ClaimSeatRequestSchema.safeParse({ displayName: "Avery", public: true })
+        .success,
+    ).toBe(false);
+  });
+});
 
 describe("CreateRoomRequestSchema", () => {
   it("accepts every seat count in the 2-8 range", () => {

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -17,6 +17,8 @@ export const MIN_SEAT_COUNT = 2;
 export const MAX_SEAT_COUNT = 8;
 /** What the picker starts on, and the size a room gets absent any choice — a full table. */
 export const DEFAULT_SEAT_COUNT = MAX_SEAT_COUNT;
+/** Maximum display-name length accepted during a seat claim. */
+export const MAX_DISPLAY_NAME_LENGTH = 10;
 
 /**
  * The one definition of "a size a room may have". Both the HTTP edge and
@@ -35,6 +37,13 @@ export const CreateRoomRequestSchema = z.strictObject({
 });
 
 export type CreateRoomRequest = z.infer<typeof CreateRoomRequestSchema>;
+
+/** Body of a player's required display-name seat claim. */
+export const ClaimSeatRequestSchema = z.strictObject({
+  displayName: z.string().trim().min(1).max(MAX_DISPLAY_NAME_LENGTH),
+});
+
+export type ClaimSeatRequest = z.infer<typeof ClaimSeatRequestSchema>;
 
 /** Body of the table-only room settings request (issue #77). */
 export const ChangeSeatCountRequestSchema = z.strictObject({
@@ -85,6 +94,8 @@ export interface SeatCountChange {
 export interface SeatView {
   readonly id: SeatId;
   readonly claimed: boolean;
+  /** The required display name for newer claims; absent on pre-name seats. */
+  readonly displayName?: string | null;
   readonly sittingOut: boolean;
   /** Presence-only badge (ticket 33 §7) — never affects folding or legal actions. */
   readonly disconnected: boolean;

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -48,6 +48,7 @@ interface RoomQrBody {
 interface SeatClaimBody {
   readonly seatId: number;
   readonly token: string;
+  readonly displayName: string;
   readonly sittingOut: boolean;
 }
 
@@ -331,27 +332,83 @@ describe("seat claim/evict routes", () => {
     return created.json<RoomCreatedBody>().code;
   }
 
+  function claimPayload(displayName = "Avery") {
+    return { payload: { displayName } };
+  }
+
   it("claims a free seat, issuing a token", async () => {
     const code = await createRoom();
 
     const response = await app.inject({
       method: "POST",
       url: `/rooms/${code}/seats/0/claim`,
+      ...claimPayload(" Avery "),
     });
 
     expect(response.statusCode).toBe(200);
     const body = response.json<SeatClaimBody>();
     expect(typeof body.token).toBe("string");
-    expect(body).toMatchObject({ seatId: 0, sittingOut: false });
+    expect(body).toMatchObject({
+      seatId: 0,
+      displayName: "Avery",
+      sittingOut: false,
+    });
+  });
+
+  it("requires a display name of 1 to 10 characters", async () => {
+    const code = await createRoom();
+
+    const missing = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/claim`,
+    });
+    const blank = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/claim`,
+      ...claimPayload("   "),
+    });
+    const tooLong = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/claim`,
+      ...claimPayload("12345678901"),
+    });
+
+    expect(missing.statusCode).toBe(400);
+    expect(blank.statusCode).toBe(400);
+    expect(tooLong.statusCode).toBe(400);
+    expect(blank.json()).toEqual({ error: "invalid-display-name" });
+  });
+
+  it("rejects a case-insensitive duplicate display name", async () => {
+    const code = await createRoom();
+    await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/claim`,
+      ...claimPayload("Avery"),
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/1/claim`,
+      ...claimPayload("aVERY"),
+    });
+
+    expect(response.statusCode).toBe(409);
+    expect(response.json()).toEqual({ error: "duplicate-display-name" });
   });
 
   it("rejects claiming an already-claimed seat", async () => {
     const code = await createRoom();
-    await app.inject({ method: "POST", url: `/rooms/${code}/seats/0/claim` });
+    await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/claim`,
+      ...claimPayload("Avery"),
+    });
 
     const response = await app.inject({
       method: "POST",
       url: `/rooms/${code}/seats/0/claim`,
+      ...claimPayload("Blair"),
     });
 
     expect(response.statusCode).toBe(409);
@@ -362,6 +419,7 @@ describe("seat claim/evict routes", () => {
     const response = await app.inject({
       method: "POST",
       url: "/rooms/ZZZZ/seats/0/claim",
+      ...claimPayload(),
     });
     expect(response.statusCode).toBe(404);
   });
@@ -371,6 +429,7 @@ describe("seat claim/evict routes", () => {
     const response = await app.inject({
       method: "POST",
       url: `/rooms/${code}/seats/${String(DEFAULT_SEAT_COUNT)}/claim`,
+      ...claimPayload(),
     });
     expect(response.statusCode).toBe(404);
   });
@@ -386,13 +445,14 @@ describe("seat claim/evict routes", () => {
 
   it("marks a seat claimed mid-hand as sitting out", async () => {
     const code = await createRoom();
-    rooms.claimSeat(code, 0);
-    rooms.claimSeat(code, 1);
+    rooms.claimSeat(code, 0, "P0");
+    rooms.claimSeat(code, 1, "P1");
     rooms.dispatch(code, "table", "startHand");
 
     const response = await app.inject({
       method: "POST",
       url: `/rooms/${code}/seats/2/claim`,
+      ...claimPayload("Casey"),
     });
 
     expect(response.json<SeatClaimBody>().sittingOut).toBe(true);
@@ -400,7 +460,11 @@ describe("seat claim/evict routes", () => {
 
   it("evicts a seat so it can be reclaimed (ADR-0003)", async () => {
     const code = await createRoom();
-    await app.inject({ method: "POST", url: `/rooms/${code}/seats/0/claim` });
+    await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/claim`,
+      ...claimPayload("Avery"),
+    });
 
     const evicted = await app.inject({
       method: "POST",
@@ -411,6 +475,7 @@ describe("seat claim/evict routes", () => {
     const reclaimed = await app.inject({
       method: "POST",
       url: `/rooms/${code}/seats/0/claim`,
+      ...claimPayload("Avery"),
     });
     expect(reclaimed.statusCode).toBe(200);
   });
@@ -467,9 +532,9 @@ describe("seat-count settings route", () => {
 
   it("rejects a count below the live claimed-seat floor", async () => {
     const room = rooms.create();
-    rooms.claimSeat(room.code, 0);
-    rooms.claimSeat(room.code, 4);
-    rooms.claimSeat(room.code, 7);
+    rooms.claimSeat(room.code, 0, "P0");
+    rooms.claimSeat(room.code, 4, "P4");
+    rooms.claimSeat(room.code, 7, "P7");
 
     const response = await app.inject({
       method: "POST",
@@ -487,8 +552,8 @@ describe("seat-count settings route", () => {
 
   it("grows and shrinks the room, returning the repack moves", async () => {
     const room = rooms.create(4);
-    rooms.claimSeat(room.code, 0);
-    const moved = rooms.claimSeat(room.code, 3);
+    rooms.claimSeat(room.code, 0, "P0");
+    const moved = rooms.claimSeat(room.code, 3, "P3");
     if (!("seat" in moved)) throw new Error("expected a claimed seat");
 
     const grown = await app.inject({
@@ -519,8 +584,8 @@ describe("seat-count settings route", () => {
 
   it("broadcasts a queued shrink in the room view", async () => {
     const room = rooms.create();
-    rooms.claimSeat(room.code, 0);
-    rooms.claimSeat(room.code, 1);
+    rooms.claimSeat(room.code, 0, "P0");
+    rooms.claimSeat(room.code, 1, "P1");
     rooms.dispatch(room.code, "table", "startHand");
 
     const table = new WebSocket(
@@ -616,9 +681,9 @@ describe("seat-count movement over WebSocket", () => {
 
   it("moves an open player socket and reconnects at its new seat", async () => {
     const room = rooms.create();
-    const claim0 = rooms.claimSeat(room.code, 2);
-    const claim1 = rooms.claimSeat(room.code, 5);
-    const claim2 = rooms.claimSeat(room.code, 7);
+    const claim0 = rooms.claimSeat(room.code, 2, "P2");
+    const claim1 = rooms.claimSeat(room.code, 5, "P5");
+    const claim2 = rooms.claimSeat(room.code, 7, "P7");
     if (!("seat" in claim0) || !("seat" in claim1) || !("seat" in claim2)) {
       throw new Error("expected claimed seats");
     }
@@ -752,6 +817,59 @@ describe("WebSocket upgrade", () => {
     socket.close();
   });
 
+  it("pushes seat-count changes to an unclaimed player connection", async () => {
+    const room = rooms.create(4);
+    const socket = new WebSocket(
+      `ws://127.0.0.1:${String(port)}/ws?room=${room.code}&role=lobby`,
+    );
+    const messages: ServerMessage[] = [];
+    socket.on("message", (data: Buffer) => {
+      messages.push(JSON.parse(data.toString()) as ServerMessage);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      socket.once("open", resolve);
+      socket.once("error", reject);
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const initial = messages[0];
+    if (initial?.type !== "room-view") throw new Error("expected a room view");
+    expect(initial.view.code).toBe(room.code);
+    expect(initial.view.seats).toHaveLength(4);
+
+    socket.send(JSON.stringify({ type: "startHand" }));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(messages).toContainEqual({
+      type: "command-rejected",
+      reason: "not-permitted",
+    });
+
+    await app.inject({
+      method: "POST",
+      url: `/rooms/${room.code}/seats/count`,
+      payload: { seatCount: 6 },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const latest = messages.findLast((message) => message.type === "room-view");
+    if (latest?.type !== "room-view") throw new Error("expected a room view");
+    expect(latest.view.seats).toHaveLength(6);
+
+    await app.inject({
+      method: "POST",
+      url: `/rooms/${room.code}/seats/count`,
+      payload: { seatCount: 2 },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const shrunk = messages.findLast((message) => message.type === "room-view");
+    if (shrunk?.type !== "room-view") throw new Error("expected a room view");
+    expect(shrunk.view.seats).toHaveLength(2);
+
+    socket.close();
+  });
+
   it("pushes a fresh room view on connect and on every seat claim", async () => {
     const room = rooms.create();
     const socket = new WebSocket(
@@ -781,6 +899,7 @@ describe("WebSocket upgrade", () => {
     await app.inject({
       method: "POST",
       url: `/rooms/${room.code}/seats/0/claim`,
+      payload: { displayName: "Avery" },
     });
     await new Promise((resolve) => setTimeout(resolve, 20));
 
@@ -789,6 +908,7 @@ describe("WebSocket upgrade", () => {
     expect((messages[1] as { view: RoomView }).view.seats[0]).toEqual({
       id: 0,
       claimed: true,
+      displayName: "Avery",
       sittingOut: false,
       disconnected: false,
     });
@@ -811,7 +931,7 @@ describe("WebSocket upgrade", () => {
 
   it("accepts a player connection with a valid seat token", async () => {
     const room = rooms.create();
-    const claim = rooms.claimSeat(room.code, 0);
+    const claim = rooms.claimSeat(room.code, 0, "P0");
     if (!("seat" in claim)) throw new Error("expected a claimed seat");
 
     const socket = new WebSocket(
@@ -874,7 +994,7 @@ describe("hand command dispatch over WebSocket", () => {
     code: string,
     seatId: number,
   ): Promise<{ socket: WebSocket; messages: ServerMessage[] }> {
-    const claim = rooms.claimSeat(code, seatId);
+    const claim = rooms.claimSeat(code, seatId, `P${String(seatId)}`);
     if (!("seat" in claim)) throw new Error("expected a claimed seat");
     const conn = connect(
       `room=${code}&seat=${String(seatId)}&token=${claim.seat.token ?? ""}`,
@@ -935,6 +1055,41 @@ describe("hand command dispatch over WebSocket", () => {
       (m) => m.type === "hand-update" && m.event.type === "StreetStarted",
     );
     expect(tableStreetStarted).toBeDefined();
+  });
+
+  it("never sends hand views to a lobby socket, mid-hand or on reconnect", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const seat0 = await claimAndConnect(room.code, 0);
+    await claimAndConnect(room.code, 1);
+    const lobby = connect(`room=${room.code}&role=lobby`);
+    await opened(lobby.socket);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    // A socket that joins mid-hand takes the connect-time snapshot path,
+    // which is the other place a seat view is handed out.
+    const lateLobby = connect(`room=${room.code}&role=lobby`);
+    await opened(lateLobby.socket);
+    await settle();
+
+    for (const watcher of [lobby, lateLobby]) {
+      expect(watcher.messages.length).toBeGreaterThan(0);
+      expect(
+        watcher.messages.every((message) => message.type === "room-view"),
+      ).toBe(true);
+      expect(JSON.stringify(watcher.messages)).not.toContain("yourHoleCards");
+    }
+
+    // The seat itself still got its cards — the guard is about identity, not
+    // about the hand having failed to start.
+    expect(JSON.stringify(seat0.messages)).toContain("yourHoleCards");
+
+    lobby.socket.close();
+    lateLobby.socket.close();
   });
 
   it("excludes a sitting-out seat from the deal and it stays sitting out", async () => {
@@ -1309,8 +1464,8 @@ describe("hand persistence", () => {
     const table = new WebSocket(
       `ws://127.0.0.1:${String(address.port)}/ws?room=${room.code}&role=table`,
     );
-    const seat0Claim = rooms.claimSeat(room.code, 0);
-    const seat1Claim = rooms.claimSeat(room.code, 1);
+    const seat0Claim = rooms.claimSeat(room.code, 0, "P0");
+    const seat1Claim = rooms.claimSeat(room.code, 1, "P1");
     if (!("seat" in seat0Claim) || !("seat" in seat1Claim)) {
       throw new Error("expected both seats to be claimed");
     }
@@ -1470,7 +1625,7 @@ describe("action clock", () => {
     code: string,
     seatId: number,
   ): Promise<{ socket: WebSocket; messages: ServerMessage[] }> {
-    const claim = rooms.claimSeat(code, seatId);
+    const claim = rooms.claimSeat(code, seatId, `P${String(seatId)}`);
     if (!("seat" in claim)) throw new Error("expected a claimed seat");
     const conn = connect(
       `room=${code}&seat=${String(seatId)}&token=${claim.seat.token ?? ""}`,
@@ -1517,7 +1672,8 @@ describe("action clock", () => {
     const room = rooms.create();
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
-    for (const seatId of [0, 1, 2]) rooms.claimSeat(room.code, seatId);
+    for (const seatId of [0, 1, 2])
+      rooms.claimSeat(room.code, seatId, `P${String(seatId)}`);
     await settle();
 
     table.socket.send(JSON.stringify({ type: "startHand" }));
@@ -1711,7 +1867,7 @@ describe("presence and reconnection", () => {
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
 
-    const claim = rooms.claimSeat(room.code, 0);
+    const claim = rooms.claimSeat(room.code, 0, "P0");
     if (!("seat" in claim)) throw new Error("expected a claimed seat");
     const seat0 = connect(
       `room=${room.code}&seat=0&token=${claim.seat.token ?? ""}`,
@@ -1732,7 +1888,7 @@ describe("presence and reconnection", () => {
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
 
-    const claim = rooms.claimSeat(room.code, 0);
+    const claim = rooms.claimSeat(room.code, 0, "P0");
     if (!("seat" in claim)) throw new Error("expected a claimed seat");
     const token = claim.seat.token ?? "";
     const seat0 = connect(`room=${room.code}&seat=0&token=${token}`);
@@ -1755,8 +1911,8 @@ describe("presence and reconnection", () => {
     const room = rooms.create();
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
-    const claim0 = rooms.claimSeat(room.code, 0);
-    const claim1 = rooms.claimSeat(room.code, 1);
+    const claim0 = rooms.claimSeat(room.code, 0, "P0");
+    const claim1 = rooms.claimSeat(room.code, 1, "P1");
     if (!("seat" in claim0) || !("seat" in claim1)) {
       throw new Error("expected claimed seats");
     }
@@ -1792,9 +1948,9 @@ describe("presence and reconnection", () => {
     const room = rooms.create();
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
-    const claim0 = rooms.claimSeat(room.code, 0);
-    const claim1 = rooms.claimSeat(room.code, 1);
-    const claim2 = rooms.claimSeat(room.code, 2);
+    const claim0 = rooms.claimSeat(room.code, 0, "P0");
+    const claim1 = rooms.claimSeat(room.code, 1, "P1");
+    const claim2 = rooms.claimSeat(room.code, 2, "P2");
     if (!("seat" in claim0) || !("seat" in claim1) || !("seat" in claim2)) {
       throw new Error("expected claimed seats");
     }
@@ -1847,7 +2003,7 @@ describe("presence and reconnection", () => {
 
   it("rejects a WS connect with a stale token after the seat is evicted", async () => {
     const room = rooms.create();
-    const claim = rooms.claimSeat(room.code, 0);
+    const claim = rooms.claimSeat(room.code, 0, "P0");
     if (!("seat" in claim)) throw new Error("expected a claimed seat");
     const token = claim.seat.token ?? "";
     rooms.evictSeat(room.code, 0);
@@ -1867,7 +2023,7 @@ describe("presence and reconnection", () => {
     const room = rooms.create();
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
-    const claim = rooms.claimSeat(room.code, 0);
+    const claim = rooms.claimSeat(room.code, 0, "P0");
     if (!("seat" in claim)) throw new Error("expected a claimed seat");
     const seat0 = connect(
       `room=${room.code}&seat=0&token=${claim.seat.token ?? ""}`,

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -2,6 +2,7 @@ import fastifyStatic from "@fastify/static";
 import fastifyWebsocket from "@fastify/websocket";
 import {
   ChangeSeatCountRequestSchema,
+  ClaimSeatRequestSchema,
   ClientCommandSchema,
   CreateRoomRequestSchema,
   view,
@@ -78,6 +79,21 @@ interface RoomSeatRoute {
   Params: { code: string; seatId: string };
 }
 
+/**
+ * The two roles that skip seat-token authentication, kept in one place so the
+ * set of unauthenticated connections is reviewable at a glance: `table` is the
+ * shared table device, `lobby` is an unclaimed player watching the room view.
+ * Anything else must present a seat token.
+ */
+const UNAUTHENTICATED_ROLES = ["table", "lobby"] as const;
+type UnauthenticatedRole = (typeof UNAUTHENTICATED_ROLES)[number];
+
+function isUnauthenticatedRole(
+  role: string | undefined,
+): role is UnauthenticatedRole {
+  return UNAUTHENTICATED_ROLES.includes(role as UnauthenticatedRole);
+}
+
 interface WsRoute {
   Querystring: {
     room?: string;
@@ -87,10 +103,24 @@ interface WsRoute {
   };
 }
 
+type SocketIdentity = SeatId | "table" | "lobby";
+
+/**
+ * Narrows a socket's identity to a seat. Only a seat may be handed
+ * `view(state, seatId)` or have its presence tracked; the table and lobby
+ * identities are deliberately excluded, so every per-seat path goes through
+ * this one guard rather than its own `!== "lobby"` check.
+ */
+function isSeat(identity: SocketIdentity | undefined): identity is SeatId {
+  return identity !== undefined && identity !== "table" && identity !== "lobby";
+}
+
 const CLAIM_ERROR_STATUS: Record<ClaimSeatError, number> = {
   "room-not-found": 404,
   "seat-not-found": 404,
   "seat-already-claimed": 409,
+  "invalid-display-name": 400,
+  "duplicate-display-name": 409,
 };
 
 /** Looks up a room, replying 404 and returning undefined when it's not live. */
@@ -177,7 +207,7 @@ export async function buildApp(
   const missedPongLimit = options.missedPongLimit ?? 2;
   const graceWindowMs = options.graceWindowMs ?? 60_000;
   const roomSockets = new Map<string, Set<WebSocket>>();
-  const socketIdentity = new Map<WebSocket, SeatId | "table">();
+  const socketIdentity = new Map<WebSocket, SocketIdentity>();
   const actionClock = new ActionClock(options.actionClockMs);
   const socketRoomCode = new Map<WebSocket, string>();
   const pingMissed = new Map<WebSocket, number>();
@@ -223,7 +253,7 @@ export async function buildApp(
           type: "view-snapshot",
           view: view(room.engine, "table"),
         });
-      } else if (room.engine.seats.includes(identity)) {
+      } else if (isSeat(identity) && room.engine.seats.includes(identity)) {
         send(socket, {
           type: "view-snapshot",
           view: view(room.engine, identity),
@@ -274,9 +304,7 @@ export async function buildApp(
   function markPresence(socket: WebSocket, disconnected: boolean): void {
     const identity = socketIdentity.get(socket);
     const code = socketRoomCode.get(socket);
-    if (identity === undefined || identity === "table" || code === undefined) {
-      return;
-    }
+    if (!isSeat(identity) || code === undefined) return;
     rooms.setSeatDisconnected(code, identity, disconnected);
     broadcastRoomView(code);
   }
@@ -378,7 +406,7 @@ export async function buildApp(
           event: redactEventFor(step.event, "table"),
           view: view(step.state, "table"),
         });
-      } else if (step.state.seats.includes(identity)) {
+      } else if (isSeat(identity) && step.state.seats.includes(identity)) {
         send(socket, {
           type: "hand-update",
           event: redactEventFor(step.event, identity),
@@ -536,7 +564,15 @@ export async function buildApp(
       if (seatId === undefined) {
         return reply.code(400).send({ error: "invalid-seat-id" });
       }
-      const result = rooms.claimSeat(request.params.code, seatId);
+      const body = ClaimSeatRequestSchema.safeParse(request.body);
+      if (!body.success) {
+        return reply.code(400).send({ error: "invalid-display-name" });
+      }
+      const result = rooms.claimSeat(
+        request.params.code,
+        seatId,
+        body.data.displayName,
+      );
       if ("error" in result) {
         return reply
           .code(CLAIM_ERROR_STATUS[result.error])
@@ -546,6 +582,7 @@ export async function buildApp(
       return {
         seatId: result.seat.id,
         token: result.seat.token,
+        displayName: result.seat.displayName,
         sittingOut: rooms.isSittingOut(request.params.code, result.seat.id),
       };
     },
@@ -587,7 +624,7 @@ export async function buildApp(
             await reply.code(404).send({ error: "room-not-found" });
             return;
           }
-          if (role === "table") return;
+          if (isUnauthenticatedRole(role)) return;
 
           if (!authenticateSeat(rooms, code, request.query)) {
             await reply.code(403).send({ error: "invalid-seat-token" });
@@ -600,10 +637,10 @@ export async function buildApp(
         if (code === undefined) return;
 
         const { role } = request.query;
-        let identity: SeatId | "table";
+        let identity: SocketIdentity;
         let movedFrom: SeatId | undefined;
-        if (role === "table") {
-          identity = "table";
+        if (isUnauthenticatedRole(role)) {
+          identity = role;
         } else {
           const authenticated = authenticateSeat(rooms, code, request.query);
           if (!authenticated) return;
@@ -627,13 +664,13 @@ export async function buildApp(
             clearTimeout(timer);
             tableGraceTimers.delete(code);
           }
-        } else {
+        } else if (isSeat(identity)) {
           // A reconnecting seat resumes silently, no penalty (§7) — clear
           // any presence badge a prior drop had set.
           rooms.setSeatDisconnected(code, identity, false);
         }
 
-        if (movedFrom !== undefined && identity !== "table") {
+        if (movedFrom !== undefined && isSeat(identity)) {
           // A disconnected player may still have the pre-repack seat in
           // localStorage. The token authenticates the player; this stale
           // position is only the source for the resync notice.
@@ -650,7 +687,10 @@ export async function buildApp(
                 type: "view-snapshot",
                 view: view(room.engine, "table"),
               });
-            } else if (room.engine.seats.includes(identity)) {
+            } else if (
+              isSeat(identity) &&
+              room.engine.seats.includes(identity)
+            ) {
               send(socket, {
                 type: "view-snapshot",
                 view: view(room.engine, identity),
@@ -689,7 +729,7 @@ export async function buildApp(
             parseResult.data.type === "sitIn"
           ) {
             const currentIdentity = socketIdentity.get(socket);
-            if (currentIdentity === undefined || currentIdentity === "table") {
+            if (!isSeat(currentIdentity)) {
               sendRejection(socket, "not-permitted");
               return;
             }
@@ -703,6 +743,10 @@ export async function buildApp(
           }
 
           const currentIdentity = socketIdentity.get(socket);
+          if (currentIdentity === "lobby") {
+            sendRejection(socket, "not-permitted");
+            return;
+          }
           if (currentIdentity === undefined) {
             sendRejection(socket, "invalid-command");
             return;
@@ -755,7 +799,7 @@ export async function buildApp(
                 }, graceWindowMs),
               );
             }
-          } else if (currentIdentity !== undefined) {
+          } else if (isSeat(currentIdentity)) {
             rooms.setSeatDisconnected(code, currentIdentity, true);
             broadcastRoomView(code);
           }

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SEAT_COUNT,
+  MAX_DISPLAY_NAME_LENGTH,
   MAX_SEAT_COUNT,
   MIN_SEAT_COUNT,
 } from "@table-top-poker/protocol";
@@ -88,12 +89,13 @@ describe("RoomStore", () => {
       );
       const room = store.create();
 
-      const result = store.claimSeat(room.code, 0);
+      const result = store.claimSeat(room.code, 0, "P0");
 
       expect(result).toEqual({
         seat: {
           id: 0,
           claimed: true,
+          displayName: "P0",
           token: "token-0",
           sittingOut: false,
           disconnected: false,
@@ -102,18 +104,60 @@ describe("RoomStore", () => {
       expect(room.seats[0]).toEqual({
         id: 0,
         claimed: true,
+        displayName: "P0",
         token: "token-0",
         sittingOut: false,
         disconnected: false,
       });
     });
 
+    it("stores the display name in the seat and public room view", () => {
+      const store = new RoomStore();
+      const room = store.create();
+
+      const result = store.claimSeat(room.code, 0, " Avery ");
+
+      if (!("seat" in result)) throw new Error("expected a claimed seat");
+      expect(result.seat.displayName).toBe("Avery");
+      expect(toRoomView(room).seats[0]).toMatchObject({
+        claimed: true,
+        displayName: "Avery",
+      });
+    });
+
+    it("rejects a blank or over-long display name without claiming the seat", () => {
+      const store = new RoomStore();
+      const room = store.create();
+
+      expect(store.claimSeat(room.code, 0, "   ")).toEqual({
+        error: "invalid-display-name",
+      });
+      expect(
+        store.claimSeat(room.code, 0, "1".repeat(MAX_DISPLAY_NAME_LENGTH + 1)),
+      ).toEqual({ error: "invalid-display-name" });
+      expect(room.seats[0]?.claimed).toBe(false);
+    });
+
+    it("rejects a case-insensitive duplicate among claimed seats", () => {
+      const store = new RoomStore();
+      const room = store.create();
+      store.claimSeat(room.code, 0, "Avery");
+
+      expect(store.claimSeat(room.code, 1, " aVERY ")).toEqual({
+        error: "duplicate-display-name",
+      });
+      expect(room.seats[1]?.claimed).toBe(false);
+
+      store.evictSeat(room.code, 0);
+      expect(store.claimSeat(room.code, 1, "Avery")).toHaveProperty("seat");
+    });
+
     it("rejects claiming an already-claimed seat", () => {
       const store = new RoomStore();
       const room = store.create();
-      store.claimSeat(room.code, 0);
+      store.claimSeat(room.code, 0, "P0");
 
-      const result = store.claimSeat(room.code, 0);
+      const result = store.claimSeat(room.code, 0, "P0");
 
       expect(result).toEqual({ error: "seat-already-claimed" });
     });
@@ -121,7 +165,7 @@ describe("RoomStore", () => {
     it("finds a claimed seat by its token", () => {
       const store = new RoomStore(Math.random, () => "token");
       const room = store.create();
-      const claim = store.claimSeat(room.code, 2);
+      const claim = store.claimSeat(room.code, 2, "P2");
 
       if (!("seat" in claim)) throw new Error("expected a claimed seat");
       expect(store.findSeatByToken(room.code, "token")).toBe(claim.seat);
@@ -130,16 +174,18 @@ describe("RoomStore", () => {
 
     it("rejects claiming a seat in an unknown room", () => {
       const store = new RoomStore();
-      expect(store.claimSeat("ZZZZ", 0)).toEqual({ error: "room-not-found" });
+      expect(store.claimSeat("ZZZZ", 0, "Avery")).toEqual({
+        error: "room-not-found",
+      });
     });
 
     it("rejects claiming an out-of-range seat", () => {
       const store = new RoomStore();
       const room = store.create();
-      expect(store.claimSeat(room.code, DEFAULT_SEAT_COUNT)).toEqual({
+      expect(store.claimSeat(room.code, DEFAULT_SEAT_COUNT, "Avery")).toEqual({
         error: "seat-not-found",
       });
-      expect(store.claimSeat(room.code, -1)).toEqual({
+      expect(store.claimSeat(room.code, -1, "Avery")).toEqual({
         error: "seat-not-found",
       });
     });
@@ -147,11 +193,11 @@ describe("RoomStore", () => {
     it("claims a seat mid-hand with sittingOut false internally, shown as sitting out in the room view", () => {
       const store = new RoomStore();
       const room = store.create();
-      store.claimSeat(room.code, 0);
-      store.claimSeat(room.code, 1);
+      store.claimSeat(room.code, 0, "P0");
+      store.claimSeat(room.code, 1, "P1");
       store.dispatch(room.code, "table", "startHand");
 
-      const result = store.claimSeat(room.code, 2);
+      const result = store.claimSeat(room.code, 2, "P2");
 
       if (!("seat" in result)) throw new Error("expected a claimed seat");
       expect(typeof result.seat.token).toBe("string");
@@ -166,7 +212,7 @@ describe("RoomStore", () => {
     it("evicts a claimed seat so it can be reclaimed (ADR-0003)", () => {
       const store = new RoomStore();
       const room = store.create();
-      store.claimSeat(room.code, 0);
+      store.claimSeat(room.code, 0, "P0");
 
       store.evictSeat(room.code, 0);
 
@@ -177,7 +223,7 @@ describe("RoomStore", () => {
         sittingOut: false,
         disconnected: false,
       });
-      const reclaimed = store.claimSeat(room.code, 0);
+      const reclaimed = store.claimSeat(room.code, 0, "P0");
       if (!("seat" in reclaimed)) throw new Error("expected a claimed seat");
       expect(typeof reclaimed.seat.token).toBe("string");
       expect(reclaimed.seat).toMatchObject({
@@ -185,6 +231,22 @@ describe("RoomStore", () => {
         claimed: true,
         sittingOut: false,
       });
+    });
+
+    it("carries names through a repack and clears them on eviction", () => {
+      const store = new RoomStore();
+      const room = store.create();
+      store.claimSeat(room.code, 3, "Blair");
+      store.changeSeatCount(room.code, 4);
+
+      expect(room.seats[0]).toMatchObject({
+        claimed: true,
+        displayName: "Blair",
+      });
+
+      store.evictSeat(room.code, 0);
+
+      expect(room.seats[0]).not.toHaveProperty("displayName");
     });
 
     it("evicting a seat in an unknown room is a no-op", () => {
@@ -198,7 +260,7 @@ describe("RoomStore", () => {
   describe("seat-count changes", () => {
     function claimSeats(store: RoomStore, room: Room, ids: readonly number[]) {
       for (const seatId of ids) {
-        const result = store.claimSeat(room.code, seatId);
+        const result = store.claimSeat(room.code, seatId, `P${String(seatId)}`);
         if (!("seat" in result)) throw new Error("expected a claimed seat");
       }
     }
@@ -239,7 +301,7 @@ describe("RoomStore", () => {
     it("grows immediately and appends only fresh unclaimed seats", () => {
       const store = new RoomStore();
       const room = store.create(4);
-      const claimed = store.claimSeat(room.code, 1);
+      const claimed = store.claimSeat(room.code, 1, "P1");
       if (!("seat" in claimed)) throw new Error("expected a claimed seat");
 
       const result = store.changeSeatCount(room.code, 6);
@@ -397,7 +459,7 @@ describe("RoomStore", () => {
     function roomWithClaimedSeats(store: RoomStore, count: number) {
       const room = store.create();
       for (let seatId = 0; seatId < count; seatId++) {
-        store.claimSeat(room.code, seatId);
+        store.claimSeat(room.code, seatId, `P${String(seatId)}`);
       }
       return room;
     }
@@ -471,7 +533,7 @@ describe("RoomStore", () => {
       const store = new RoomStore();
       const room = roomWithClaimedSeats(store, 2);
       store.dispatch(room.code, "table", "startHand");
-      const midHandJoin = store.claimSeat(room.code, 2);
+      const midHandJoin = store.claimSeat(room.code, 2, "P2");
       if (!("seat" in midHandJoin)) throw new Error("expected a claim");
 
       const foldResult = store.dispatch(room.code, 2, "fold");
@@ -558,7 +620,7 @@ describe("RoomStore", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 2);
         store.dispatch(room.code, "table", "startHand");
-        store.claimSeat(room.code, 2);
+        store.claimSeat(room.code, 2, "P2");
         completeHand(store, room);
 
         const result = store.dispatch(room.code, "table", "nextHand");
@@ -581,7 +643,7 @@ describe("RoomStore", () => {
         const room = roomWithClaimedSeats(store, 2);
         store.dispatch(room.code, "table", "startHand");
         completeHand(store, room);
-        store.claimSeat(room.code, 2);
+        store.claimSeat(room.code, 2, "P2");
 
         expect(toRoomView(room).seats[2]).toMatchObject({ sittingOut: true });
 
@@ -756,7 +818,7 @@ describe("RoomStore", () => {
     function roomWithClaimedSeats(store: RoomStore, count: number) {
       const room = store.create();
       for (let seatId = 0; seatId < count; seatId++) {
-        store.claimSeat(room.code, seatId);
+        store.claimSeat(room.code, seatId, `P${String(seatId)}`);
       }
       return room;
     }
@@ -803,7 +865,7 @@ describe("toRoomView", () => {
   it("projects seats without their tokens", () => {
     const store = new RoomStore();
     const room = store.create();
-    store.claimSeat(room.code, 0);
+    store.claimSeat(room.code, 0, "P0");
 
     const view = toRoomView(room);
 
@@ -811,7 +873,13 @@ describe("toRoomView", () => {
       code: room.code,
       pendingSeatCount: null,
       seats: [
-        { id: 0, claimed: true, sittingOut: false, disconnected: false },
+        {
+          id: 0,
+          claimed: true,
+          displayName: "P0",
+          sittingOut: false,
+          disconnected: false,
+        },
         ...Array.from({ length: DEFAULT_SEAT_COUNT - 1 }, (_, i) => ({
           id: i + 1,
           claimed: false,

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_SEAT_COUNT,
   decide,
   MAX_SEAT_COUNT,
+  MAX_DISPLAY_NAME_LENGTH,
   MIN_SEAT_COUNT,
   SeatCountSchema,
   type ClientCommandType,
@@ -33,6 +34,8 @@ import { generateRoomCode } from "./room-code.js";
 export interface Seat {
   readonly id: SeatId;
   claimed: boolean;
+  /** Required for new claims; absent only for rooms created before names existed. */
+  displayName?: string;
   token: string | null;
   /**
    * Voluntary opt-out only (ADR-0002) — set solely by the `sitOut`/`sitIn`
@@ -58,7 +61,11 @@ export interface Room {
 }
 
 export type ClaimSeatError =
-  "room-not-found" | "seat-not-found" | "seat-already-claimed";
+  | "room-not-found"
+  | "seat-not-found"
+  | "seat-already-claimed"
+  | "invalid-display-name"
+  | "duplicate-display-name";
 
 export type ClaimSeatResult = { seat: Seat } | { error: ClaimSeatError };
 
@@ -150,6 +157,9 @@ function repackSeats(room: Room, seatCount: number): SeatRepack {
     replacement[index] = {
       ...target,
       claimed: true,
+      ...(seat.displayName === undefined
+        ? {}
+        : { displayName: seat.displayName }),
       token: seat.token,
       sittingOut: seat.sittingOut,
       disconnected: seat.disconnected,
@@ -248,6 +258,7 @@ function claimedSeatFloor(room: Room): number {
 /** Resets a seat to its unclaimed default — used by the manual evict action. */
 function freeSeat(seat: Seat): void {
   seat.claimed = false;
+  delete seat.displayName;
   seat.token = null;
   seat.sittingOut = false;
   seat.disconnected = false;
@@ -354,15 +365,38 @@ export class RoomStore {
     this.#rooms.delete(code);
   }
 
-  claimSeat(code: string, seatId: SeatId): ClaimSeatResult {
+  /**
+   * A name is required of every new claim (issue #88) — the seat, not just the
+   * HTTP edge, owns that rule. `Seat.displayName` stays optional only because
+   * rooms created before names existed still have nameless claimed seats.
+   */
+  claimSeat(
+    code: string,
+    seatId: SeatId,
+    displayName: string,
+  ): ClaimSeatResult {
     const room = this.#rooms.get(code);
     if (!room) return { error: "room-not-found" };
 
     const seat = room.seats[seatId];
     if (!seat) return { error: "seat-not-found" };
     if (seat.claimed) return { error: "seat-already-claimed" };
+    const trimmedName = displayName.trim();
+    if (trimmedName === "" || trimmedName.length > MAX_DISPLAY_NAME_LENGTH) {
+      return { error: "invalid-display-name" };
+    }
+    const nameKey = trimmedName.toLowerCase();
+    if (
+      room.seats.some(
+        (candidate) =>
+          candidate.claimed && candidate.displayName?.toLowerCase() === nameKey,
+      )
+    ) {
+      return { error: "duplicate-display-name" };
+    }
 
     seat.claimed = true;
+    seat.displayName = trimmedName;
     seat.token = this.#generateToken();
     seat.sittingOut = false;
     seat.disconnected = false;
@@ -570,6 +604,9 @@ export function toRoomView(room: Room): RoomView {
     seats: room.seats.map((seat) => ({
       id: seat.id,
       claimed: seat.claimed,
+      ...(seat.displayName === undefined
+        ? {}
+        : { displayName: seat.displayName }),
       sittingOut: isSittingOut(room, seat.id),
       disconnected: seat.disconnected,
     })),

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -149,6 +149,10 @@ export function App() {
               <SeatMenu
                 seatId={menuSeatId}
                 seatCount={seats.length}
+                displayName={
+                  seats.find((seat) => seat.id === menuSeatId)?.displayName ??
+                  null
+                }
                 onEvict={handleEvictSeat}
                 onDismiss={dismissSeatMenu}
               />
@@ -164,7 +168,7 @@ export function App() {
                   pointerEvents: "none",
                 }}
               >
-                <Board view={handView} />
+                <Board view={handView} seats={seats} />
               </div>
             )}
             <JoinCodeToggle

--- a/packages/table-client/src/Board.test.tsx
+++ b/packages/table-client/src/Board.test.tsx
@@ -36,11 +36,25 @@ describe("Board", () => {
 
   it("names the winner in a hand-complete banner after everyone else folds", () => {
     const view: TableView = { phase: "folded-out", button: 0, winner: 1 };
-    const html = renderToStaticMarkup(<Board view={view} />);
+    const html = renderToStaticMarkup(
+      <Board
+        view={view}
+        seats={[
+          { id: 0, claimed: false, sittingOut: false, disconnected: false },
+          {
+            id: 1,
+            claimed: true,
+            displayName: "Avery",
+            sittingOut: false,
+            disconnected: false,
+          },
+        ]}
+      />,
+    );
 
     expect(html).toMatch(/data-testid="board"[^>]*data-phase="folded-out"/);
     expect(html).toContain('data-testid="hand-complete-banner"');
-    expect(html).toContain("Seat 2 wins — everyone folded");
+    expect(html).toContain("Avery wins — everyone folded");
     expect(html).not.toContain('data-testid="community-cards"');
   });
 

--- a/packages/table-client/src/Board.tsx
+++ b/packages/table-client/src/Board.tsx
@@ -1,13 +1,21 @@
-import type { Card as CardType, TableView } from "@table-top-poker/protocol";
+import type {
+  Card as CardType,
+  SeatView,
+  TableView,
+} from "@table-top-poker/protocol";
 import { Card, color, font } from "@table-top-poker/ui-shared";
 import { motion } from "motion/react";
 
 export interface BoardProps {
   readonly view: TableView;
+  readonly seats?: readonly SeatView[];
 }
 
-function seatLabel(seatId: number): string {
-  return `Seat ${String(seatId + 1)}`;
+function seatLabel(seatId: number, seats: readonly SeatView[]): string {
+  return (
+    seats.find((seat) => seat.id === seatId)?.displayName ??
+    `Seat ${String(seatId + 1)}`
+  );
 }
 
 /** The community cards, dealt in one at a time via Motion rather than CSS keyframes. */
@@ -84,8 +92,9 @@ function HandCompleteBanner({ text }: { readonly text: string }) {
 function showdownText(
   winners: readonly number[],
   description: string | undefined,
+  seats: readonly SeatView[],
 ): string {
-  const names = winners.map(seatLabel).join(" & ");
+  const names = winners.map((winner) => seatLabel(winner, seats)).join(" & ");
   const verb = winners.length > 1 ? "split" : "wins";
   return description ? `${names} ${verb} — ${description}` : `${names} ${verb}`;
 }
@@ -98,11 +107,11 @@ function showdownText(
  * (once here, once at the pod) was most of what made the felt unreadable
  * at a full 8-player table.
  */
-export function Board({ view }: BoardProps) {
+export function Board({ view, seats = [] }: BoardProps) {
   if (view.phase === "no-hand") {
     return (
       <div data-testid="board" data-phase="no-hand">
-        Waiting to deal — button on Seat {view.button + 1}.
+        Waiting to deal — button on {seatLabel(view.button, seats)}.
       </div>
     );
   }
@@ -111,7 +120,7 @@ export function Board({ view }: BoardProps) {
     return (
       <div data-testid="board" data-phase="folded-out">
         <HandCompleteBanner
-          text={`${seatLabel(view.winner)} wins — everyone folded`}
+          text={`${seatLabel(view.winner, seats)} wins — everyone folded`}
         />
       </div>
     );
@@ -133,7 +142,7 @@ export function Board({ view }: BoardProps) {
         }}
       >
         <HandCompleteBanner
-          text={showdownText(view.winners, winnerResult?.description)}
+          text={showdownText(view.winners, winnerResult?.description, seats)}
         />
         <CommunityCards board={view.board} />
       </div>

--- a/packages/table-client/src/HouseRulesSheet.test.tsx
+++ b/packages/table-client/src/HouseRulesSheet.test.tsx
@@ -5,12 +5,30 @@ import { describe, expect, it } from "vitest";
 import { HouseRulesSheet } from "./HouseRulesSheet.js";
 
 const seats: SeatView[] = [
-  { id: 0, claimed: true, sittingOut: false, disconnected: false },
+  {
+    id: 0,
+    claimed: true,
+    displayName: "Avery",
+    sittingOut: false,
+    disconnected: false,
+  },
   { id: 1, claimed: false, sittingOut: false, disconnected: false },
   { id: 2, claimed: false, sittingOut: false, disconnected: false },
-  { id: 3, claimed: true, sittingOut: true, disconnected: false },
+  {
+    id: 3,
+    claimed: true,
+    displayName: "Blair",
+    sittingOut: true,
+    disconnected: false,
+  },
   { id: 4, claimed: false, sittingOut: false, disconnected: false },
-  { id: 5, claimed: true, sittingOut: false, disconnected: true },
+  {
+    id: 5,
+    claimed: true,
+    displayName: "Casey",
+    sittingOut: false,
+    disconnected: true,
+  },
   { id: 6, claimed: false, sittingOut: false, disconnected: false },
   { id: 7, claimed: false, sittingOut: false, disconnected: false },
 ];
@@ -34,8 +52,8 @@ describe("HouseRulesSheet", () => {
 
     expect(html).toContain('data-testid="house-rules-sheet"');
     expect(html).toContain("House rules");
-    expect(html).toContain("Seat 4→2");
-    expect(html).toContain("Seat 6→3");
+    expect(html).toContain("Blair → Seat 2");
+    expect(html).toContain("Casey → Seat 3");
     expect(html).toContain("Applies from the next hand");
   });
 

--- a/packages/table-client/src/HouseRulesSheet.tsx
+++ b/packages/table-client/src/HouseRulesSheet.tsx
@@ -61,8 +61,11 @@ const stepperButtonStyle: CSSProperties = {
   cursor: "pointer",
 };
 
-function seatLabel(seatId: number): string {
-  return `Seat ${String(seatId + 1)}`;
+function seatLabel(seatId: number, seats: readonly SeatView[]): string {
+  return (
+    seats.find((seat) => seat.id === seatId)?.displayName ??
+    `Seat ${String(seatId + 1)}`
+  );
 }
 
 /** The table-device House rules sheet; seat count is its first setting. */
@@ -262,7 +265,10 @@ export function HouseRulesSheet({
                   {moves
                     .map(
                       (move) =>
-                        `${seatLabel(move.from)}→${String(move.to + 1)}`,
+                        // The destination stays labelled: a bare number beside
+                        // a name reads as a score, and numeric names ("7→2")
+                        // would be unreadable otherwise.
+                        `${seatLabel(move.from, seats)} → Seat ${String(move.to + 1)}`,
                     )
                     .join(", ")}
                 </span>

--- a/packages/table-client/src/SeatMenu.test.tsx
+++ b/packages/table-client/src/SeatMenu.test.tsx
@@ -18,6 +18,20 @@ describe("SeatMenu", () => {
     expect(html).toContain("Evict");
   });
 
+  it("shows the player's name while retaining the seat number", () => {
+    const html = renderToStaticMarkup(
+      <SeatMenu
+        seatId={2}
+        seatCount={8}
+        displayName="Avery"
+        onEvict={noop}
+        onDismiss={noop}
+      />,
+    );
+
+    expect(html).toContain("Avery · Seat 3");
+  });
+
   it("renders a full-screen backdrop for dismissal", () => {
     const html = renderToStaticMarkup(
       <SeatMenu seatId={0} seatCount={8} onEvict={noop} onDismiss={noop} />,

--- a/packages/table-client/src/SeatMenu.tsx
+++ b/packages/table-client/src/SeatMenu.tsx
@@ -10,6 +10,7 @@ import { posFor } from "./table/posFor.js";
 export interface SeatMenuProps {
   readonly seatId: number;
   readonly seatCount: number;
+  readonly displayName?: string | null;
   readonly onEvict: () => void;
   readonly onDismiss: () => void;
 }
@@ -23,6 +24,7 @@ export interface SeatMenuProps {
 export function SeatMenu({
   seatId,
   seatCount,
+  displayName,
   onEvict,
   onDismiss,
 }: SeatMenuProps) {
@@ -60,7 +62,7 @@ export function SeatMenu({
             padding: "0 0.2em",
           }}
         >
-          Seat {seatId + 1}
+          {displayName ? `${displayName} · ` : ""}Seat {seatId + 1}
         </div>
         <PillButton
           data-testid={`evict-seat-${String(seatId)}-button`}

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -12,6 +12,27 @@ const seats: SeatView[] = [
 ];
 
 describe("Seats", () => {
+  it("shows a claimed player's display name as a small seat caption", () => {
+    const html = renderToStaticMarkup(
+      <Seats
+        seats={[
+          {
+            id: 0,
+            claimed: true,
+            displayName: "Avery",
+            sittingOut: false,
+            disconnected: false,
+          },
+          ...seats.slice(1),
+        ]}
+        view={null}
+      />,
+    );
+
+    expect(html).toContain('data-testid="seat-pod-0-name"');
+    expect(html).toContain("Avery");
+  });
+
   it("shows every seat as open or sitting-out before any hand exists", () => {
     const html = renderToStaticMarkup(<Seats seats={seats} view={null} />);
     expect(html).toMatch(/data-testid="seat-pod-0"[^>]*data-status="in-hand"/);

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -184,6 +184,25 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
           </div>
         );
 
+        const nameBlock = seat.claimed && seat.displayName && (
+          <div
+            key="name"
+            data-testid={`seat-pod-${String(seat.id)}-name`}
+            title={seat.displayName}
+            style={{
+              maxWidth: "8em",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              fontSize: "0.7em",
+              fontWeight: 600,
+              color: color.textBright,
+            }}
+          >
+            {seat.displayName}
+          </div>
+        );
+
         const holeCardsBlock = visual.holeCards && (
           <div
             key="cards"
@@ -258,12 +277,25 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
         // Boundary rule: the avatar is the fixed anchor `posFor` placed —
         // cards and the hand-description caption only ever grow inward,
         // toward the felt's centre, never past the seat toward the rail.
-        // Top row reads avatar → cards → caption top to bottom; bottom row
-        // is the mirror, so the caption always ends up on the table-facing
-        // side, closest to the centre everyone's looking at.
+        // Top row reads avatar → name → cards/status → caption top to bottom;
+        // bottom row is the mirror, so the name, status, and caption always
+        // end up on the table-facing side, closest to the centre everyone's
+        // looking at.
         const stack = isTopRow
-          ? [avatarBlock, holeCardsBlock, sittingOutBlock, captionBlock]
-          : [captionBlock, holeCardsBlock, sittingOutBlock, avatarBlock];
+          ? [
+              avatarBlock,
+              nameBlock,
+              holeCardsBlock,
+              sittingOutBlock,
+              captionBlock,
+            ]
+          : [
+              captionBlock,
+              sittingOutBlock,
+              holeCardsBlock,
+              nameBlock,
+              avatarBlock,
+            ];
 
         return (
           <div

--- a/packages/table-client/vite.config.ts
+++ b/packages/table-client/vite.config.ts
@@ -16,6 +16,8 @@ export default defineConfig(({ command, mode }) => {
     .split(",")
     .map((host) => host.trim())
     .filter(Boolean);
+  const backendOrigin = env.BACKEND_ORIGIN ?? "http://localhost:3000";
+  const backendWebSocketOrigin = backendOrigin.replace(/^http/, "ws");
 
   return {
     plugins: [react()],
@@ -29,10 +31,10 @@ export default defineConfig(({ command, mode }) => {
       allowedHosts,
       proxy: {
         "/ws": {
-          target: "ws://localhost:3000",
+          target: backendWebSocketOrigin,
           ws: true,
         },
-        "/rooms": "http://localhost:3000",
+        "/rooms": backendOrigin,
       },
     },
   };


### PR DESCRIPTION
## Context

Issue #88 adds required player display names to seats while preserving the existing table layout. Names are trimmed, limited to 10 characters, and unique case-insensitively; profanity and public-name checks are intentionally out of scope.

The room seat count is mutable from 2 to 8. Before this change, an unclaimed player only received the initial room snapshot, so changing the table size left the seat picker stale and a race against a removed seat was reported as “someone just took that seat.”

## Implementation

- Persist display names through room views, reconnects, and positional seat repacks.
- Add larger, viewport-filling player seat cards with seat-count-aware rows.
- Add a room-scoped lobby WebSocket for unclaimed players; it receives room views but cannot issue table or player commands.
- Preserve truthful claim errors, including a specific message when a seat disappears during a claim.

## Validation

- `npm run lint`
- `npm run build`
- `npm test -- --reporter=dot --maxWorkers=1` — 67 files, 419 tests passing after merging main.
- Regression coverage verifies live seat-count growth and shrink updates (`4 → 6 → 2`) and rejects lobby commands.