### PR TITLE
fix(server): resolve evicted non-current seats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,12 +36,12 @@ Single-context: one `CONTEXT.md` and one `docs/adr/` at the repo root, both crea
 
 ## Local testing
 
-While iterating locally, run only the test file(s) covering the code you've
-changed (e.g. `npx vitest run packages/server/src/rooms.test.ts`), not the
-full suite — CI runs the full suite on every push. This keeps local
-feedback loops fast. Still run the full suite (`npm test`) before a deploy,
-per the Raspberry Pi workflow below, and before finishing a task, run it once
-to confirm nothing else broke.
+Run only the test file(s) covering the code you've changed locally (e.g.
+`npx vitest run packages/server/src/rooms.test.ts`), never the full suite.
+CI runs the full suite on every push and is the source of truth for the
+complete test run. Before finishing a task, run the relevant targeted tests,
+typecheck/build, and lint as appropriate; do not run `npm test` unless the
+human explicitly asks for a full local run.
 
 ## Raspberry Pi deployment
 
@@ -52,7 +52,8 @@ When the human asks to deploy a new app version to the Raspberry Pi, use the
 1. Work from the checkout containing the requested commit. Inspect `git status`
    and do not deploy unrelated or uncommitted changes without explicit
    approval.
-2. Build and verify locally with `npm ci`, `npm run lint`, `npm test`, and
+2. Confirm the commit's CI full-suite run passed, then build and verify locally
+   with `npm ci`, the relevant targeted test files, `npm run lint`, and
    `npm run build:release`. The release must be built on the development
    machine; do not build TypeScript or run `npm install` on the Pi.
 3. Before restarting, warn that the server keeps rooms and hands in memory, so

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -83,18 +83,19 @@ A Player's private two cards, dealt once at the start of a Hand and pushed
 to their Device at deal time (not fetched later at reveal).
 
 **Action**:
-A completed decision by a Player — fold, check, call, or raise. Logged as
-an Event. Distinct from *to act* / the *Actor* (see below), which is about
-whose turn it is, not a decision that has happened.
+A completed poker decision for a Seat — fold, check, call, or raise — whether
+chosen by its Player or synthesized by the server when the Seat cannot act.
+Logged as an Event. Distinct from *to act* / the *Actor* (see below), which is
+about whose turn it is, not a decision that has happened.
 
 **Actor**:
 The Player whose turn it currently is. A derived property of Hand state,
 not a persistent identity.
 
 **Command**:
-The input a Player sends proposing an Action, before it is validated and
-turned into an Event. Matches the engine shape `decide(state, command) ->
-Event[] | Rejection`.
+An input proposing or directing a Hand transition, before it is validated and
+turned into Events. It may come from a Player or be synthesized by the server
+for a trusted Table action or action-clock decision.
 
 **Button**:
 The Seat marked as dealer for the current Hand — a positional marker that

--- a/docs/phase-1-spec.md
+++ b/docs/phase-1-spec.md
@@ -111,6 +111,9 @@ No uniform envelope — each type declares its own fields:
   engine level; table-device-only is enforced at the server/UI layer.
 - `{ type: 'fold' | 'check' | 'call' | 'raise', playerId }` — engine
   validates `playerId` is the current Actor.
+- `{ type: 'evict', playerId }` — server-synthesized for a table eviction,
+  never accepted from a player client; it folds a live seat immediately even
+  when that seat is not the current Actor.
 - `{ type: 'nextHand', playerId, seed }` — dismisses the showdown reveal and
   starts the next hand in one step; carries the new seed.
 
@@ -356,7 +359,10 @@ network round trip.
   (active, sitting-out, or disconnected) at any time; there is no
   missed-hands counter or threshold. On eviction: the seat's token is
   invalidated server-side, the seat is freed into the join picker, and the
