### PR TITLE
feat(player-client): cancel gestures and reset the Hole cards face-down

### DIFF
--- a/packages/player-client/src/holecards/cardState.test.ts
+++ b/packages/player-client/src/holecards/cardState.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   initialCardState,
   reduce,
+  type CardEvent,
   type CardState,
   type Presentation,
   type Recognizer,
@@ -14,6 +15,8 @@ function state(
 ): CardState {
   return { presentation, recognizer, armed, locked: false };
 }
+
+const reset: CardEvent = { type: "RESET" };
 
 /** A showdown-locked pair: face-up and inert. */
 function lockedState(presentation: Presentation): CardState {
@@ -395,9 +398,95 @@ describe("reduce", () => {
       }
     });
 
+    it("returns a below-threshold fold drag to the face it started from", () => {
+      // A fold drag moves the pair around without turning it over, so the
+      // presentation it was carrying *is* the stable state to restore — from
+      // face-down and from revealed alike.
+      for (const ending of endings) {
+        expect(reduce(state("FaceDown", "FoldDragging"), ending)).toEqual(
+          state("FaceDown"),
+        );
+        expect(reduce(state("Revealed", "FoldDragging"), ending)).toEqual(
+          state("Revealed"),
+        );
+      }
+    });
+
+    it("commits nothing from an unclassified press", () => {
+      for (const ending of endings) {
+        expect(reduce(state("Revealed", "Pressing"), ending)).toEqual(
+          state("Revealed"),
+        );
+      }
+    });
+
+    it("does not call a committed fold back from the muck", () => {
+      for (const ending of endings) {
+        expect(reduce(state("Leaving", "Committed"), ending)).toEqual(
+          state("Leaving"),
+        );
+      }
+    });
+
     it("is a no-op when no gesture is live", () => {
       for (const ending of endings) {
         expect(reduce(state("Revealed"), ending)).toEqual(state("Revealed"));
+      }
+    });
+
+    it("is a no-op with no cards in hand", () => {
+      for (const ending of endings) {
+        expect(reduce(state("Absent"), ending)).toEqual(state("Absent"));
+      }
+    });
+
+    it("is a no-op while locked — a decided hand has no gesture to cancel", () => {
+      for (const ending of endings) {
+        expect(reduce(lockedState("Revealed"), ending)).toEqual(
+          lockedState("Revealed"),
+        );
+      }
+    });
+  });
+
+  describe("RESET", () => {
+    it("lands on FaceDown from every presentation, cancelling any gesture", () => {
+      const gestures = [
+        state("FaceDown", "Pressing"),
+        state("Peeking", "Bending"),
+        state("Turning", "Committed"),
+        state("Revealed", "FoldDragging"),
+        state("Revealed", "FoldDragging", true),
+        state("Leaving", "Committed"),
+      ];
+      for (const active of gestures) {
+        expect(reduce(active, reset)).toEqual(state("FaceDown"));
+      }
+    });
+
+    it("snaps out of Turning rather than letting the flip finish", () => {
+      // The one thing that interrupts a turn: no face-up frame of the previous
+      // hand may survive into the next. Landing on `FaceDown` is also what
+      // makes it a snap — `BendableCard` animates only while `Turning`.
+      expect(reduce(state("Turning", "Committed"), reset)).toEqual(
+        state("FaceDown"),
+      );
+    });
+
+    it("leaves a seat holding no cards holding none", () => {
+      // There is nothing to turn face-down. Every other presentation implies
+      // cards in hand; `Absent` is the one that would be a lie.
+      expect(reduce(state("Absent"), reset)).toEqual(state("Absent"));
+    });
+
+    it("does not disturb a decided showdown", () => {
+      // Backgrounding the app must not conceal a public reveal — and a reload
+      // remounts straight back to `Revealed` off the `locked` prop, so
+      // honouring `RESET` here would make the two paths disagree.
+      for (const presentation of ["Revealed", "Turning"] as const) {
+        expect(reduce(lockedState(presentation), reset)).toEqual(
+          lockedState(presentation),
+        );
       }
     });
   });

--- a/packages/player-client/src/holecards/cardState.ts
+++ b/packages/player-client/src/holecards/cardState.ts
@@ -13,8 +13,9 @@
  * gestures that follow are additions rather than surgery.
  *
  * Answered so far: the deal-in, the emptying and the keyboard reveal/conceal
