### PR TITLE
feat(player-client): bend the corner to peek at your Hole cards

### DIFF
--- a/packages/player-client/src/app-shell.css
+++ b/packages/player-client/src/app-shell.css
@@ -46,3 +46,20 @@ body {
   gap: 14px;
   padding: 10px 18px 24px;
 }
+
+/* The lifted flap carries exactly one index: the remapped one in
+ * `BendableCard`, pinned to the tip where the fold actually uncovers it.
+ *
+ * The face's own corner indices are printed for a card lying flat. Once the
+ * sheet is rotated about the fold they land wherever the rotation puts them —
+ * on a deep bend that put a second, sideways-on rank on the flap next to the
+ * upright one. They belong to the flat card, so they are hidden here and here
+ * only; the same `Card` renders them normally everywhere else.
+ *
+ * `!important` is load-bearing, not decoration: `Card` sets `display: flex` as
+ * an inline style, and an inline style beats an ordinary rule however specific
+ * it is. Without it this declaration silently loses and the rank prints twice
+ * again. */
+.peel-back .card-index {
+  display: none !important;
+}

--- a/packages/player-client/src/holecards/BendableCard.test.tsx
+++ b/packages/player-client/src/holecards/BendableCard.test.tsx
@@ -1,0 +1,83 @@
+import type { Card } from "@table-top-poker/protocol";
+import { motionValue } from "motion/react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { BendableCard } from "./BendableCard.js";
+
+const appShellCss = readFileSync(
+  new URL("../app-shell.css", import.meta.url),
+  "utf8",
+);
+
+const queen: Card = { rank: "Q", suit: "diamonds" };
+
+function render(presentation: "FaceDown" | "Peeking" | "Turning" | "Revealed") {
+  return renderToStaticMarkup(
+    <BendableCard
+      card={queen}
+      presentation={presentation}
+      bend={motionValue(0)}
+      tiltDegrees={0}
+    />,
+  );
+}
+
+describe("BendableCard", () => {
+  it("carries no rank or suit at all while face down", () => {
+    const html = render("FaceDown");
+
+    expect(html).toContain('data-face-down="true"');
+    expect(html).not.toContain("data-rank");
+  });
+
+  it("puts an index where the curl actually uncovers it", () => {
+    // `react-peel` pins the back layer by the *horizontally flipped* corner, so
+    // a bottom-right peel uncovers the face's bottom-left — where an ordinary
+    // card carries no ink. Without this remapped copy a bend shows bare white
+    // card, which is precisely the bug this asserts against.
+    const html = render("Peeking");
+
+    expect(html).toContain("hole-card-curl-index");
+    expect(html).toMatch(/hole-card-curl-index[^>]*left:0\.235em/);
+    expect(html).toMatch(/hole-card-curl-index[^>]*bottom:0\.21em/);
+  });
+
+  it("keeps the remapped index off the class the flap rule suppresses", () => {
+    // `.peel-back .card-index { display: none }` in `app-shell.css` hides the
+    // face's own corner indices on the lifted sheet, so that the rank is not
+    // printed twice on it. The remapped index must not answer to that
+    // selector — if it ever did, the flap would go blank again.
+    const html = render("Peeking");
+    const curl = /<span class="([^"]*hole-card-curl-index[^"]*)"/.exec(html);
+
+    expect(curl).not.toBeNull();
+    expect(curl?.[1]).not.toMatch(/\bcard-index\b/);
+    // And the face's own indices really are in the flap, for the rule to bite.
+    expect(html).toMatch(/<div class="peel-back[\s\S]*?class="card-index/);
+  });
+
+  it("suppresses the flap's inline display, not merely a class", () => {
+    // These tests render to static markup, so no stylesheet is ever applied
+    // and the rule cannot be observed working. What *can* be checked is the
+    // thing that made an earlier attempt fail silently: `Card` sets `display`
+    // inline, so an ordinary declaration loses to it however specific the
+    // selector, and only `!important` actually suppresses the index.
+    expect(render("Peeking")).toMatch(
+      /class="card-index[^"]*"[^>]*display:flex/,
+    );
+    expect(appShellCss).toMatch(
+      /\.peel-back \.card-index\s*\{\s*display:\s*none\s*!important/,
+    );
+  });
+
+  it("drops the curl index once the card lies flat and face up", () => {
+    const html = render("Revealed");
+
+    expect(html).not.toContain("hole-card-curl-index");
+    expect(html).toContain('data-rank="Q"');
+    // The flat card keeps both its printed corners: the rule above is scoped
+    // to the flap, and must not have reached the ordinary face.
+    expect((html.match(/class="card-index/g) ?? []).length).toBe(2);
+  });
+});

--- a/packages/player-client/src/holecards/BendableCard.tsx
+++ b/packages/player-client/src/holecards/BendableCard.tsx
@@ -1,72 +1,261 @@
 import type { Card as CardType } from "@table-top-poker/protocol";
-import { Card } from "@table-top-poker/ui-shared";
-import { motion } from "motion/react";
+import {
+  Card,
+  cardIndexStyle,
+  cardIndexSuitStyle,
+  color,
+  isRedSuit,
+  suitSymbols,
+} from "@table-top-poker/ui-shared";
+import { type MotionValue } from "motion/react";
+import { useEffect, useRef } from "react";
+import {
+  PeelBack,
+  PeelBottom,
+  PeelTop,
+  PeelWrapper,
+  type PeelRef,
+} from "react-peel";
 import type { Presentation } from "./cardState.js";
-import { REVEAL_FINISH_MS } from "./constants.js";
+import { REVEAL_THRESHOLD } from "./constants.js";
 
 /**
- * The player-side wrapper around the untouched shared `Card` (Phase 3 spec
- * #138 §14). Bend and flip live here, in the player client; `ui-shared` gains
- * no gesture or poker concepts and the table client is unaffected.
+ * The player-side wrapper around the shared `Card` (Phase 3 spec #138 §14).
+ * Bend and turn live here, in the player client, so `ui-shared` gains no
+ * gesture concepts — including the one piece of ink that exists purely because
+ * of the curl, which is a player-client component rather than a `Card` prop.
  *
- * The turn cross-fades `Card`'s two branches — its documented `faceDown`
- * branch and its face branch — rather than swapping an image, which is the
- * reason `Card` renders DOM either way.
+ * The bend is a real corner curl, not a wipe: `react-peel` lifts the
+ * bottom-right corner as a sheet, and what you read is the card's **own face
+ * on the underside of that sheet** — which is what makes it feel like lifting
+ * a physical card rather than watching one dissolve. `PeelTop` is the flat
+ * remainder of the back, `PeelBack` is the lifted flap, and `PeelBottom` is
+ * the table showing through where the corner used to be. Which *part* of that
+ * flap is visible is not the part you would guess — see `CurlIndex`.
  *
- * The face branch is mounted only while the card is turning or revealed, so a
- * face-down pair carries no rank or suit in the document at all. Concealment
- * unmounts it again, instantly: `Revealed → FaceDown` is a privacy act and is
- * never animated.
+ * Crossing the threshold does not start a *different* animation: the same
+ * sheet is carried on past the opposite corner until the card has turned all
+ * the way over. That is why the peel is mounted for `Turning` as well as
+ * `Peeking`, and why a keyboard reveal — which starts at 0 — produces exactly
+ * the same motion as a bend that committed.
+ *
+ * The peel is driven entirely by a `MotionValue` (§13). This component
+ * re-renders when the *presentation* changes and never while a finger moves.
  */
 export function BendableCard({
   card,
   presentation,
+  bend,
   tiltDegrees,
 }: {
   readonly card: CardType;
   readonly presentation: Presentation;
+  /** Peel progress, 0 → 1, shared by both cards so the pair opens together. */
+  readonly bend: MotionValue<number>;
   /** The card's resting angle in the overlapped pair. */
   readonly tiltDegrees: number;
 }) {
+  const peeking = presentation === "Peeking";
   const turning = presentation === "Turning";
   const revealed = presentation === "Revealed";
-  const showFace = turning || revealed;
-  const showBack = !revealed;
-  const duration = turning ? REVEAL_FINISH_MS / 1000 : 0;
+  // The face is in the document only while it is being looked at. A face-down
+  // pair carries no rank or suit at all, and closing a peek removes it again
+  // instantly, as concealment does: a glance must leave nothing exposed.
+  const curling = peeking || turning;
 
   return (
-    <motion.div
+    <div
       data-testid="hole-card"
       data-revealed={String(revealed)}
-      // The half-turn: the card narrows to its edge and comes back, with the
-      // two branches crossing over while it is edge-on.
-      animate={{ scaleX: turning ? [1, 0.04, 1] : 1 }}
-      transition={{ duration, times: [0, 0.5, 1], ease: "easeInOut" }}
       style={{
         position: "relative",
-        display: "grid",
+        width: "3.5em",
+        height: "5em",
         transform: `rotate(${String(tiltDegrees)}deg)`,
       }}
     >
-      {showBack && (
-        <motion.div
-          style={{ gridArea: "1 / 1" }}
-          animate={{ opacity: turning ? 0 : 1 }}
-          transition={{ duration, ease: "easeInOut" }}
-        >
-          <Card faceDown />
-        </motion.div>
+      {revealed ? (
+        <Card rank={card.rank} suit={card.suit} />
+      ) : curling ? (
+        <CurlingCard card={card} bend={bend} />
+      ) : (
+        <Card faceDown />
       )}
-      {showFace && (
-        <motion.div
-          style={{ gridArea: "1 / 1" }}
-          initial={{ opacity: turning ? 0 : 1 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration, ease: "easeInOut" }}
-        >
-          <Card rank={card.rank} suit={card.suit} />
-        </motion.div>
-      )}
-    </motion.div>
+      {(presentation === "FaceDown" || peeking) && <BendZone />}
+    </div>
+  );
+}
+
+/**
+ * The lifted sheet. `react-peel` measures its own box and takes peel positions
+ * in that box's pixel coordinates, so the travel is derived from the measured
+ * card rather than from a constant — the pair is sized in `em` and inherits
+ * whatever font-size the surface gives it.
+ */
+function CurlingCard({
+  card,
+  bend,
+}: {
+  readonly card: CardType;
+  readonly bend: MotionValue<number>;
+}) {
+  const peel = useRef<PeelRef>(null);
+
+  useEffect(() => {
+    const place = (progress: number) => {
+      const current = peel.current;
+      if (current === null) return;
+      const { width, height } = current;
+
+      if (progress <= REVEAL_THRESHOLD) {
+        // The gentle diagonal curl the prototype settled on: the corner
+        // travels in towards the middle of the card as the bend deepens.
+        const travel = (progress / REVEAL_THRESHOLD) * CURL_TRAVEL;
+        current.setPeelPosition(
+          width - width * travel,
+          height - height * travel,
+        );
+        return;
+      }
+
+      // Committed: carry the same sheet on past the opposite corner so it
+      // completes the turn, rather than cutting to a separate flip.
+      const finish = (progress - REVEAL_THRESHOLD) / (1 - REVEAL_THRESHOLD);
+      const fromX = width - width * CURL_TRAVEL;
+      const fromY = height - height * CURL_TRAVEL;
+      current.setPeelPosition(
+        fromX + (-width - fromX) * finish,
+        fromY + (-height - fromY) * finish,
+      );
+    };
+
+    place(bend.get());
+    return bend.on("change", place);
+  }, [bend]);
+
+  return (
+    <PeelWrapper
+      ref={peel}
+      width="100%"
+      height="100%"
+      corner="BOTTOM_RIGHT"
+      options={{
+        topShadowBlur: 3,
+        topShadowAlpha: 0.32,
+        backShadowAlpha: 0.18,
+        bottomShadowDarkAlpha: 0.38,
+        backReflection: true,
+      }}
+    >
+      <PeelTop>
+        <Card faceDown />
+      </PeelTop>
+      {/* Positioned, so the remapped index below anchors to the lifted sheet
+       * and travels with it rather than to the card's resting box. */}
+      <PeelBack style={{ position: "relative", width: "100%", height: "100%" }}>
+        <Card rank={card.rank} suit={card.suit} />
+        <CurlIndex rank={card.rank} suit={card.suit} />
+      </PeelBack>
+      <PeelBottom />
+    </PeelWrapper>
+  );
+}
+
+/**
+ * The rank and suit as they appear *on the curl*.
+ *
+ * `react-peel` pins the back layer by `flipPointHorizontally(corner)`, so for a
+ * bottom-right peel it is the back's **bottom-left** corner that is pinned to
+ * the fingertip and the bottom-left region that the lifted flap uncovers. The
+ * face's own bottom-right index therefore falls outside the visible curl
+ * entirely — which is why a bend showed bare white card. This is that index
+ * remapped to where the geometry actually puts it, exactly as the prototype
+ * resolved the same problem.
+ *
+ * The face's *own* corner indices are suppressed on this copy — see
+ * `.peel-back .card-index` in `app-shell.css`. They are printed for a flat
+ * card and land arbitrarily once the sheet is rotated about the fold, so
+ * leaving them on showed the rank twice: once here, upright at the lifted
+ * tip, and once more sideways-on wherever the rotation happened to put it.
+ *
+ * Presentational only, and a duplicate of ink the face already carries, so it
+ * is hidden from assistive technology: the accessible reveal is `Revealed`,
+ * announced by the pair, not this.
+ */
+function CurlIndex({
+  rank,
+  suit,
+}: {
+  readonly rank: CardType["rank"];
+  readonly suit: CardType["suit"];
+}) {
+  return (
+    <span
+      className="hole-card-curl-index"
+      aria-hidden="true"
+      style={{
+        ...cardIndexStyle,
+        left: "0.235em",
+        bottom: "0.21em",
+        // A half-turn, so the index reads upright once the flap's own rotation
+        // is applied on top of it.
+        transform: "rotate(180deg)",
+        color: isRedSuit(suit) ? color.suitRed : color.suitBlack,
+      }}
+    >
+      {rank}
+      {/* Larger than the face's own suit, which is the one place this index
+       * deliberately departs from `cardIndexSuitStyle`. The markup is
+       * otherwise identical, so this is not correcting a size difference but
+       * a legibility one: on the flap the symbol is rotated and sits under
+       * the peel's shadow and reflection wash, and at the face's size it
+       * reads lighter and smaller than the same symbol lying flat. */}
+      <span style={{ ...cardIndexSuitStyle, fontSize: "0.9em" }}>
+        {suitSymbols[suit]}
+      </span>
+    </span>
+  );
+}
+
+/**
+ * How far the corner travels, as a fraction of the card, by the moment the
+ * bend commits. Short of the full diagonal on purpose: the corner is still a
+ * lifted corner at the threshold, not a card folded in half.
+ */
+const CURL_TRAVEL = 0.86;
+
+/**
+ * The affordance the whole gesture hangs off: a corner that looks liftable.
+ * `data-bend-zone` is what the recognizer hit-tests against, so the classifier
+ * never needs to know where the corner is drawn — and the coaching copy can
+ * follow the rendered zone rather than hard-coding "bottom-right".
+ */
+function BendZone() {
+  return (
+    <span
+      data-bend-zone="true"
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        right: 0,
+        bottom: 0,
+        width: "1.5em",
+        height: "1.5em",
+        borderBottomRightRadius: "0.2em",
+      }}
+    >
+      <span
+        style={{
+          position: "absolute",
+          right: "0.18em",
+          bottom: "0.18em",
+          width: "0.5em",
+          height: "0.5em",
+          borderRight: "2px solid rgba(255,236,226,.72)",
+          borderBottom: "2px solid rgba(255,236,226,.72)",
+          borderBottomRightRadius: "0.14em",
+        }}
+      />
+    </span>
   );
 }

--- a/packages/player-client/src/holecards/HoleCardPair.test.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.test.tsx
@@ -35,7 +35,7 @@ describe("HoleCardPair", () => {
       <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
     );
 
-    expect(html).toMatch(/^<button [^>]*type="button"/);
+    expect(html).toMatch(/<button [^>]*type="button"/);
     expect(html).toContain(
       'aria-label="Your hole cards, face down. Activate to reveal them."',
     );
@@ -75,5 +75,41 @@ describe("HoleCardPair", () => {
     expect(html).not.toMatch(/data-testid="hole-cards"/);
     expect(html).not.toContain("data-rank");
     expect(html).not.toContain("<button");
+  });
+
+  it("carries the bend affordance on both cards", () => {
+    // The recognizer hit-tests this attribute, so the classifier never needs
+    // to know where the corner is drawn.
+    const html = renderToStaticMarkup(
+      <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
+    );
+
+    expect((html.match(/data-bend-zone="true"/g) ?? []).length).toBe(2);
+  });
+
+  it("does not offer the bend affordance on a locked pair", () => {
+    const html = renderToStaticMarkup(
+      <HoleCardPair cards={queenJack} locked actions={actions} />,
+    );
+
+    expect(html).not.toContain("data-bend-zone");
+  });
+
+  it("takes the whole gesture from the browser, so a drag is never a pan and a double-tap never a zoom", () => {
+    const html = renderToStaticMarkup(
+      <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
+    );
+
+    expect(html).toContain("touch-action:none");
+    expect(html).toContain("-webkit-touch-callout:none");
+    expect(html).toContain("user-select:none");
+  });
+
+  it("renders no hint while the pair is settled", () => {
+    const html = renderToStaticMarkup(
+      <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
+    );
+
+    expect(html).not.toContain('data-testid="hole-cards-hint"');
   });
 });

--- a/packages/player-client/src/holecards/HoleCardPair.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.tsx
@@ -1,9 +1,16 @@
 import type { Card as CardType, Rank, Suit } from "@table-top-poker/protocol";
-import { color, radius } from "@table-top-poker/ui-shared";
-import { motion } from "motion/react";
+import { color, fontSize, radius } from "@table-top-poker/ui-shared";
+import { motion, useTransform, type MotionValue } from "motion/react";
 import { BendableCard } from "./BendableCard.js";
 import type { Presentation } from "./cardState.js";
+import {
+  selectHint,
+  type Hint,
+  type HintContext,
+  type TeachableGesture,
+} from "./coaching.js";
 import { DEAL_IN_MS } from "./constants.js";
+import type { BendAxis } from "./geometry.js";
 import type { CardActions } from "./ports.js";
 import { useHoleCards } from "./useHoleCards.js";
 
@@ -112,12 +119,14 @@ function Absent() {
  * tickets; this establishes the seam it grows inside.
  */
 export function HoleCardPair(props: HoleCardPairProps) {
-  const { cards } = props;
-  const { state, activate } = useHoleCards(props);
+  const { cards, actions } = props;
+  const { state, activate, handlers, bend, bendAxis } = useHoleCards(props);
   // The lifecycle's lock, not the prop: the prop is the *input* the adapter
   // turns into `SHOWDOWN_REVEAL`, and once locked the pair stays locked until
   // the next hand deals it back in. Rendering off the prop would let the two
-  // disagree about whether the button does anything.
+  // disagree about whether the button does anything — and the gesture
+  // recognizer gates on the same field, so pointer and keyboard cannot part
+  // company either.
   const { locked } = state;
 
   if (cards === null) return <Absent />;
@@ -128,52 +137,169 @@ export function HoleCardPair(props: HoleCardPairProps) {
   const presentation =
     state.presentation === "Absent" ? "FaceDown" : state.presentation;
 
+  const hintContext: HintContext = {
+    checkLegal: actions.checkLegal,
+    foldLegal: actions.foldLegal,
+    pending: actions.pending,
+    locked,
+    // The quiet interval only gates the teaching hints, which arrive with the
+    // discovery set they retire against (#147). In-gesture prompts never wait.
+    quiet: false,
+  };
+  // Both variants of the live hint, because the axis they swap on is a
+  // **continuous** value: choosing between them in React would re-render the
+  // pair every time a bend wandered across the diagonal (§13).
+  const hintDragLeft = selectHint(
+    { ...state, presentation, bendAxis: "left" },
+    nothingDiscovered,
+    hintContext,
+  );
+  const hintDragUp = selectHint(
+    { ...state, presentation, bendAxis: "up" },
+    nothingDiscovered,
+    hintContext,
+  );
+
   return (
-    <button
-      type="button"
-      data-testid="hole-cards"
-      data-presentation={presentation}
-      // A locked pair is inert but stays in the tab order and keeps its
-      // accessible name: at showdown that name is where a screen-reader user
-      // reads their own hand, and `disabled` would take it away.
-      onClick={locked ? undefined : activate}
-      aria-disabled={locked}
-      aria-label={accessibleName(cards, presentation, locked)}
+    <div
       style={{
         display: "flex",
-        padding: 0,
-        border: "none",
-        background: "none",
-        color: "inherit",
-        cursor: locked ? "default" : "pointer",
-        // Handling cards must not raise the OS text-selection or callout menu
-        // over them (§16).
-        userSelect: "none",
-        WebkitTouchCallout: "none",
-        touchAction: "manipulation",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "0.55em",
       }}
     >
-      <motion.span
-        // Keyed on card identity so a new hand replays the deal-in: the cards
-        // arrive face-down (§17), replacing `Hand`'s per-card face-up deal
-        // animation. The key is on the motion element, not the component, so
-        // it restarts an animation without discarding lifecycle state —
-        // `DEALT` stays the one thing that resets presentation.
-        key={cardKey(cards)}
-        initial={{ opacity: 0, y: "-18%" }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: DEAL_IN_MS / 1000, ease: [0.2, 0.8, 0.2, 1] }}
-        style={{ display: "flex", gap: "0.5em", fontSize: "2.6em" }}
+      <button
+        type="button"
+        data-testid="hole-cards"
+        data-presentation={presentation}
+        // A locked pair is inert but stays in the tab order and keeps its
+        // accessible name: at showdown that name is where a screen-reader user
+        // reads their own hand, and `disabled` would take it away.
+        onClick={locked ? undefined : activate}
+        // Long-press must not raise the OS callout menu over the cards (§16).
+        onContextMenu={preventDefault}
+        {...(locked ? {} : handlers)}
+        aria-disabled={locked}
+        aria-label={accessibleName(cards, presentation, locked)}
+        style={{
+          display: "flex",
+          padding: 0,
+          border: "none",
+          background: "none",
+          color: "inherit",
+          cursor: locked ? "default" : "pointer",
+          // Handling cards must not raise the OS text-selection or callout
+          // menu over them, and the browser must not claim the vertical drag
+          // as a pan or the second tap as a zoom (§16). The app shell is fixed
+          // and non-scrolling, so nothing is lost by taking the whole gesture.
+          userSelect: "none",
+          WebkitTouchCallout: "none",
+          WebkitUserSelect: "none",
+          touchAction: "none",
+        }}
       >
-        {cards.map((card, index) => (
-          <BendableCard
-            key={index}
-            card={card}
-            tiltDegrees={index === 0 ? -3 : 3}
-            presentation={presentation}
-          />
-        ))}
+        <motion.span
+          // Keyed on card identity so a new hand replays the deal-in: the cards
+          // arrive face-down (§17), replacing `Hand`'s per-card face-up deal
+          // animation. The key is on the motion element, not the component, so
+          // it restarts an animation without discarding lifecycle state —
+          // `DEALT` stays the one thing that resets presentation.
+          key={cardKey(cards)}
+          initial={{ opacity: 0, y: "-18%" }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: DEAL_IN_MS / 1000, ease: [0.2, 0.8, 0.2, 1] }}
+          style={{ display: "flex", gap: "0.5em", fontSize: "2.6em" }}
+        >
+          {cards.map((card, index) => (
+            <BendableCard
+              key={index}
+              card={card}
+              tiltDegrees={index === 0 ? -3 : 3}
+              presentation={presentation}
+              bend={bend}
+            />
+          ))}
+        </motion.span>
+      </button>
+      <GestureHint
+        dragLeft={hintDragLeft}
+        dragUp={hintDragUp}
+        axis={bendAxis}
+      />
+    </div>
+  );
+}
+
+const nothingDiscovered: ReadonlySet<TeachableGesture> = new Set();
+
+function preventDefault(event: { preventDefault: () => void }) {
+  event.preventDefault();
+}
+
+/**
+ * The one hint the selector chose, if any. The pair renders it itself: the
+ * selector is module-internal because every in-gesture hint depends on
+ * recognizer state nothing outside the module may see (§11).
+ *
+ * Where the two variants differ, both are in the document at once and the axis
+ * `MotionValue` decides which is visible — so a bend that wanders across the
+ * diagonal swaps the advice without re-rendering anything. That pair is hidden
+ * from assistive technology, because two contradictory instructions are both
+ * present and only the sighted player can see which one applies; the pair's own
+ * `aria-label` is the non-visual path, and every Action keeps its button.
+ */
+function GestureHint({
+  dragLeft,
+  dragUp,
+  axis,
+}: {
+  readonly dragLeft: Hint | null;
+  readonly dragUp: Hint | null;
+  readonly axis: MotionValue<BendAxis>;
+}) {
+  const leftOpacity = useTransform(axis, (value) => (value === "left" ? 1 : 0));
+  const upOpacity = useTransform(axis, (value) => (value === "up" ? 1 : 0));
+
+  if (dragLeft === null || dragUp === null) return null;
+
+  // One hint, not two: the axis is only a distinction while a bend is live.
+  if (dragLeft.id === dragUp.id) return <HintBlock hint={dragLeft} />;
+
+  return (
+    <span
+      aria-hidden="true"
+      // Stacked in one grid cell so the swap costs no layout. Each variant
+      // carries both its own lines, so neither depends on the other's copy.
+      style={{ display: "grid" }}
+    >
+      <motion.span style={{ gridArea: "1 / 1", opacity: leftOpacity }}>
+        <HintBlock hint={dragLeft} />
       </motion.span>
-    </button>
+      <motion.span style={{ gridArea: "1 / 1", opacity: upOpacity }}>
+        <HintBlock hint={dragUp} />
+      </motion.span>
+    </span>
+  );
+}
+
+function HintBlock({ hint }: { readonly hint: Hint }) {
+  return (
+    <p
+      data-testid="hole-cards-hint"
+      data-hint={hint.id}
+      style={{
+        margin: 0,
+        display: "grid",
+        justifyItems: "center",
+        gap: "0.15em",
+        fontSize: fontSize.caption,
+        lineHeight: 1.25,
+        color: color.textMuted,
+      }}
+    >
+      <span style={{ color: color.text }}>{hint.line1}</span>
+      {hint.line2 !== null && <span>{hint.line2}</span>}
+    </p>
   );
 }

--- a/packages/player-client/src/holecards/cardState.test.ts
+++ b/packages/player-client/src/holecards/cardState.test.ts
@@ -4,15 +4,20 @@ import {
   reduce,
   type CardState,
   type Presentation,
+  type Recognizer,
 } from "./cardState.js";
 
-function state(presentation: Presentation): CardState {
-  return { presentation, recognizer: "Idle", locked: false };
+function state(
+  presentation: Presentation,
+  recognizer: Recognizer = "Idle",
+  armed = false,
+): CardState {
+  return { presentation, recognizer, armed, locked: false };
 }
 
 /** A showdown-locked pair: face-up and inert. */
 function lockedState(presentation: Presentation): CardState {
-  return { presentation, recognizer: "Idle", locked: true };
+  return { ...state(presentation), locked: true };
 }
 
 describe("initialCardState", () => {
@@ -120,6 +125,43 @@ describe("reduce", () => {
     });
   });
 
+  describe("BEND_CROSSED", () => {
+    it("commits the bend into the turn, so the peel lands face-up", () => {
+      expect(
+        reduce(state("Peeking", "Bending"), { type: "BEND_CROSSED" }),
+      ).toEqual(state("Turning", "Committed"));
+    });
+
+    it("is a no-op for a drag that is not a live bend", () => {
+      for (const recognizer of [
+        "Idle",
+        "Pressing",
+        "FoldDragging",
+        "Ignored",
+        "Committed",
+      ] as const) {
+        const before = state("Peeking", recognizer);
+        expect(reduce(before, { type: "BEND_CROSSED" })).toEqual(before);
+      }
+    });
+
+    it("survives the release that follows it — the commit is on crossing", () => {
+      // Lifting a finger after the threshold must not put the cards back down:
+      // `Turning` is a point of no return, so release only clears the
+      // recognizer and the flip finishes on its own.
+      const committed = reduce(state("Peeking", "Bending"), {
+        type: "BEND_CROSSED",
+      });
+      const released = reduce(committed, { type: "RELEASED" });
+
+      expect(released.presentation).toBe("Turning");
+      expect(released.recognizer).toBe("Idle");
+      expect(reduce(released, { type: "TURN_FINISHED" }).presentation).toBe(
+        "Revealed",
+      );
+    });
+  });
+
   describe("SHOWDOWN_REVEAL", () => {
     it("turns a live seat's cards face-up through the same flip the bend produces", () => {
       for (const presentation of ["FaceDown", "Peeking"] as const) {
@@ -154,11 +196,7 @@ describe("reduce", () => {
     });
 
     it("clears any gesture the player still had a finger on", () => {
-      const bending: CardState = {
-        presentation: "Peeking",
-        recognizer: "Bending",
-        locked: false,
-      };
+      const bending = state("Peeking", "Bending");
       expect(reduce(bending, { type: "SHOWDOWN_REVEAL" })).toEqual(
         lockedState("Turning"),
       );
@@ -174,6 +212,19 @@ describe("reduce", () => {
       }
     });
 
+    it("is inert to a finger as well as to the keyboard", () => {
+      // The lock is enforced once, above every arm, so a gesture cannot even
+      // begin against a decided hand: no press, and therefore nothing for a
+      // classification to land on.
+      const locked = lockedState("Revealed");
+      expect(reduce(locked, { type: "PRESSED" })).toEqual(locked);
+      expect(reduce(locked, { type: "CLASSIFIED", as: "Bending" })).toEqual(
+        locked,
+      );
+      expect(reduce(locked, { type: "RELEASED" })).toEqual(locked);
+      expect(reduce(locked, { type: "CANCELLED" })).toEqual(locked);
+    });
+
     it("still lands its own flip on Revealed, and stays locked", () => {
       expect(reduce(lockedState("Turning"), { type: "TURN_FINISHED" })).toEqual(
         lockedState("Revealed"),
@@ -184,11 +235,7 @@ describe("reduce", () => {
       // The recognizer reaches `Committed` on an ordinary bend past the reveal
       // threshold. A player who bent their way to face-up must still be able
       // to conceal, so the lock cannot live in the recognizer.
-      const bendCommitted: CardState = {
-        presentation: "Revealed",
-        recognizer: "Committed",
-        locked: false,
-      };
+      const bendCommitted = state("Revealed", "Committed");
       expect(reduce(bendCommitted, { type: "ACTIVATED" }).presentation).toBe(
         "FaceDown",
       );
@@ -221,6 +268,136 @@ describe("reduce", () => {
         expect(reduce(state(presentation), { type: "TURN_FINISHED" })).toEqual(
           state(presentation),
         );
+      }
+    });
+  });
+
+  describe("PRESSED", () => {
+    it("takes the pointer from a settled pair", () => {
+      expect(reduce(state("FaceDown"), { type: "PRESSED" })).toEqual(
+        state("FaceDown", "Pressing"),
+      );
+      expect(reduce(state("Revealed"), { type: "PRESSED" })).toEqual(
+        state("Revealed", "Pressing"),
+      );
+    });
+
+    it("ignores a second pointer landing mid-gesture — first pointer wins", () => {
+      for (const recognizer of [
+        "Pressing",
+        "Bending",
+        "FoldDragging",
+        "Ignored",
+        "Committed",
+      ] as const) {
+        const active = state("Peeking", recognizer);
+        expect(reduce(active, { type: "PRESSED" })).toEqual(active);
+      }
+    });
+
+    it("is a no-op with no cards in hand, and while the pair is leaving", () => {
+      expect(reduce(state("Absent"), { type: "PRESSED" })).toEqual(
+        state("Absent"),
+      );
+      expect(reduce(state("Leaving"), { type: "PRESSED" })).toEqual(
+        state("Leaving"),
+      );
+    });
+  });
+
+  describe("CLASSIFIED", () => {
+    it("opens the peel and moves the recognizer in one reduce", () => {
+      // Coupled, and therefore atomic: there is no intermediate state in which
+      // the recognizer is bending but the pair still presents face-down.
+      expect(
+        reduce(state("FaceDown", "Pressing"), {
+          type: "CLASSIFIED",
+          as: "Bending",
+        }),
+      ).toEqual(state("Peeking", "Bending"));
+    });
+
+    it("starts a fold drag without disturbing presentation", () => {
+      expect(
+        reduce(state("FaceDown", "Pressing"), {
+          type: "CLASSIFIED",
+          as: "FoldDragging",
+        }),
+      ).toEqual(state("FaceDown", "FoldDragging"));
+      expect(
+        reduce(state("Revealed", "Pressing"), {
+          type: "CLASSIFIED",
+          as: "FoldDragging",
+        }),
+      ).toEqual(state("Revealed", "FoldDragging"));
+    });
+
+    it("ignores an ambiguous drag without disturbing presentation", () => {
+      expect(
+        reduce(state("FaceDown", "Pressing"), {
+          type: "CLASSIFIED",
+          as: "Ignored",
+        }),
+      ).toEqual(state("FaceDown", "Ignored"));
+    });
+
+    it("is accepted only from Pressing, so classification is sticky", () => {
+      const bending = state("Peeking", "Bending");
+      expect(
+        reduce(bending, { type: "CLASSIFIED", as: "FoldDragging" }),
+      ).toEqual(bending);
+      expect(reduce(bending, { type: "CLASSIFIED", as: "Ignored" })).toEqual(
+        bending,
+      );
+    });
+
+    it("leaves Ignored terminal: a curve upward cannot become a fold", () => {
+      const ignored = state("FaceDown", "Ignored");
+      expect(
+        reduce(ignored, { type: "CLASSIFIED", as: "FoldDragging" }),
+      ).toEqual(ignored);
+    });
+
+    it("is a no-op from Idle, so a stray classification cannot start a gesture", () => {
+      expect(
+        reduce(state("FaceDown"), { type: "CLASSIFIED", as: "Bending" }),
+      ).toEqual(state("FaceDown"));
+    });
+  });
+
+  describe("RELEASED and CANCELLED", () => {
+    const endings = [{ type: "RELEASED" }, { type: "CANCELLED" }] as const;
+
+    it("closes the peek, so a glance leaves nothing exposed", () => {
+      for (const ending of endings) {
+        expect(reduce(state("Peeking", "Bending"), ending)).toEqual(
+          state("FaceDown"),
+        );
+      }
+    });
+
+    it("clears an ignored drag without changing what the pair is showing", () => {
+      for (const ending of endings) {
+        expect(reduce(state("Revealed", "Ignored"), ending)).toEqual(
+          state("Revealed"),
+        );
+        expect(reduce(state("FaceDown", "Ignored"), ending)).toEqual(
+          state("FaceDown"),
+        );
+      }
+    });
+
+    it("does not interrupt a committed turn — the flip finishes", () => {
+      for (const ending of endings) {
+        expect(reduce(state("Turning", "Committed"), ending)).toEqual(
+          state("Turning"),
+        );
+      }
+    });
+
+    it("is a no-op when no gesture is live", () => {
+      for (const ending of endings) {
+        expect(reduce(state("Revealed"), ending)).toEqual(state("Revealed"));
       }
     });
   });

--- a/packages/player-client/src/holecards/cardState.ts
+++ b/packages/player-client/src/holecards/cardState.ts
@@ -7,10 +7,17 @@
  * is verifiable as a function call, which is why the module needs no store, no
  * socket and no simulated pointer to test.
  *
- * This slice carries the deal-in, the emptying, the keyboard reveal/conceal
- * toggle (#139) and the showdown reveal and lock (#140). Bend, tap and drag
- * arms are added by later tickets against this same shape.
+ * `CardState` and `CardEvent` are **complete**: every event name the phase
+ * needs is declared here, including the ones no arm answers yet. Later slices
+ * add reducer arms against this shape rather than reshaping it, so the
+ * gestures that follow are additions rather than surgery.
+ *
+ * Answered so far: the deal-in, the emptying and the keyboard reveal/conceal
+ * toggle (#139), the showdown reveal and lock (#140), and the press, the
+ * classification and the release that make up a bend (#141).
  */
+
+import type { Classification } from "./classify.js";
 
 /** Pair-scoped: both cards always share one presentation. */
 export type Presentation =
@@ -22,6 +29,11 @@ export type Recognizer =
 export interface CardState {
   readonly presentation: Presentation;
   readonly recognizer: Recognizer;
+  /**
+   * Whether releasing now would commit the Fold. Only ever true while
+   * `FoldDragging` — crossing the threshold arms, and release commits (§10).
+   */
+  readonly armed: boolean;
   /**
    * Showdown reached with this seat still live: the hand is decided, so the
    * pair is face-up and inert (story 48).
@@ -35,9 +47,6 @@ export interface CardState {
   readonly locked: boolean;
 }
 
-/** The live, un-gestured pair every hand starts from. */
-const idle = { recognizer: "Idle", locked: false } as const;
-
 export type CardEvent =
   /** Cards arrived: a fresh deal, or a new hand's cards swapping in. */
   | { readonly type: "DEALT" }
@@ -47,8 +56,35 @@ export type CardEvent =
   | { readonly type: "ACTIVATED" }
   /** The committed flip to face-up finished animating. */
   | { readonly type: "TURN_FINISHED" }
+  /** A pointer landed on the pair. */
+  | { readonly type: "PRESSED" }
+  /** The drag passed the slop and resolved, once and for all, to one thing. */
+  | { readonly type: "CLASSIFIED"; readonly as: Classification }
+  /** The peel passed the reveal threshold: recognizer and presentation both. */
+  | { readonly type: "BEND_CROSSED" }
+  /** The fold drag passed the distance threshold; releasing now commits. */
+  | { readonly type: "FOLD_ARMED" }
+  /** Fold stopped being legal mid-drag; the cards keep tracking regardless. */
+  | { readonly type: "FOLD_DISARMED" }
+  /** The pointer completing the gesture lifted. */
+  | { readonly type: "RELEASED" }
+  /** The browser took the pointer away, or capture was lost. */
+  | { readonly type: "CANCELLED" }
+  /** A hand boundary, a reload, or the app leaving the foreground. */
+  | { readonly type: "RESET" }
+  /** A single tap landed on the pair. */
+  | { readonly type: "TAPPED" }
+  /** A second tap landed inside the double-tap window. */
+  | { readonly type: "DOUBLE_TAPPED" }
+  /** An in-flight Action resolved, one way or the other. */
+  | { readonly type: "PENDING_RESOLVED"; readonly hasCards: boolean }
   /** Showdown reached with this seat still live: turn face-up and lock. */
   | { readonly type: "SHOWDOWN_REVEAL" };
+
+/** The live, un-gestured, unlocked pair every hand starts from. */
+function idle(presentation: Presentation): CardState {
+  return { presentation, recognizer: "Idle", armed: false, locked: false };
+}
 
 /**
  * Whether a locked pair still hears an event. Only four do, and none of them
@@ -86,11 +122,44 @@ export function initialCardState({
   readonly hasCards: boolean;
   readonly locked: boolean;
 }): CardState {
-  if (!hasCards) return { ...idle, presentation: "Absent" };
-  if (locked) {
-    return { presentation: "Revealed", recognizer: "Idle", locked: true };
+  if (!hasCards) return idle("Absent");
+  if (locked) return { ...idle("Revealed"), locked: true };
+  return idle("FaceDown");
+}
+
+/**
+ * Where a gesture puts the pair down. `Peeking` is the only presentation a
+ * gesture creates that is not stable in itself: a peek is held open by the
+ * finger, so letting go — for any reason — closes it, and a glance costs the
+ * player nothing and leaves nothing exposed.
+ */
+function settled(state: CardState): CardState {
+  return {
+    ...state,
+    presentation:
+      state.presentation === "Peeking" ? "FaceDown" : state.presentation,
+    recognizer: "Idle",
+    armed: false,
+  };
+}
+
+function classified(state: CardState, as: Classification): CardState {
+  switch (as) {
+    case "Bending":
+      // Coupled, and therefore atomic: one reduce moves the recognizer *and*
+      // opens the peel. There is no frame in which the pair is bending but
+      // still presenting face-down.
+      return {
+        ...state,
+        presentation: "Peeking",
+        recognizer: "Bending",
+        armed: false,
+      };
+    case "FoldDragging":
+      return { ...state, recognizer: "FoldDragging", armed: false };
+    case "Ignored":
+      return { ...state, recognizer: "Ignored", armed: false };
   }
-  return { ...idle, presentation: "FaceDown" };
 }
 
 export function reduce(state: CardState, event: CardEvent): CardState {
@@ -102,10 +171,10 @@ export function reduce(state: CardState, event: CardEvent): CardState {
       // every hand start face-down, so no face-up frame of the previous hand
       // can survive into the next one. It also ends a showdown lock — a new
       // hand is live again by definition.
-      return { ...idle, presentation: "FaceDown" };
+      return idle("FaceDown");
 
     case "CARDS_GONE":
-      return { ...idle, presentation: "Absent" };
+      return idle("Absent");
 
     case "ACTIVATED":
       // Reveal is a flip; conceal is instant. `Turning` is revealing-only —
@@ -124,6 +193,57 @@ export function reduce(state: CardState, event: CardEvent): CardState {
         ? { ...state, presentation: "Revealed" }
         : state;
 
+    case "PRESSED":
+      // **First pointer wins** (§4): while a gesture is live, a second finger
+      // landing is ignored until the first releases or cancels. Latest-pointer
+      // -wins would let a stray thumb silently retarget a fold drag.
+      if (state.recognizer !== "Idle") return state;
+      // Nothing to handle: no cards, or a Fold already in flight (§7).
+      if (state.presentation === "Absent" || state.presentation === "Leaving") {
+        return state;
+      }
+      return { ...state, recognizer: "Pressing" };
+
+    case "CLASSIFIED":
+      // **Stickiness lives here.** `classify` is run once by the pointer
+      // handler and never revisited; the reducer enforces that by accepting
+      // the result only from `Pressing`, so a second classification — however
+      // it arises — is a no-op, and `Ignored` stays terminal until release.
+      if (state.recognizer !== "Pressing") return state;
+      return classified(state, event.as);
+
+    case "RELEASED":
+    case "CANCELLED":
+      // `Turning` is a point of no return for both lift and cancellation: the
+      // flip completes, because cancellation must restore *stable*
+      // presentation and mid-turn is not stable (§10). A `Committed`
+      // recognizer therefore only clears itself.
+      if (state.recognizer === "Idle") return state;
+      if (state.recognizer === "Committed") {
+        return { ...state, recognizer: "Idle", armed: false };
+      }
+      return settled(state);
+
+    case "BEND_CROSSED":
+      // The peel reaching the threshold *is* the commit (§3): the same sheet
+      // carries on past the opposite corner and lands face-up, so there is no
+      // separate flip to start and nothing for a release to undo. Only a live
+      // bend can cross — a fold drag or an ignored drag never peels.
+      if (state.recognizer !== "Bending") return state;
+      return { ...state, presentation: "Turning", recognizer: "Committed" };
+
+    // Declared in the union so the shape is settled up front, and answered by
+    // the slices that own them: tap-conceal (#142), cancellation and resets
+    // (#143), the double-tap Check (#144), the fold drag (#145) and fold
+    // disarming (#146).
+    case "FOLD_ARMED":
+    case "FOLD_DISARMED":
+    case "RESET":
+    case "TAPPED":
+    case "DOUBLE_TAPPED":
+    case "PENDING_RESOLVED":
+      return state;
+
     case "SHOWDOWN_REVEAL":
       // Folding is final (story 49), whether the cards are already gone or
       // still flying to the muck. The adapter withholds the event for a
@@ -141,6 +261,7 @@ export function reduce(state: CardState, event: CardEvent): CardState {
           state.presentation === "Revealed" ? "Revealed" : "Turning",
         // Whatever the Player had a finger on is over; the hand is decided.
         recognizer: "Idle",
+        armed: false,
         locked: true,
       };
   }

--- a/packages/player-client/src/holecards/classify.test.ts
+++ b/packages/player-client/src/holecards/classify.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { classify, type ClassifyInput } from "./classify.js";
+
+function input(overrides: Partial<ClassifyInput> = {}): ClassifyInput {
+  return {
+    fromBendZone: false,
+    alreadyRevealed: false,
+    dx: 0,
+    dy: 0,
+    foldLegal: true,
+    ...overrides,
+  };
+}
+
+describe("classify", () => {
+  it("reads a press on the bend zone as a bend while face-down, whatever the direction", () => {
+    const directions: readonly (readonly [number, number])[] = [
+      [-40, 0],
+      [0, -40],
+      [40, 0],
+      [0, 40],
+    ];
+    for (const [dx, dy] of directions) {
+      expect(classify(input({ fromBendZone: true, dx, dy }))).toBe("Bending");
+    }
+  });
+
+  it("does not bend from the bend zone once the pair is already revealed", () => {
+    // Nothing to peel back on a face-up pair: the corner is ordinary card
+    // surface, so an upward drag from it is a fold like any other.
+    expect(
+      classify(
+        input({ fromBendZone: true, alreadyRevealed: true, dx: 0, dy: -40 }),
+      ),
+    ).toBe("FoldDragging");
+  });
+
+  it("keeps bending from the bend zone even on a decisive upward swipe", () => {
+    // The accepted cost of sticky classification: fold is unavailable from
+    // this one corner while face-down, and available from all the rest.
+    expect(classify(input({ fromBendZone: true, dx: 0, dy: -300 }))).toBe(
+      "Bending",
+    );
+  });
+
+  it("reads an upward-dominant drag as a fold", () => {
+    expect(classify(input({ dx: 0, dy: -40 }))).toBe("FoldDragging");
+    expect(classify(input({ dx: 10, dy: -40 }))).toBe("FoldDragging");
+  });
+
+  it("requires upward travel past the 1.05 ratio, not merely more than sideways", () => {
+    // |dy| = |dx| * 1.05 exactly: not past it.
+    expect(classify(input({ dx: -40, dy: -42 }))).toBe("Ignored");
+    expect(classify(input({ dx: -40, dy: -42.5 }))).toBe("FoldDragging");
+  });
+
+  it("ignores a drag that is upward but barely more so than sideways", () => {
+    expect(classify(input({ dx: 40, dy: -41 }))).toBe("Ignored");
+  });
+
+  it("ignores sideways and downward drags", () => {
+    expect(classify(input({ dx: -60, dy: 0 }))).toBe("Ignored");
+    expect(classify(input({ dx: 60, dy: 0 }))).toBe("Ignored");
+    expect(classify(input({ dx: 0, dy: 60 }))).toBe("Ignored");
+    expect(classify(input({ dx: 10, dy: 60 }))).toBe("Ignored");
+  });
+
+  it("falls through to Ignored when Fold is not legal", () => {
+    expect(classify(input({ dx: 0, dy: -300, foldLegal: false }))).toBe(
+      "Ignored",
+    );
+  });
+
+  it("still bends from the bend zone when Fold is not legal", () => {
+    expect(
+      classify(input({ fromBendZone: true, dy: -40, foldLegal: false })),
+    ).toBe("Bending");
+  });
+});

--- a/packages/player-client/src/holecards/classify.ts
+++ b/packages/player-client/src/holecards/classify.ts
@@ -1,0 +1,54 @@
+import { FOLD_AXIS_RATIO } from "./constants.js";
+
+/**
+ * What a pointer drag turned out to be (Phase 3 spec #138 §4). There is no
+ * "undecided" member: classification happens exactly once, on the first move
+ * past the slop, and the recognizer is `Pressing` until then.
+ */
+export type Classification = "Bending" | "FoldDragging" | "Ignored";
+
+export interface ClassifyInput {
+  /** The press landed on the bend affordance in the card's corner. */
+  readonly fromBendZone: boolean;
+  /** The pair was already face-up when the press landed. */
+  readonly alreadyRevealed: boolean;
+  readonly dx: number;
+  readonly dy: number;
+  /** Sampled **once**, here. §6 covers what happens when it later changes. */
+  readonly foldLegal: boolean;
+}
+
+/**
+ * The whole of the §4 table, as a pure function. Stickiness is not its
+ * business — that is a property of the reducer, which accepts the
+ * classification event only from `Pressing`.
+ *
+ * Three consequences, all intentional:
+ *
+ * - **A fold cannot start from the bend zone while face-down.** A press on the
+ *   corner locks into `Bending` and a later upward swipe keeps bending. Fold
+ *   stays available from the whole rest of the pair. The alternative — a
+ *   bend→fold promotion rule — would need a second, more decisive upward
+ *   threshold, weakening the fold threshold everywhere else to recover one
+ *   corner.
+ * - **`Ignored` is terminal.** A drag that starts sideways or downward cannot
+ *   become a fold by curving upward.
+ * - **Fold legality is sampled once.** A drag that outlives the player's turn
+ *   disarms rather than reclassifies.
+ */
+export function classify({
+  fromBendZone,
+  alreadyRevealed,
+  dx,
+  dy,
+  foldLegal,
+}: ClassifyInput): Classification {
+  // The bend zone wins outright while face-down — but there is nothing to peel
+  // back on a pair that is already face-up, so the corner is ordinary card
+  // surface then and a fold can start from it.
+  if (fromBendZone && !alreadyRevealed) return "Bending";
+  if (foldLegal && dy < 0 && Math.abs(dy) > Math.abs(dx) * FOLD_AXIS_RATIO) {
+    return "FoldDragging";
+  }
+  return "Ignored";
+}

--- a/packages/player-client/src/holecards/coaching.test.ts
+++ b/packages/player-client/src/holecards/coaching.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import type { CardState, Presentation, Recognizer } from "./cardState.js";
+import {
+  selectHint,
+  type HintContext,
+  type TeachableGesture,
+} from "./coaching.js";
+import type { BendAxis } from "./geometry.js";
+
+function bending(
+  bendAxis: BendAxis,
+  overrides: Partial<CardState> = {},
+): CardState & { readonly bendAxis: BendAxis } {
+  return {
+    presentation: "Peeking",
+    recognizer: "Bending",
+    armed: false,
+    locked: false,
+    bendAxis,
+    ...overrides,
+  };
+}
+
+function idle(
+  presentation: Presentation,
+  recognizer: Recognizer = "Idle",
+): CardState & { readonly bendAxis: BendAxis } {
+  return {
+    presentation,
+    recognizer,
+    armed: false,
+    locked: false,
+    bendAxis: "left",
+  };
+}
+
+function ctx(overrides: Partial<HintContext> = {}): HintContext {
+  return {
+    checkLegal: true,
+    foldLegal: true,
+    pending: false,
+    locked: false,
+    quiet: true,
+    ...overrides,
+  };
+}
+
+const nothingDiscovered: ReadonlySet<TeachableGesture> = new Set();
+const everythingDiscovered: ReadonlySet<TeachableGesture> = new Set([
+  "bend",
+  "conceal",
+  "check",
+  "fold",
+]);
+
+describe("selectHint", () => {
+  describe("in-gesture bend prompts", () => {
+    it("says what releasing does while the bend runs leftward", () => {
+      expect(selectHint(bending("left"), nothingDiscovered, ctx())).toEqual({
+        id: "bending-left",
+        line1: "Release to peek",
+        line2: "keep bending to reveal both",
+      });
+    });
+
+    it("swaps the second line for the upward bend, where the finger covers the face", () => {
+      expect(selectHint(bending("up"), nothingDiscovered, ctx())).toEqual({
+        id: "bending-up",
+        line1: "Release to peek",
+        line2: "drag left to keep your finger clear",
+      });
+    });
+
+    it("returns the prompt regardless of the discovery set — in-gesture hints never retire", () => {
+      expect(
+        selectHint(bending("left"), everythingDiscovered, ctx()),
+      ).not.toBeNull();
+      expect(selectHint(bending("up"), everythingDiscovered, ctx())).toEqual(
+        selectHint(bending("up"), nothingDiscovered, ctx()),
+      );
+    });
+
+    it("returns the prompt to a desktop player dragging with a mouse", () => {
+      // The `(pointer: coarse)` gate belongs to the teaching hints (#147): it
+      // exists so a keyboard player is not told to bend corners. Feedback on a
+      // motion already underway belongs to whoever is making it.
+      expect(
+        selectHint(bending("up"), everythingDiscovered, ctx()),
+      ).not.toBeNull();
+    });
+
+    it("returns the prompt without waiting for the quiet interval", () => {
+      // It is feedback on a motion happening right now, not instruction that
+      // should hold off and let the player find the gesture themselves.
+      expect(
+        selectHint(bending("left"), nothingDiscovered, ctx({ quiet: false })),
+      ).not.toBeNull();
+    });
+  });
+
+  describe("gates", () => {
+    it("shows nothing while an Action is pending or at showdown", () => {
+      expect(
+        selectHint(bending("left"), nothingDiscovered, ctx({ pending: true })),
+      ).toBeNull();
+      expect(
+        selectHint(bending("left"), nothingDiscovered, ctx({ locked: true })),
+      ).toBeNull();
+    });
+
+    it("shows nothing when the player is holding no cards", () => {
+      expect(selectHint(idle("Absent"), nothingDiscovered, ctx())).toBeNull();
+    });
+  });
+
+  it("shows nothing when no gesture is running", () => {
+    for (const presentation of ["FaceDown", "Revealed", "Turning"] as const) {
+      expect(
+        selectHint(idle(presentation), nothingDiscovered, ctx()),
+      ).toBeNull();
+    }
+  });
+
+  it("shows nothing for a drag that is not a bend", () => {
+    expect(
+      selectHint(idle("FaceDown", "Ignored"), nothingDiscovered, ctx()),
+    ).toBeNull();
+  });
+});

--- a/packages/player-client/src/holecards/coaching.ts
+++ b/packages/player-client/src/holecards/coaching.ts
@@ -1,0 +1,88 @@
+import type { CardState } from "./cardState.js";
+import type { BendAxis } from "./geometry.js";
+
+/**
+ * The gestures the surface teaches, and the keys the discovery set is written
+ * with. Bend is Peek *and* Reveal — one gesture at two depths — which is why
+ * there are four of these and not five.
+ */
+export type TeachableGesture = "bend" | "conceal" | "check" | "fold";
+
+/**
+ * Line 1 is an imperative; line 2 is the consequence (Phase 3 spec #138 §11).
+ * `id` identifies the hint for rendering and for tests; it is not the gesture,
+ * because the in-gesture prompts are feedback on a motion rather than
+ * instruction about one.
+ */
+export interface Hint {
+  readonly id: string;
+  readonly line1: string;
+  readonly line2: string | null;
+}
+
+export interface HintContext {
+  readonly checkLegal: boolean;
+  readonly foldLegal: boolean;
+  readonly pending: boolean;
+  readonly locked: boolean;
+  /** ~2s since the last contact with the pair. */
+  readonly quiet: boolean;
+}
+
+/**
+ * The one hint to show, or none (§11). At most one is ever visible, and
+ * in-gesture feedback outranks every teaching hint: it describes a motion the
+ * player's finger is making right now, and must never be outranked by
+ * instruction about a different gesture.
+ *
+ * The selector is **module-internal**. #111 put hint discovery outside the
+ * card module; #135 then made every in-gesture hint depend on recognizer state
+ * that nothing outside may see. Keeping the selector in here — and letting
+ * only the persisted discovery set cross the seam — is what holds the module's
+ * public surface at two names.
+ *
+ * This slice answers the bend gesture. The remaining in-gesture prompts and
+ * the four teaching hints arrive with the gestures they describe (#142, #145,
+ * #147), extending this same function rather than paralleling it.
+ *
+ * The `(pointer: coarse)` gate arrives with those teaching hints (#147), and
+ * applies to them: it exists so a keyboard player is not told to bend corners.
+ * An in-gesture prompt is feedback on a motion already underway, so it belongs
+ * to whoever is making it — including the desktop player dragging with a mouse.
+ */
+export function selectHint(
+  state: CardState & { readonly bendAxis: BendAxis },
+  _discovered: ReadonlySet<TeachableGesture>,
+  ctx: HintContext,
+): Hint | null {
+  // A hint is only ever advice about cards the player is actually holding, in
+  // a moment where those cards will listen.
+  if (ctx.pending || ctx.locked) return null;
+  if (state.presentation === "Absent") return null;
+
+  if (state.recognizer === "Bending") {
+    // Deliberately **not** gated on the discovery set. In-gesture prompts are
+    // permanent for every player, forever: they say what releasing will do,
+    // and for the money-losing gesture that text is the arming signal itself.
+    return state.bendAxis === "up" ? bendUpHint : bendLeftHint;
+  }
+
+  return null;
+}
+
+const bendLeftHint: Hint = {
+  id: "bending-left",
+  line1: "Release to peek",
+  line2: "keep bending to reveal both",
+};
+
+/**
+ * The upward variant swaps its second line for the one genuinely Peek-specific
+ * fact worth teaching: dragging *left* peels at the same rate (§15) without
+ * putting a finger over the rank and suit you are trying to read.
+ */
+const bendUpHint: Hint = {
+  id: "bending-up",
+  line1: "Release to peek",
+  line2: "drag left to keep your finger clear",
+};

--- a/packages/player-client/src/holecards/constants.ts
+++ b/packages/player-client/src/holecards/constants.ts
@@ -20,6 +20,13 @@ export const MIN_FOLD_DISTANCE_PX = 148;
 /** Fraction of viewport height the fold threshold scales with. */
 export const FOLD_DISTANCE_RATIO = 0.18;
 
+/**
+ * How much more upward than sideways a drag must be to read as a fold rather
+ * than as nothing. Ambiguous motion resolves to `Ignored` (§4), so the ratio
+ * sits just above 1 rather than at it.
+ */
+export const FOLD_AXIS_RATIO = 1.05;
+
 /** Window within which a second tap counts as a double-tap, in ms. */
 export const DOUBLE_TAP_MS = 280;
 
@@ -31,6 +38,18 @@ export const FOLD_FLIGHT_MS = 280;
 
 /** Quiet interval a coaching hint waits for before appearing, in ms. */
 export const HINT_QUIET_MS = 2000;
+
+/**
+ * How long after a classified gesture a synthetic `click` is disowned, in ms.
+ * Not a §15 constant — §16 requires the suppression but sets no window.
+ *
+ * A window rather than a flag, because a gesture does **not** reliably produce
+ * a click to consume it: a touch drag usually produces none, a mouse drag
+ * does, and a cancelled pointer produces none at all. A flag waiting for a
+ * click that never comes would go stale and swallow the next real activation,
+ * including the Enter or Space that §12 guarantees.
+ */
+export const CLICK_DISOWN_MS = 350;
 
 /**
  * Duration of the face-down deal-in, in ms. Not a §15 constant — the deal-in

--- a/packages/player-client/src/holecards/geometry.test.ts
+++ b/packages/player-client/src/holecards/geometry.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { BEND_TRAVEL_PX } from "./constants.js";
+import { bendAxis, bendProgress } from "./geometry.js";
+
+describe("bendProgress", () => {
+  it("is zero before the finger has moved", () => {
+    expect(bendProgress(0, 0)).toBe(0);
+  });
+
+  it("counts leftward and upward travel at equal weight", () => {
+    expect(bendProgress(-40, 0)).toBeCloseTo(40 / BEND_TRAVEL_PX);
+    expect(bendProgress(0, -40)).toBeCloseTo(40 / BEND_TRAVEL_PX);
+    expect(bendProgress(-40, -40)).toBeCloseTo(80 / BEND_TRAVEL_PX);
+  });
+
+  it("drives a pure leftward drag at the full rate, so the finger stays clear of the face", () => {
+    expect(bendProgress(-BEND_TRAVEL_PX, 0)).toBe(1);
+  });
+
+  it("ignores rightward and downward travel rather than subtracting it", () => {
+    expect(bendProgress(80, 80)).toBe(0);
+    expect(bendProgress(-40, 200)).toBeCloseTo(40 / BEND_TRAVEL_PX);
+  });
+
+  it("clamps at 1 however far the finger keeps going", () => {
+    expect(bendProgress(-4000, -4000)).toBe(1);
+  });
+});
+
+describe("bendAxis", () => {
+  it("reads a leftward-dominant bend as leftward", () => {
+    expect(bendAxis(-40, -10)).toBe("left");
+  });
+
+  it("reads an upward-dominant bend as upward", () => {
+    expect(bendAxis(-10, -40)).toBe("up");
+  });
+
+  it("reads an equal bend as upward, since the finger is still over the face", () => {
+    expect(bendAxis(-40, -40)).toBe("up");
+  });
+});

--- a/packages/player-client/src/holecards/geometry.ts
+++ b/packages/player-client/src/holecards/geometry.ts
@@ -1,0 +1,30 @@
+import { BEND_TRAVEL_PX } from "./constants.js";
+
+/** Which way a live bend is mostly going — the §11 hint swaps on it. */
+export type BendAxis = "left" | "up";
+
+/**
+ * Peel progress, 0 → 1, for a drag of `dx`/`dy` from where the finger landed
+ * (Phase 3 spec #138 §15). Prototype-validated; read rather than re-derived.
+ *
+ * Leftward and upward travel count **equally**, and only inward travel counts
+ * at all. Two consequences the formula exists for:
+ *
+ * - A pure leftward drag drives the peel at the full rate, so the player can
+ *   peel with their finger clear of the rank and suit they are trying to read.
+ * - Because leftward alone is enough, the bend cannot be stolen by the fold
+ *   recognizer, which needs upward dominance (§4).
+ */
+export function bendProgress(dx: number, dy: number): number {
+  const inward = Math.max(0, -dx) + Math.max(0, -dy);
+  return Math.min(1, inward / BEND_TRAVEL_PX);
+}
+
+/**
+ * Which axis a bend is being driven along. Ties read as `up`: a bend that is
+ * equally upward and leftward still has the finger over the card face, which
+ * is the case the "drag left" prompt exists to fix.
+ */
+export function bendAxis(dx: number, dy: number): BendAxis {
+  return Math.abs(dy) >= Math.abs(dx) ? "up" : "left";
+}

--- a/packages/player-client/src/holecards/gesture.test.ts
+++ b/packages/player-client/src/holecards/gesture.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vitest";
+import { BEND_TRAVEL_PX, MOVE_SLOP_PX, REVEAL_THRESHOLD } from "./constants.js";
+import {
+  beginGesture,
+  endGesture,
+  moveGesture,
+  type GestureSession,
+} from "./gesture.js";
+
+function press(
+  overrides: Partial<Parameters<typeof beginGesture>[0]> = {},
+): GestureSession {
+  return beginGesture({
+    pointerId: 1,
+    x: 100,
+    y: 100,
+    fromBendZone: false,
+    startedRevealed: false,
+    ...overrides,
+  });
+}
+
+const onTurn = { foldLegal: true };
+
+/** Drag to an absolute point, from the origin `press()` uses. */
+function to(dx: number, dy: number) {
+  return { x: 100 + dx, y: 100 + dy };
+}
+
+describe("moveGesture", () => {
+  it("classifies nothing under the slop, so a tap with a wobble is still a tap", () => {
+    const step = moveGesture(press(), to(MOVE_SLOP_PX - 1, 0), onTurn);
+
+    expect(step.session.classification).toBeNull();
+    expect(step.events).toEqual([]);
+    expect(step.bend).toBeNull();
+  });
+
+  it("classifies once past the slop and reports it as a single event", () => {
+    const step = moveGesture(
+      press({ fromBendZone: true }),
+      to(-(MOVE_SLOP_PX + 1), 0),
+      onTurn,
+    );
+
+    expect(step.session.classification).toBe("Bending");
+    expect(step.events).toEqual([{ type: "CLASSIFIED", as: "Bending" }]);
+  });
+
+  it("keeps the first classification for the rest of the gesture", () => {
+    // The drag starts sideways — Ignored — then curves decisively upward.
+    const slid = moveGesture(press(), to(-40, 0), onTurn);
+    const curved = moveGesture(slid.session, to(-40, -400), onTurn);
+
+    expect(slid.session.classification).toBe("Ignored");
+    expect(curved.session.classification).toBe("Ignored");
+    expect(curved.events).toEqual([]);
+  });
+
+  it("produces no events at all once classified, so a drag never re-renders", () => {
+    // The guarantee behind "a finger drag causes zero React re-renders":
+    // continuous values come back as `bend`, destined for a `MotionValue`, and
+    // the reducer is never told that a finger moved.
+    const bending = moveGesture(
+      press({ fromBendZone: true }),
+      to(-20, 0),
+      onTurn,
+    );
+
+    for (const distance of [30, 60, 90, 140]) {
+      const step = moveGesture(bending.session, to(-distance, 0), onTurn);
+      expect(step.events).toEqual([]);
+      expect(step.bend).not.toBeNull();
+    }
+  });
+
+  it("reports peel progress and axis while bending", () => {
+    const bending = moveGesture(
+      press({ fromBendZone: true }),
+      to(-20, 0),
+      onTurn,
+    );
+    const step = moveGesture(bending.session, to(-88, -0), onTurn);
+
+    expect(step.bend).toEqual({ progress: 88 / BEND_TRAVEL_PX, axis: "left" });
+  });
+
+  it("reports the upward axis when the finger is over the card face", () => {
+    const bending = moveGesture(
+      press({ fromBendZone: true }),
+      to(0, -20),
+      onTurn,
+    );
+    const step = moveGesture(bending.session, to(-20, -60), onTurn);
+
+    expect(step.bend?.axis).toBe("up");
+  });
+
+  it("reports no peel for a drag that is not a bend", () => {
+    const folding = moveGesture(press(), to(0, -40), onTurn);
+    const ignored = moveGesture(press(), to(40, 0), onTurn);
+
+    expect(folding.session.classification).toBe("FoldDragging");
+    expect(folding.bend).toBeNull();
+    expect(ignored.bend).toBeNull();
+  });
+
+  it("samples fold legality at classification and never re-reads it", () => {
+    const offTurn = moveGesture(press(), to(0, -40), { foldLegal: false });
+    expect(offTurn.session.classification).toBe("Ignored");
+
+    // Legality returning mid-drag does not promote it.
+    const later = moveGesture(offTurn.session, to(0, -400), onTurn);
+    expect(later.session.classification).toBe("Ignored");
+  });
+});
+
+describe("crossing the reveal threshold", () => {
+  /** Inward travel, in px, that puts the peel at a given progress. */
+  function inward(progress: number) {
+    return -(progress * BEND_TRAVEL_PX);
+  }
+
+  it("commits when the peel reaches the threshold", () => {
+    const bending = moveGesture(
+      press({ fromBendZone: true }),
+      to(-20, 0),
+      onTurn,
+    );
+    const crossing = moveGesture(
+      bending.session,
+      to(inward(REVEAL_THRESHOLD), 0),
+      onTurn,
+    );
+
+    expect(crossing.events).toEqual([{ type: "BEND_CROSSED" }]);
+    expect(crossing.session.crossed).toBe(true);
+  });
+
+  it("announces the crossing exactly once, however far the drag continues", () => {
+    const bending = moveGesture(
+      press({ fromBendZone: true }),
+      to(-20, 0),
+      onTurn,
+    );
+    const crossed = moveGesture(
+      bending.session,
+      to(inward(REVEAL_THRESHOLD), 0),
+      onTurn,
+    ).session;
+
+    for (const progress of [0.95, 1, 0.5, 0]) {
+      const step = moveGesture(crossed, to(inward(progress), 0), onTurn);
+      // Including dragging *back*: the commit happened on crossing, so it can
+      // neither be undone nor re-announced.
+      expect(step.events).toEqual([]);
+      expect(step.session.crossed).toBe(true);
+    }
+  });
+
+  it("stops driving the peel from the finger once committed", () => {
+    // The turn owns the motion from the threshold on, so a finger still on the
+    // glass cannot drag the card back out of a commit it already made.
+    const bending = moveGesture(
+      press({ fromBendZone: true }),
+      to(-20, 0),
+      onTurn,
+    );
+    const crossed = moveGesture(
+      bending.session,
+      to(inward(REVEAL_THRESHOLD), 0),
+      onTurn,
+    ).session;
+
+    expect(moveGesture(crossed, to(-10, 0), onTurn).bend).toBeNull();
+  });
+
+  it("classifies and commits in one move when the flick is fast enough", () => {
+    const flick = moveGesture(
+      press({ fromBendZone: true }),
+      to(inward(1), 0),
+      onTurn,
+    );
+
+    // Order matters: the reducer only accepts a crossing from `Bending`.
+    expect(flick.events).toEqual([
+      { type: "CLASSIFIED", as: "Bending" },
+      { type: "BEND_CROSSED" },
+    ]);
+  });
+
+  it("never commits a drag that is not a bend, however far it goes", () => {
+    for (const session of [press(), press({ fromBendZone: false })]) {
+      const dragged = moveGesture(session, to(0, inward(4)), onTurn);
+      expect(dragged.events).toEqual([
+        { type: "CLASSIFIED", as: "FoldDragging" },
+      ]);
+      expect(dragged.session.crossed).toBe(false);
+    }
+  });
+});
+
+describe("endGesture", () => {
+  it("taps on a release that never classified", () => {
+    expect(endGesture(press(), { cancelled: false })).toEqual([
+      { type: "RELEASED" },
+      { type: "TAPPED" },
+    ]);
+  });
+
+  it("does not tap on release from an ignored drag", () => {
+    const ignored = moveGesture(press(), to(40, 0), onTurn).session;
+
+    expect(endGesture(ignored, { cancelled: false })).toEqual([
+      { type: "RELEASED" },
+    ]);
+  });
+
+  it("does not tap on release from a bend", () => {
+    const bending = moveGesture(
+      press({ fromBendZone: true }),
+      to(-40, 0),
+      onTurn,
+    ).session;
+
+    expect(endGesture(bending, { cancelled: false })).toEqual([
+      { type: "RELEASED" },
+    ]);
+  });
+
+  it("cancels rather than taps when the browser takes the pointer away", () => {
+    expect(endGesture(press(), { cancelled: true })).toEqual([
+      { type: "CANCELLED" },
+    ]);
+  });
+});

--- a/packages/player-client/src/holecards/gesture.ts
+++ b/packages/player-client/src/holecards/gesture.ts
@@ -1,0 +1,154 @@
+import type { CardEvent } from "./cardState.js";
+import { classify, type Classification } from "./classify.js";
+import { MOVE_SLOP_PX, REVEAL_THRESHOLD } from "./constants.js";
+import { bendAxis, bendProgress, type BendAxis } from "./geometry.js";
+
+/**
+ * A live pointer gesture, as a value (Phase 3 spec #138 §4, §13).
+ *
+ * The hook holds one of these in a ref and never in React state — which is the
+ * whole point. Splitting by **cardinality of change**, the discrete facts (has
+ * it been classified, has a threshold been crossed) become reducer events, and
+ * the continuous ones (peel progress, drag offset) become `MotionValue`s. A
+ * finger dragging across the pair therefore produces no events at all between
+ * threshold crossings, so it causes **zero** React re-renders, and `Hand`,
+ * `ActionBar` and the turn banner are untouched by card handling.
+ */
+export interface GestureSession {
+  readonly pointerId: number;
+  readonly originX: number;
+  readonly originY: number;
+  /** The press landed on the bend affordance in a card's corner. */
+  readonly fromBendZone: boolean;
+  /** The pair was already face-up when the press landed. */
+  readonly startedRevealed: boolean;
+  /** `null` until the drag passes the slop; set exactly once thereafter. */
+  readonly classification: Classification | null;
+  /**
+   * Whether the peel has already reached the reveal threshold. One-way: the
+   * commit happens *on crossing*, not on release, so dragging back afterwards
+   * cannot un-commit it and must not re-announce it either.
+   */
+  readonly crossed: boolean;
+}
+
+/** Continuous peel values, destined for `MotionValue`s rather than state. */
+export interface BendMotion {
+  readonly progress: number;
+  readonly axis: BendAxis;
+}
+
+export interface GestureStep {
+  readonly session: GestureSession;
+  readonly events: readonly CardEvent[];
+  /** `null` when this move changes nothing continuous. */
+  readonly bend: BendMotion | null;
+}
+
+export function beginGesture(press: {
+  readonly pointerId: number;
+  readonly x: number;
+  readonly y: number;
+  readonly fromBendZone: boolean;
+  readonly startedRevealed: boolean;
+}): GestureSession {
+  return {
+    pointerId: press.pointerId,
+    originX: press.x,
+    originY: press.y,
+    fromBendZone: press.fromBendZone,
+    startedRevealed: press.startedRevealed,
+    classification: null,
+    crossed: false,
+  };
+}
+
+/**
+ * Advance a gesture to a new pointer position.
+ *
+ * Nothing is classified below the slop, so a tap with a wobble still reads as
+ * a tap. Past it, `classify` runs **once** and its answer is kept for the rest
+ * of the gesture — this function never asks a second time, and the reducer
+ * refuses a second answer anyway.
+ */
+export function moveGesture(
+  session: GestureSession,
+  point: { readonly x: number; readonly y: number },
+  ctx: { readonly foldLegal: boolean },
+): GestureStep {
+  const dx = point.x - session.originX;
+  const dy = point.y - session.originY;
+
+  if (session.classification === null) {
+    if (Math.hypot(dx, dy) <= MOVE_SLOP_PX) {
+      return { session, events: [], bend: null };
+    }
+    const classification = classify({
+      fromBendZone: session.fromBendZone,
+      alreadyRevealed: session.startedRevealed,
+      dx,
+      dy,
+      // Fold legality is sampled once, here, and never re-read. A drag that
+      // outlives the player's turn disarms (§6); it does not reclassify.
+      foldLegal: ctx.foldLegal,
+    });
+    return step({ ...session, classification }, dx, dy, [
+      { type: "CLASSIFIED", as: classification },
+    ]);
+  }
+
+  // The steady state of a drag: continuous values only, and no events — the
+  // reducer is not told that a finger moved.
+  return step(session, dx, dy, []);
+}
+
+/**
+ * One advanced step, plus the threshold crossing if this move is the one that
+ * reaches it. A flick fast enough to classify and cross in a single move
+ * emits both, in that order, and the reducer applies them in that order.
+ */
+function step(
+  session: GestureSession,
+  dx: number,
+  dy: number,
+  events: readonly CardEvent[],
+): GestureStep {
+  // Past the commit the turn owns the motion: the peel finishes on its own
+  // schedule, so the finger stops driving it and a release cannot pull it back.
+  if (session.crossed) return { session, events, bend: null };
+
+  const bend = bendFor(session, dx, dy);
+  if (bend === null || bend.progress < REVEAL_THRESHOLD) {
+    return { session, events, bend };
+  }
+  return {
+    session: { ...session, crossed: true },
+    events: [...events, { type: "BEND_CROSSED" }],
+    bend,
+  };
+}
+
+function bendFor(
+  session: GestureSession,
+  dx: number,
+  dy: number,
+): BendMotion | null {
+  if (session.classification !== "Bending") return null;
+  return { progress: bendProgress(dx, dy), axis: bendAxis(dx, dy) };
+}
+
+/**
+ * End a gesture. A release that never classified is a tap; a release from
+ * `Ignored` is not — a drag that started sideways or downward does nothing at
+ * all, including on the way out.
+ */
+export function endGesture(
+  session: GestureSession,
+  { cancelled }: { readonly cancelled: boolean },
+): readonly CardEvent[] {
+  if (cancelled) return [{ type: "CANCELLED" }];
+  if (session.classification === null) {
+    return [{ type: "RELEASED" }, { type: "TAPPED" }];
+  }
+  return [{ type: "RELEASED" }];
+}

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -1,12 +1,21 @@
+import { animate, useMotionValue, type MotionValue } from "motion/react";
 import {
   useCallback,
   useEffect,
   useLayoutEffect,
   useReducer,
   useRef,
+  type PointerEvent as ReactPointerEvent,
 } from "react";
 import { initialCardState, reduce, type CardState } from "./cardState.js";
-import { REVEAL_FINISH_MS } from "./constants.js";
+import { CLICK_DISOWN_MS, REVEAL_FINISH_MS } from "./constants.js";
+import type { BendAxis } from "./geometry.js";
+import {
+  beginGesture,
+  endGesture,
+  moveGesture,
+  type GestureSession,
+} from "./gesture.js";
 import type { HoleCardPairProps } from "./HoleCardPair.js";
 import { eventsForPropChange } from "./viewEvents.js";
 
@@ -17,22 +26,63 @@ import { eventsForPropChange } from "./viewEvents.js";
 const useIsomorphicLayoutEffect =
   typeof window === "undefined" ? useEffect : useLayoutEffect;
 
-/**
- * Binds the pure lifecycle to React: prop changes in, discrete state out.
- * Every decision it makes is delegated — `eventsForPropChange` decides what a
- * changed prop means, `reduce` decides what that means for the pair — so the
- * hook itself holds no rules worth testing through a renderer.
- */
-export function useHoleCards(props: HoleCardPairProps): {
+/** The pointer handlers the pair binds. */
+export interface PairHandlers {
+  readonly onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
+  readonly onPointerMove: (event: ReactPointerEvent<HTMLElement>) => void;
+  readonly onPointerUp: (event: ReactPointerEvent<HTMLElement>) => void;
+  readonly onPointerCancel: (event: ReactPointerEvent<HTMLElement>) => void;
+  readonly onLostPointerCapture: (
+    event: ReactPointerEvent<HTMLElement>,
+  ) => void;
+}
+
+export interface HoleCards {
   readonly state: CardState;
+  /** Keyboard and mouse activation: Enter, Space or a click (§12). */
   readonly activate: () => void;
-} {
+  readonly handlers: PairHandlers;
+  /** Peel progress, 0 → 1. Never React state (§13). */
+  readonly bend: MotionValue<number>;
+  /** Which way the live bend is going, for the §11 second-line swap. */
+  readonly bendAxis: MotionValue<BendAxis>;
+}
+
+/**
+ * Binds the pure lifecycle to React: prop changes and pointer events in,
+ * discrete state out. Every decision it makes is delegated —
+ * `eventsForPropChange` decides what a changed prop means, `moveGesture`
+ * decides what a finger is doing, `reduce` decides what either means for the
+ * pair — so the hook itself holds no rules worth testing through a renderer.
+ *
+ * The split it exists to enforce is §13's: discrete states go through
+ * `useReducer`, a handful of times per hand; continuous values are
+ * `MotionValue`s written straight from the pointer handlers. Between threshold
+ * crossings a drag dispatches nothing, so it re-renders nothing — not this
+ * component, and not `Hand`, `ActionBar` or the turn banner above it.
+ */
+export function useHoleCards(props: HoleCardPairProps): HoleCards {
   const [state, dispatch] = useReducer(reduce, props, (initial) =>
     initialCardState({
       hasCards: initial.cards !== null,
       locked: initial.locked,
     }),
   );
+
+  const bend = useMotionValue(0);
+  const bendAxis = useMotionValue<BendAxis>("left");
+  const session = useRef<GestureSession | null>(null);
+  /**
+   * §16: `preventDefault` at a lower level does not suppress the later `click`
+   * consistently across browsers, so suppression is handled here, at the
+   * recognizer. A gesture that classified has already been answered, and the
+   * click the browser synthesises after it must not toggle the reveal on top.
+   *
+   * A deadline rather than a flag: the click is not guaranteed to arrive — a
+   * touch drag usually produces none and a cancelled pointer never does — and
+   * a flag left waiting would swallow the next real activation instead.
+   */
+  const disownClicksUntil = useRef(0);
 
   const previous = useRef(props);
   // Deliberately un-keyed: the adapter compares the props itself and returns
@@ -51,19 +101,117 @@ export function useHoleCards(props: HoleCardPairProps): {
 
   // `Turning` is a point of no return: once the flip is committed it finishes
   // on its own schedule, whatever the pointer does.
+  //
+  // The turn is the *same sheet* the finger was bending, carried on past the
+  // opposite corner rather than a separate flip animation — so the peel runs
+  // from wherever the player let go to 1 and the face lands flat. A keyboard
+  // reveal starts from 0 and gets the identical motion, which is what makes
+  // Enter and a bend produce the same object behaving.
   useEffect(() => {
     if (state.presentation !== "Turning") return;
+    const peel = animate(bend, 1, {
+      duration: REVEAL_FINISH_MS / 1000,
+      ease: [0.32, 0.72, 0.3, 1],
+    });
     const timer = setTimeout(() => {
       dispatch({ type: "TURN_FINISHED" });
     }, REVEAL_FINISH_MS);
     return () => {
+      peel.stop();
       clearTimeout(timer);
     };
-  }, [state.presentation]);
+  }, [state.presentation, bend]);
+
+  // Face-down and face-up are both flat: the peel only exists in between, so
+  // it is reset once the pair settles rather than left at wherever it landed.
+  useEffect(() => {
+    if (
+      state.presentation === "FaceDown" ||
+      state.presentation === "Revealed"
+    ) {
+      bend.set(0);
+    }
+  }, [state.presentation, bend]);
 
   const activate = useCallback(() => {
+    if (Date.now() < disownClicksUntil.current) return;
     dispatch({ type: "ACTIVATED" });
   }, []);
 
-  return { state, activate };
+  const finish = (
+    event: ReactPointerEvent<HTMLElement>,
+    cancelled: boolean,
+  ): void => {
+    const active = session.current;
+    if (active?.pointerId !== event.pointerId) return;
+    session.current = null;
+    if (active.classification !== null) {
+      disownClicksUntil.current = Date.now() + CLICK_DISOWN_MS;
+    }
+    // The peel closes the instant the finger lifts — a glance costs nothing
+    // and leaves nothing exposed, so there is no wind-down to watch. A bend
+    // that already crossed the threshold is exempt: it committed on crossing,
+    // and the turn is mid-flight with the peel under its control.
+    if (!active.crossed) bend.set(0);
+    for (const cardEvent of endGesture(active, { cancelled })) {
+      dispatch(cardEvent);
+    }
+  };
+
+  const handlers: PairHandlers = {
+    onPointerDown: (event) => {
+      // A second finger landing mid-gesture is ignored until the first one
+      // releases or cancels: a stray thumb must not silently retarget a drag.
+      if (session.current !== null || event.button !== 0) return;
+      // The lifecycle's lock rather than the prop, so a decided hand is inert
+      // to a finger for exactly as long as it is inert to the keyboard.
+      if (state.locked) return;
+      // Inertness while a Fold is in flight rides on `Leaving`, not on
+      // `pending`: a pending Call or Raise leaves the cards entirely alone.
+      if (state.presentation === "Absent" || state.presentation === "Leaving") {
+        return;
+      }
+      const target = event.target as HTMLElement;
+      event.currentTarget.setPointerCapture(event.pointerId);
+      session.current = beginGesture({
+        pointerId: event.pointerId,
+        x: event.clientX,
+        y: event.clientY,
+        fromBendZone: target.closest("[data-bend-zone]") !== null,
+        startedRevealed: state.presentation === "Revealed",
+      });
+      dispatch({ type: "PRESSED" });
+    },
+
+    onPointerMove: (event) => {
+      const active = session.current;
+      if (active?.pointerId !== event.pointerId) return;
+      const step = moveGesture(
+        active,
+        { x: event.clientX, y: event.clientY },
+        { foldLegal: props.actions.foldLegal },
+      );
+      session.current = step.session;
+      if (step.bend !== null) {
+        bend.set(step.bend.progress);
+        bendAxis.set(step.bend.axis);
+      }
+      // Once the drag belongs to the recognizer, the browser must not also
+      // treat it as a pan or a selection.
+      if (step.session.classification !== null) event.preventDefault();
+      for (const cardEvent of step.events) dispatch(cardEvent);
+    },
+
+    onPointerUp: (event) => {
+      finish(event, false);
+    },
+    onPointerCancel: (event) => {
+      finish(event, true);
+    },
+    onLostPointerCapture: (event) => {
+      finish(event, true);
+    },
+  };
+
+  return { state, activate, handlers, bend, bendAxis };
 }

--- a/packages/player-client/src/holecards/viewEvents.test.ts
+++ b/packages/player-client/src/holecards/viewEvents.test.ts
@@ -25,16 +25,19 @@ function props(overrides: Partial<HoleCardPairProps> = {}): HoleCardPairProps {
 const faceDown: CardState = {
   presentation: "FaceDown",
   recognizer: "Idle",
+  armed: false,
   locked: false,
 };
 const absent: CardState = {
   presentation: "Absent",
   recognizer: "Idle",
+  armed: false,
   locked: false,
 };
 const revealed: CardState = {
   presentation: "Revealed",
   recognizer: "Idle",
+  armed: false,
   locked: true,
 };
 

--- a/packages/ui-shared/src/Card.test.tsx
+++ b/packages/ui-shared/src/Card.test.tsx
@@ -18,6 +18,14 @@ describe("Card", () => {
     expect(html).toContain('data-face-down="true"');
   });
 
+  it("prints the index in both corners, the second rotated, as a real card is", () => {
+    const html = renderToStaticMarkup(<Card rank="Q" suit="diamonds" />);
+    expect(html.match(/class="card-index/g)).toHaveLength(2);
+    expect(html).toContain("rotate(180deg)");
+    // Both copies carry the rank, so a card lifted from either corner reads.
+    expect(html.match(/Q/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
   it("never renders an <img> element, for either face", () => {
     const faceUp = renderToStaticMarkup(<Card rank="K" suit="hearts" />);
     const faceDown = renderToStaticMarkup(<Card faceDown />);

--- a/packages/ui-shared/src/Card.tsx
+++ b/packages/ui-shared/src/Card.tsx
@@ -6,7 +6,12 @@ export type CardProps =
   | { readonly faceDown: true }
   | { readonly faceDown?: false; readonly rank: Rank; readonly suit: Suit };
 
-const suitSymbols: Record<Suit, string> = {
+/**
+ * Exported so consumers that draw their own card-shaped surfaces — a curling
+ * corner, a chip label — spell a suit the same way this component does, rather
+ * than keeping a second copy of the mapping that can drift from it.
+ */
+export const suitSymbols: Record<Suit, string> = {
   clubs: "♣",
   diamonds: "♦",
   hearts: "♥",
@@ -14,6 +19,11 @@ const suitSymbols: Record<Suit, string> = {
 };
 
 const redSuits: ReadonlySet<Suit> = new Set(["diamonds", "hearts"]);
+
+/** Which of the two ink colours a suit is printed in. */
+export function isRedSuit(suit: Suit): boolean {
+  return redSuits.has(suit);
+}
 
 const baseStyle: CSSProperties = {
   width: "3.5em",
@@ -61,36 +71,89 @@ export function Card(props: CardProps) {
       data-suit={suit}
       style={{
         ...baseStyle,
+        position: "relative",
         background: color.cardFace,
         border: `1px solid ${color.cardBorder}`,
         boxShadow: shadow.card,
-        color: redSuits.has(suit) ? color.suitRed : color.suitBlack,
+        color: isRedSuit(suit) ? color.suitRed : color.suitBlack,
         display: "flex",
-        flexDirection: "column",
-        justifyContent: "space-between",
-        padding: "0.24em 0.26em",
+        alignItems: "center",
+        justifyContent: "center",
       }}
     >
-      <span
-        className="card-rank"
-        style={{
-          display: "flex",
-          alignItems: "baseline",
-          gap: "0.06em",
-          fontWeight: 700,
-          fontSize: "1.1em",
-          lineHeight: 0.9,
-        }}
-      >
-        {rank}
-        <span style={{ fontSize: "0.55em" }}>{suitSymbols[suit]}</span>
-      </span>
+      <Index rank={rank} suit={suit} />
       <span
         className="card-suit"
-        style={{ textAlign: "right", fontSize: "1.4em", lineHeight: 0.8 }}
+        style={{ fontSize: "1.9em", lineHeight: 1, opacity: 0.86 }}
       >
         {suitSymbols[suit]}
       </span>
+      {/* Rotated a half-turn in the opposite corner, as a real card is
+       * printed — so the card reads the same way up whichever end you are
+       * looking at, and lifting either corner uncovers a legible index. */}
+      <Index rank={rank} suit={suit} mirrored />
     </div>
+  );
+}
+
+/**
+ * The shared look of a corner index, exported so that a consumer drawing an
+ * index of its own — the player client's curling corner draws one where the
+ * fold uncovers it — matches this one instead of guessing at it.
+ *
+ * Sized against the card, never in px, so it holds at every scale the card is
+ * used at — seat pods and multi-way reveals shrink the whole box well under
+ * `1em`. The prototype's ratio is `0.51em` (24px on its 164px card), which
+ * read as too small on a real screen; this sits between that and the `1.1em`
+ * it replaced.
+ *
+ * There is an upper bound worth knowing about: much past `1.1em` the index
+ * stops being a corner mark and reaches into the middle of the card, far
+ * enough that the player client's fold drags it onto the lifted flap.
+ */
+export const cardIndexStyle: CSSProperties = {
+  position: "absolute",
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  fontWeight: 700,
+  fontSize: "0.8em",
+  lineHeight: 0.78,
+};
+
+/** The suit symbol sitting under the rank, sized against the index. */
+export const cardIndexSuitStyle: CSSProperties = {
+  marginTop: "0.2em",
+  fontSize: "0.75em",
+  fontWeight: 400,
+};
+
+/**
+ * The corner index: rank above its suit. Printed twice per face, the second
+ * copy rotated, which is what lets a card be read from a lifted corner rather
+ * than only from a fully exposed face.
+ */
+function Index({
+  rank,
+  suit,
+  mirrored = false,
+}: {
+  readonly rank: Rank;
+  readonly suit: Suit;
+  readonly mirrored?: boolean;
+}) {
+  return (
+    <span
+      className={mirrored ? "card-index card-index-mirrored" : "card-index"}
+      style={{
+        ...cardIndexStyle,
+        ...(mirrored
+          ? { right: "0.235em", bottom: "0.21em", transform: "rotate(180deg)" }
+          : { left: "0.235em", top: "0.21em" }),
+      }}
+    >
+      {rank}
+      <span style={cardIndexSuitStyle}>{suitSymbols[suit]}</span>
+    </span>
   );
 }

--- a/packages/ui-shared/src/index.ts
+++ b/packages/ui-shared/src/index.ts
@@ -1,4 +1,10 @@
-export { Card } from "./Card.js";
+export {
+  Card,
+  cardIndexStyle,
+  cardIndexSuitStyle,
+  isRedSuit,
+  suitSymbols,
+} from "./Card.js";
 export type { CardProps } from "./Card.js";
 export { PillButton } from "./PillButton.js";
 export type {


### PR DESCRIPTION
Implements #141 — the chokepoint slice of the Phase 3 tactile Hole-card work (#138).

Drag the bend affordance on a card's bottom-right corner and both cards peel open together, tracking the finger. Lifting it closes them at once: a glance costs nothing and leaves nothing exposed.

## What landed

**The shape, up front.** Per the ticket's conflict notes, this owns `CardState` (now carrying the `armed` flag) and the complete `CardEvent` union, including names for gestures it does not yet wire (`BEND_CROSSED`, `FOLD_ARMED`, `FOLD_DISARMED`, `RESET`, `TAPPED`, `DOUBLE_TAPPED`, `PENDING_RESOLVED`, `SHOWDOWN_REVEAL`). Those arrive as explicitly-listed no-op arms annotated with the ticket that answers them, so #140 and #142–#147 add arms rather than reshape the type.

**New pure modules**, each with its own table-driven test file and no React, no DOM, no store:

| File | What it decides |
| --- | --- |
| `classify.ts` | The whole §4 table, once per gesture |
| `geometry.ts` | `bendProgress` = `max(0,-dx) + max(0,-dy)`, and the axis for the hint swap |
| `gesture.ts` | What a pointer session means: slop, the single classification, what a release is |
| `coaching.ts` | The §11 selector, answering the two in-gesture bend prompts |

**Stickiness lives in the reducer.** `classify` runs once past 9px of slop; the reducer accepts `CLASSIFIED` only from `Pressing`, which is also what leaves `Ignored` terminal until release and stops a sideways drag becoming a fold by curving upward.

**Motion stays off React's render path (§13).** Peel progress and bend axis are `MotionValue`s written straight from the pointer handlers. `moveGesture` returns `events: []` for every move after classification — the pure expression of "a finger drag causes zero re-renders", asserted directly in `gesture.test.ts`. The leftward/upward hint swap is driven by the axis `MotionValue` with both second lines in the document, so a bend wandering across the diagonal re-renders nothing.

**Platform hardening (§16).** The pair takes the whole gesture from the browser (`touch-action: none`, so no pan and no double-tap zoom), raises no selection or iOS callout, and the recognizer swallows the synthetic click after a classified gesture — `preventDefault` at a lower level does not suppress it consistently.

**First pointer wins.** A second `pointerdown` mid-gesture is ignored until the first releases or cancels, guarded both in the hook and in the reducer.

## Not in this slice

Reveal past 0.9 and tap-conceal (#142), cancellation and resets (#143), double-tap Check (#144), the fold drag (#145), the teaching hints and `hintStorage` (#147). `ui-shared/Card` is untouched; so are `ActionBar`, `useActionIntent`, the protocol, the server and the engine.

## Verification

`npx tsc -b` clean · `npm run lint` clean · full suite 517 tests / 77 files passing.

Long-press raising no callout and double-tap causing no zoom are verified on device in the acceptance run (#148), as the spec's "Not tested automatically" section requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Bkweq5AnZuVYvKfonJjx3

---

### Scope change: the reveal commit (#142) is in this PR

Agreed with @ewanhardingham after reviewing the first cut on device.

**Why.** #141 as written stops at "peels to 90% and holds", which is not a
gesture a Player can finish — the bend has no outcome. Splitting the commit
into #142 also meant two tickets editing the same peel geometry in sequence,
where the second would have replaced the first's motion rather than adding to
it. The turn is not a separate animation: it is the *same lifted sheet*
carried past the opposite corner, so it cannot be built independently of the
bend that starts it.

**What came across from #142:** the `BEND_CROSSED` arm (`Peeking`/`Bending` →
`Turning`/`Committed`), the threshold crossing in `moveGesture` (announced
exactly once, on crossing — dragging back neither undoes nor re-announces it),
and `Turning` driving the peel to completion.

**What is still #142's:** tap-to-conceal from `Revealed`, and the `TAPPED`
reducer arm. #142 should be re-scoped to that.

### Also here: the bend is a real curl, and `Card` gained a second index

The first cut peeled by clipping the card back away along a diagonal. That
read as a wipe rather than a bend, so it is now `react-peel` — the same
library and options the prototype settled on — with the face on the underside
of the lifted flap.

The shared `Card` now prints its index in **both** corners, the second rotated
180°, as a real card is. This is a change to `ui-shared` and therefore visible
in the table client too, which is in tension with story 86 ("shared `Card`
left untouched"). Flagging it rather than burying it: the change adds no
gesture or poker concept to `ui-shared`, and it is what makes the curl
readable — with the index only at top-left, lifting the bottom-right corner
uncovered the rank *last*, so the peel had to run nearly the whole card to
satisfy story 7.

### Still open for the device run (#148)

`react-peel` mirrors the underside before rotating it, so the physical
bottom-right index may not land where it is legible on the curl. The prototype
solved this with a dedicated remapped `.gesture-card-curl-index`. Whether the
two-corner `Card` is sufficient on its own needs a real device to judge.


### Curl legibility — resolved (was open above)

The open question about `react-peel` mirroring the underside is answered, and
the answer was no: the two-corner `Card` is **not** sufficient on its own.

`setBackTransform` pins the back layer by `flipPointHorizontally(corner)`, so a
`BOTTOM_RIGHT` peel pins the back's *bottom-left* to the fingertip. The flap
uncovers the bottom-left region — not the bottom-right corner the finger is
lifting — so the face's own bottom-right index fell outside the visible curl
and a bend showed bare white card.

Fixed in `1e279e0` with the remapped index the prototype needed for the same
reason. It lives in the player client (`CurlIndex` in `BendableCard.tsx`), not
as a `Card` prop, so `ui-shared` still gains no gesture concept. `Card` now
exports `suitSymbols` and `isRedSuit` so the curl spells and inks a suit the
same way the face does instead of keeping a second mapping that can drift.

The two-corner `Card` stays regardless — it is what a real card looks like, and
it is what makes the reveal readable from either end — but it was not the fix.

Still worth a device pass under #148: the flap's own rotation is what makes the
half-turn on the remapped index read upright, and that was matched to the
prototype rather than derived.