-  eviction is broadcast to the table.
+  eviction is broadcast to the table. If the seat was dealt into the live
+  hand, the server also records and broadcasts its immediate fold; when that
+  seat is not the current Actor, the current Actor and its action-clock
+  deadline are preserved.
 
 ## 8. Deployment
 ([Research: hosting on a Pi](https://github.com/ewanhardingham/table-top-poker/issues/7),

--- a/docs/phase-1-spec.md
+++ b/docs/phase-1-spec.md
@@ -111,7 +111,7 @@ No uniform envelope — each type declares its own fields:
   engine level; table-device-only is enforced at the server/UI layer.
 - `{ type: 'fold' | 'check' | 'call' | 'raise', playerId }` — engine
   validates `playerId` is the current Actor.
-- `{ type: 'evict', playerId }` — server-synthesized for a table eviction,
+- `{ type: 'evict', seatId }` — server-synthesized for a table eviction,
   never accepted from a player client; it folds a live seat immediately even
   when that seat is not the current Actor.
 - `{ type: 'nextHand', playerId, seed }` — dismisses the showdown reveal and

--- a/packages/engine/src/apply.ts
+++ b/packages/engine/src/apply.ts
@@ -87,7 +87,10 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
       }
       const raiseOccurred = hand.raiseOccurred || event.action === "raise";
 
-      let toAct = hand.toAct.slice(1);
+      // Ordinary actions always belong to `toAct[0]`; an eviction may fold a
+      // live seat later in the queue, so remove the event's seat by identity
+      // and leave the current actor at the head of the queue.
+      let toAct = hand.toAct.filter((seat) => seat !== event.seatId);
       let bbOptionPending = hand.bbOptionPending;
 
       if (event.action === "raise") {

--- a/packages/engine/src/decide.ts
+++ b/packages/engine/src/decide.ts
@@ -58,6 +58,9 @@ export function decide(
     case "call":
     case "raise":
       return decideAction(state, command);
+
+    case "evict":
+      return decideEviction(state, command);
   }
 }
 
@@ -108,13 +111,39 @@ function decideAction(
     return reject("action-not-legal", command);
   }
 
+  return decideActionEvents(state, currentActor, command.type);
+}
+
+function decideEviction(
+  state: EngineState,
+  command: Extract<Command, { type: "evict" }>,
+): HandEvent[] | Rejection {
+  if (state.hand?.status !== "betting") {
+    return reject("hand-not-in-progress", command);
+  }
+  const player = state.hand.players.get(command.playerId);
+  if (player === undefined || player.folded) {
+    return reject("action-not-legal", command);
+  }
+
+  return decideActionEvents(state, command.playerId, "fold");
+}
+
+function decideActionEvents(
+  state: EngineState,
+  seatId: SeatId,
+  action: ActionType,
+): HandEvent[] {
+  const hand = state.hand;
+  if (hand?.status !== "betting") {
+    throw new Error("expected a betting hand while resolving an action");
+  }
   const events: HandEvent[] = [];
-  const actorSeat = command.playerId;
 
   const actionTaken: HandEvent = {
     type: "ActionTaken",
-    seatId: actorSeat,
-    action: command.type,
+    seatId,
+    action,
   };
   events.push(actionTaken);
   let scratch = apply(state, actionTaken);

--- a/packages/engine/src/decide.ts
+++ b/packages/engine/src/decide.ts
@@ -121,12 +121,12 @@ function decideEviction(
   if (state.hand?.status !== "betting") {
     return reject("hand-not-in-progress", command);
   }
-  const player = state.hand.players.get(command.playerId);
+  const player = state.hand.players.get(command.seatId);
   if (player === undefined || player.folded) {
     return reject("action-not-legal", command);
   }
 
-  return decideActionEvents(state, command.playerId, "fold");
+  return decideActionEvents(state, command.seatId, "fold");
 }
 
 function decideActionEvents(

--- a/packages/engine/src/eviction.test.ts
+++ b/packages/engine/src/eviction.test.ts
@@ -1,0 +1,133 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import { apply } from "./apply.js";
+import { createInitialState } from "./room.js";
+import { decide } from "./decide.js";
+import { legalActions } from "./table.js";
+import { playAll } from "./test-utils.js";
+import type { EngineState, HandEvent } from "./types.js";
+
+function applyEvents(state: EngineState, events: HandEvent[]): EngineState {
+  let next = state;
+  for (const event of events) next = apply(next, event);
+  return next;
+}
+
+describe("eviction command", () => {
+  it("preserves the current actor for every supported multi-seat ring", () => {
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(fc.integer({ min: 0, max: 7 }), {
+          minLength: 3,
+          maxLength: 8,
+        }),
+        fc.string({ minLength: 1, maxLength: 10 }),
+        (seats, seed) => {
+          const firstSeat = seats[0];
+          if (firstSeat === undefined) {
+            throw new Error("expected at least one seat");
+          }
+          let state = createInitialState(seats);
+          state = playAll(state, [
+            { type: "startHand", playerId: firstSeat, seed },
+          ]);
+          if (state.hand?.status !== "betting") {
+            throw new Error("expected a betting hand");
+          }
+
+          const actor = state.hand.toAct[0];
+          const evicted = state.hand.toAct[1];
+          if (actor === undefined || evicted === undefined) {
+            throw new Error("expected two seats to be awaiting action");
+          }
+          const result = decide(state, { type: "evict", playerId: evicted });
+          if (!Array.isArray(result)) {
+            throw new Error("expected eviction events");
+          }
+          const next = applyEvents(state, result);
+          if (next.hand?.status !== "betting") {
+            throw new Error("expected the hand to continue");
+          }
+
+          expect(next.hand.toAct[0]).toBe(actor);
+          expect(next.hand.toAct).not.toContain(evicted);
+          expect(next.hand.players.get(evicted)?.folded).toBe(true);
+        },
+      ),
+    );
+  });
+
+  it("folds a later seat without moving the current actor", () => {
+    let state = createInitialState([0, 1, 2]);
+    state = playAll(state, [
+      { type: "startHand", playerId: 0, seed: "eviction" },
+    ]);
+    if (state.hand?.status !== "betting") {
+      throw new Error("expected a betting hand");
+    }
+
+    const actor = state.hand.toAct[0];
+    const evicted = state.hand.toAct[1];
+    if (actor === undefined || evicted === undefined) {
+      throw new Error("expected two seats to be awaiting action");
+    }
+
+    const result = decide(state, { type: "evict", playerId: evicted });
+    if (!Array.isArray(result)) throw new Error("expected eviction events");
+
+    expect(result).toEqual([
+      { type: "ActionTaken", seatId: evicted, action: "fold" },
+    ]);
+    state = applyEvents(state, result);
+
+    if (state.hand?.status !== "betting") {
+      throw new Error("expected the hand to continue");
+    }
+    expect(state.hand.toAct[0]).toBe(actor);
+    expect(state.hand.toAct).not.toContain(evicted);
+    expect(state.hand.players.get(evicted)?.folded).toBe(true);
+
+    const currentAction = legalActions(state.hand, actor)[0];
+    if (currentAction === undefined) {
+      throw new Error("expected the current actor to retain legal actions");
+    }
+    expect(decide(state, { type: currentAction, playerId: actor })).toEqual(
+      expect.any(Array),
+    );
+  });
+
+  it("completes a heads-up hand when the non-current seat is evicted", () => {
+    let state = createInitialState([0, 1]);
+    state = playAll(state, [
+      { type: "startHand", playerId: 0, seed: "eviction-heads-up" },
+    ]);
+    if (state.hand?.status !== "betting") {
+      throw new Error("expected a betting hand");
+    }
+
+    const actor = state.hand.toAct[0];
+    const evicted = state.hand.toAct[1];
+    if (actor === undefined || evicted === undefined) {
+      throw new Error("expected both seats to be awaiting action");
+    }
+
+    const result = decide(state, { type: "evict", playerId: evicted });
+    if (!Array.isArray(result)) throw new Error("expected eviction events");
+
+    expect(result.map((event) => event.type)).toEqual([
+      "ActionTaken",
+      "HandFoldedOut",
+      "HandComplete",
+    ]);
+    state = applyEvents(state, result);
+
+    expect(state.hand?.status).toBe("complete");
+    if (
+      state.hand?.status !== "complete" ||
+      state.hand.reason !== "folded-out"
+    ) {
+      throw new Error("expected a folded-out hand");
+    }
+    expect(state.hand.winner).toBe(actor);
+  });
+});

--- a/packages/engine/src/eviction.test.ts
+++ b/packages/engine/src/eviction.test.ts
@@ -40,7 +40,7 @@ describe("eviction command", () => {
           if (actor === undefined || evicted === undefined) {
             throw new Error("expected two seats to be awaiting action");
           }
-          const result = decide(state, { type: "evict", playerId: evicted });
+          const result = decide(state, { type: "evict", seatId: evicted });
           if (!Array.isArray(result)) {
             throw new Error("expected eviction events");
           }
@@ -72,7 +72,7 @@ describe("eviction command", () => {
       throw new Error("expected two seats to be awaiting action");
     }
 
-    const result = decide(state, { type: "evict", playerId: evicted });
+    const result = decide(state, { type: "evict", seatId: evicted });
     if (!Array.isArray(result)) throw new Error("expected eviction events");
 
     expect(result).toEqual([
@@ -111,7 +111,7 @@ describe("eviction command", () => {
       throw new Error("expected both seats to be awaiting action");
     }
 
-    const result = decide(state, { type: "evict", playerId: evicted });
+    const result = decide(state, { type: "evict", seatId: evicted });
     if (!Array.isArray(result)) throw new Error("expected eviction events");
 
     expect(result.map((event) => event.type)).toEqual([

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -29,7 +29,7 @@ export type Command =
   | { type: "startHand"; playerId: SeatId; seed: string }
   | { type: ActionType; playerId: SeatId }
   /** Server-synthesized table action; never accepted from a player client. */
-  | { type: "evict"; playerId: SeatId }
+  | { type: "evict"; seatId: SeatId }
   | { type: "nextHand"; playerId: SeatId; seed: string };
 
 export type HandEvent =

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -28,6 +28,8 @@ export type HandRank = number;
 export type Command =
   | { type: "startHand"; playerId: SeatId; seed: string }
   | { type: ActionType; playerId: SeatId }
+  /** Server-synthesized table action; never accepted from a player client. */
+  | { type: "evict"; playerId: SeatId }
   | { type: "nextHand"; playerId: SeatId; seed: string };
 
 export type HandEvent =

--- a/packages/engine/src/version.ts
+++ b/packages/engine/src/version.ts
@@ -3,4 +3,4 @@
  * whenever a change to `HandEvent`/`Command` shapes or the shuffle would
  * break bit-identical replay. See docs/phase-1-spec.md §5.
  */
-export const ENGINE_LOG_VERSION = 1;
+export const ENGINE_LOG_VERSION = 2;

--- a/packages/harness/src/replay.test.ts
+++ b/packages/harness/src/replay.test.ts
@@ -56,10 +56,9 @@ describe("replay guarantee", () => {
 
     const commands = [
       { type: "startHand", playerId: 0, seed: "replay-seed" },
+      { type: "evict", playerId: 2 },
       { type: "call", playerId: 1 },
-      { type: "raise", playerId: 2 },
       { type: "call", playerId: 0 },
-      { type: "call", playerId: 1 },
     ];
     const original = collectingWritable();
     await runHarness({

--- a/packages/harness/src/replay.test.ts
+++ b/packages/harness/src/replay.test.ts
@@ -56,7 +56,7 @@ describe("replay guarantee", () => {
 
     const commands = [
       { type: "startHand", playerId: 0, seed: "replay-seed" },
-      { type: "evict", playerId: 2 },
+      { type: "evict", seatId: 2 },
       { type: "call", playerId: 1 },
       { type: "call", playerId: 0 },
     ];

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -1369,6 +1369,52 @@ describe("hand command dispatch over WebSocket", () => {
     );
   });
 
+  it("auto-folds an evicted later seat immediately and preserves the current actor", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    await claimAndConnect(room.code, 0);
+    await claimAndConnect(room.code, 1);
+    await claimAndConnect(room.code, 2);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    const engine = rooms.get(room.code)?.engine;
+    if (engine?.hand?.status !== "betting") {
+      throw new Error("expected a betting hand");
+    }
+    const actor = engine.hand.toAct[0];
+    const evicted = engine.hand.toAct[1];
+    if (actor === undefined || evicted === undefined) {
+      throw new Error("expected two seats to be awaiting action");
+    }
+
+    const before = table.messages.filter(
+      (message) => message.type === "hand-update",
+    ).length;
+    const response = await app.inject({
+      method: "POST",
+      url: `/rooms/${room.code}/seats/${String(evicted)}/evict`,
+    });
+    await settle();
+
+    expect(response.statusCode).toBe(204);
+    expect(table.messages.slice(before)).toContainEqual(
+      expect.objectContaining({
+        type: "hand-update",
+        event: { type: "ActionTaken", seatId: evicted, action: "fold" },
+      }),
+    );
+    expect(rooms.currentActor(room.code)).toBe(actor);
+    const updated = rooms.get(room.code)?.engine;
+    if (updated?.hand?.status !== "betting") {
+      throw new Error("expected the hand to continue");
+    }
+    expect(updated.hand.toAct[0]).toBe(actor);
+    expect(updated.hand.toAct).not.toContain(evicted);
+  });
+
   it("rejects an out-of-turn action, visible only to the sender", async () => {
     const room = rooms.create();
     const table = connect(`room=${room.code}&role=table`);

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -445,7 +445,11 @@ export async function buildApp(
   }
 
   /** Publishes an accepted dispatch, including any positional seat moves. */
-  function publishDispatch(code: string, result: DispatchSuccess): void {
+  function publishDispatch(
+    code: string,
+    result: DispatchSuccess,
+    options: { readonly resetActionClock?: boolean } = {},
+  ): void {
     if (result.seatMoves !== undefined) {
       applySeatMoves(code, result.seatMoves);
     }
@@ -453,7 +457,11 @@ export async function buildApp(
     for (const step of result.steps) {
       fanOutHandUpdate(code, step);
     }
-    rescheduleActionClock(code);
+    if (options.resetActionClock === false) {
+      if (rooms.currentActor(code) === undefined) actionClock.clear(code);
+    } else {
+      rescheduleActionClock(code);
+    }
   }
 
   // `index: false` — the explicit "/" route below owns index resolution
@@ -600,7 +608,12 @@ export async function buildApp(
       if (!room) return;
       const eviction = rooms.evictSeat(request.params.code, seatId);
       if (eviction.dispatch !== undefined) {
-        publishDispatch(request.params.code, eviction.dispatch);
+        publishDispatch(request.params.code, eviction.dispatch, {
+          // A non-current eviction leaves the actor and its existing deadline
+          // untouched; a current-seat eviction uses a normal fold command and
+          // starts the next actor's clock as usual.
+          resetActionClock: eviction.dispatch.command.type !== "evict",
+        });
       }
       broadcastRoomView(request.params.code);
       closeSeatSockets(request.params.code, seatId);

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -104,6 +104,7 @@ interface WsRoute {
 }
 
 type SocketIdentity = SeatId | "table" | "lobby";
+type ActionClockPolicy = "reschedule" | "preserve";
 
 /**
  * Narrows a socket's identity to a seat. Only a seat may be handed
@@ -448,7 +449,9 @@ export async function buildApp(
   function publishDispatch(
     code: string,
     result: DispatchSuccess,
-    options: { readonly resetActionClock?: boolean } = {},
+    options: {
+      readonly actionClock?: ActionClockPolicy;
+    } = {},
   ): void {
     if (result.seatMoves !== undefined) {
       applySeatMoves(code, result.seatMoves);
@@ -457,7 +460,7 @@ export async function buildApp(
     for (const step of result.steps) {
       fanOutHandUpdate(code, step);
     }
-    if (options.resetActionClock === false) {
+    if (options.actionClock === "preserve") {
       if (rooms.currentActor(code) === undefined) actionClock.clear(code);
     } else {
       rescheduleActionClock(code);
@@ -612,7 +615,10 @@ export async function buildApp(
           // A non-current eviction leaves the actor and its existing deadline
           // untouched; a current-seat eviction uses a normal fold command and
           // starts the next actor's clock as usual.
-          resetActionClock: eviction.dispatch.command.type !== "evict",
+          actionClock:
+            eviction.dispatch.command.type === "evict"
+              ? "preserve"
+              : "reschedule",
         });
       }
       broadcastRoomView(request.params.code);

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -734,7 +734,7 @@ describe("RoomStore", () => {
         }
         expect(result.dispatch.command).toEqual({
           type: "evict",
-          playerId: evicted,
+          seatId: evicted,
         });
         expect(result.dispatch.steps.map((step) => step.event)).toEqual([
           { type: "ActionTaken", seatId: evicted, action: "fold" },

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -714,6 +714,37 @@ describe("RoomStore", () => {
         expect(room.engine.hand.players.get(actor)?.folded).toBe(true);
       });
 
+      it("auto-folds a later in-hand seat without moving the current actor", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 3);
+        store.dispatch(room.code, "table", "startHand");
+        if (room.engine?.hand?.status !== "betting") {
+          throw new Error("expected a betting hand");
+        }
+        const actor = room.engine.hand.toAct[0];
+        const evicted = room.engine.hand.toAct[1];
+        if (actor === undefined || evicted === undefined) {
+          throw new Error("expected two seats to be awaiting action");
+        }
+
+        const result = store.evictSeat(room.code, evicted);
+
+        if (result.dispatch === undefined) {
+          throw new Error("expected the eviction fold to dispatch");
+        }
+        expect(result.dispatch.command).toEqual({
+          type: "evict",
+          playerId: evicted,
+        });
+        expect(result.dispatch.steps.map((step) => step.event)).toEqual([
+          { type: "ActionTaken", seatId: evicted, action: "fold" },
+        ]);
+        expect(room.seats[evicted]).toMatchObject({ claimed: false });
+        expect(store.currentActor(room.code)).toBe(actor);
+        expect(room.engine.hand.toAct).not.toContain(evicted);
+        expect(room.engine.hand.players.get(evicted)?.folded).toBe(true);
+      });
+
       it("completes a heads-up hand when evicting the current actor", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 2);

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -594,7 +594,7 @@ export class RoomStore {
     if (room.engine === null) return undefined;
     const result = this.#runEngineCommand(room, room.engine, {
       type: "evict",
-      playerId: seatId,
+      seatId,
     });
     return "steps" in result ? result : undefined;
   }

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -69,7 +69,7 @@ export type ClaimSeatError =
 
 export type ClaimSeatResult = { seat: Seat } | { error: ClaimSeatError };
 
-/** The engine fold, when evicting the seat currently owed a decision. */
+/** The engine dispatch, when eviction resolves a seat during a live hand. */
 export interface EvictSeatResult {
   readonly dispatch?: DispatchSuccess;
 }
@@ -407,28 +407,48 @@ export class RoomStore {
    * Frees any claimed seat — active, sitting-out, or disconnected alike —
    * back into the join picker and invalidates its token. The table
    * device's manual "evict" action (ADR-0003); there is no automatic trigger.
-   * An actor evicted during a live hand is folded first so the engine can
-   * advance to the next decision.
+   * Any live seat evicted during a live hand is folded first. If it is not the
+   * current actor, the engine removes it from the outstanding queue without
+   * disturbing whoever is currently to act.
    */
   evictSeat(code: string, seatId: SeatId): EvictSeatResult {
     const room = this.#rooms.get(code);
     const seat = room?.seats[seatId];
     if (!seat) return {};
 
-    if (this.currentActor(code) !== seatId) {
+    if (this.currentActor(code) === seatId) {
+      const result = this.dispatch(code, seatId, "fold");
+      // `currentActor` was read as the live actor, and fold is unconditionally
+      // legal for that seat. If that invariant ever breaks, leave the seat
+      // claimed so the action clock can recover instead of freeing an actor the
+      // engine is still waiting on.
+      if (!("steps" in result)) return {};
+
       freeSeat(seat);
-      return {};
+      return { dispatch: result };
     }
 
-    const result = this.dispatch(code, seatId, "fold");
-    // `currentActor` was read as the live actor, and fold is unconditionally
-    // legal for that seat. If that invariant ever breaks, leave the seat
-    // claimed so the action clock can recover instead of freeing an actor the
-    // engine is still waiting on.
-    if (!("steps" in result)) return {};
+    const hand = room.engine?.hand;
+    const player =
+      hand?.status === "betting" ? hand.players.get(seatId) : undefined;
+    if (
+      hand?.status === "betting" &&
+      hand.ring.includes(seatId) &&
+      player !== undefined &&
+      !player.folded
+    ) {
+      const result = this.#dispatchEviction(room, seatId);
+      // The engine must accept a live in-hand seat eviction. If that invariant
+      // ever breaks, leave the claim intact so a later action-clock fold can
+      // recover rather than freeing a seat the engine still considers live.
+      if (result === undefined) return {};
+
+      freeSeat(seat);
+      return { dispatch: result };
+    }
 
     freeSeat(seat);
-    return { dispatch: result };
+    return {};
   }
 
   /**
@@ -564,6 +584,26 @@ export class RoomStore {
     if (candidateEngine === null) return { reason: "hand-not-in-progress" };
 
     const command = this.#buildCommand(identity, type);
+    const result = this.#runEngineCommand(room, candidateEngine, command);
+    if (!("steps" in result)) return result;
+
+    return seatMoves.length > 0 ? { ...result, seatMoves } : result;
+  }
+
+  #dispatchEviction(room: Room, seatId: SeatId): DispatchSuccess | undefined {
+    if (room.engine === null) return undefined;
+    const result = this.#runEngineCommand(room, room.engine, {
+      type: "evict",
+      playerId: seatId,
+    });
+    return "steps" in result ? result : undefined;
+  }
+
+  #runEngineCommand(
+    room: Room,
+    candidateEngine: EngineState,
+    command: Command,
+  ): DispatchSuccess | DispatchRejection {
     const result = decide(candidateEngine, command);
     if (!Array.isArray(result)) {
       return { reason: result.reason, command, rejection: result };
@@ -576,10 +616,7 @@ export class RoomStore {
       steps.push({ event, state });
     }
     room.engine = state;
-
-    return seatMoves.length > 0
-      ? { command, steps, seatMoves }
-      : { command, steps };
+    return { command, steps };
   }
 
   /**


### PR DESCRIPTION
Fixes #103

## What changed

- Add a server-only `evict` engine command that immediately folds a non-current seat.
- Remove evicted seats from the action queue by seat identity, preserving the current actor turn.
- Preserve the current actor action clock and deadline when a different seat is evicted.
- Cover the behavior with engine property tests, server/HTTP tests, replay coverage, and phase-1 documentation.
- Bump the engine log version for the new replayable command shape.

## Why

Previously, an evicted non-current seat could remain in the engine ring and wait for the normal production action timeout when its turn arrived. The new forced fold resolves it immediately while preserving hand event ordering and the current actor turn.

## Verification

- `npm run build`
- `npm run lint`
- Full Vitest suite: 68 files and 427 tests passed
- `git diff --check`