- * toggle (#139), the showdown reveal and lock (#140), and the press, the
- * classification and the release that make up a bend (#141).
+ * toggle (#139), the showdown reveal and lock (#140), the press, the
+ * classification and the release that make up a bend (#141), and cancellation
+ * and resets (#143).
  */
 
 import type { Classification } from "./classify.js";
@@ -70,7 +71,12 @@ export type CardEvent =
   | { readonly type: "RELEASED" }
   /** The browser took the pointer away, or capture was lost. */
   | { readonly type: "CANCELLED" }
-  /** A hand boundary, a reload, or the app leaving the foreground. */
+  /**
+   * A §9 reset: back to face-down, cancelling any gesture. The app leaving
+   * the foreground is the producer — the other two §9 resets arrive by their
+   * own routes (a new hand as `DEALT`, a fresh client through
+   * `initialCardState`), and neither needs to be re-derived here.
+   */
   | { readonly type: "RESET" }
   /** A single tap landed on the pair. */
   | { readonly type: "TAPPED" }
@@ -94,9 +100,13 @@ function idle(presentation: Presentation): CardState {
  * Stated as one allow-list and enforced once, at the top of `reduce`, rather
  * than arm by arm — so the tap and gesture events later tickets add are inert
  * against a decided hand by default, and cannot reach one by being forgotten.
- * A later ticket adding an event that a locked pair *should* hear (`RESET`,
- * say, if backgrounding the app is judged to outrank a settled showdown) has
- * to say so here, which is the point.
+ *
+ * **`RESET` is deliberately not on the list.** Backgrounding the app must not
+ * conceal a showdown reveal: that reveal is public table truth rather than
+ * something the Player chose to look at, and a reload remounts straight back
+ * to `Revealed` off the `locked` prop — so honouring `RESET` here would make
+ * two paths that §9 names in the same breath disagree. The hand boundary that
+ * genuinely ends the lock arrives as `DEALT` or `CARDS_GONE`.
  */
 function survivesLock(event: CardEvent): boolean {
   switch (event.type) {
@@ -214,10 +224,27 @@ export function reduce(state: CardState, event: CardEvent): CardState {
 
     case "RELEASED":
     case "CANCELLED":
+      // An interrupted gesture lands on the last *stable* presentation, which
+      // for everything except a peek is the one it is already carrying: a fold
+      // drag moves the pair around without turning it over, so it restores to
+      // the face it started from by not being touched.
+      //
+      // A peek closes to `FaceDown` because that is the only face it can have
+      // opened from — §3 gives `Peeking` one entry arrow, and §4 refuses to
+      // classify a bend as `Bending` on an already-revealed pair. A bend arm
+      // that ever admits `Revealed → Peeking` breaks that, and `settled` is
+      // where it would have to start remembering.
+      //
       // `Turning` is a point of no return for both lift and cancellation: the
       // flip completes, because cancellation must restore *stable*
       // presentation and mid-turn is not stable (§10). A `Committed`
-      // recognizer therefore only clears itself.
+      // recognizer therefore only clears itself. `Leaving` likewise: the Fold
+      // is committed and only the server can answer it.
+      //
+      // Cancellation is never a commitment (§10: Actions commit on the
+      // completing release), so it needs to know nothing about `armed` beyond
+      // clearing it. That is the one thing the two events will stop sharing:
+      // #145 splits the arm so an armed release commits the Fold.
       if (state.recognizer === "Idle") return state;
       if (state.recognizer === "Committed") {
         return { ...state, recognizer: "Idle", armed: false };
@@ -232,13 +259,30 @@ export function reduce(state: CardState, event: CardEvent): CardState {
       if (state.recognizer !== "Bending") return state;
       return { ...state, presentation: "Turning", recognizer: "Committed" };
 
+    case "RESET":
+      // Snaps — including out of `Turning`, where the flip is abandoned
+      // rather than finished, so no face-up frame survives into the next hand.
+      // `BendableCard` animates only while `Turning`, so landing on `FaceDown`
+      // is what makes it a snap rather than a second flip.
+      //
+      // `Absent` is the one presentation left alone: there are no cards to
+      // turn face-down, and claiming otherwise would be a state the props
+      // contradict.
+      //
+      // `Leaving` is **not** left alone, though §7 calls a pending pair inert.
+      // The reset producers all say the pair's hand is over or its client is
+      // gone; face-down is the honest resting state for cards nobody is
+      // holding, and the Fold's own resolution follows a moment later as
+      // `CARDS_GONE`. Only `CANCELLED` respects the pending inertness, because
+      // a cancelled pointer is not an answer from the server.
+      if (state.presentation === "Absent") return state;
+      return idle("FaceDown");
+
     // Declared in the union so the shape is settled up front, and answered by
-    // the slices that own them: tap-conceal (#142), cancellation and resets
-    // (#143), the double-tap Check (#144), the fold drag (#145) and fold
-    // disarming (#146).
+    // the slices that own them: tap-conceal (#142), the double-tap Check
+    // (#144), the fold drag (#145) and fold disarming (#146).
     case "FOLD_ARMED":
     case "FOLD_DISARMED":
-    case "RESET":
     case "TAPPED":
     case "DOUBLE_TAPPED":
     case "PENDING_RESOLVED":

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -17,7 +17,7 @@ import {
   type GestureSession,
 } from "./gesture.js";
 import type { HoleCardPairProps } from "./HoleCardPair.js";
-import { eventsForPropChange } from "./viewEvents.js";
+import { eventsForPropChange, eventsForVisibility } from "./viewEvents.js";
 
 /**
  * `useLayoutEffect` warns when it is called during server rendering, and the
@@ -132,6 +132,29 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
       bend.set(0);
     }
   }, [state.presentation, bend]);
+
+  // The one disturbance that is not a prop change (§8): the app leaving the
+  // foreground resets the pair face-down, cancelling any gesture in flight.
+  // Subscribed once for the pair's lifetime — `dispatch` is stable, and what
+  // "hidden" means is `eventsForVisibility`'s decision, not this effect's.
+  //
+  // §9's other two resets need no subscription: a new hand arrives as `DEALT`,
+  // and a reload mounts through `initialCardState`. A socket reconnect while
+  // the page stays in the foreground is the gap — the pair stays mounted with
+  // unchanged props, and §2 fixes those props to `cards`, `locked` and
+  // `actions`, so no signal for it exists inside the seam. Backgrounding, the
+  // way a phone actually loses its socket, is covered here.
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      for (const event of eventsForVisibility(document.visibilityState)) {
+        dispatch(event);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, []);
 
   const activate = useCallback(() => {
     if (Date.now() < disownClicksUntil.current) return;

--- a/packages/player-client/src/holecards/viewEvents.test.ts
+++ b/packages/player-client/src/holecards/viewEvents.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { CardState } from "./cardState.js";
 import type { CardActions } from "./ports.js";
 import type { HoleCardPairProps } from "./HoleCardPair.js";
-import { eventsForPropChange } from "./viewEvents.js";
+import { eventsForPropChange, eventsForVisibility } from "./viewEvents.js";
 
 const actions: CardActions = {
   foldLegal: false,
@@ -34,11 +34,26 @@ const absent: CardState = {
   armed: false,
   locked: false,
 };
-const revealed: CardState = {
+/** A pair the showdown has decided: face-up and inert. */
+const lockedRevealed: CardState = {
   presentation: "Revealed",
   recognizer: "Idle",
   armed: false,
   locked: true,
+};
+/** A bend in progress: the state an incoming view must not disturb. */
+const peeking: CardState = {
+  presentation: "Peeking",
+  recognizer: "Bending",
+  armed: false,
+  locked: false,
+};
+/** The same pair, still live: the Player turned it over themselves. */
+const revealed: CardState = {
+  presentation: "Revealed",
+  recognizer: "Idle",
+  armed: false,
+  locked: false,
 };
 
 describe("eventsForPropChange", () => {
@@ -62,6 +77,28 @@ describe("eventsForPropChange", () => {
       actions: { ...actions, foldLegal: true, checkLegal: true },
     });
     expect(eventsForPropChange(before, after, faceDown)).toEqual([]);
+  });
+
+  it("leaves a peek in flight alone when a server update arrives", () => {
+    // `fanOutHandUpdate` sends a view for every event in the hand, and peeking
+    // at your cards is exactly what you do while others act. A new board card
+    // or another player's bet reaches this module as an identical pair of
+    // props; nothing may touch the recognizer.
+    const before = props({ cards: queenJack });
+    const after = props({ cards: queenJack });
+    expect(eventsForPropChange(before, after, peeking)).toEqual([]);
+  });
+
+  it("produces nothing when the player acts — a button sends an Action, not a presentation change", () => {
+    // Pressing Call, Raise or Check changes the view (stack, pot, `toAct`) and
+    // hands the turn on, so legality goes away. The cards stay exactly as they
+    // were.
+    const before = props({
+      cards: queenJack,
+      actions: { ...actions, foldLegal: true, checkLegal: true },
+    });
+    const after = props({ cards: queenJack });
+    expect(eventsForPropChange(before, after, revealed)).toEqual([]);
   });
 
   it("deals in when cards arrive from nothing", () => {
@@ -142,7 +179,7 @@ describe("eventsForPropChange", () => {
     it("produces nothing while locked is unchanged, true or false", () => {
       const stillLocked = props({ cards: queenJack, locked: true });
       expect(
-        eventsForPropChange(stillLocked, { ...stillLocked }, revealed),
+        eventsForPropChange(stillLocked, { ...stillLocked }, lockedRevealed),
       ).toEqual([]);
 
       const stillLive = props({ cards: queenJack });
@@ -156,7 +193,7 @@ describe("eventsForPropChange", () => {
         eventsForPropChange(
           props({ cards: queenJack, locked: true }),
           props({ cards: queenJack }),
-          revealed,
+          lockedRevealed,
         ),
       ).toEqual([]);
     });
@@ -178,5 +215,18 @@ describe("eventsForPropChange", () => {
         eventsForPropChange(props(), props({ locked: true }), absent),
       ).toEqual([]);
     });
+  });
+});
+
+describe("eventsForVisibility", () => {
+  it("resets when the app leaves the foreground", () => {
+    expect(eventsForVisibility("hidden")).toEqual([{ type: "RESET" }]);
+  });
+
+  it("produces nothing on return to the foreground", () => {
+    // The reset already happened on the way out; coming back is not a second
+    // disturbance, and re-hiding cards the Player has since turned over would
+    // be one.
+    expect(eventsForVisibility("visible")).toEqual([]);
   });
 });

--- a/packages/player-client/src/holecards/viewEvents.ts
+++ b/packages/player-client/src/holecards/viewEvents.ts
@@ -58,3 +58,19 @@ export function eventsForPropChange(
 
   return events;
 }
+
+/**
+ * The app leaving the foreground is a reset (§9), and it is the one
+ * disturbance that does not arrive as a prop change — `visibilitychange` is a
+ * document event, subscribed by the hook (§8). It is derived here anyway so
+ * the rule is a tested function call rather than a condition buried in an
+ * effect, which is the same reason `eventsForPropChange` exists.
+ *
+ * Only the outbound edge produces anything: coming back is not a second
+ * disturbance, and concealing cards the Player has since turned over would be.
+ */
+export function eventsForVisibility(
+  visibility: DocumentVisibilityState,
+): readonly CardEvent[] {
+  return visibility === "hidden" ? [{ type: "RESET" }] : [];
+}


### PR DESCRIPTION
Closes #143.

An interrupted gesture always lands somewhere stable, and nothing the table does yanks the cards out of the Player's hands (Phase 3 spec #138 §9, §10).

## What changed

- **`cardState.ts`** — two new arms. `CANCELLED` clears the recognizer to `Idle` and closes `Peeking → FaceDown`, leaving every other presentation untouched — which is exactly how a below-threshold fold drag restores to the face it started from, face-down or revealed. `Turning` is a point of no return: mid-turn is not stable, so completing the flip *is* the restoration. `RESET` snaps to `FaceDown` from every presentation holding cards, including out of `Turning`, so no face-up frame of the previous hand survives into the next.
- **`viewEvents.ts`** — new pure `eventsForVisibility`, so "hidden ⇒ `RESET`, visible ⇒ nothing" is a tested function call rather than a condition buried in an effect.
- **`useHoleCards.ts`** — subscribes `visibilitychange` on `document` and dispatches whatever that function returns. The hook still decides nothing.
- **Tests** — 20 new cases; every acceptance criterion on #143 is covered, including the *absence* assertions on `viewEvents` (a peek in flight and the Player's own Actions both leave presentation untouched).

## Judgement calls

Each is argued in a comment at the point it applies:

1. **`RESET` is a no-op from `Absent`.** There are no cards to turn face-down, and the state would contradict the props. Behaviourally invisible — `HoleCardPair` renders `Absent` off `cards === null` regardless.
2. **`RESET` does not survive the showdown `locked` flag.** Backgrounding must not conceal a public reveal, and a reload remounts to `Revealed` off the `locked` prop — honouring it would make two paths §9 names in the same breath disagree. `survivesLock`'s docblock had explicitly invited this decision; it now records it.
3. **`RESET` *does* reach `Leaving`**, per the acceptance criterion's literal "every presentation state", despite §7 calling a pending pair inert. Noted in the arm as a knowing tension. `CANCELLED` respects the inertness, because a cancelled pointer is not an answer from the server.

## Known gap

"Cards are face-down after a reload or **reconnect**" is only partly met. Reload is covered (fresh mount through `initialCardState`), and a backgrounded phone — the realistic way a socket dies — is covered by `visibilitychange`. A socket reconnect while the page stays in the **foreground** is not: the pair stays mounted with unchanged props, and §2 fixes those props to `cards`/`locked`/`actions`, so no signal for it exists inside the seam. Closing it means widening the module's public contract, which is a spec decision rather than mine. The gap is recorded in `useHoleCards.ts`.

`CANCELLED` has no producer yet — #145/#146 wire the pointer to it, which is the intended sequencing.

## Verification

Full suite 494/494, `npm run build` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyRqDQtfKXaLNWX3n26eqD