### PR TITLE
feat(player-client): double-tap the Hole cards to Check

### DIFF
--- a/packages/player-client/src/holecards/HoleCardPair.test.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.test.tsx
@@ -112,4 +112,14 @@ describe("HoleCardPair", () => {
 
     expect(html).not.toContain('data-testid="hole-cards-hint"');
   });
+
+  it("mounts the live region empty, before there is any news to put in it", () => {
+    const html = renderToStaticMarkup(
+      <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
+    );
+
+    // A live region inserted along with its own text is not reliably
+    // announced, so the region has to be here first — with nothing in it.
+    expect(html).toMatch(/<span role="status"[^>]*><\/span>/);
+  });
 });

--- a/packages/player-client/src/holecards/HoleCardPair.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.tsx
@@ -112,15 +112,16 @@ function Absent() {
  * the reducer, the hook, the bendable card — is module-internal, so nothing
  * outside can reach a lifecycle state and no consumer learns what a pointer is.
  *
- * The pair is a real focusable `button`: Enter, Space or a click toggles
- * reveal and conceal, so reading your own cards never depends on getting a
- * gesture's timing right (§12). The pointer recognizer layered on top of this
- * — bend to peek, swipe to fold, double-tap to check — arrives in later
- * tickets; this establishes the seam it grows inside.
+ * The pair is a real focusable `button`: Enter and Space toggle reveal and
+ * conceal, so reading your own cards never depends on getting a gesture's
+ * timing right (§12). A pointer, by contrast, is answered by the recognizer —
+ * bend to peek, tap to conceal, double-tap to Check, and the swipe to Fold
+ * that arrives with #145.
  */
 export function HoleCardPair(props: HoleCardPairProps) {
   const { cards, actions } = props;
-  const { state, activate, handlers, bend, bendAxis } = useHoleCards(props);
+  const { state, activate, handlers, bend, bendAxis, checkConfirmed } =
+    useHoleCards(props);
   // The lifecycle's lock, not the prop: the prop is the *input* the adapter
   // turns into `SHOWDOWN_REVEAL`, and once locked the pair stays locked until
   // the next hand deals it back in. Rendering off the prop would let the two
@@ -145,6 +146,7 @@ export function HoleCardPair(props: HoleCardPairProps) {
     // The quiet interval only gates the teaching hints, which arrive with the
     // discovery set they retire against (#147). In-gesture prompts never wait.
     quiet: false,
+    checkConfirmed,
   };
   // Both variants of the live hint, because the axis they swap on is a
   // **continuous** value: choosing between them in React would re-render the
@@ -288,6 +290,10 @@ function HintBlock({ hint }: { readonly hint: Hint }) {
     <p
       data-testid="hole-cards-hint"
       data-hint={hint.id}
+      // News is announced; advice is not. A live region over the in-gesture
+      // prompts would read a bend out loud as the finger wandered across the
+      // diagonal, so only the Check confirmation asks for it.
+      {...(hint.announce ? { role: "status" } : {})}
       style={{
         margin: 0,
         display: "grid",

--- a/packages/player-client/src/holecards/HoleCardPair.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.tsx
@@ -1,6 +1,7 @@
 import type { Card as CardType, Rank, Suit } from "@table-top-poker/protocol";
 import { color, fontSize, radius } from "@table-top-poker/ui-shared";
 import { motion, useTransform, type MotionValue } from "motion/react";
+import type { CSSProperties } from "react";
 import { BendableCard } from "./BendableCard.js";
 import type { Presentation } from "./cardState.js";
 import {
@@ -161,6 +162,9 @@ export function HoleCardPair(props: HoleCardPairProps) {
     nothingDiscovered,
     hintContext,
   );
+  // An announced hint is news, and news does not depend on which way a finger
+  // is going: the selector returns the same hint on both axes for it.
+  const announced = hintDragLeft?.announce === true ? hintDragLeft : null;
 
   return (
     <div
@@ -229,9 +233,44 @@ export function HoleCardPair(props: HoleCardPairProps) {
         dragUp={hintDragUp}
         axis={bendAxis}
       />
+      <Announcer hint={announced} />
     </div>
   );
 }
+
+/**
+ * The live region the announced hints speak through — mounted for the pair's
+ * lifetime and empty until there is news.
+ *
+ * It cannot be the visible hint's own element: a live region inserted into the
+ * document *together with* its text is not reliably announced, because there
+ * was no region there to observe the change. The region has to already exist
+ * when the text arrives, which means it outlives every hint that passes
+ * through it. The visible copy is hidden from assistive technology, so the
+ * news is read once rather than twice.
+ */
+function Announcer({ hint }: { readonly hint: Hint | null }) {
+  return (
+    <span role="status" style={visuallyHidden}>
+      {hint === null
+        ? ""
+        : [hint.line1, hint.line2].filter((line) => line !== null).join(", ")}
+    </span>
+  );
+}
+
+/** Present to a screen reader, absent to everything else. */
+const visuallyHidden: CSSProperties = {
+  position: "absolute",
+  width: 1,
+  height: 1,
+  margin: -1,
+  padding: 0,
+  border: 0,
+  overflow: "hidden",
+  clipPath: "inset(50%)",
+  whiteSpace: "nowrap",
+};
 
 const nothingDiscovered: ReadonlySet<TeachableGesture> = new Set();
 
@@ -292,8 +331,9 @@ function HintBlock({ hint }: { readonly hint: Hint }) {
       data-hint={hint.id}
       // News is announced; advice is not. A live region over the in-gesture
       // prompts would read a bend out loud as the finger wandered across the
-      // diagonal, so only the Check confirmation asks for it.
-      {...(hint.announce ? { role: "status" } : {})}
+      // diagonal, so only the Check confirmation asks for it — and it is
+      // `Announcer` that speaks it, leaving this copy purely visual.
+      {...(hint.announce ? { "aria-hidden": true } : {})}
       style={{
         margin: 0,
         display: "grid",

--- a/packages/player-client/src/holecards/cardState.test.ts
+++ b/packages/player-client/src/holecards/cardState.test.ts
@@ -490,4 +490,64 @@ describe("reduce", () => {
       }
     });
   });
+
+  describe("TAPPED", () => {
+    it("conceals a revealed pair instantly", () => {
+      expect(reduce(state("Revealed"), { type: "TAPPED" })).toEqual(
+        state("FaceDown"),
+      );
+    });
+
+    it("does nothing to a face-down pair, so the first tap of a Check is free", () => {
+      // A tap that revealed would put a face-up frame between the two taps of
+      // a double-tap Check, and make the commonest free Action cost a reveal.
+      expect(reduce(state("FaceDown"), { type: "TAPPED" })).toEqual(
+        state("FaceDown"),
+      );
+    });
+
+    it("is a no-op mid-turn, exactly as an activation is", () => {
+      expect(reduce(state("Turning"), { type: "TAPPED" })).toEqual(
+        state("Turning"),
+      );
+    });
+
+    it("is a no-op with no cards, or with a Fold in flight", () => {
+      for (const presentation of ["Absent", "Leaving"] as const) {
+        expect(reduce(state(presentation), { type: "TAPPED" })).toEqual(
+          state(presentation),
+        );
+      }
+    });
+
+    it("is a no-op against a decided showdown", () => {
+      expect(reduce(lockedState("Revealed"), { type: "TAPPED" })).toEqual(
+        lockedState("Revealed"),
+      );
+    });
+  });
+
+  describe("DOUBLE_TAPPED", () => {
+    it("changes no presentation — the Check is an Action, not a card movement", () => {
+      // The first tap has already concealed; the second sends. Turning the
+      // cards over again here would undo the conceal the player just saw.
+      for (const presentation of [
+        "Absent",
+        "FaceDown",
+        "Turning",
+        "Revealed",
+        "Leaving",
+      ] as const) {
+        expect(reduce(state(presentation), { type: "DOUBLE_TAPPED" })).toEqual(
+          state(presentation),
+        );
+      }
+    });
+
+    it("is a no-op against a decided showdown", () => {
+      expect(
+        reduce(lockedState("Revealed"), { type: "DOUBLE_TAPPED" }),
+      ).toEqual(lockedState("Revealed"));
+    });
+  });
 });

--- a/packages/player-client/src/holecards/cardState.ts
+++ b/packages/player-client/src/holecards/cardState.ts
@@ -14,8 +14,8 @@
  *
  * Answered so far: the deal-in, the emptying and the keyboard reveal/conceal
  * toggle (#139), the showdown reveal and lock (#140), the press, the
- * classification and the release that make up a bend (#141), and cancellation
- * and resets (#143).
+ * classification and the release that make up a bend (#141), cancellation
+ * and resets (#143), and the tap and double-tap that conceal and Check (#144).
  */
 
 import type { Classification } from "./classify.js";
@@ -278,13 +278,34 @@ export function reduce(state: CardState, event: CardEvent): CardState {
       if (state.presentation === "Absent") return state;
       return idle("FaceDown");
 
+    case "TAPPED":
+      // One tap hides the hand the moment someone leans over (story 5), and
+      // does nothing at all to a pair that is already face-down — which is
+      // what makes the first tap of a double-tap Check free (§5). A revealing
+      // tap would put a face-up frame between the two taps and charge the
+      // commonest free Action a reveal.
+      //
+      // Mid-turn it is dropped rather than queued, for the same reason
+      // `ACTIVATED` is: the flip is a point of no return.
+      return state.presentation === "Revealed"
+        ? { ...state, presentation: "FaceDown" }
+        : state;
+
+    case "DOUBLE_TAPPED":
+      // Presentation-wise, nothing: the first tap already concealed, and the
+      // second one buys a Check rather than a card movement. The Action itself
+      // is an **effect**, which this function cannot have — the hook sends it
+      // through `actions.check`, so a gesture and the button reach
+      // `intent.check` by the identical route and `canAct` stays the single
+      // legality gate (§2). Reducing it here anyway is what makes the event
+      // inert against a decided hand for free, through `survivesLock`.
+      return state;
+
     // Declared in the union so the shape is settled up front, and answered by
-    // the slices that own them: tap-conceal (#142), the double-tap Check
-    // (#144), the fold drag (#145) and fold disarming (#146).
+    // the slices that own them: the fold drag (#145) and fold disarming
+    // (#146).
     case "FOLD_ARMED":
     case "FOLD_DISARMED":
-    case "TAPPED":
-    case "DOUBLE_TAPPED":
     case "PENDING_RESOLVED":
       return state;
 

--- a/packages/player-client/src/holecards/coaching.test.ts
+++ b/packages/player-client/src/holecards/coaching.test.ts
@@ -41,6 +41,7 @@ function ctx(overrides: Partial<HintContext> = {}): HintContext {
     pending: false,
     locked: false,
     quiet: true,
+    checkConfirmed: false,
     ...overrides,
   };
 }
@@ -60,6 +61,7 @@ describe("selectHint", () => {
         id: "bending-left",
         line1: "Release to peek",
         line2: "keep bending to reveal both",
+        announce: false,
       });
     });
 
@@ -68,6 +70,7 @@ describe("selectHint", () => {
         id: "bending-up",
         line1: "Release to peek",
         line2: "drag left to keep your finger clear",
+        announce: false,
       });
     });
 
@@ -95,6 +98,47 @@ describe("selectHint", () => {
       expect(
         selectHint(bending("left"), nothingDiscovered, ctx({ quiet: false })),
       ).not.toBeNull();
+    });
+  });
+
+  describe("the Check confirmation", () => {
+    it("says the Action landed, and says it to a screen reader too", () => {
+      expect(
+        selectHint(
+          idle("FaceDown"),
+          nothingDiscovered,
+          ctx({
+            checkConfirmed: true,
+          }),
+        ),
+      ).toEqual({
+        id: "checked",
+        line1: "Checked",
+        line2: "your turn passed on",
+        announce: true,
+      });
+    });
+
+    it("survives the pending Action it is confirming", () => {
+      // Sending the Check is what makes an Action pending, so a confirmation
+      // that deferred to the pending gate could never appear at all.
+      expect(
+        selectHint(
+          idle("FaceDown"),
+          everythingDiscovered,
+          ctx({ checkConfirmed: true, pending: true }),
+        )?.id,
+      ).toBe("checked");
+    });
+
+    it("outranks an in-gesture prompt, and never retires", () => {
+      expect(
+        selectHint(
+          bending("left"),
+          everythingDiscovered,
+          ctx({ checkConfirmed: true }),
+        )?.id,
+      ).toBe("checked");
     });
   });
 

--- a/packages/player-client/src/holecards/coaching.ts
+++ b/packages/player-client/src/holecards/coaching.ts
@@ -18,6 +18,13 @@ export interface Hint {
   readonly id: string;
   readonly line1: string;
   readonly line2: string | null;
+  /**
+   * Whether the hint is news rather than advice, and should therefore reach a
+   * screen reader when it appears. Only the Check confirmation is: every
+   * teaching hint and in-gesture prompt describes what the player *could* do,
+   * and announcing those over a live gesture would be noise.
+   */
+  readonly announce: boolean;
 }
 
 export interface HintContext {
@@ -27,6 +34,8 @@ export interface HintContext {
   readonly locked: boolean;
   /** ~2s since the last contact with the pair. */
   readonly quiet: boolean;
+  /** A gesture Check landed moments ago and is still being confirmed (§5). */
+  readonly checkConfirmed: boolean;
 }
 
 /**
@@ -55,6 +64,12 @@ export function selectHint(
   _discovered: ReadonlySet<TeachableGesture>,
   ctx: HintContext,
 ): Hint | null {
+  // Outranks every gate below, including the pending one it necessarily trips:
+  // this is not advice about a gesture, it is the answer to one the player just
+  // made (story 31). Without it the only sign a double-tap landed is the
+  // ActionBar the gesture exists to stop them watching.
+  if (ctx.checkConfirmed) return checkedHint;
+
   // A hint is only ever advice about cards the player is actually holding, in
   // a moment where those cards will listen.
   if (ctx.pending || ctx.locked) return null;
@@ -70,10 +85,24 @@ export function selectHint(
   return null;
 }
 
+/**
+ * The visible confirmation a gesture Check lands with (story 31). It says the
+ * Action, not the gesture, because that is what the player needs to trust: the
+ * cards are already back face-down by the time it appears, so nothing else on
+ * this surface has changed to say the double-tap was heard.
+ */
+const checkedHint: Hint = {
+  id: "checked",
+  line1: "Checked",
+  line2: "your turn passed on",
+  announce: true,
+};
+
 const bendLeftHint: Hint = {
   id: "bending-left",
   line1: "Release to peek",
   line2: "keep bending to reveal both",
+  announce: false,
 };
 
 /**
@@ -85,4 +114,5 @@ const bendUpHint: Hint = {
   id: "bending-up",
   line1: "Release to peek",
   line2: "drag left to keep your finger clear",
+  announce: false,
 };

--- a/packages/player-client/src/holecards/constants.ts
+++ b/packages/player-client/src/holecards/constants.ts
@@ -52,6 +52,14 @@ export const HINT_QUIET_MS = 2000;
 export const CLICK_DISOWN_MS = 350;
 
 /**
+ * How long the confirmation of a gesture Check stays up, in ms. Not a §15
+ * constant — the prototype ran the cue at this length and it is carried
+ * forward: long enough to be read after the eyes come back off the cards,
+ * short enough to be gone before the next Player's Action lands.
+ */
+export const CHECK_CONFIRM_MS = 2400;
+
+/**
  * Duration of the face-down deal-in, in ms. Not a §15 constant — the deal-in
  * motion is §17 and had no prototype value; this matches the per-card deal
  * animation it replaces in `Hand`.

--- a/packages/player-client/src/holecards/taps.test.ts
+++ b/packages/player-client/src/holecards/taps.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { DOUBLE_TAP_MS } from "./constants.js";
+import { confirmsCheck, tapLanded } from "./taps.js";
+
+describe("tapLanded", () => {
+  it("opens the window on the first tap", () => {
+    expect(tapLanded(null, 1000)).toEqual({
+      window: 1000,
+      event: { type: "TAPPED" },
+    });
+  });
+
+  it("composes a Check from a second tap inside the window", () => {
+    const first = tapLanded(null, 1000);
+
+    expect(tapLanded(first.window, 1000 + DOUBLE_TAP_MS - 1)).toEqual({
+      window: null,
+      event: { type: "DOUBLE_TAPPED" },
+    });
+  });
+
+  it("counts a tap landing exactly on the window's edge", () => {
+    const first = tapLanded(null, 1000);
+
+    expect(tapLanded(first.window, 1000 + DOUBLE_TAP_MS).event).toEqual({
+      type: "DOUBLE_TAPPED",
+    });
+  });
+
+  it("does not compose a Check from taps outside the window", () => {
+    const first = tapLanded(null, 1000);
+
+    expect(tapLanded(first.window, 1000 + DOUBLE_TAP_MS + 1)).toEqual({
+      window: 1000 + DOUBLE_TAP_MS + 1,
+      event: { type: "TAPPED" },
+    });
+  });
+
+  it("closes the window on the Check, so a third tap starts a fresh pair", () => {
+    const first = tapLanded(null, 1000);
+    const second = tapLanded(first.window, 1100);
+    const third = tapLanded(second.window, 1200);
+
+    expect(second.event).toEqual({ type: "DOUBLE_TAPPED" });
+    // Without this, a triple-tap would send two Checks 100ms apart.
+    expect(third).toEqual({ window: 1200, event: { type: "TAPPED" } });
+  });
+
+  it("keeps a slow stream of taps composing nothing", () => {
+    let window = tapLanded(null, 0).window;
+    for (const now of [400, 800, 1200]) {
+      const step = tapLanded(window, now);
+      expect(step.event).toEqual({ type: "TAPPED" });
+      window = step.window;
+    }
+  });
+});
+
+describe("confirmsCheck", () => {
+  it("confirms a Check the player could actually make", () => {
+    expect(confirmsCheck({ checkLegal: true, pending: false })).toBe(true);
+  });
+
+  it("says nothing when Check is not on offer — off-turn, or facing a bet", () => {
+    expect(confirmsCheck({ checkLegal: false, pending: false })).toBe(false);
+  });
+
+  it("says nothing while another Action is already in flight", () => {
+    expect(confirmsCheck({ checkLegal: true, pending: true })).toBe(false);
+  });
+});

--- a/packages/player-client/src/holecards/taps.ts
+++ b/packages/player-client/src/holecards/taps.ts
@@ -1,0 +1,62 @@
+import type { CardEvent } from "./cardState.js";
+import { DOUBLE_TAP_MS } from "./constants.js";
+import type { CardActions } from "./ports.js";
+
+/**
+ * The double-tap window as a value (Phase 3 spec #138 §5, story 27).
+ *
+ * **No timer arbitration.** A tap is answered the moment it lands — the Check
+ * goes on the second tap's arrival rather than on a timer deciding, 280ms
+ * later, that no second tap is coming. That is what makes the gesture a reflex
+ * instead of a delay, and it is why the conceal a first tap performs is visible
+ * before the Check it may turn out to be half of.
+ *
+ * The accepted trade-off (§5): a Check cannot be sent while keeping the cards
+ * face-up, because the first of the two taps has already put them down. One tap
+ * gets them back.
+ *
+ * `null` when no window is open. Otherwise the timestamp of the last tap that
+ * did not itself complete a pair.
+ */
+export type TapWindow = number | null;
+
+export interface TapStep {
+  readonly window: TapWindow;
+  /**
+   * Narrowed to the two events a tap can possibly be, so the caller reading
+   * `DOUBLE_TAPPED` off it is checking an outcome this function can actually
+   * produce rather than a name from the whole lifecycle union.
+   */
+  readonly event: Extract<CardEvent, { type: "TAPPED" | "DOUBLE_TAPPED" }>;
+}
+
+/**
+ * Answer a tap that has just landed: on its own, or as the second half of a
+ * double-tap.
+ *
+ * A completed pair closes the window rather than carrying the second tap
+ * forward, so three taps in quick succession send **one** Check and start
+ * counting again — a stream of taps cannot become a stream of Actions.
+ */
+export function tapLanded(window: TapWindow, now: number): TapStep {
+  if (window !== null && now - window <= DOUBLE_TAP_MS) {
+    return { window: null, event: { type: "DOUBLE_TAPPED" } };
+  }
+  return { window: now, event: { type: "TAPPED" } };
+}
+
+/**
+ * Whether a double-tap Check should claim, visibly, that it landed (story 31).
+ *
+ * **Rendering only.** Whether the Action is *sent* is not decided here and not
+ * decided by these two flags: `check` is `intent.check`, and `canAct` on the
+ * latest view is the single gate (§2). This function answers the different
+ * question of whether to tell the player it went — so a double-tap off-turn,
+ * or while a Fold is in flight, is silent as well as inert, and a stale prop
+ * can at worst confirm an Action the intent then refuses.
+ */
+export function confirmsCheck(
+  actions: Pick<CardActions, "checkLegal" | "pending">,
+): boolean {
+  return actions.checkLegal && !actions.pending;
+}

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -5,10 +5,15 @@ import {
   useLayoutEffect,
   useReducer,
   useRef,
+  useState,
   type PointerEvent as ReactPointerEvent,
 } from "react";
 import { initialCardState, reduce, type CardState } from "./cardState.js";
-import { CLICK_DISOWN_MS, REVEAL_FINISH_MS } from "./constants.js";
+import {
+  CHECK_CONFIRM_MS,
+  CLICK_DISOWN_MS,
+  REVEAL_FINISH_MS,
+} from "./constants.js";
 import type { BendAxis } from "./geometry.js";
 import {
   beginGesture,
@@ -17,6 +22,7 @@ import {
   type GestureSession,
 } from "./gesture.js";
 import type { HoleCardPairProps } from "./HoleCardPair.js";
+import { confirmsCheck, tapLanded, type TapWindow } from "./taps.js";
 import { eventsForPropChange, eventsForVisibility } from "./viewEvents.js";
 
 /**
@@ -46,6 +52,8 @@ export interface HoleCards {
   readonly bend: MotionValue<number>;
   /** Which way the live bend is going, for the §11 second-line swap. */
   readonly bendAxis: MotionValue<BendAxis>;
+  /** A gesture Check landed and is still being confirmed (story 31). */
+  readonly checkConfirmed: boolean;
 }
 
 /**
@@ -83,6 +91,18 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
    * a flag left waiting would swallow the next real activation instead.
    */
   const disownClicksUntil = useRef(0);
+  /**
+   * When the last tap landed, for the double-tap Check (§5). A ref, not state:
+   * a tap that opens the window changes nothing on screen, so re-rendering for
+   * it would be a render per touch with nothing to paint.
+   */
+  const tapWindow = useRef<TapWindow>(null);
+  /**
+   * When the last gesture Check was confirmed, or `null`. A timestamp rather
+   * than a flag, so two Checks in a row restart the cue instead of the second
+   * one landing silently inside the first one's window.
+   */
+  const [checkConfirmedAt, setCheckConfirmedAt] = useState<number | null>(null);
 
   const previous = useRef(props);
   // Deliberately un-keyed: the adapter compares the props itself and returns
@@ -156,10 +176,40 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     };
   }, []);
 
+  // The confirmation is transient by construction: nothing has to remember to
+  // take it down, and a re-check simply replaces the timestamp and the timer.
+  useEffect(() => {
+    if (checkConfirmedAt === null) return;
+    const timer = setTimeout(() => {
+      setCheckConfirmedAt(null);
+    }, CHECK_CONFIRM_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [checkConfirmedAt]);
+
   const activate = useCallback(() => {
     if (Date.now() < disownClicksUntil.current) return;
     dispatch({ type: "ACTIVATED" });
   }, []);
+
+  /**
+   * The double-tap Action (§5, stories 27 and 28). `check` **is**
+   * `intent.check`, so the gesture and the ActionBar button reach the Action
+   * by the identical route and `canAct` — inside the intent, on the latest
+   * view — is the single gate deciding whether it may be sent. An off-turn or
+   * illegal double-tap therefore needs no guard here to be a no-op.
+   *
+   * `checkLegal` and `pending` are read for **rendering only**, exactly as the
+   * port promises: they decide whether to claim the Check landed. A stale prop
+   * can at worst show a confirmation for an Action the intent then refuses —
+   * never send one.
+   */
+  const sendCheck = (): void => {
+    const confirm = confirmsCheck(props.actions);
+    props.actions.check();
+    if (confirm) setCheckConfirmedAt(Date.now());
+  };
 
   const finish = (
     event: ReactPointerEvent<HTMLElement>,
@@ -168,16 +218,34 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     const active = session.current;
     if (active?.pointerId !== event.pointerId) return;
     session.current = null;
-    if (active.classification !== null) {
-      disownClicksUntil.current = Date.now() + CLICK_DISOWN_MS;
-    }
+    // Every completed gesture disowns its click, a tap included: the tap is
+    // answered here, by the recognizer, and the click the browser synthesises
+    // afterwards would answer it a second time — re-revealing the pair the tap
+    // just concealed, or revealing on the first tap of a Check that §5 requires
+    // to cost nothing. §12's non-gesture path is unaffected: Enter and Space
+    // raise a click with no pointer sequence in front of it.
+    disownClicksUntil.current = Date.now() + CLICK_DISOWN_MS;
     // The peel closes the instant the finger lifts — a glance costs nothing
     // and leaves nothing exposed, so there is no wind-down to watch. A bend
     // that already crossed the threshold is exempt: it committed on crossing,
     // and the turn is mid-flight with the peel under its control.
     if (!active.crossed) bend.set(0);
     for (const cardEvent of endGesture(active, { cancelled })) {
-      dispatch(cardEvent);
+      if (cardEvent.type !== "TAPPED") {
+        dispatch(cardEvent);
+        continue;
+      }
+      // A tap is only *provisionally* a tap: whether it is one, or the second
+      // half of a Check, is `taps` to decide. The clock is monotonic, because
+      // a wall clock stepping backwards mid-hand would turn two unrelated taps
+      // into an Action.
+      const tap = tapLanded(tapWindow.current, performance.now());
+      tapWindow.current = tap.window;
+      dispatch(tap.event);
+      // Dispatched first, so the Action is sent against a pair that has
+      // already taken the conceal — the player sees the cards go down, then the
+      // confirmation, in that order and with no timer between them.
+      if (tap.event.type === "DOUBLE_TAPPED") sendCheck();
     }
   };
 
@@ -236,5 +304,12 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     },
   };
 
-  return { state, activate, handlers, bend, bendAxis };
+  return {
+    state,
+    activate,
+    handlers,
+    bend,
+    bendAxis,
+    checkConfirmed: checkConfirmedAt !== null,
+  };
 }

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -230,6 +230,7 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     // that already crossed the threshold is exempt: it committed on crossing,
     // and the turn is mid-flight with the peel under its control.
     if (!active.crossed) bend.set(0);
