### PR TITLE
feat(player-client): Showdown auto-reveal and lock

### DIFF
--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -234,6 +234,17 @@ describe("Hand", () => {
       expect(html).not.toContain("Pair of Kings");
     });
 
+    it("hands the pair to showdown locked, so it renders revealed and inert", () => {
+      // `HoleCardPair.test.tsx` owns what locked *looks* like; the fact worth
+      // asserting here is that showdown is where the lock comes from.
+      const html = renderToStaticMarkup(
+        <Hand view={showdownView} seatId={0} />,
+      );
+
+      expect(html).toContain('data-presentation="Revealed"');
+      expect(html).toContain('aria-disabled="true"');
+    });
+
     it("shows the loser's own hole cards and a loss banner naming the winner", () => {
       const html = renderToStaticMarkup(
         <Hand view={showdownView} seatId={1} />,
@@ -253,6 +264,7 @@ describe("Hand", () => {
       );
 
       expect(html).toMatch(/data-testid="no-hole-cards"/);
+      expect(html).not.toMatch(/data-testid="hole-cards"/);
       expect(html).toContain("you folded earlier");
       expect(html).toContain("You folded — cards are in the muck.");
     });
@@ -267,6 +279,7 @@ describe("Hand", () => {
       expect(html).toMatch(/data-testid="turn-banner"[^>]*data-tone="win"/);
       expect(html).toContain("You win — everyone folded");
       expect(html).toMatch(/data-testid="no-hole-cards"/);
+      expect(html).not.toMatch(/data-testid="hole-cards"/);
     });
 
     it("shows a loss banner naming the winner when this seat folded", () => {
@@ -276,6 +289,15 @@ describe("Hand", () => {
       expect(html).toMatch(/data-testid="turn-banner"[^>]*data-tone="loss"/);
       expect(html).toContain("Seat 2 wins — everyone folded");
       expect(html).toContain("You folded — cards are in the muck.");
+    });
+
+    it("never reveals a pair for a seat that folded out — folding is final", () => {
+      const view: PlayerView = { phase: "folded-out", button: 0, winner: 1 };
+      const html = renderToStaticMarkup(<Hand view={view} seatId={0} />);
+
+      expect(html).not.toMatch(/data-testid="hole-cards"/);
+      expect(html).not.toContain("data-rank");
+      expect(html).not.toContain("data-presentation");
     });
   });
 });

