### PR TITLE
feat(player-client): Hole-card module seam, face-down deal-in and keyboard reveal

### DIFF
--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -202,6 +202,7 @@ export function App() {
             seatId={seatId}
             seats={seats}
             connectionStatus={connectionStatus}
+            intent={intent}
           />
         )}
         {handView !== null && handView.phase === "betting" && (

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -54,7 +54,7 @@ describe("Hand", () => {
     expect(html).toContain("Waiting on Avery");
   });
 
-  it("reveals own hole cards but never the shared board mid-hand", () => {
+  it("deals own hole cards in face-down, and never shows the shared board mid-hand", () => {
     const view: PlayerView = {
       phase: "betting",
       button: 0,
@@ -75,12 +75,14 @@ describe("Hand", () => {
     };
     const html = renderToStaticMarkup(<Hand view={view} seatId={0} />);
 
+    // Cards arrive face-down and stay that way until the player asks for
+    // them (Phase 3 spec #138): nothing is exposed on deal, so the hand isn't
+    // in the document at all — not merely hidden by a style.
     expect(html).toMatch(/data-testid="hole-cards"/);
-    expect(html).toContain('data-rank="Q"');
-    expect(html).toContain('data-rank="J"');
-    expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(2);
+    expect(html).toContain('data-presentation="FaceDown"');
+    expect((html.match(/data-face-down="true"/g) ?? []).length).toBe(2);
+    expect(html).not.toContain("data-rank");
     expect(html).not.toContain('data-testid="community-cards"');
-    expect(html).not.toContain('data-rank="A"');
   });
 
   it("hides hole cards once folded, without a placeholder leak", () => {
@@ -101,6 +103,7 @@ describe("Hand", () => {
     const html = renderToStaticMarkup(<Hand view={view} seatId={0} />);
 
     expect(html).toMatch(/data-testid="no-hole-cards"/);
+    expect(html).not.toMatch(/data-testid="hole-cards"/);
     expect(html).not.toContain("data-rank");
   });
 
@@ -119,6 +122,7 @@ describe("Hand", () => {
     const html = renderToStaticMarkup(<Hand view={view} seatId={0} />);
 
     expect(html).toMatch(/data-testid="no-hole-cards"/);
+    expect(html).not.toMatch(/data-testid="hole-cards"/);
     expect(html).toContain("Waiting for the next deal.");
     expect(html).not.toContain("muck");
   });

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -4,7 +4,6 @@ import type {
   SeatView,
 } from "@table-top-poker/protocol";
 import {
-  Card,
   color,
   font,
   fontSize,
@@ -12,6 +11,8 @@ import {
   shadow,
 } from "@table-top-poker/ui-shared";
 import { motion } from "motion/react";
+import type { ActionIntent } from "./actions/useActionIntent.js";
+import { HoleCardPair, type CardActions } from "./holecards/index.js";
 import type { ConnectionStatus } from "./store/connectionSlice.js";
 
 export interface HandProps {
@@ -19,6 +20,39 @@ export interface HandProps {
   readonly seatId: number;
   readonly seats?: readonly SeatView[];
   readonly connectionStatus?: ConnectionStatus;
+  /**
+   * The action intent `App` already owns. `Hand` narrows it to the card
+   * module's own port — the module never sees `ActionIntent`, so growing the
+   * intent layer later does not ripple into card code.
+   */
+  readonly intent?: ActionIntent;
+}
+
+const noAction = () => undefined;
+
+/**
+ * `actions.fold`/`actions.check` **are** `intent.fold`/`intent.check`: a
+ * gesture and a button reach the same Action by the same route, and `canAct`
+ * stays the single legality gate. The legality flags are arming and rendering
+ * input only.
+ */
+function cardActionsFrom(intent: ActionIntent | undefined): CardActions {
+  if (intent === undefined) {
+    return {
+      foldLegal: false,
+      checkLegal: false,
+      pending: false,
+      fold: noAction,
+      check: noAction,
+    };
+  }
+  return {
+    foldLegal: intent.legalActions.includes("fold"),
+    checkLegal: intent.legalActions.includes("check"),
+    pending: intent.pendingAction !== null,
+    fold: intent.fold,
+    check: intent.check,
+  };
 }
 
 type BannerTone = "turn" | "win" | "loss" | "idle" | "offline";
@@ -263,11 +297,21 @@ function TurnBanner({ banner }: { readonly banner: Banner }) {
   );
 }
 
-function HoleCards({
+/**
+ * The card region: the pair itself, plus the copy around it. `Hand` keeps
+ * every caption on this screen; the pair owns card presentation and nothing
+ * else, which is why the `Absent` copy is decided here (folded reads
+ * differently from not-dealt-in) while the empty slots are drawn there.
+ */
+function HoleCardsRegion({
   cards,
+  locked = false,
+  actions,
   caption,
 }: {
-  readonly cards: readonly [CardType, CardType];
+  readonly cards: readonly [CardType, CardType] | null;
+  readonly locked?: boolean;
+  readonly actions: CardActions;
   readonly caption: string;
 }) {
   return (
@@ -278,91 +322,31 @@ function HoleCards({
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-        gap: "0.9em",
+        gap: cards === null ? "1.1em" : "0.9em",
         minHeight: 0,
-      }}
-    >
-      <div
-        data-testid="hole-cards"
-        style={{ display: "flex", gap: "0.5em", fontSize: "2.6em" }}
-      >
-        {cards.map((card, i) => (
-          <motion.div
-            key={i}
-            initial={{ opacity: 0, rotateY: -92 }}
-            animate={{ opacity: 1, rotateY: 0, rotate: i === 0 ? -3 : 3 }}
-            transition={{
-              duration: 0.42,
-              delay: i * 0.08,
-              ease: [0.2, 0.8, 0.2, 1],
-            }}
-          >
-            <Card rank={card.rank} suit={card.suit} />
-          </motion.div>
-        ))}
-      </div>
-      <span
-        style={{
-          fontFamily: font.mono,
-          fontSize: fontSize.xs,
-          letterSpacing: "0.2em",
-          textTransform: "uppercase",
-          color: color.textDim,
-        }}
-      >
-        {caption}
-      </span>
-    </div>
-  );
-}
-
-function EmptyHoleCards({ text }: { readonly text: string }) {
-  return (
-    <div
-      data-testid="no-hole-cards"
-      style={{
-        flex: 1,
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: "1.1em",
         textAlign: "center",
       }}
     >
-      <div style={{ display: "flex", gap: "0.9em" }}>
-        <span
-          style={{
-            width: "6.5em",
-            height: "9.2em",
-            display: "block",
-            borderRadius: radius.card,
-            border: `1px dashed ${color.border}`,
-            background: "rgba(255,255,255,.03)",
-            transform: "rotate(-5deg)",
-          }}
-        />
-        <span
-          style={{
-            width: "6.5em",
-            height: "9.2em",
-            display: "block",
-            borderRadius: radius.card,
-            border: `1px dashed ${color.border}`,
-            background: "rgba(255,255,255,.03)",
-            transform: "rotate(5deg)",
-          }}
-        />
-      </div>
+      <HoleCardPair cards={cards} locked={locked} actions={actions} />
       <span
-        style={{
-          fontSize: fontSize.md,
-          lineHeight: 1.5,
-          color: color.textDim,
-          maxWidth: "16em",
-        }}
+        style={
+          cards === null
+            ? {
+                fontSize: fontSize.md,
+                lineHeight: 1.5,
+                color: color.textDim,
+                maxWidth: "16em",
+              }
+            : {
+                fontFamily: font.mono,
+                fontSize: fontSize.xs,
+                letterSpacing: "0.2em",
+                textTransform: "uppercase",
+                color: color.textDim,
+              }
+        }
       >
-        {text}
+        {caption}
       </span>
     </div>
   );
@@ -384,7 +368,10 @@ export function Hand({
   seatId,
   seats = [],
   connectionStatus = "connected",
+  intent,
 }: HandProps) {
+  const actions = cardActionsFrom(intent);
+
   if (view.phase === "no-hand") {
     return (
       <div
@@ -399,7 +386,11 @@ export function Hand({
         }}
       >
         <TurnBanner banner={bannerFor(view, connectionStatus, seatId, seats)} />
-        <EmptyHoleCards text="Waiting for the next hand." />
+        <HoleCardsRegion
+          cards={null}
+          actions={actions}
+          caption="Waiting for the next hand."
+        />
       </div>
     );
   }
@@ -419,8 +410,10 @@ export function Hand({
         }}
       >
         <TurnBanner banner={bannerFor(view, connectionStatus, seatId, seats)} />
-        <EmptyHoleCards
-          text={
+        <HoleCardsRegion
+          cards={null}
+          actions={actions}
+          caption={
             iWon
               ? "No showdown — everyone else folded."
               : "You folded — cards are in the muck."
@@ -446,12 +439,18 @@ export function Hand({
       >
         <TurnBanner banner={bannerFor(view, connectionStatus, seatId, seats)} />
         {myResult ? (
-          <HoleCards
+          <HoleCardsRegion
             cards={myResult.holeCards}
+            locked
+            actions={actions}
             caption="Your hole cards · showdown"
           />
         ) : (
-          <EmptyHoleCards text="You folded — cards are in the muck." />
+          <HoleCardsRegion
+            cards={null}
+            actions={actions}
+            caption="You folded — cards are in the muck."
+          />
         )}
       </div>
     );
@@ -472,13 +471,16 @@ export function Hand({
     >
       <TurnBanner banner={bannerFor(view, connectionStatus, seatId, seats)} />
       {view.yourHoleCards ? (
-        <HoleCards
+        <HoleCardsRegion
           cards={view.yourHoleCards}
+          actions={actions}
           caption={`Your hole cards · ${view.street}`}
         />
       ) : (
-        <EmptyHoleCards
-          text={
+        <HoleCardsRegion
+          cards={null}
+          actions={actions}
+          caption={
             isDealtIn(view)
               ? "You folded — cards are in the muck."
               : "Waiting for the next deal."

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -11,6 +11,7 @@ import {
   shadow,
 } from "@table-top-poker/ui-shared";
 import { motion } from "motion/react";
+import type { CSSProperties } from "react";
 import type { ActionIntent } from "./actions/useActionIntent.js";
 import { HoleCardPair, type CardActions } from "./holecards/index.js";
 import type { ConnectionStatus } from "./store/connectionSlice.js";
@@ -298,6 +299,27 @@ function TurnBanner({ banner }: { readonly banner: Banner }) {
 }
 
 /**
+ * A caption under a pair is a label — small, spaced, uppercase; a caption
+ * under empty slots is a sentence explaining why they're empty, and reads as
+ * prose.
+ */
+const captionStyle: Record<"label" | "prose", CSSProperties> = {
+  label: {
+    fontFamily: font.mono,
+    fontSize: fontSize.xs,
+    letterSpacing: "0.2em",
+    textTransform: "uppercase",
+    color: color.textDim,
+  },
+  prose: {
+    fontSize: fontSize.md,
+    lineHeight: 1.5,
+    color: color.textDim,
+    maxWidth: "16em",
+  },
+};
+
+/**
  * The card region: the pair itself, plus the copy around it. `Hand` keeps
  * every caption on this screen; the pair owns card presentation and nothing
  * else, which is why the `Absent` copy is decided here (folded reads
@@ -314,6 +336,7 @@ function HoleCardsRegion({
   readonly actions: CardActions;
   readonly caption: string;
 }) {
+  const absent = cards === null;
   return (
     <div
       style={{
@@ -322,32 +345,13 @@ function HoleCardsRegion({
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-        gap: cards === null ? "1.1em" : "0.9em",
+        gap: absent ? "1.1em" : "0.9em",
         minHeight: 0,
         textAlign: "center",
       }}
     >
       <HoleCardPair cards={cards} locked={locked} actions={actions} />
-      <span
-        style={
-          cards === null
-            ? {
-                fontSize: fontSize.md,
-                lineHeight: 1.5,
-                color: color.textDim,
-                maxWidth: "16em",
-              }
-            : {
-                fontFamily: font.mono,
-                fontSize: fontSize.xs,
-                letterSpacing: "0.2em",
-                textTransform: "uppercase",
-                color: color.textDim,
-              }
-        }
-      >
-        {caption}
-      </span>
+      <span style={captionStyle[absent ? "prose" : "label"]}>{caption}</span>
     </div>
   );
 }

--- a/packages/player-client/src/holecards/BendableCard.tsx
+++ b/packages/player-client/src/holecards/BendableCard.tsx
@@ -21,11 +21,12 @@ import { REVEAL_FINISH_MS } from "./constants.js";
 export function BendableCard({
   card,
   presentation,
-  index,
+  tiltDegrees,
 }: {
   readonly card: CardType;
   readonly presentation: Presentation;
-  readonly index: 0 | 1;
+  /** The card's resting angle in the overlapped pair. */
+  readonly tiltDegrees: number;
 }) {
   const turning = presentation === "Turning";
   const revealed = presentation === "Revealed";
@@ -44,7 +45,7 @@ export function BendableCard({
       style={{
         position: "relative",
         display: "grid",
-        transform: `rotate(${index === 0 ? "-3" : "3"}deg)`,
+        transform: `rotate(${String(tiltDegrees)}deg)`,
       }}
     >
       {showBack && (

--- a/packages/player-client/src/holecards/BendableCard.tsx
+++ b/packages/player-client/src/holecards/BendableCard.tsx
@@ -1,0 +1,71 @@
+import type { Card as CardType } from "@table-top-poker/protocol";
+import { Card } from "@table-top-poker/ui-shared";
+import { motion } from "motion/react";
+import type { Presentation } from "./cardState.js";
+import { REVEAL_FINISH_MS } from "./constants.js";
+
+/**
+ * The player-side wrapper around the untouched shared `Card` (Phase 3 spec
+ * #138 §14). Bend and flip live here, in the player client; `ui-shared` gains
+ * no gesture or poker concepts and the table client is unaffected.
+ *
+ * The turn cross-fades `Card`'s two branches — its documented `faceDown`
+ * branch and its face branch — rather than swapping an image, which is the
+ * reason `Card` renders DOM either way.
+ *
+ * The face branch is mounted only while the card is turning or revealed, so a
+ * face-down pair carries no rank or suit in the document at all. Concealment
+ * unmounts it again, instantly: `Revealed → FaceDown` is a privacy act and is
+ * never animated.
+ */
+export function BendableCard({
+  card,
+  presentation,
+  index,
+}: {
+  readonly card: CardType;
+  readonly presentation: Presentation;
+  readonly index: 0 | 1;
+}) {
+  const turning = presentation === "Turning";
+  const revealed = presentation === "Revealed";
+  const showFace = turning || revealed;
+  const showBack = !revealed;
+  const duration = turning ? REVEAL_FINISH_MS / 1000 : 0;
+
+  return (
+    <motion.div
+      data-testid="hole-card"
+      data-revealed={String(revealed)}
+      // The half-turn: the card narrows to its edge and comes back, with the
+      // two branches crossing over while it is edge-on.
+      animate={{ scaleX: turning ? [1, 0.04, 1] : 1 }}
+      transition={{ duration, times: [0, 0.5, 1], ease: "easeInOut" }}
+      style={{
+        position: "relative",
+        display: "grid",
+        transform: `rotate(${index === 0 ? "-3" : "3"}deg)`,
+      }}
+    >
+      {showBack && (
+        <motion.div
+          style={{ gridArea: "1 / 1" }}
+          animate={{ opacity: turning ? 0 : 1 }}
+          transition={{ duration, ease: "easeInOut" }}
+        >
+          <Card faceDown />
+        </motion.div>
+      )}
+      {showFace && (
+        <motion.div
+          style={{ gridArea: "1 / 1" }}
+          initial={{ opacity: turning ? 0 : 1 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration, ease: "easeInOut" }}
+        >
+          <Card rank={card.rank} suit={card.suit} />
+        </motion.div>
+      )}
+    </motion.div>
+  );
+}

--- a/packages/player-client/src/holecards/HoleCardPair.test.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.test.tsx
@@ -1,0 +1,76 @@
+import type { Card } from "@table-top-poker/protocol";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { HoleCardPair } from "./HoleCardPair.js";
+import type { CardActions } from "./ports.js";
+
+const actions: CardActions = {
+  foldLegal: true,
+  checkLegal: true,
+  pending: false,
+  fold: () => undefined,
+  check: () => undefined,
+};
+
+const queenJack: readonly [Card, Card] = [
+  { rank: "Q", suit: "diamonds" },
+  { rank: "J", suit: "clubs" },
+];
+
+describe("HoleCardPair", () => {
+  it("deals in face-down, with no rank or suit anywhere in the document", () => {
+    const html = renderToStaticMarkup(
+      <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
+    );
+
+    expect(html).toMatch(/data-testid="hole-cards"/);
+    expect(html).toContain('data-presentation="FaceDown"');
+    expect((html.match(/data-face-down="true"/g) ?? []).length).toBe(2);
+    expect(html).not.toContain("data-rank");
+  });
+
+  it("renders as a real focusable button with an accessible name", () => {
+    const html = renderToStaticMarkup(
+      <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
+    );
+
+    expect(html).toMatch(/^<button [^>]*type="button"/);
+    expect(html).toContain(
+      'aria-label="Your hole cards, face down. Activate to reveal them."',
+    );
+  });
+
+  it("names the cards for a screen reader once they are revealed", () => {
+    const html = renderToStaticMarkup(
+      <HoleCardPair cards={queenJack} locked actions={actions} />,
+    );
+
+    expect(html).toContain(
+      'aria-label="Your hole cards, Queen of diamonds and Jack of clubs"',
+    );
+  });
+
+  it("renders a locked pair face-up and inert", () => {
+    const html = renderToStaticMarkup(
+      <HoleCardPair cards={queenJack} locked actions={actions} />,
+    );
+
+    expect(html).toContain('data-presentation="Revealed"');
+    expect(html).toContain('data-rank="Q"');
+    expect(html).toContain('data-rank="J"');
+    expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(2);
+    expect(html).toContain("disabled");
+  });
+
+  it("renders the Absent presentation and no card pair for a seat holding nothing", () => {
+    const html = renderToStaticMarkup(
+      <HoleCardPair cards={null} locked={false} actions={actions} />,
+    );
+
+    expect(html).toMatch(/data-testid="no-hole-cards"/);
+    expect(html).not.toMatch(/data-testid="hole-cards"/);
+    expect(html).not.toContain("data-rank");
+    expect(html).not.toContain("<button");
+  });
+});

--- a/packages/player-client/src/holecards/HoleCardPair.test.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.test.tsx
@@ -60,7 +60,10 @@ describe("HoleCardPair", () => {
     expect(html).toContain('data-rank="Q"');
     expect(html).toContain('data-rank="J"');
     expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(2);
-    expect(html).toContain("disabled");
+    expect(html).toContain('aria-disabled="true"');
+    // Inert, but still in the tab order with its name intact: at showdown
+    // that name is where a screen-reader user reads their own hand.
+    expect(html).not.toMatch(/<button[^>]*\sdisabled/);
   });
 
   it("renders the Absent presentation and no card pair for a seat holding nothing", () => {

--- a/packages/player-client/src/holecards/HoleCardPair.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.tsx
@@ -1,0 +1,161 @@
+import type { Card as CardType, Rank, Suit } from "@table-top-poker/protocol";
+import { color, radius } from "@table-top-poker/ui-shared";
+import { motion } from "motion/react";
+import { BendableCard } from "./BendableCard.js";
+import type { Presentation } from "./cardState.js";
+import { DEAL_IN_MS } from "./constants.js";
+import type { CardActions } from "./ports.js";
+import { useHoleCards } from "./useHoleCards.js";
+
+export interface HoleCardPairProps {
+  /** `null` ⇒ `Absent`: not dealt in, folded, or mucked. */
+  readonly cards: readonly [CardType, CardType] | null;
+  /** Showdown: revealed and inert. */
+  readonly locked: boolean;
+  readonly actions: CardActions;
+}
+
+const rankWords: Record<Rank, string> = {
+  "2": "Two",
+  "3": "Three",
+  "4": "Four",
+  "5": "Five",
+  "6": "Six",
+  "7": "Seven",
+  "8": "Eight",
+  "9": "Nine",
+  "10": "Ten",
+  J: "Jack",
+  Q: "Queen",
+  K: "King",
+  A: "Ace",
+};
+
+const suitWords: Record<Suit, string> = {
+  clubs: "clubs",
+  diamonds: "diamonds",
+  hearts: "hearts",
+  spades: "spades",
+};
+
+function cardWords(card: CardType): string {
+  return `${rankWords[card.rank]} of ${suitWords[card.suit]}`;
+}
+
+/**
+ * The accessible name carries the state and the outcome of activating, and —
+ * once revealed — the cards themselves, since a screen-reader user reads them
+ * here rather than off the card faces.
+ */
+function accessibleName(
+  cards: readonly [CardType, CardType],
+  presentation: Presentation,
+  locked: boolean,
+): string {
+  const faces = `${cardWords(cards[0])} and ${cardWords(cards[1])}`;
+  if (locked) return `Your hole cards, ${faces}`;
+  if (presentation === "Revealed" || presentation === "Turning") {
+    return `Your hole cards, ${faces}. Activate to hide them.`;
+  }
+  return "Your hole cards, face down. Activate to reveal them.";
+}
+
+/**
+ * The `Absent` presentation: a seat holding no cards — not dealt in, folded,
+ * or mucked. Two empty slots, so the surface never implies the player is
+ * holding something. The surrounding copy belongs to `Hand`, which owns every
+ * caption on this screen.
+ */
+function Absent() {
+  return (
+    <div
+      data-testid="no-hole-cards"
+      style={{ display: "flex", gap: "0.9em", fontSize: "2.6em" }}
+    >
+      {[-5, 5].map((tilt) => (
+        <span
+          key={tilt}
+          style={{
+            width: "3.5em",
+            height: "5em",
+            display: "block",
+            borderRadius: radius.card,
+            border: `1px dashed ${color.border}`,
+            background: "rgba(255,255,255,.03)",
+            transform: `rotate(${String(tilt)}deg)`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * The player's own hole cards as an object they handle, not a picture they
+ * read (Phase 3 spec #138). Cards arrive **face-down** and stay that way until
+ * the player asks for them; nothing here touches the server, changes poker
+ * visibility, or affects showdown.
+ *
+ * This is one of the module's two public names. Everything it is built from —
+ * the reducer, the hook, the bendable card — is module-internal, so nothing
+ * outside can reach a lifecycle state and no consumer learns what a pointer is.
+ *
+ * The pair is a real focusable `button`: Enter, Space or a click toggles
+ * reveal and conceal, so reading your own cards never depends on getting a
+ * gesture's timing right (§12). The pointer recognizer layered on top of this
+ * — bend to peek, swipe to fold, double-tap to check — arrives in later
+ * tickets; this establishes the seam it grows inside.
+ */
+export function HoleCardPair(props: HoleCardPairProps) {
+  const { cards, locked } = props;
+  const { state, activate } = useHoleCards(props);
+
+  if (cards === null) return <Absent />;
+
+  // A render can land between cards arriving and the deal being observed;
+  // face-down is the entry state for every hand, so it is also the honest
+  // presentation for that gap.
+  const presentation =
+    state.presentation === "Absent" ? "FaceDown" : state.presentation;
+
+  return (
+    <motion.button
+      type="button"
+      data-testid="hole-cards"
+      data-presentation={presentation}
+      // Remounting on a new deal replays the deal-in: the cards arrive
+      // face-down (§17), replacing `Hand`'s per-card face-up deal animation.
+      key={`${cards[0].rank}${cards[0].suit}-${cards[1].rank}${cards[1].suit}`}
+      onClick={activate}
+      disabled={locked}
+      aria-label={accessibleName(cards, presentation, locked)}
+      initial={{ opacity: 0, y: "-18%" }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: DEAL_IN_MS / 1000, ease: [0.2, 0.8, 0.2, 1] }}
+      style={{
+        display: "flex",
+        gap: "0.5em",
+        fontSize: "2.6em",
+        padding: 0,
+        border: "none",
+        background: "none",
+        color: "inherit",
+        cursor: locked ? "default" : "pointer",
+        // Handling cards must not raise the OS text-selection or callout menu
+        // over them (§16).
+        userSelect: "none",
+        WebkitTouchCallout: "none",
+        touchAction: "manipulation",
+      }}
+    >
+      {cards.map((card, index) => (
+        <BendableCard
+          key={index}
+          card={card}
+          index={index === 0 ? 0 : 1}
+          presentation={presentation}
+        />
+      ))}
+    </motion.button>
+  );
+}

--- a/packages/player-client/src/holecards/HoleCardPair.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.tsx
@@ -42,6 +42,11 @@ function cardWords(card: CardType): string {
   return `${rankWords[card.rank]} of ${suitWords[card.suit]}`;
 }
 
+/** A pair's identity as a value — a hand's cards, never their position. */
+function cardKey(cards: readonly [CardType, CardType]): string {
+  return cards.map((card) => `${card.rank}${card.suit}`).join("-");
+}
+
 /**
  * The accessible name carries the state and the outcome of activating, and —
  * once revealed — the cards themselves, since a screen-reader user reads them
@@ -119,23 +124,18 @@ export function HoleCardPair(props: HoleCardPairProps) {
     state.presentation === "Absent" ? "FaceDown" : state.presentation;
 
   return (
-    <motion.button
+    <button
       type="button"
       data-testid="hole-cards"
       data-presentation={presentation}
-      // Remounting on a new deal replays the deal-in: the cards arrive
-      // face-down (§17), replacing `Hand`'s per-card face-up deal animation.
-      key={`${cards[0].rank}${cards[0].suit}-${cards[1].rank}${cards[1].suit}`}
-      onClick={activate}
-      disabled={locked}
+      // A locked pair is inert but stays in the tab order and keeps its
+      // accessible name: at showdown that name is where a screen-reader user
+      // reads their own hand, and `disabled` would take it away.
+      onClick={locked ? undefined : activate}
+      aria-disabled={locked}
       aria-label={accessibleName(cards, presentation, locked)}
-      initial={{ opacity: 0, y: "-18%" }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: DEAL_IN_MS / 1000, ease: [0.2, 0.8, 0.2, 1] }}
       style={{
         display: "flex",
-        gap: "0.5em",
-        fontSize: "2.6em",
         padding: 0,
         border: "none",
         background: "none",
@@ -148,14 +148,27 @@ export function HoleCardPair(props: HoleCardPairProps) {
         touchAction: "manipulation",
       }}
     >
-      {cards.map((card, index) => (
-        <BendableCard
-          key={index}
-          card={card}
-          index={index === 0 ? 0 : 1}
-          presentation={presentation}
-        />
-      ))}
-    </motion.button>
+      <motion.span
+        // Keyed on card identity so a new hand replays the deal-in: the cards
+        // arrive face-down (§17), replacing `Hand`'s per-card face-up deal
+        // animation. The key is on the motion element, not the component, so
+        // it restarts an animation without discarding lifecycle state —
+        // `DEALT` stays the one thing that resets presentation.
+        key={cardKey(cards)}
+        initial={{ opacity: 0, y: "-18%" }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: DEAL_IN_MS / 1000, ease: [0.2, 0.8, 0.2, 1] }}
+        style={{ display: "flex", gap: "0.5em", fontSize: "2.6em" }}
+      >
+        {cards.map((card, index) => (
+          <BendableCard
+            key={index}
+            card={card}
+            tiltDegrees={index === 0 ? -3 : 3}
+            presentation={presentation}
+          />
+        ))}
+      </motion.span>
+    </button>
   );
 }

--- a/packages/player-client/src/holecards/cardState.test.ts
+++ b/packages/player-client/src/holecards/cardState.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  initialCardState,
+  reduce,
+  type CardState,
+  type Presentation,
+} from "./cardState.js";
+
+function state(presentation: Presentation): CardState {
+  return { presentation, recognizer: "Idle" };
+}
+
+describe("initialCardState", () => {
+  it("starts Absent when the seat holds no cards", () => {
+    expect(initialCardState({ hasCards: false, locked: false })).toEqual(
+      state("Absent"),
+    );
+  });
+
+  it("starts FaceDown when cards are already in hand on mount", () => {
+    expect(initialCardState({ hasCards: true, locked: false })).toEqual(
+      state("FaceDown"),
+    );
+  });
+
+  it("starts Revealed when mounting into a locked (showdown) pair", () => {
+    expect(initialCardState({ hasCards: true, locked: true })).toEqual(
+      state("Revealed"),
+    );
+  });
+
+  it("stays Absent when locked with no cards", () => {
+    expect(initialCardState({ hasCards: false, locked: true })).toEqual(
+      state("Absent"),
+    );
+  });
+});
+
+describe("reduce", () => {
+  describe("DEALT", () => {
+    it("deals in face-down from Absent", () => {
+      expect(reduce(state("Absent"), { type: "DEALT" })).toEqual(
+        state("FaceDown"),
+      );
+    });
+
+    it("returns every other presentation to face-down, so a new hand never inherits a face-up frame", () => {
+      for (const presentation of [
+        "FaceDown",
+        "Peeking",
+        "Turning",
+        "Revealed",
+        "Leaving",
+      ] as const) {
+        expect(reduce(state(presentation), { type: "DEALT" })).toEqual(
+          state("FaceDown"),
+        );
+      }
+    });
+  });
+
+  describe("CARDS_GONE", () => {
+    it("empties the pair from any presentation", () => {
+      for (const presentation of [
+        "FaceDown",
+        "Revealed",
+        "Turning",
+        "Leaving",
+      ] as const) {
+        expect(reduce(state(presentation), { type: "CARDS_GONE" })).toEqual(
+          state("Absent"),
+        );
+      }
+    });
+  });
+
+  describe("ACTIVATED", () => {
+    it("starts the flip to face-up from FaceDown", () => {
+      expect(reduce(state("FaceDown"), { type: "ACTIVATED" })).toEqual(
+        state("Turning"),
+      );
+    });
+
+    it("conceals instantly from Revealed — there is no concealing flip", () => {
+      expect(reduce(state("Revealed"), { type: "ACTIVATED" })).toEqual(
+        state("FaceDown"),
+      );
+    });
+
+    it("toggles reveal and conceal across repeated activations", () => {
+      const revealing = reduce(state("FaceDown"), { type: "ACTIVATED" });
+      const revealed = reduce(revealing, { type: "TURN_FINISHED" });
+      expect(revealed.presentation).toBe("Revealed");
+      expect(reduce(revealed, { type: "ACTIVATED" }).presentation).toBe(
+        "FaceDown",
+      );
+    });
+
+    it("is a no-op mid-turn, so a second activation cannot stall the flip", () => {
+      expect(reduce(state("Turning"), { type: "ACTIVATED" })).toEqual(
+        state("Turning"),
+      );
+    });
+
+    it("is a no-op with no cards in hand", () => {
+      expect(reduce(state("Absent"), { type: "ACTIVATED" })).toEqual(
+        state("Absent"),
+      );
+    });
+
+    it("is a no-op while the pair is leaving for the muck", () => {
+      expect(reduce(state("Leaving"), { type: "ACTIVATED" })).toEqual(
+        state("Leaving"),
+      );
+    });
+  });
+
+  describe("TURN_FINISHED", () => {
+    it("lands the committed flip on Revealed", () => {
+      expect(reduce(state("Turning"), { type: "TURN_FINISHED" })).toEqual(
+        state("Revealed"),
+      );
+    });
+
+    it("is a no-op from any other presentation", () => {
+      for (const presentation of [
+        "Absent",
+        "FaceDown",
+        "Revealed",
+        "Leaving",
+      ] as const) {
+        expect(reduce(state(presentation), { type: "TURN_FINISHED" })).toEqual(
+          state(presentation),
+        );
+      }
+    });
+  });
+});

--- a/packages/player-client/src/holecards/cardState.ts
+++ b/packages/player-client/src/holecards/cardState.ts
@@ -1,0 +1,84 @@
+/**
+ * The Hole-card lifecycle (Phase 3 spec #138 §3): Presentation and Recognizer
+ * modelled as orthogonal machines but reduced by **one** pure function, so a
+ * coupled event applies atomically and cannot half-land.
+ *
+ * Nothing here touches React or the DOM — every rule in the behaviour contract
+ * is verifiable as a function call, which is why the module needs no store, no
+ * socket and no simulated pointer to test.
+ *
+ * This slice (#139) carries the deal-in, the emptying, and the keyboard
+ * reveal/conceal toggle. Bend, tap, drag and showdown arms are added by later
+ * tickets against this same shape.
+ */
+
+/** Pair-scoped: both cards always share one presentation. */
+export type Presentation =
+  "Absent" | "FaceDown" | "Peeking" | "Turning" | "Revealed" | "Leaving";
+
+export type Recognizer =
+  "Idle" | "Pressing" | "Bending" | "FoldDragging" | "Ignored" | "Committed";
+
+export interface CardState {
+  readonly presentation: Presentation;
+  readonly recognizer: Recognizer;
+}
+
+export type CardEvent =
+  /** Cards arrived: a fresh deal, or a new hand's cards swapping in. */
+  | { readonly type: "DEALT" }
+  /** Cards left: folded, mucked, or dealt out. */
+  | { readonly type: "CARDS_GONE" }
+  /** The pair was activated as a button — Enter, Space or a click. */
+  | { readonly type: "ACTIVATED" }
+  /** The committed flip to face-up finished animating. */
+  | { readonly type: "TURN_FINISHED" };
+
+/**
+ * Mount state. A pair that mounts holding cards has not been dealt in as far
+ * as this module is concerned — there is no deal-in event to observe — so it
+ * simply starts face-down, and a locked (showdown) pair starts face-up.
+ */
+export function initialCardState({
+  hasCards,
+  locked,
+}: {
+  readonly hasCards: boolean;
+  readonly locked: boolean;
+}): CardState {
+  if (!hasCards) return { presentation: "Absent", recognizer: "Idle" };
+  return {
+    presentation: locked ? "Revealed" : "FaceDown",
+    recognizer: "Idle",
+  };
+}
+
+export function reduce(state: CardState, event: CardEvent): CardState {
+  switch (event.type) {
+    case "DEALT":
+      // Unconditional, from every presentation: deal detection is what makes
+      // every hand start face-down, so no face-up frame of the previous hand
+      // can survive into the next one.
+      return { presentation: "FaceDown", recognizer: "Idle" };
+
+    case "CARDS_GONE":
+      return { presentation: "Absent", recognizer: "Idle" };
+
+    case "ACTIVATED":
+      // Reveal is a flip; conceal is instant. `Turning` is revealing-only —
+      // there is no concealing flip, and an activation mid-turn is dropped
+      // rather than queued.
+      if (state.presentation === "FaceDown") {
+        return { ...state, presentation: "Turning" };
+      }
+      if (state.presentation === "Revealed") {
+        return { ...state, presentation: "FaceDown" };
+      }
+      return state;
+
+    case "TURN_FINISHED":
+      return state.presentation === "Turning"
+        ? { ...state, presentation: "Revealed" }
+        : state;
+  }
+}

--- a/packages/player-client/src/holecards/constants.ts
+++ b/packages/player-client/src/holecards/constants.ts
@@ -1,0 +1,40 @@
+/**
+ * Prototype-validated constants (Phase 3 spec #138 §15), carried forward as
+ * defaults rather than re-derived. Several are unused until the pointer
+ * recognizer lands; they live here from the start so the numbers are stated
+ * once, in the module that owns them.
+ */
+
+/** Pointer travel before a gesture is classified, in px. */
+export const MOVE_SLOP_PX = 9;
+
+/** Fraction of bend travel past which the reveal is committed. */
+export const REVEAL_THRESHOLD = 0.9;
+
+/** Full bend travel, in px, over which peel progress runs 0 → 1. */
+export const BEND_TRAVEL_PX = 176;
+
+/** Floor of the fold threshold, in px. */
+export const MIN_FOLD_DISTANCE_PX = 148;
+
+/** Fraction of viewport height the fold threshold scales with. */
+export const FOLD_DISTANCE_RATIO = 0.18;
+
+/** Window within which a second tap counts as a double-tap, in ms. */
+export const DOUBLE_TAP_MS = 280;
+
+/** Duration of the committed flip to face-up, in ms. */
+export const REVEAL_FINISH_MS = 520;
+
+/** Duration of the muck flight after a committed Fold, in ms. */
+export const FOLD_FLIGHT_MS = 280;
+
+/** Quiet interval a coaching hint waits for before appearing, in ms. */
+export const HINT_QUIET_MS = 2000;
+
+/**
+ * Duration of the face-down deal-in, in ms. Not a §15 constant — the deal-in
+ * motion is §17 and had no prototype value; this matches the per-card deal
+ * animation it replaces in `Hand`.
+ */
+export const DEAL_IN_MS = 420;

--- a/packages/player-client/src/holecards/index.ts
+++ b/packages/player-client/src/holecards/index.ts
@@ -1,0 +1,13 @@
+/**
+ * The Hole-card module's seam (Phase 3 spec #138 §1). It exports **two**
+ * names and nothing else: the component, and the Action port the module
+ * defines for itself.
+ *
+ * Everything else — the reducer, the hook, the view adapter, the bendable
+ * card, the constants — is module-internal and imported by nothing outside
+ * this directory. That is what keeps pointers, bends and recognizer states
+ * out of `Hand`, and what lets every later gesture be an addition inside
+ * `holecards/` rather than surgery on the component tree.
+ */
+export { HoleCardPair } from "./HoleCardPair.js";
+export type { CardActions } from "./ports.js";

--- a/packages/player-client/src/holecards/ports.ts
+++ b/packages/player-client/src/holecards/ports.ts
@@ -1,0 +1,17 @@
+/**
+ * The Action port the Hole-card module defines for itself (Phase 3 spec #138
+ * §2). `fold` and `check` **are** `intent.fold`/`intent.check` — a gesture and
+ * a button reach the same Action by the same route, and `canAct` stays the
+ * single legality gate.
+ *
+ * `foldLegal`, `checkLegal` and `pending` are for arming and rendering only.
+ * The module never uses them to decide whether an Action is permitted, so a
+ * stale prop can at worst arm a gesture that `canAct` then refuses.
+ */
+export interface CardActions {
+  readonly foldLegal: boolean;
+  readonly checkLegal: boolean;
+  readonly pending: boolean;
+  readonly fold: () => void;
+  readonly check: () => void;
+}

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -1,8 +1,21 @@
-import { useCallback, useEffect, useReducer, useRef } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useReducer,
+  useRef,
+} from "react";
 import { initialCardState, reduce, type CardState } from "./cardState.js";
 import { REVEAL_FINISH_MS } from "./constants.js";
 import type { HoleCardPairProps } from "./HoleCardPair.js";
 import { eventsForPropChange } from "./viewEvents.js";
+
+/**
+ * `useLayoutEffect` warns when it is called during server rendering, and the
+ * component tests render to static markup — where no effect runs either way.
+ */
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 /**
  * Binds the pure lifecycle to React: prop changes in, discrete state out.
@@ -26,7 +39,11 @@ export function useHoleCards(props: HoleCardPairProps): {
   // nothing for the overwhelming majority of renders, which is exactly the
   // "inert by default" guarantee. A dependency list here would be a second,
   // weaker copy of that comparison.
-  useEffect(() => {
+  //
+  // A **layout** effect, so a new hand's cards can never be painted under the
+  // previous hand's presentation: `DEALT` lands between commit and paint, and
+  // no face-up frame survives from one hand into the next.
+  useIsomorphicLayoutEffect(() => {
     const events = eventsForPropChange(previous.current, props, state);
     previous.current = props;
     for (const event of events) dispatch(event);

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useReducer, useRef } from "react";
+import { initialCardState, reduce, type CardState } from "./cardState.js";
+import { REVEAL_FINISH_MS } from "./constants.js";
+import type { HoleCardPairProps } from "./HoleCardPair.js";
+import { eventsForPropChange } from "./viewEvents.js";
+
+/**
+ * Binds the pure lifecycle to React: prop changes in, discrete state out.
+ * Every decision it makes is delegated — `eventsForPropChange` decides what a
+ * changed prop means, `reduce` decides what that means for the pair — so the
+ * hook itself holds no rules worth testing through a renderer.
+ */
+export function useHoleCards(props: HoleCardPairProps): {
+  readonly state: CardState;
+  readonly activate: () => void;
+} {
+  const [state, dispatch] = useReducer(reduce, props, (initial) =>
+    initialCardState({
+      hasCards: initial.cards !== null,
+      locked: initial.locked,
+    }),
+  );
+
+  const previous = useRef(props);
+  // Deliberately un-keyed: the adapter compares the props itself and returns
+  // nothing for the overwhelming majority of renders, which is exactly the
+  // "inert by default" guarantee. A dependency list here would be a second,
+  // weaker copy of that comparison.
+  useEffect(() => {
+    const events = eventsForPropChange(previous.current, props, state);
+    previous.current = props;
+    for (const event of events) dispatch(event);
+  });
+
+  // `Turning` is a point of no return: once the flip is committed it finishes
+  // on its own schedule, whatever the pointer does.
+  useEffect(() => {
+    if (state.presentation !== "Turning") return;
+    const timer = setTimeout(() => {
+      dispatch({ type: "TURN_FINISHED" });
+    }, REVEAL_FINISH_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [state.presentation]);
+
+  const activate = useCallback(() => {
+    dispatch({ type: "ACTIVATED" });
+  }, []);
+
+  return { state, activate };
+}

--- a/packages/player-client/src/holecards/viewEvents.test.ts
+++ b/packages/player-client/src/holecards/viewEvents.test.ts
@@ -1,0 +1,114 @@
+import type { Card } from "@table-top-poker/protocol";
+import { describe, expect, it } from "vitest";
+import type { CardState } from "./cardState.js";
+import type { CardActions } from "./ports.js";
+import type { HoleCardPairProps } from "./HoleCardPair.js";
+import { eventsForPropChange } from "./viewEvents.js";
+
+const actions: CardActions = {
+  foldLegal: false,
+  checkLegal: false,
+  pending: false,
+  fold: () => undefined,
+  check: () => undefined,
+};
+
+const queenJack: readonly [Card, Card] = [
+  { rank: "Q", suit: "diamonds" },
+  { rank: "J", suit: "clubs" },
+];
+
+function props(overrides: Partial<HoleCardPairProps> = {}): HoleCardPairProps {
+  return { cards: null, locked: false, actions, ...overrides };
+}
+
+const faceDown: CardState = { presentation: "FaceDown", recognizer: "Idle" };
+const absent: CardState = { presentation: "Absent", recognizer: "Idle" };
+
+describe("eventsForPropChange", () => {
+  it("produces nothing by default — an incoming view is inert unless proven otherwise", () => {
+    const before = props({ cards: queenJack });
+    expect(eventsForPropChange(before, { ...before }, faceDown)).toEqual([]);
+  });
+
+  it("produces nothing for a new street, a new board card or another player's bet", () => {
+    // None of those reach this module at all: they change `PlayerView`, not
+    // any of the three props, so the adapter sees an identical pair of props.
+    const before = props({ cards: queenJack });
+    const after = props({ cards: before.cards });
+    expect(eventsForPropChange(before, after, faceDown)).toEqual([]);
+  });
+
+  it("produces nothing when the turn changes — legality is arming input, not a lifecycle event", () => {
+    const before = props({ cards: queenJack });
+    const after = props({
+      cards: queenJack,
+      actions: { ...actions, foldLegal: true, checkLegal: true },
+    });
+    expect(eventsForPropChange(before, after, faceDown)).toEqual([]);
+  });
+
+  it("deals in when cards arrive from nothing", () => {
+    expect(
+      eventsForPropChange(props(), props({ cards: queenJack }), absent),
+    ).toEqual([{ type: "DEALT" }]);
+  });
+
+  it("deals in on a card-identity change with no intervening empty view", () => {
+    const next: readonly [Card, Card] = [
+      { rank: "7", suit: "spades" },
+      { rank: "2", suit: "hearts" },
+    ];
+    expect(
+      eventsForPropChange(
+        props({ cards: queenJack }),
+        props({ cards: next }),
+        faceDown,
+      ),
+    ).toEqual([{ type: "DEALT" }]);
+  });
+
+  it("treats an equal-valued but newly built pair as the same cards", () => {
+    const sameValues: readonly [Card, Card] = [
+      { rank: "Q", suit: "diamonds" },
+      { rank: "J", suit: "clubs" },
+    ];
+    expect(
+      eventsForPropChange(
+        props({ cards: queenJack }),
+        props({ cards: sameValues }),
+        faceDown,
+      ),
+    ).toEqual([]);
+  });
+
+  it("deals in when only one card of the pair changes", () => {
+    const swapped: readonly [Card, Card] = [
+      { rank: "Q", suit: "diamonds" },
+      { rank: "J", suit: "spades" },
+    ];
+    expect(
+      eventsForPropChange(
+        props({ cards: queenJack }),
+        props({ cards: swapped }),
+        faceDown,
+      ),
+    ).toEqual([{ type: "DEALT" }]);
+  });
+
+  it("empties the pair when the cards go away", () => {
+    expect(
+      eventsForPropChange(props({ cards: queenJack }), props(), faceDown),
+    ).toEqual([{ type: "CARDS_GONE" }]);
+  });
+
+  it("produces nothing while the seat holds no cards at all", () => {
+    expect(eventsForPropChange(props(), props(), absent)).toEqual([]);
+  });
+
+  it("produces nothing when the cards go away from a pair already showing nothing", () => {
+    expect(
+      eventsForPropChange(props({ cards: queenJack }), props(), absent),
+    ).toEqual([]);
+  });
+});

--- a/packages/player-client/src/holecards/viewEvents.ts
+++ b/packages/player-client/src/holecards/viewEvents.ts
@@ -1,0 +1,49 @@
+import type { Card } from "@table-top-poker/protocol";
+import type { CardEvent, CardState } from "./cardState.js";
+import type { HoleCardPairProps } from "./HoleCardPair.js";
+
+function sameCard(a: Card, b: Card): boolean {
+  return a.rank === b.rank && a.suit === b.suit;
+}
+
+function samePair(
+  a: readonly [Card, Card] | null,
+  b: readonly [Card, Card] | null,
+): boolean {
+  if (a === null || b === null) return a === b;
+  return sameCard(a[0], b[0]) && sameCard(a[1], b[1]);
+}
+
+/**
+ * The one place a server-shaped input becomes a lifecycle event (Phase 3 spec
+ * #138 §8). The reducer never sees a `PlayerView`, and the hook decides
+ * nothing. Keeping the derivation pure is what makes "an incoming view is
+ * inert" a tested property rather than a remembered one.
+ *
+ * **The default return is the empty array.** `fanOutHandUpdate` sends a
+ * `hand-update` for every event in the hand, and peeking at your cards is
+ * exactly what you do while others act — so a new street, a new board card,
+ * another player's bet and a changed `toAct` must all produce nothing.
+ *
+ * `state` is the current lifecycle state, which the later arms
+ * (`FOLD_DISARMED`, `PENDING_RESOLVED`) consult; this slice's two events do
+ * not depend on it.
+ */
+export function eventsForPropChange(
+  prev: HoleCardPairProps,
+  next: HoleCardPairProps,
+  state: CardState,
+): readonly CardEvent[] {
+  if (next.cards === null) {
+    // An event is a transition, never a restatement: a pair already showing
+    // nothing has nothing to be told.
+    if (prev.cards === null || state.presentation === "Absent") return [];
+    return [{ type: "CARDS_GONE" }];
+  }
+
+  // Card identity, not reference: `PlayerView` carries no hand id, so cards
+  // arriving is the deal signal — with a value comparison as the defensive
+  // second signal for a betting→betting view that swaps cards without an
+  // intervening empty one.
+  return samePair(prev.cards, next.cards) ? [] : [{ type: "DEALT" }];
+}


### PR DESCRIPTION
Implements #139 — the prefactor slice of the Phase 3 tactile Hole-card spec (#138).

## What lands

A new player-client module `packages/player-client/src/holecards/`, whose index exports exactly two names: the `HoleCardPair` component and the `CardActions` port the module defines for itself. Everything else — the reducer, the view adapter, the hook, the bendable card, the constants — is module-internal, so every later gesture is an addition inside `holecards/` rather than surgery on `Hand`.

- **Cards deal in face-down** with their own deal-in motion, replacing `Hand`'s per-card face-up deal animation (§17). The face branch is mounted only once the pair is turning or revealed, so a face-down hand carries no rank or suit in the document at all.
- **`Absent` presentation** for a Seat holding no cards — not dealt in, folded, or mucked — replacing `Hand`'s `EmptyHoleCards`. `Hand` keeps every caption, so folded still reads differently from not-dealt-in.
- **The pair is a real focusable `button`** with an accessible name that carries the cards themselves once revealed. Enter, Space or a click flips it face-up; the flip completes on its own schedule and conceal is instant, never animated (§3, §12).
- **`BendableCard`** wraps the untouched shared `Card`, cross-fading its `faceDown` and face branches rather than swapping an image (§14). `ui-shared` gains nothing.
- **`eventsForPropChange`** is a pure adapter returning the empty array by default, so an incoming server view is inert unless proven otherwise (§8).
- **`constants.ts`** carries the §15 prototype-validated values.

`Hand` builds a `CardActions` from the `intent` that already lives in `App` and renders `<HoleCardPair/>`. It learns nothing about pointers or recognizer states, and keeps its caption and `data-testid="hand"` contract.

## Testing

The whole behaviour contract is pure functions — `reduce` and `eventsForPropChange`, table-driven, no DOM, no store, no socket, no simulated pointer. The rendered surface is asserted as static markup. No new dev dependency and no per-package environment divergence, per the spec's testing decisions.

`Hand.test.tsx`'s face-up expectations were **updated, not worked around**: a betting view now asserts the pair is face-down with no rank in the document.

Full suite green: 462 tests across 73 files. Typecheck and lint clean.

## Two judgement calls worth a look

1. **Showdown renders through the pair.** `Hand`'s old `HoleCards` component is deleted, so the showdown branch had to render something. It renders the pair with `locked`, which starts `Revealed`. The `SHOWDOWN_REVEAL` event and reducer-level inertness stay with #140; this is the minimum that keeps the spec's own Layer 2/3 lines ("a locked pair renders both faces", "a showdown view renders it locked and revealed") true today.

2. **A locked pair is `aria-disabled`, not `disabled`.** `disabled` would take it out of the tab order and hide the accessible name — which at Showdown is where a screen-reader Player reads their own hand.

Out of scope by design, owned by #140–#147: bend to peek, reveal past the threshold, tap to conceal, double-tap Check, swipe to Fold, cancellation and resets, coaching hints. No `cardSlice`, no `ui-shared` change, no protocol/server/engine change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RE312eUsgNZKycWgVWitqZ