+    let tapped = false;
     for (const cardEvent of endGesture(active, { cancelled })) {
       if (cardEvent.type !== "TAPPED") {
         dispatch(cardEvent);
@@ -241,12 +242,20 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
       // into an Action.
       const tap = tapLanded(tapWindow.current, performance.now());
       tapWindow.current = tap.window;
+      tapped = true;
       dispatch(tap.event);
       // Dispatched first, so the Action is sent against a pair that has
       // already taken the conceal — the player sees the cards go down, then the
       // confirmation, in that order and with no timer between them.
       if (tap.event.type === "DOUBLE_TAPPED") sendCheck();
     }
+    // The two taps of a Check must be *consecutive*. A gesture that ended as
+    // anything else — a bend, a cancelled press — closes the window, so
+    // tap → quick peek → tap cannot compose an Action out of two taps the
+    // player never meant to pair. Sending a Check nobody asked for is the one
+    // failure here that costs money, so the window is closed rather than left
+    // open on a technicality of what the middle gesture happened to be.
+    if (!tapped) tapWindow.current = null;
   };
 
   const handlers: PairHandlers = {


### PR DESCRIPTION
Closes #144.

## What this does

A second tap inside 280ms sends Check the moment it lands — no timer arbitrating whether a single tap was still coming. A tap on a revealed pair conceals it instantly, so the conceal is visible before the Check it may turn out to be half of. The accepted trade-off from the issue holds: a Check cannot be sent while keeping the cards face-up, and one tap gets them back.

`actions.check` **is** `intent.check`, so the gesture and the ActionBar button reach the Action by the identical route and `canAct` — on the latest view, inside the intent — stays the single legality gate. An off-turn or illegal double-tap is inert without a guard of its own. `checkLegal`/`pending` are read only to decide whether to *claim* the Action landed, exactly as `ports.ts` promises.

`ActionBar` and `useActionIntent` are untouched; every file in the diff is inside `holecards/`.

## Shape of the change

| File | Why |
| --- | --- |
| `taps.ts` (new) | The double-tap window as a pure value, plus the rendering-only "should this confirm?" predicate |
| `cardState.ts` | The `TAPPED` and `DOUBLE_TAPPED` arms the module had declared and left unanswered |
| `coaching.ts` | The Check confirmation, as the one hint that is news rather than advice |
| `useHoleCards.ts` | Binds the tap to the Action and holds the transient confirmation |
| `constants.ts` | `CHECK_CONFIRM_MS`, carried forward from the prototype |

## One deliberate deviation, flagged for review

#138 §12 guarantees "Enter, Space **or a click** toggles reveal and conceal". To make #144's *"face-down state: first tap is a no-op"* true, a completed pointer gesture now disowns its synthetic click whether or not it classified — otherwise the click answers the tap a second time, re-revealing the pair the tap just concealed.

The consequence: **a desktop mouse click on a face-down pair no longer reveals it.** Enter and Space still do (they raise a click with no pointer sequence in front of it), a mouse drag on the corner still bends, and a mouse double-click now sends Check. The two spec statements can't both hold; I took #144's explicit acceptance criterion as the more recent word. Say if you'd rather keep the click and weaken the criterion instead.

## Testing

Pure-module contract tests only — `taps`, the two new reducer arms, and the confirmation's place in the hint ranking. The repo has no DOM test environment (`environment: "node"`, no jsdom), so the hook wiring itself is verified by construction, as it was for #141 and #143. This is the first slice where an Action leaves the module on a gesture, so it may be worth deciding separately whether the component-level layer #138's testing strategy names should exist.

Full suite: 581 passed. `tsc -b`, `npm run lint`, `npm run build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P2ongHEHMVVcoRkYJLHGqm