--- a/packages/player-client/src/holecards/HoleCardPair.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.tsx
@@ -112,8 +112,13 @@ function Absent() {
  * tickets; this establishes the seam it grows inside.
  */
 export function HoleCardPair(props: HoleCardPairProps) {
-  const { cards, locked } = props;
+  const { cards } = props;
   const { state, activate } = useHoleCards(props);
+  // The lifecycle's lock, not the prop: the prop is the *input* the adapter
+  // turns into `SHOWDOWN_REVEAL`, and once locked the pair stays locked until
+  // the next hand deals it back in. Rendering off the prop would let the two
+  // disagree about whether the button does anything.
+  const { locked } = state;
 
   if (cards === null) return <Absent />;
 

--- a/packages/player-client/src/holecards/cardState.test.ts
+++ b/packages/player-client/src/holecards/cardState.test.ts
@@ -7,7 +7,12 @@ import {
 } from "./cardState.js";
 
 function state(presentation: Presentation): CardState {
-  return { presentation, recognizer: "Idle" };
+  return { presentation, recognizer: "Idle", locked: false };
+}
+
+/** A showdown-locked pair: face-up and inert. */
+function lockedState(presentation: Presentation): CardState {
+  return { presentation, recognizer: "Idle", locked: true };
 }
 
 describe("initialCardState", () => {
@@ -23,9 +28,9 @@ describe("initialCardState", () => {
     );
   });
 
-  it("starts Revealed when mounting into a locked (showdown) pair", () => {
+  it("starts Revealed and inert when mounting into a locked (showdown) pair", () => {
     expect(initialCardState({ hasCards: true, locked: true })).toEqual(
-      state("Revealed"),
+      lockedState("Revealed"),
     );
   });
 
@@ -111,6 +116,90 @@ describe("reduce", () => {
     it("is a no-op while the pair is leaving for the muck", () => {
       expect(reduce(state("Leaving"), { type: "ACTIVATED" })).toEqual(
         state("Leaving"),
+      );
+    });
+  });
+
+  describe("SHOWDOWN_REVEAL", () => {
+    it("turns a live seat's cards face-up through the same flip the bend produces", () => {
+      for (const presentation of ["FaceDown", "Peeking"] as const) {
+        expect(
+          reduce(state(presentation), { type: "SHOWDOWN_REVEAL" }),
+        ).toEqual(lockedState("Turning"));
+      }
+    });
+
+    it("lets a flip already in flight finish rather than restarting it", () => {
+      expect(reduce(state("Turning"), { type: "SHOWDOWN_REVEAL" })).toEqual(
+        lockedState("Turning"),
+      );
+    });
+
+    it("locks an already-revealed pair without replaying the flip", () => {
+      expect(reduce(state("Revealed"), { type: "SHOWDOWN_REVEAL" })).toEqual(
+        lockedState("Revealed"),
+      );
+    });
+
+    it("never reveals a seat holding no cards — folding is final", () => {
+      expect(reduce(state("Absent"), { type: "SHOWDOWN_REVEAL" })).toEqual(
+        state("Absent"),
+      );
+    });
+
+    it("never reveals a pair still flying to the muck", () => {
+      expect(reduce(state("Leaving"), { type: "SHOWDOWN_REVEAL" })).toEqual(
+        state("Leaving"),
+      );
+    });
+
+    it("clears any gesture the player still had a finger on", () => {
+      const bending: CardState = {
+        presentation: "Peeking",
+        recognizer: "Bending",
+        locked: false,
+      };
+      expect(reduce(bending, { type: "SHOWDOWN_REVEAL" })).toEqual(
+        lockedState("Turning"),
+      );
+    });
+  });
+
+  describe("a locked pair", () => {
+    it("is inert to activation — the hand is already decided", () => {
+      for (const presentation of ["Revealed", "Turning"] as const) {
+        expect(
+          reduce(lockedState(presentation), { type: "ACTIVATED" }),
+        ).toEqual(lockedState(presentation));
+      }
+    });
+
+    it("still lands its own flip on Revealed, and stays locked", () => {
+      expect(reduce(lockedState("Turning"), { type: "TURN_FINISHED" })).toEqual(
+        lockedState("Revealed"),
+      );
+    });
+
+    it("is not what a committed gesture produces — only showdown locks", () => {
+      // The recognizer reaches `Committed` on an ordinary bend past the reveal
+      // threshold. A player who bent their way to face-up must still be able
+      // to conceal, so the lock cannot live in the recognizer.
+      const bendCommitted: CardState = {
+        presentation: "Revealed",
+        recognizer: "Committed",
+        locked: false,
+      };
+      expect(reduce(bendCommitted, { type: "ACTIVATED" }).presentation).toBe(
+        "FaceDown",
+      );
+    });
+
+    it("unlocks on the next hand boundary, face-down and live again", () => {
+      expect(reduce(lockedState("Revealed"), { type: "DEALT" })).toEqual(
+        state("FaceDown"),
+      );
+      expect(reduce(lockedState("Revealed"), { type: "CARDS_GONE" })).toEqual(
+        state("Absent"),
       );
     });
   });

--- a/packages/player-client/src/holecards/cardState.ts
+++ b/packages/player-client/src/holecards/cardState.ts
@@ -7,9 +7,9 @@
  * is verifiable as a function call, which is why the module needs no store, no
  * socket and no simulated pointer to test.
  *
- * This slice (#139) carries the deal-in, the emptying, and the keyboard
- * reveal/conceal toggle. Bend, tap, drag and showdown arms are added by later
- * tickets against this same shape.
+ * This slice carries the deal-in, the emptying, the keyboard reveal/conceal
+ * toggle (#139) and the showdown reveal and lock (#140). Bend, tap and drag
+ * arms are added by later tickets against this same shape.
  */
 
 /** Pair-scoped: both cards always share one presentation. */
@@ -22,7 +22,21 @@ export type Recognizer =
 export interface CardState {
   readonly presentation: Presentation;
   readonly recognizer: Recognizer;
+  /**
+   * Showdown reached with this seat still live: the hand is decided, so the
+   * pair is face-up and inert (story 48).
+   *
+   * Its own field rather than a recognizer state, because the lock is not a
+   * gesture outcome — `Committed` is what an ordinary bend past the reveal
+   * threshold enters, and a Player who bent their way to face-up must not end
+   * up holding a pair they can no longer conceal. It is not a presentation
+   * either: `Revealed` is reachable both ways and only one of them is final.
+   */
+  readonly locked: boolean;
 }
+
+/** The live, un-gestured pair every hand starts from. */
+const idle = { recognizer: "Idle", locked: false } as const;
 
 export type CardEvent =
   /** Cards arrived: a fresh deal, or a new hand's cards swapping in. */
@@ -32,7 +46,33 @@ export type CardEvent =
   /** The pair was activated as a button — Enter, Space or a click. */
   | { readonly type: "ACTIVATED" }
   /** The committed flip to face-up finished animating. */
-  | { readonly type: "TURN_FINISHED" };
+  | { readonly type: "TURN_FINISHED" }
+  /** Showdown reached with this seat still live: turn face-up and lock. */
+  | { readonly type: "SHOWDOWN_REVEAL" };
+
+/**
+ * Whether a locked pair still hears an event. Only four do, and none of them
+ * is the Player handling the cards: the two hand boundaries that end the lock,
+ * the reveal that starts it, and the flip it starts finishing.
+ *
+ * Stated as one allow-list and enforced once, at the top of `reduce`, rather
+ * than arm by arm — so the tap and gesture events later tickets add are inert
+ * against a decided hand by default, and cannot reach one by being forgotten.
+ * A later ticket adding an event that a locked pair *should* hear (`RESET`,
+ * say, if backgrounding the app is judged to outrank a settled showdown) has
+ * to say so here, which is the point.
+ */
+function survivesLock(event: CardEvent): boolean {
+  switch (event.type) {
+    case "DEALT":
+    case "CARDS_GONE":
+    case "SHOWDOWN_REVEAL":
+    case "TURN_FINISHED":
+      return true;
+    default:
+      return false;
+  }
+}
 
 /**
  * Mount state. A pair that mounts holding cards has not been dealt in as far
@@ -46,23 +86,26 @@ export function initialCardState({
   readonly hasCards: boolean;
   readonly locked: boolean;
 }): CardState {
-  if (!hasCards) return { presentation: "Absent", recognizer: "Idle" };
-  return {
-    presentation: locked ? "Revealed" : "FaceDown",
-    recognizer: "Idle",
-  };
+  if (!hasCards) return { ...idle, presentation: "Absent" };
+  if (locked) {
+    return { presentation: "Revealed", recognizer: "Idle", locked: true };
+  }
+  return { ...idle, presentation: "FaceDown" };
 }
 
 export function reduce(state: CardState, event: CardEvent): CardState {
+  if (state.locked && !survivesLock(event)) return state;
+
   switch (event.type) {
     case "DEALT":
       // Unconditional, from every presentation: deal detection is what makes
       // every hand start face-down, so no face-up frame of the previous hand
-      // can survive into the next one.
-      return { presentation: "FaceDown", recognizer: "Idle" };
+      // can survive into the next one. It also ends a showdown lock — a new
+      // hand is live again by definition.
+      return { ...idle, presentation: "FaceDown" };
 
     case "CARDS_GONE":
-      return { presentation: "Absent", recognizer: "Idle" };
+      return { ...idle, presentation: "Absent" };
 
     case "ACTIVATED":
       // Reveal is a flip; conceal is instant. `Turning` is revealing-only —
@@ -80,5 +123,25 @@ export function reduce(state: CardState, event: CardEvent): CardState {
       return state.presentation === "Turning"
         ? { ...state, presentation: "Revealed" }
         : state;
+
+    case "SHOWDOWN_REVEAL":
+      // Folding is final (story 49), whether the cards are already gone or
+      // still flying to the muck. The adapter withholds the event for a
+      // folded-out seat anyway; the reducer holds the guarantee so it does not
+      // rest on being called correctly.
+      if (state.presentation === "Absent" || state.presentation === "Leaving") {
+        return state;
+      }
+      return {
+        // The **same** animated flip the bend commits to, so showdown reads
+        // as the same object behaving (story 47) — except when the Player
+        // already turned the cards over themselves, where re-flipping a
+        // face-up pair would be motion with nothing to say.
+        presentation:
+          state.presentation === "Revealed" ? "Revealed" : "Turning",
+        // Whatever the Player had a finger on is over; the hand is decided.
+        recognizer: "Idle",
+        locked: true,
+      };
   }
 }

--- a/packages/player-client/src/holecards/viewEvents.test.ts
+++ b/packages/player-client/src/holecards/viewEvents.test.ts
@@ -22,8 +22,21 @@ function props(overrides: Partial<HoleCardPairProps> = {}): HoleCardPairProps {
   return { cards: null, locked: false, actions, ...overrides };
 }
 
-const faceDown: CardState = { presentation: "FaceDown", recognizer: "Idle" };
-const absent: CardState = { presentation: "Absent", recognizer: "Idle" };
+const faceDown: CardState = {
+  presentation: "FaceDown",
+  recognizer: "Idle",
+  locked: false,
+};
+const absent: CardState = {
+  presentation: "Absent",
+  recognizer: "Idle",
+  locked: false,
+};
+const revealed: CardState = {
+  presentation: "Revealed",
+  recognizer: "Idle",
+  locked: true,
+};
 
 describe("eventsForPropChange", () => {
   it("produces nothing by default — an incoming view is inert unless proven otherwise", () => {
@@ -110,5 +123,57 @@ describe("eventsForPropChange", () => {
     expect(
       eventsForPropChange(props({ cards: queenJack }), props(), absent),
     ).toEqual([]);
+  });
+
+  describe("showdown", () => {
+    it("reveals when locked goes false → true", () => {
+      expect(
+        eventsForPropChange(
+          props({ cards: queenJack }),
+          props({ cards: queenJack, locked: true }),
+          faceDown,
+        ),
+      ).toEqual([{ type: "SHOWDOWN_REVEAL" }]);
+    });
+
+    it("produces nothing while locked is unchanged, true or false", () => {
+      const stillLocked = props({ cards: queenJack, locked: true });
+      expect(
+        eventsForPropChange(stillLocked, { ...stillLocked }, revealed),
+      ).toEqual([]);
+
+      const stillLive = props({ cards: queenJack });
+      expect(
+        eventsForPropChange(stillLive, { ...stillLive }, faceDown),
+      ).toEqual([]);
+    });
+
+    it("produces nothing when a lock is released — showdown does not un-reveal", () => {
+      expect(
+        eventsForPropChange(
+          props({ cards: queenJack, locked: true }),
+          props({ cards: queenJack }),
+          revealed,
+        ),
+      ).toEqual([]);
+    });
+
+    it("deals the cards in before revealing them when both land at once", () => {
+      // A seat whose cards were withheld until showdown: the deal has to be
+      // observed first, or the reveal would land on an `Absent` pair.
+      expect(
+        eventsForPropChange(
+          props(),
+          props({ cards: queenJack, locked: true }),
+          absent,
+        ),
+      ).toEqual([{ type: "DEALT" }, { type: "SHOWDOWN_REVEAL" }]);
+    });
+
+    it("never reveals a seat that folded out — no cards, no reveal", () => {
+      expect(
+        eventsForPropChange(props(), props({ locked: true }), absent),
+      ).toEqual([]);
+    });
   });
 });

--- a/packages/player-client/src/holecards/viewEvents.ts
+++ b/packages/player-client/src/holecards/viewEvents.ts
@@ -26,8 +26,8 @@ function samePair(
  * another player's bet and a changed `toAct` must all produce nothing.
  *
  * `state` is the current lifecycle state, which the later arms
- * (`FOLD_DISARMED`, `PENDING_RESOLVED`) consult; this slice's two events do
- * not depend on it.
+ * (`FOLD_DISARMED`, `PENDING_RESOLVED`) consult; of the events derived so far
+ * only `CARDS_GONE` does.
  */
 export function eventsForPropChange(
   prev: HoleCardPairProps,
@@ -41,9 +41,20 @@ export function eventsForPropChange(
     return [{ type: "CARDS_GONE" }];
   }
 
+  const events: CardEvent[] = [];
+
   // Card identity, not reference: `PlayerView` carries no hand id, so cards
   // arriving is the deal signal — with a value comparison as the defensive
   // second signal for a betting→betting view that swaps cards without an
   // intervening empty one.
-  return samePair(prev.cards, next.cards) ? [] : [{ type: "DEALT" }];
+  if (!samePair(prev.cards, next.cards)) events.push({ type: "DEALT" });
+
+  // Ordered after the deal deliberately: a seat whose cards only arrive at
+  // showdown must be dealt in before it is revealed, or the reveal lands on a
+  // pair that is still `Absent`. Losing the lock produces nothing — showdown
+  // does not un-reveal, and the next hand's `DEALT` is what turns the cards
+  // back over.
+  if (!prev.locked && next.locked) events.push({ type: "SHOWDOWN_REVEAL" });
+
+  return events;
 }


### PR DESCRIPTION
Closes #140.

At Showdown a Player still live sees their own Hole cards turn themselves face-up and lock there; a Player who folded out never sees theirs.

## What's here

- **`SHOWDOWN_REVEAL` reducer arm** — `any → Turning → Revealed`, the **same** animated flip the bend commits to (§3, story 47), except from `Revealed`, where the Player already turned the cards over and re-flipping would be motion with nothing to say.
- **`viewEvents.ts`** derives it from `locked` false → true, ordered **after** `DEALT` so a seat whose cards only arrive at Showdown is dealt in before it is revealed. Losing the lock produces nothing — Showdown does not un-reveal.
- **Folding stays final** (story 49): a pair that is `Absent`, or still `Leaving` for the muck, is never revealed. The adapter withholds the event for a folded-out seat and the reducer guards it independently, so the guarantee does not rest on being called correctly.
- **A locked pair is inert** (story 48), enforced once at the top of `reduce` rather than arm by arm — so the tap and gesture events later tickets add are no-ops against a decided hand by default. Only the two hand boundaries, the reveal itself and the flip finishing survive the lock.

## The one design call worth a look

The lock is **its own `CardState` field**, not the recognizer's `Committed` state.

The first cut used `Committed`, which reads well until #141 lands: `Committed` is what an *ordinary bend past the reveal threshold* enters, so a blanket "Committed ⇒ inert" rule would leave a Player who bent their way to face-up holding a pair they can no longer conceal, and deaf to `RELEASED`/`CANCELLED`. It is not a presentation either — `Revealed` is reachable both ways and only one of them is final. There's a regression test pinning that a bend-committed pair still conceals.

This is the one place the branch touches the shape of `CardState`, which #141's conflict note assigns to that ticket. The addition is orthogonal to what #141 lands (the `armed` flag and the event union) and the event name is the one from that union, so a rebase should keep it — but flagging it explicitly since it crosses the line the note drew.

`HoleCardPair` now renders inertness off `state.locked` rather than the `locked` prop, so the two cannot disagree about whether the button does anything.

## Verification

- Full suite: **479 passed** (73 files)
- `npm run build` and `npm run lint`: clean
- Reviewed on both axes with `/code-review`; the recognizer-overload problem above was a review finding, as were the folded-pair `Leaving` gap and the prop-vs-state split.

Not covered here: the on-device acceptance run (#148).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016j81DGmuGY9eUzSUpCf11x