### PR TITLE
feat(player-client): swipe the Hole cards up to Fold

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -96,6 +96,18 @@ and reveal are one gesture at two depths, not two gestures.
 Returning revealed Hole cards to face-down. Player-facing copy says "hide";
 *conceal* is the domain term.
 
+**Muck**:
+Where a folded Hand goes. Not a place the engine models and not a pile
+anything is added to: folding simply stops the Seat's Hole cards being
+projected to anyone, including its own Player, and Replay re-projects the
+same way so a muck stays mucked. The word survives because it names the
+*direction of travel* the player client acts out — the muck flight, the
+committed pair departing on the swipe that folds it — which is local
+presentation, on its own schedule, and never a state cards can be recovered
+from.
+_Avoid_: Treating the Muck as storage, or as somewhere a Hand can be read
+back from — a fold is final, and nothing is kept.
+
 **Action**:
 A completed poker decision for a Seat — fold, check, call, or raise — whether
 chosen by its Player or synthesized by the server when the Seat cannot act.

--- a/packages/player-client/src/holecards/BendableCard.test.tsx
+++ b/packages/player-client/src/holecards/BendableCard.test.tsx
@@ -12,13 +12,17 @@ const appShellCss = readFileSync(
 
 const queen: Card = { rank: "Q", suit: "diamonds" };
 
-function render(presentation: "FaceDown" | "Peeking" | "Turning" | "Revealed") {
+function render(
+  presentation: "FaceDown" | "Peeking" | "Turning" | "Revealed" | "Leaving",
+  leavingFaceUp = false,
+) {
   return renderToStaticMarkup(
     <BendableCard
       card={queen}
       presentation={presentation}
       bend={motionValue(0)}
       tiltDegrees={0}
+      leavingFaceUp={leavingFaceUp}
     />,
   );
 }
@@ -79,5 +83,29 @@ describe("BendableCard", () => {
     // The flat card keeps both its printed corners: the rule above is scoped
     // to the flap, and must not have reached the ordinary face.
     expect((html.match(/class="card-index/g) ?? []).length).toBe(2);
+  });
+
+  describe("leaving for the muck", () => {
+    it("flies away face-up when that is the face it had", () => {
+      // Flipping face-down inside a 280ms departure is illegible motion, and
+      // the privacy boundary is the physical table rather than the flight (§7).
+      const html = render("Leaving", true);
+
+      expect(html).toContain('data-rank="Q"');
+      expect(html).not.toContain('data-face-down="true"');
+    });
+
+    it("flies away face-down when that is the face it had", () => {
+      const html = render("Leaving", false);
+
+      expect(html).toContain('data-face-down="true"');
+      expect(html).not.toContain("data-rank");
+    });
+
+    it("offers no bend affordance on the way out — the pair is inert", () => {
+      for (const faceUp of [true, false]) {
+        expect(render("Leaving", faceUp)).not.toContain("data-bend-zone");
+      }
+    });
   });
 });

--- a/packages/player-client/src/holecards/BendableCard.tsx
+++ b/packages/player-client/src/holecards/BendableCard.tsx
@@ -47,6 +47,7 @@ export function BendableCard({
   presentation,
   bend,
   tiltDegrees,
+  leavingFaceUp,
 }: {
   readonly card: CardType;
   readonly presentation: Presentation;
@@ -54,10 +55,19 @@ export function BendableCard({
   readonly bend: MotionValue<number>;
   /** The card's resting angle in the overlapped pair. */
   readonly tiltDegrees: number;
+  /**
+   * Whether the pair was face-up when the Fold committed. The cards leave with
+   * whatever face they had (§7): flipping face-down inside a 280ms departure
+   * is illegible motion, and the privacy boundary is the physical table rather
+   * than the flight.
+   */
+  readonly leavingFaceUp: boolean;
 }) {
   const peeking = presentation === "Peeking";
   const turning = presentation === "Turning";
-  const revealed = presentation === "Revealed";
+  const revealed =
+    presentation === "Revealed" ||
+    (presentation === "Leaving" && leavingFaceUp);
   // The face is in the document only while it is being looked at. A face-down
   // pair carries no rank or suit at all, and closing a peek removes it again
   // instantly, as concealment does: a glance must leave nothing exposed.

--- a/packages/player-client/src/holecards/HoleCardPair.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.tsx
@@ -66,6 +66,9 @@ function accessibleName(
   locked: boolean,
 ): string {
   const faces = `${cardWords(cards[0])} and ${cardWords(cards[1])}`;
+  // Inert, and there is no undo once the Fold is sent — so the name says what
+  // is happening and offers nothing to activate.
+  if (presentation === "Leaving") return "Your hole cards, folding";
   if (locked) return `Your hole cards, ${faces}`;
   if (presentation === "Revealed" || presentation === "Turning") {
     return `Your hole cards, ${faces}. Activate to hide them.`;
@@ -116,13 +119,22 @@ function Absent() {
  * The pair is a real focusable `button`: Enter and Space toggle reveal and
  * conceal, so reading your own cards never depends on getting a gesture's
  * timing right (§12). A pointer, by contrast, is answered by the recognizer —
- * bend to peek, tap to conceal, double-tap to Check, and the swipe to Fold
- * that arrives with #145.
+ * bend to peek, tap to conceal, double-tap to Check, and swipe up to Fold.
  */
 export function HoleCardPair(props: HoleCardPairProps) {
   const { cards, actions } = props;
-  const { state, activate, handlers, bend, bendAxis, checkConfirmed } =
-    useHoleCards(props);
+  const {
+    state,
+    activate,
+    handlers,
+    bend,
+    bendAxis,
+    foldOffset,
+    foldFade,
+    leavingFaceUp,
+    departing,
+    checkConfirmed,
+  } = useHoleCards(props);
   // The lifecycle's lock, not the prop: the prop is the *input* the adapter
   // turns into `SHOWDOWN_REVEAL`, and once locked the pair stays locked until
   // the next hand deals it back in. Rendering off the prop would let the two
@@ -131,13 +143,23 @@ export function HoleCardPair(props: HoleCardPairProps) {
   // company either.
   const { locked } = state;
 
-  if (cards === null) return <Absent />;
+  // A committed pair outlives the prop that carried it, for exactly as long as
+  // its flight to the muck runs: the server usually takes the cards away tens
+  // of milliseconds in, and the departure the player was promised must not be a
+  // blink (§7, story 20).
+  const shown = cards ?? departing;
+  if (shown === null) return <Absent />;
 
   // A render can land between cards arriving and the deal being observed;
   // face-down is the entry state for every hand, so it is also the honest
-  // presentation for that gap.
+  // presentation for that gap. A pair still in the air is the mirror case: the
+  // lifecycle has resolved past it, and the flight is what is on screen.
   const presentation =
-    state.presentation === "Absent" ? "FaceDown" : state.presentation;
+    cards === null
+      ? "Leaving"
+      : state.presentation === "Absent"
+        ? "FaceDown"
+        : state.presentation;
 
   const hintContext: HintContext = {
     checkLegal: actions.checkLegal,
@@ -187,7 +209,7 @@ export function HoleCardPair(props: HoleCardPairProps) {
         onContextMenu={preventDefault}
         {...(locked ? {} : handlers)}
         aria-disabled={locked}
-        aria-label={accessibleName(cards, presentation, locked)}
+        aria-label={accessibleName(shown, presentation, locked)}
         style={{
           display: "flex",
           padding: 0,
@@ -211,21 +233,35 @@ export function HoleCardPair(props: HoleCardPairProps) {
           // animation. The key is on the motion element, not the component, so
           // it restarts an animation without discarding lifecycle state —
           // `DEALT` stays the one thing that resets presentation.
-          key={cardKey(cards)}
+          key={cardKey(shown)}
           initial={{ opacity: 0, y: "-18%" }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: DEAL_IN_MS / 1000, ease: [0.2, 0.8, 0.2, 1] }}
-          style={{ display: "flex", gap: "0.5em", fontSize: "2.6em" }}
+          style={{ display: "flex", fontSize: "2.6em" }}
         >
-          {cards.map((card, index) => (
-            <BendableCard
-              key={index}
-              card={card}
-              tiltDegrees={index === 0 ? -3 : 3}
-              presentation={presentation}
-              bend={bend}
-            />
-          ))}
+          {/* A layer of its own, so the fold drag and the muck flight can drive
+           * `y` and `opacity` from `MotionValue`s while the deal-in above keeps
+           * animating the same two properties declaratively. The two would
+           * fight on one element; nested, they simply compose. */}
+          <motion.span
+            style={{
+              display: "flex",
+              gap: "0.5em",
+              y: foldOffset,
+              opacity: foldFade,
+            }}
+          >
+            {shown.map((card, index) => (
+              <BendableCard
+                key={index}
+                card={card}
+                tiltDegrees={index === 0 ? -3 : 3}
+                presentation={presentation}
+                bend={bend}
+                leavingFaceUp={leavingFaceUp}
+              />
+            ))}
+          </motion.span>
         </motion.span>
       </button>
       <GestureHint

--- a/packages/player-client/src/holecards/cardState.test.ts
+++ b/packages/player-client/src/holecards/cardState.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   initialCardState,
   reduce,
+  releaseCommitsFold,
   type CardEvent,
   type CardState,
   type Presentation,
@@ -46,6 +47,32 @@ describe("initialCardState", () => {
     expect(initialCardState({ hasCards: false, locked: true })).toEqual(
       state("Absent"),
     );
+  });
+});
+
+describe("releaseCommitsFold", () => {
+  it("is true only for an armed fold drag", () => {
+    expect(releaseCommitsFold(state("FaceDown", "FoldDragging", true))).toBe(
+      true,
+    );
+    expect(releaseCommitsFold(state("Revealed", "FoldDragging", true))).toBe(
+      true,
+    );
+    expect(releaseCommitsFold(state("FaceDown", "FoldDragging"))).toBe(false);
+  });
+
+  it("is false for every other gesture, armed or not", () => {
+    for (const recognizer of [
+      "Idle",
+      "Pressing",
+      "Bending",
+      "Ignored",
+      "Committed",
+    ] as const) {
+      expect(releaseCommitsFold(state("FaceDown", recognizer, true))).toBe(
+        false,
+      );
+    }
   });
 });
 
@@ -398,6 +425,33 @@ describe("reduce", () => {
       }
     });
 
+    it("flies an armed fold drag to the muck — but only on the release", () => {
+      // The commitment is on release, never on crossing the line: the armed
+      // state is what a crossing produced, and this is the pointer lift that
+      // answers it.
+      expect(
+        reduce(state("FaceDown", "FoldDragging", true), { type: "RELEASED" }),
+      ).toEqual(state("Leaving"));
+    });
+
+    it("takes a revealed pair to the muck with the face it had", () => {
+      expect(
+        reduce(state("Revealed", "FoldDragging", true), { type: "RELEASED" }),
+      ).toEqual(state("Leaving"));
+    });
+
+    it("commits nothing when the browser takes the pointer away mid-flick", () => {
+      // Cancellation is never a commitment: the player never completed the
+      // gesture, so the cards go back down rather than into the muck.
+      for (const presentation of ["FaceDown", "Revealed"] as const) {
+        expect(
+          reduce(state(presentation, "FoldDragging", true), {
+            type: "CANCELLED",
+          }),
+        ).toEqual(state(presentation));
+      }
+    });
+
     it("returns a below-threshold fold drag to the face it started from", () => {
       // A fold drag moves the pair around without turning it over, so the
       // presentation it was carrying *is* the stable state to restore — from
@@ -445,6 +499,120 @@ describe("reduce", () => {
         expect(reduce(lockedState("Revealed"), ending)).toEqual(
           lockedState("Revealed"),
         );
+      }
+    });
+  });
+
+  describe("a pair flying to the muck", () => {
+    it("is inert to bend, tap and drag alike — there is no undo once Fold is sent", () => {
+      const leaving = state("Leaving");
+      for (const event of [
+        { type: "PRESSED" },
+        { type: "CLASSIFIED", as: "Bending" },
+        { type: "CLASSIFIED", as: "FoldDragging" },
+        { type: "BEND_CROSSED" },
+        { type: "FOLD_ARMED" },
+        { type: "TAPPED" },
+        { type: "DOUBLE_TAPPED" },
+        { type: "ACTIVATED" },
+      ] as const) {
+        expect(reduce(leaving, event)).toEqual(leaving);
+      }
+    });
+  });
+
+  describe("FOLD_ARMED and FOLD_DISARMED", () => {
+    it("arms a live fold drag without ending it or moving the cards over", () => {
+      expect(
+        reduce(state("FaceDown", "FoldDragging"), { type: "FOLD_ARMED" }),
+      ).toEqual(state("FaceDown", "FoldDragging", true));
+    });
+
+    it("disarms without ending the drag, so the surface never freezes under the hand", () => {
+      expect(
+        reduce(state("Revealed", "FoldDragging", true), {
+          type: "FOLD_DISARMED",
+        }),
+      ).toEqual(state("Revealed", "FoldDragging"));
+    });
+
+    it("commits nothing on the release that follows a disarm", () => {
+      const armed = reduce(state("FaceDown", "FoldDragging"), {
+        type: "FOLD_ARMED",
+      });
+      const disarmed = reduce(armed, { type: "FOLD_DISARMED" });
+
+      expect(reduce(disarmed, { type: "RELEASED" })).toEqual(state("FaceDown"));
+    });
+
+    it("arms nothing that is not a fold drag", () => {
+      for (const recognizer of [
+        "Idle",
+        "Pressing",
+        "Bending",
+        "Ignored",
+        "Committed",
+      ] as const) {
+        const before = state("FaceDown", recognizer);
+        expect(reduce(before, { type: "FOLD_ARMED" })).toEqual(before);
+      }
+    });
+
+    it("is a no-op against a decided showdown", () => {
+      expect(reduce(lockedState("Revealed"), { type: "FOLD_ARMED" })).toEqual(
+        lockedState("Revealed"),
+      );
+    });
+  });
+
+  describe("PENDING_RESOLVED", () => {
+    it("lands the pair in the muck when the server took the cards", () => {
+      expect(
+        reduce(state("Leaving"), { type: "PENDING_RESOLVED", hasCards: false }),
+      ).toEqual(state("Absent"));
+    });
+
+    it("returns the cards face-down when the Fold was rejected", () => {
+      expect(
+        reduce(state("Leaving"), { type: "PENDING_RESOLVED", hasCards: true }),
+      ).toEqual(state("FaceDown"));
+    });
+
+    it("never returns a rejected Fold to Revealed", () => {
+      // The pair left face-up, but it comes back face-down: a rejection leaves
+      // the player holding a live hand, not the one they had already shown
+      // themselves.
+      const revealedThenLeaving = reduce(
+        state("Revealed", "FoldDragging", true),
+        { type: "RELEASED" },
+      );
+      expect(
+        reduce(revealedThenLeaving, {
+          type: "PENDING_RESOLVED",
+          hasCards: true,
+        }).presentation,
+      ).toBe("FaceDown");
+    });
+
+    it("leaves every other presentation exactly as it was", () => {
+      // Only a Fold is waiting on this. A Call, a Raise or a button Check
+      // resolves through the same prop, and pressing one must not make the
+      // player's cards vanish or turn over unbidden (§9).
+      for (const presentation of [
+        "Absent",
+        "FaceDown",
+        "Peeking",
+        "Turning",
+        "Revealed",
+      ] as const) {
+        for (const hasCards of [true, false]) {
+          expect(
+            reduce(state(presentation), {
+              type: "PENDING_RESOLVED",
+              hasCards,
+            }),
+          ).toEqual(state(presentation));
+        }
       }
     });
   });

--- a/packages/player-client/src/holecards/cardState.ts
+++ b/packages/player-client/src/holecards/cardState.ts
@@ -15,7 +15,8 @@
  * Answered so far: the deal-in, the emptying and the keyboard reveal/conceal
  * toggle (#139), the showdown reveal and lock (#140), the press, the
  * classification and the release that make up a bend (#141), cancellation
- * and resets (#143), and the tap and double-tap that conceal and Check (#144).
+ * and resets (#143), the tap and double-tap that conceal and Check (#144), and
+ * the armed swipe that folds and the server answer that resolves it (#145).
  */
 
 import type { Classification } from "./classify.js";
@@ -153,6 +154,23 @@ function settled(state: CardState): CardState {
   };
 }
 
+/**
+ * Whether lifting the finger right now sends the Fold (§10).
+ *
+ * Exported so the rule is a tested function call rather than a condition
+ * buried in the `RELEASED` arm below. Its counterpart is `endGesture`'s
+ * `commitsFold`, which answers the same question about the live pointer
+ * session so the Action — an **effect** this function cannot have — is sent by
+ * the hook on exactly the releases that land here.
+ *
+ * It reads `armed` rather than any notion of how far the cards travelled:
+ * arming is the only thing a threshold crossing does, and a drag whose
+ * legality disappeared underneath it is disarmed while still moving (§6).
+ */
+export function releaseCommitsFold(state: CardState): boolean {
+  return state.recognizer === "FoldDragging" && state.armed;
+}
+
 function classified(state: CardState, as: Classification): CardState {
   switch (as) {
     case "Bending":
@@ -223,6 +241,18 @@ export function reduce(state: CardState, event: CardEvent): CardState {
       return classified(state, event.as);
 
     case "RELEASED":
+      // **The one commitment a pointer lift makes.** Crossing the fold
+      // threshold only armed; this is the completing release that answers it,
+      // so an accidental crossing during a scroll-like motion cannot fold for
+      // the player and putting the cards back down is always a way out (§10).
+      //
+      // The pair leaves with whatever face it had — `presentation` is not
+      // consulted, so a revealed pair flies away face-up rather than flipping
+      // over inside a 280ms departure (§7).
+      if (releaseCommitsFold(state)) {
+        return idle("Leaving");
+      }
+    // falls through: every other release settles exactly as a cancellation does
     case "CANCELLED":
       // An interrupted gesture lands on the last *stable* presentation, which
       // for everything except a peek is the one it is already carrying: a fold
@@ -243,8 +273,8 @@ export function reduce(state: CardState, event: CardEvent): CardState {
       //
       // Cancellation is never a commitment (§10: Actions commit on the
       // completing release), so it needs to know nothing about `armed` beyond
-      // clearing it. That is the one thing the two events will stop sharing:
-      // #145 splits the arm so an armed release commits the Fold.
+      // clearing it. That is the one thing the two events do not share, and
+      // the only reason `RELEASED` has an arm of its own above.
       if (state.recognizer === "Idle") return state;
       if (state.recognizer === "Committed") {
         return { ...state, recognizer: "Idle", armed: false };
@@ -301,13 +331,31 @@ export function reduce(state: CardState, event: CardEvent): CardState {
       // inert against a decided hand for free, through `survivesLock`.
       return state;
 
-    // Declared in the union so the shape is settled up front, and answered by
-    // the slices that own them: the fold drag (#145) and fold disarming
-    // (#146).
     case "FOLD_ARMED":
     case "FOLD_DISARMED":
+      // Arming and disarming are the *same* shape of change: the flag moves
+      // and the drag carries on. The cards keep tracking the finger either
+      // way, so the surface never freezes under the player's hand, and neither
+      // event has anything to say about presentation.
+      //
+      // A drag pulled back below the threshold disarms through here, and so
+      // does one whose legality disappears mid-motion (#146) — the recognizer
+      // cannot tell the two apart and does not need to.
+      if (state.recognizer !== "FoldDragging") return state;
+      return { ...state, armed: event.type === "FOLD_ARMED" };
+
     case "PENDING_RESOLVED":
-      return state;
+      // Scoped to `Leaving`, because every Action resolves through this event
+      // and only a Fold left the pair waiting on one. Pressing Call, Raise or
+      // Check must leave the cards exactly as they were (§9) — buttons send
+      // Actions, they do not touch presentation.
+      //
+      // Acknowledged is `Absent`, and visually a no-op if the flight has
+      // already finished. Rejected is **`FaceDown`, never `Revealed`**: the
+      // pair may have left face-up, but a rejection leaves the player holding
+      // a live hand rather than one they have already shown themselves.
+      if (state.presentation !== "Leaving") return state;
+      return idle(event.hasCards ? "FaceDown" : "Absent");
 
     case "SHOWDOWN_REVEAL":
       // Folding is final (story 49), whether the cards are already gone or

--- a/packages/player-client/src/holecards/coaching.test.ts
+++ b/packages/player-client/src/holecards/coaching.test.ts
@@ -24,11 +24,12 @@ function bending(
 function idle(
   presentation: Presentation,
   recognizer: Recognizer = "Idle",
+  armed = false,
 ): CardState & { readonly bendAxis: BendAxis } {
   return {
     presentation,
     recognizer,
-    armed: false,
+    armed,
     locked: false,
     bendAxis: "left",
   };
@@ -98,6 +99,58 @@ describe("selectHint", () => {
       expect(
         selectHint(bending("left"), nothingDiscovered, ctx({ quiet: false })),
       ).not.toBeNull();
+    });
+  });
+
+  describe("in-gesture fold prompts", () => {
+    function foldDragging(armed: boolean) {
+      return idle("FaceDown", "FoldDragging", armed);
+    }
+
+    it("says to keep going while the swipe is short of the threshold", () => {
+      expect(selectHint(foldDragging(false), nothingDiscovered, ctx())).toEqual(
+        {
+          id: "folding",
+          line1: "Keep dragging up",
+          line2: null,
+          announce: false,
+        },
+      );
+    });
+
+    it("says releasing folds once the swipe is armed", () => {
+      expect(selectHint(foldDragging(true), nothingDiscovered, ctx())).toEqual({
+        id: "folding-armed",
+        line1: "Release to Fold",
+        line2: null,
+        announce: false,
+      });
+    });
+
+    it("returns both prompts regardless of the discovery set", () => {
+      // The arming signal for the one irreversible, money-losing gesture never
+      // retires, for any player, ever: there is no rendered threshold marker
+      // and haptics are Blink-only, so on iPhone/Safari this text *is* the
+      // signal (§11).
+      for (const armed of [false, true]) {
+        expect(
+          selectHint(foldDragging(armed), everythingDiscovered, ctx()),
+        ).toEqual(selectHint(foldDragging(armed), nothingDiscovered, ctx()));
+      }
+    });
+
+    it("returns the prompt from a revealed pair, which folds face-up", () => {
+      expect(
+        selectHint(
+          idle("Revealed", "FoldDragging", true),
+          nothingDiscovered,
+          ctx(),
+        )?.id,
+      ).toBe("folding-armed");
+    });
+
+    it("shows nothing once the pair is on its way to the muck", () => {
+      expect(selectHint(idle("Leaving"), nothingDiscovered, ctx())).toBeNull();
     });
   });
 

--- a/packages/player-client/src/holecards/coaching.ts
+++ b/packages/player-client/src/holecards/coaching.ts
@@ -50,9 +50,10 @@ export interface HintContext {
  * only the persisted discovery set cross the seam — is what holds the module's
  * public surface at two names.
  *
- * This slice answers the bend gesture. The remaining in-gesture prompts and
- * the four teaching hints arrive with the gestures they describe (#142, #145,
- * #147), extending this same function rather than paralleling it.
+ * The in-gesture prompts are complete: the bend's two, and the fold drag's
+ * armed and unarmed lines. The four *teaching* hints arrive with #147,
+ * extending this same function rather than paralleling it — which is when the
+ * discovery set starts being read.
  *
  * The `(pointer: coarse)` gate arrives with those teaching hints (#147), and
  * applies to them: it exists so a keyboard player is not told to bend corners.
@@ -75,11 +76,19 @@ export function selectHint(
   if (ctx.pending || ctx.locked) return null;
   if (state.presentation === "Absent") return null;
 
+  // Deliberately **not** gated on the discovery set, either of them. In-gesture
+  // prompts are permanent for every player, forever: they say what releasing
+  // will do, and for the money-losing gesture that text is the arming signal
+  // itself.
   if (state.recognizer === "Bending") {
-    // Deliberately **not** gated on the discovery set. In-gesture prompts are
-    // permanent for every player, forever: they say what releasing will do,
-    // and for the money-losing gesture that text is the arming signal itself.
     return state.bendAxis === "up" ? bendUpHint : bendLeftHint;
+  }
+
+  // There is no rendered fold-threshold marker and browser vibration is
+  // Blink-only, so on iPhone/Safari this line — with the card motion — is the
+  // *whole* arming signal (§11). It has to be able to say both things.
+  if (state.recognizer === "FoldDragging") {
+    return state.armed ? foldArmedHint : foldDraggingHint;
   }
 
   return null;
@@ -114,5 +123,29 @@ const bendUpHint: Hint = {
   id: "bending-up",
   line1: "Release to peek",
   line2: "drag left to keep your finger clear",
+  announce: false,
+};
+
+/**
+ * One line each, and no consequence line: a fold drag has the player's eyes on
+ * the cards moving under their finger, and the only thing they need from the
+ * text is whether letting go now costs them the hand.
+ *
+ * Not announced, for the same reason the bend prompts are not: a live region
+ * flipping between these two as a finger wandered across the threshold would
+ * talk over the player rather than tell them anything. The `Fold` button
+ * remains the non-gesture path (§12).
+ */
+const foldDraggingHint: Hint = {
+  id: "folding",
+  line1: "Keep dragging up",
+  line2: null,
+  announce: false,
+};
+
+const foldArmedHint: Hint = {
+  id: "folding-armed",
+  line1: "Release to Fold",
+  line2: null,
   announce: false,
 };

--- a/packages/player-client/src/holecards/constants.ts
+++ b/packages/player-client/src/holecards/constants.ts
@@ -60,6 +60,13 @@ export const CLICK_DISOWN_MS = 350;
 export const CHECK_CONFIRM_MS = 2400;
 
 /**
+ * Length of the optional threshold pulse, in ms. Not a §15 constant — §16 asks
+ * for a pulse and sets no length; this is the prototype's, short enough to read
+ * as a tick against the fingertip rather than as a buzz.
+ */
+export const HAPTIC_PULSE_MS = 10;
+
+/**
  * Duration of the face-down deal-in, in ms. Not a §15 constant — the deal-in
  * motion is §17 and had no prototype value; this matches the per-card deal
  * animation it replaces in `Hand`.

--- a/packages/player-client/src/holecards/geometry.test.ts
+++ b/packages/player-client/src/holecards/geometry.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { BEND_TRAVEL_PX } from "./constants.js";
-import { bendAxis, bendProgress } from "./geometry.js";
+import {
+  BEND_TRAVEL_PX,
+  FOLD_DISTANCE_RATIO,
+  MIN_FOLD_DISTANCE_PX,
+} from "./constants.js";
+import {
+  bendAxis,
+  bendProgress,
+  foldFlightDistance,
+  foldThreshold,
+} from "./geometry.js";
 
 describe("bendProgress", () => {
   it("is zero before the finger has moved", () => {
@@ -38,5 +47,39 @@ describe("bendAxis", () => {
 
   it("reads an equal bend as upward, since the finger is still over the face", () => {
     expect(bendAxis(-40, -40)).toBe("up");
+  });
+});
+
+describe("foldThreshold", () => {
+  it("scales with the viewport, so the swipe is the same proportion of any phone", () => {
+    expect(foldThreshold(1000)).toBe(1000 * FOLD_DISTANCE_RATIO);
+  });
+
+  it("never falls below the floor on a short viewport", () => {
+    // On a small or split-screen window the proportional term would put the
+    // threshold inside an ordinary thumb flick, and Fold is the one Action
+    // that costs money.
+    expect(foldThreshold(400)).toBe(MIN_FOLD_DISTANCE_PX);
+    expect(foldThreshold(0)).toBe(MIN_FOLD_DISTANCE_PX);
+  });
+
+  it("is a distance, not a coordinate — always positive", () => {
+    for (const height of [0, 400, 812, 1400]) {
+      expect(foldThreshold(height)).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("foldFlightDistance", () => {
+  it("clears the screen, so the muck is off it rather than just above the cards", () => {
+    expect(foldFlightDistance(812)).toBeGreaterThanOrEqual(812);
+  });
+
+  it("is always further than the threshold the release crossed", () => {
+    // Otherwise a committed pair could travel *back down* as the flight took
+    // over from the finger.
+    for (const height of [0, 400, 812, 1400]) {
+      expect(foldFlightDistance(height)).toBeGreaterThan(foldThreshold(height));
+    }
   });
 });

--- a/packages/player-client/src/holecards/geometry.ts
+++ b/packages/player-client/src/holecards/geometry.ts
@@ -1,4 +1,8 @@
-import { BEND_TRAVEL_PX } from "./constants.js";
+import {
+  BEND_TRAVEL_PX,
+  FOLD_DISTANCE_RATIO,
+  MIN_FOLD_DISTANCE_PX,
+} from "./constants.js";
 
 /** Which way a live bend is mostly going — the §11 hint swaps on it. */
 export type BendAxis = "left" | "up";
@@ -27,4 +31,30 @@ export function bendProgress(dx: number, dy: number): number {
  */
 export function bendAxis(dx: number, dy: number): BendAxis {
   return Math.abs(dy) >= Math.abs(dx) ? "up" : "left";
+}
+
+/**
+ * How far up the pair must travel before releasing would commit the Fold
+ * (§15), in px — a **distance**, so the caller compares it against upward
+ * travel rather than against a coordinate.
+ *
+ * Proportional to the viewport so the swipe is the same gesture on every
+ * phone, with a floor so a short or split-screen window cannot put the one
+ * irreversible, money-losing Action inside an ordinary thumb flick.
+ */
+export function foldThreshold(viewportHeight: number): number {
+  return Math.max(
+    MIN_FOLD_DISTANCE_PX,
+    Math.round(viewportHeight * FOLD_DISTANCE_RATIO),
+  );
+}
+
+/**
+ * How far the committed pair travels on its way to the muck. Far enough to be
+ * off the screen rather than merely above the cards: the departure has to read
+ * as *gone*, and the pair starts the flight already at least a threshold's
+ * worth of travel up.
+ */
+export function foldFlightDistance(viewportHeight: number): number {
+  return Math.max(viewportHeight, foldThreshold(viewportHeight) * 2);
 }

--- a/packages/player-client/src/holecards/gesture.test.ts
+++ b/packages/player-client/src/holecards/gesture.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
+import {
+  reduce,
+  releaseCommitsFold,
+  type CardState,
+  type Presentation,
+  type Recognizer,
+} from "./cardState.js";
 import { BEND_TRAVEL_PX, MOVE_SLOP_PX, REVEAL_THRESHOLD } from "./constants.js";
+import { foldThreshold } from "./geometry.js";
 import {
   beginGesture,
   endGesture,
@@ -20,11 +28,22 @@ function press(
   });
 }
 
-const onTurn = { foldLegal: true };
+/** A viewport whose fold threshold is comfortably above the floor. */
+const VIEWPORT_HEIGHT = 900;
+const FOLD_THRESHOLD_PX = foldThreshold(VIEWPORT_HEIGHT);
+
+const onTurn = { foldLegal: true, foldThresholdPx: FOLD_THRESHOLD_PX };
 
 /** Drag to an absolute point, from the origin `press()` uses. */
 function to(dx: number, dy: number) {
   return { x: 100 + dx, y: 100 + dy };
+}
+
+function state(
+  presentation: Presentation,
+  recognizer: Recognizer = "Idle",
+): CardState {
+  return { presentation, recognizer, armed: false, locked: false };
 }
 
 describe("moveGesture", () => {
@@ -106,7 +125,10 @@ describe("moveGesture", () => {
   });
 
   it("samples fold legality at classification and never re-reads it", () => {
-    const offTurn = moveGesture(press(), to(0, -40), { foldLegal: false });
+    const offTurn = moveGesture(press(), to(0, -40), {
+      ...onTurn,
+      foldLegal: false,
+    });
     expect(offTurn.session.classification).toBe("Ignored");
 
     // Legality returning mid-drag does not promote it.
@@ -192,28 +214,122 @@ describe("crossing the reveal threshold", () => {
   it("never commits a drag that is not a bend, however far it goes", () => {
     for (const session of [press(), press({ fromBendZone: false })]) {
       const dragged = moveGesture(session, to(0, inward(4)), onTurn);
-      expect(dragged.events).toEqual([
-        { type: "CLASSIFIED", as: "FoldDragging" },
-      ]);
+      expect(dragged.session.classification).toBe("FoldDragging");
+      expect(dragged.events).not.toContainEqual({ type: "BEND_CROSSED" });
       expect(dragged.session.crossed).toBe(false);
     }
   });
 });
 
-describe("endGesture", () => {
-  it("taps on a release that never classified", () => {
-    expect(endGesture(press(), { cancelled: false })).toEqual([
-      { type: "RELEASED" },
-      { type: "TAPPED" },
+describe("the fold drag", () => {
+  /** A fold drag already classified, with the finger `up` px above the start. */
+  function dragging(up: number) {
+    return moveGesture(press(), to(0, -up), onTurn);
+  }
+
+  it("tracks the finger so the player can feel how far they are from committing", () => {
+    const step = dragging(60);
+
+    expect(step.session.classification).toBe("FoldDragging");
+    expect(step.fold).toEqual({ offset: -60 });
+  });
+
+  it("moves the pair up only, so a fold drag cannot push the cards downward", () => {
+    // The classifier admits an upward-dominant drag; wandering back below the
+    // start of it must not turn the gesture into a shove.
+    const started = dragging(40).session;
+
+    expect(moveGesture(started, to(0, 30), onTurn).fold).toEqual({ offset: 0 });
+  });
+
+  it("reports no peel — a fold drag moves the pair without turning it over", () => {
+    expect(dragging(60).bend).toBeNull();
+  });
+
+  it("arms as the threshold is reached, and says so exactly once", () => {
+    const short = dragging(FOLD_THRESHOLD_PX - 1);
+    expect(short.events).toEqual([{ type: "CLASSIFIED", as: "FoldDragging" }]);
+    expect(short.session.armed).toBe(false);
+
+    const armed = moveGesture(short.session, to(0, -FOLD_THRESHOLD_PX), onTurn);
+    expect(armed.events).toEqual([{ type: "FOLD_ARMED" }]);
+    expect(armed.session.armed).toBe(true);
+
+    const further = moveGesture(armed.session, to(0, -600), onTurn);
+    expect(further.events).toEqual([]);
+    expect(further.session.armed).toBe(true);
+  });
+
+  it("disarms again when the player pulls the cards back down", () => {
+    // Card motion and the in-gesture text are the whole arming signal, so an
+    // armed prompt over cards that have come back below the line would be a
+    // lie — and releasing there must commit nothing.
+    const armed = moveGesture(
+      dragging(FOLD_THRESHOLD_PX).session,
+      to(0, -(FOLD_THRESHOLD_PX + 40)),
+      onTurn,
+    ).session;
+
+    const pulledBack = moveGesture(armed, to(0, -20), onTurn);
+    expect(pulledBack.events).toEqual([{ type: "FOLD_DISARMED" }]);
+    expect(pulledBack.session.armed).toBe(false);
+    expect(pulledBack.fold).toEqual({ offset: -20 });
+  });
+
+  it("arms in the same move as the classification when the flick is fast enough", () => {
+    const flick = moveGesture(
+      press(),
+      to(0, -(FOLD_THRESHOLD_PX + 100)),
+      onTurn,
+    );
+
+    // Order matters: the reducer only arms a drag it has already classified.
+    expect(flick.events).toEqual([
+      { type: "CLASSIFIED", as: "FoldDragging" },
+      { type: "FOLD_ARMED" },
     ]);
+  });
+
+  it("never arms a drag that is not a fold, however far up it goes", () => {
+    const bending = moveGesture(
+      press({ fromBendZone: true }),
+      to(0, -10),
+      onTurn,
+    ).session;
+    const ignored = moveGesture(press(), to(40, 0), onTurn).session;
+
+    for (const session of [bending, ignored]) {
+      const far = moveGesture(
+        session,
+        to(0, -(FOLD_THRESHOLD_PX + 200)),
+        onTurn,
+      );
+      expect(far.events).not.toContainEqual({ type: "FOLD_ARMED" });
+      expect(far.fold).toBeNull();
+    }
+  });
+});
+
+describe("endGesture", () => {
+  /** A fold drag carried `up` px, from a pair that started face-down. */
+  function foldDragged(up: number): GestureSession {
+    return moveGesture(press(), to(0, -up), onTurn).session;
+  }
+
+  it("taps on a release that never classified", () => {
+    expect(endGesture(press(), { cancelled: false })).toEqual({
+      events: [{ type: "RELEASED" }, { type: "TAPPED" }],
+      commitsFold: false,
+    });
   });
 
   it("does not tap on release from an ignored drag", () => {
     const ignored = moveGesture(press(), to(40, 0), onTurn).session;
 
-    expect(endGesture(ignored, { cancelled: false })).toEqual([
-      { type: "RELEASED" },
-    ]);
+    expect(endGesture(ignored, { cancelled: false })).toEqual({
+      events: [{ type: "RELEASED" }],
+      commitsFold: false,
+    });
   });
 
   it("does not tap on release from a bend", () => {
@@ -223,14 +339,58 @@ describe("endGesture", () => {
       onTurn,
     ).session;
 
-    expect(endGesture(bending, { cancelled: false })).toEqual([
-      { type: "RELEASED" },
-    ]);
+    expect(endGesture(bending, { cancelled: false })).toEqual({
+      events: [{ type: "RELEASED" }],
+      commitsFold: false,
+    });
   });
 
   it("cancels rather than taps when the browser takes the pointer away", () => {
-    expect(endGesture(press(), { cancelled: true })).toEqual([
-      { type: "CANCELLED" },
-    ]);
+    expect(endGesture(press(), { cancelled: true })).toEqual({
+      events: [{ type: "CANCELLED" }],
+      commitsFold: false,
+    });
+  });
+
+  it("commits the Fold on the release that completes an armed drag", () => {
+    expect(
+      endGesture(foldDragged(FOLD_THRESHOLD_PX + 40), { cancelled: false })
+        .commitsFold,
+    ).toBe(true);
+  });
+
+  it("commits nothing from a drag that never reached the threshold", () => {
+    expect(
+      endGesture(foldDragged(FOLD_THRESHOLD_PX - 1), { cancelled: false })
+        .commitsFold,
+    ).toBe(false);
+  });
+
+  it("commits nothing when the browser takes the pointer away mid-flick", () => {
+    // The player never let go: crossing the line offers the Fold, and only the
+    // completing release accepts it.
+    expect(
+      endGesture(foldDragged(FOLD_THRESHOLD_PX + 40), { cancelled: true }),
+    ).toEqual({ events: [{ type: "CANCELLED" }], commitsFold: false });
+  });
+
+  it("agrees with the reducer about which releases fold", () => {
+    // The Action and the presentation are decided by two different `armed`
+    // flags — the session's, read synchronously in the pointer handler, and the
+    // reducer's. Both are driven by the same `FOLD_ARMED`/`FOLD_DISARMED`
+    // events; this is the invariant that keeps them from disagreeing about
+    // whether the player just folded.
+    for (const up of [
+      FOLD_THRESHOLD_PX - 1,
+      FOLD_THRESHOLD_PX,
+      FOLD_THRESHOLD_PX + 200,
+    ]) {
+      const step = moveGesture(press(), to(0, -up), onTurn);
+      const reduced = step.events.reduce(reduce, state("FaceDown", "Pressing"));
+
+      expect(endGesture(step.session, { cancelled: false }).commitsFold).toBe(
+        releaseCommitsFold(reduced),
+      );
+    }
   });
 });

--- a/packages/player-client/src/holecards/gesture.ts
+++ b/packages/player-client/src/holecards/gesture.ts
@@ -30,6 +30,13 @@ export interface GestureSession {
    * cannot un-commit it and must not re-announce it either.
    */
   readonly crossed: boolean;
+  /**
+   * Whether the fold drag is currently past its threshold. Deliberately **not**
+   * one-way, unlike `crossed`: crossing the fold line only arms, and the
+   * commitment is the release (§10) — so pulling the cards back down disarms
+   * again, and the player can always change their mind by putting them down.
+   */
+  readonly armed: boolean;
 }
 
 /** Continuous peel values, destined for `MotionValue`s rather than state. */
@@ -38,11 +45,25 @@ export interface BendMotion {
   readonly axis: BendAxis;
 }
 
+/** How far the pair has been carried towards the muck, in px. Never positive. */
+export interface FoldMotion {
+  readonly offset: number;
+}
+
+/** What the recognizer needs from the surrounding view to answer a move. */
+export interface GestureContext {
+  readonly foldLegal: boolean;
+  /** Upward travel that arms the Fold, from `foldThreshold` (§15). */
+  readonly foldThresholdPx: number;
+}
+
 export interface GestureStep {
   readonly session: GestureSession;
   readonly events: readonly CardEvent[];
   /** `null` when this move changes nothing continuous. */
   readonly bend: BendMotion | null;
+  /** `null` unless this move is carrying the pair towards the muck. */
+  readonly fold: FoldMotion | null;
 }
 
 export function beginGesture(press: {
@@ -60,6 +81,7 @@ export function beginGesture(press: {
     startedRevealed: press.startedRevealed,
     classification: null,
     crossed: false,
+    armed: false,
   };
 }
 
@@ -74,14 +96,14 @@ export function beginGesture(press: {
 export function moveGesture(
   session: GestureSession,
   point: { readonly x: number; readonly y: number },
-  ctx: { readonly foldLegal: boolean },
+  ctx: GestureContext,
 ): GestureStep {
   const dx = point.x - session.originX;
   const dy = point.y - session.originY;
 
   if (session.classification === null) {
     if (Math.hypot(dx, dy) <= MOVE_SLOP_PX) {
-      return { session, events: [], bend: null };
+      return { session, events: [], bend: null, fold: null };
     }
     const classification = classify({
       fromBendZone: session.fromBendZone,
@@ -92,14 +114,18 @@ export function moveGesture(
       // outlives the player's turn disarms (§6); it does not reclassify.
       foldLegal: ctx.foldLegal,
     });
-    return step({ ...session, classification }, dx, dy, [
-      { type: "CLASSIFIED", as: classification },
-    ]);
+    return step(
+      { ...session, classification },
+      dx,
+      dy,
+      [{ type: "CLASSIFIED", as: classification }],
+      ctx,
+    );
   }
 
   // The steady state of a drag: continuous values only, and no events — the
   // reducer is not told that a finger moved.
-  return step(session, dx, dy, []);
+  return step(session, dx, dy, [], ctx);
 }
 
 /**
@@ -112,19 +138,55 @@ function step(
   dx: number,
   dy: number,
   events: readonly CardEvent[],
+  ctx: GestureContext,
 ): GestureStep {
+  if (session.classification === "FoldDragging") {
+    return foldStep(session, dy, events, ctx);
+  }
+
   // Past the commit the turn owns the motion: the peel finishes on its own
   // schedule, so the finger stops driving it and a release cannot pull it back.
-  if (session.crossed) return { session, events, bend: null };
+  if (session.crossed) return { session, events, bend: null, fold: null };
 
   const bend = bendFor(session, dx, dy);
   if (bend === null || bend.progress < REVEAL_THRESHOLD) {
-    return { session, events, bend };
+    return { session, events, bend, fold: null };
   }
   return {
     session: { ...session, crossed: true },
     events: [...events, { type: "BEND_CROSSED" }],
     bend,
+    fold: null,
+  };
+}
+
+/**
+ * The pair following the finger towards the muck, and the arming that turns
+ * that motion into an offer.
+ *
+ * The threshold is crossed **both ways**: a player who drags past it and then
+ * changes their mind disarms by putting the cards back down, which is the whole
+ * of §10's promise that the commitment is on release and never on crossing the
+ * line. Card motion plus the in-gesture text is the entire arming signal — on
+ * iPhone/Safari there is no haptic at all — so the two must never disagree.
+ */
+function foldStep(
+  session: GestureSession,
+  dy: number,
+  events: readonly CardEvent[],
+  ctx: GestureContext,
+): GestureStep {
+  // Upward only: the cards go away from the player, and a drag that wanders
+  // back below where it started must not shove them down the screen.
+  const offset = Math.min(0, dy);
+  const fold: FoldMotion = { offset };
+  const armed = -offset >= ctx.foldThresholdPx;
+  if (armed === session.armed) return { session, events, bend: null, fold };
+  return {
+    session: { ...session, armed },
+    events: [...events, { type: armed ? "FOLD_ARMED" : "FOLD_DISARMED" }],
+    bend: null,
+    fold,
   };
 }
 
@@ -137,18 +199,45 @@ function bendFor(
   return { progress: bendProgress(dx, dy), axis: bendAxis(dx, dy) };
 }
 
+export interface GestureEnd {
+  readonly events: readonly CardEvent[];
+  /**
+   * Whether this release is the completing one that sends the Fold (§10).
+   *
+   * Answered from the **session** rather than from the reducer's state,
+   * because the caller has to act on it synchronously and a `useReducer`
+   * state read in a pointer handler can lag a threshold crossing that
+   * happened one pointer event ago. The reducer reaches the same answer from
+   * its own `armed` flag — see `releaseCommitsFold` — and the two agree
+   * because both are driven by the same `FOLD_ARMED`/`FOLD_DISARMED` events.
+   */
+  readonly commitsFold: boolean;
+}
+
 /**
  * End a gesture. A release that never classified is a tap; a release from
  * `Ignored` is not — a drag that started sideways or downward does nothing at
  * all, including on the way out.
+ *
+ * **Cancellation commits nothing**, however far the cards were carried: the
+ * player never completed the gesture, and Actions commit on the completing
+ * release alone.
  */
 export function endGesture(
   session: GestureSession,
   { cancelled }: { readonly cancelled: boolean },
-): readonly CardEvent[] {
-  if (cancelled) return [{ type: "CANCELLED" }];
-  if (session.classification === null) {
-    return [{ type: "RELEASED" }, { type: "TAPPED" }];
+): GestureEnd {
+  if (cancelled) {
+    return { events: [{ type: "CANCELLED" }], commitsFold: false };
   }
-  return [{ type: "RELEASED" }];
+  if (session.classification === null) {
+    return {
+      events: [{ type: "RELEASED" }, { type: "TAPPED" }],
+      commitsFold: false,
+    };
+  }
+  return {
+    events: [{ type: "RELEASED" }],
+    commitsFold: session.classification === "FoldDragging" && session.armed,
+  };
 }

--- a/packages/player-client/src/holecards/haptics.ts
+++ b/packages/player-client/src/holecards/haptics.ts
@@ -1,0 +1,23 @@
+/**
+ * A threshold pulse, where the platform allows one (Phase 3 spec #138 §16).
+ *
+ * **Never semantic feedback.** Browser vibration is Blink-only: there is no
+ * Vibration API in Safari at all, so the iPhone path has to work with none of
+ * this. Everything the pulse says is already said by the cards moving and by
+ * the permanent in-gesture text (§11), and this only adds weight to the moment
+ * for the players whose browser can.
+ *
+ * Reached through `Reflect` rather than `navigator.vibrate?.()` because the DOM
+ * lib types the method as always present, which is exactly the assumption the
+ * Safari path breaks.
+ */
+export function pulse(durationMs: number): void {
+  if (typeof navigator === "undefined") return;
+  const vibrate = Reflect.get(navigator, "vibrate") as unknown;
+  if (typeof vibrate !== "function") return;
+  try {
+    Reflect.apply(vibrate, navigator, [durationMs]);
+  } catch {
+    // Best-effort: a browser may refuse without a user gesture, or at all.
+  }
+}

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -1,3 +1,4 @@
+import type { Card } from "@table-top-poker/protocol";
 import { animate, useMotionValue, type MotionValue } from "motion/react";
 import {
   useCallback,
@@ -12,15 +13,22 @@ import { initialCardState, reduce, type CardState } from "./cardState.js";
 import {
   CHECK_CONFIRM_MS,
   CLICK_DISOWN_MS,
+  FOLD_FLIGHT_MS,
+  HAPTIC_PULSE_MS,
   REVEAL_FINISH_MS,
 } from "./constants.js";
-import type { BendAxis } from "./geometry.js";
+import {
+  foldFlightDistance,
+  foldThreshold,
+  type BendAxis,
+} from "./geometry.js";
 import {
   beginGesture,
   endGesture,
   moveGesture,
   type GestureSession,
 } from "./gesture.js";
+import { pulse } from "./haptics.js";
 import type { HoleCardPairProps } from "./HoleCardPair.js";
 import { confirmsCheck, tapLanded, type TapWindow } from "./taps.js";
 import { eventsForPropChange, eventsForVisibility } from "./viewEvents.js";
@@ -52,9 +60,37 @@ export interface HoleCards {
   readonly bend: MotionValue<number>;
   /** Which way the live bend is going, for the §11 second-line swap. */
   readonly bendAxis: MotionValue<BendAxis>;
+  /** How far the pair has been carried towards the muck, in px. Never state. */
+  readonly foldOffset: MotionValue<number>;
+  /** The pair fading out on its way to the muck, 1 → 0. */
+  readonly foldFade: MotionValue<number>;
+  /**
+   * Whether the pair was face-up at the moment the Fold committed. Only
+   * meaningful while it is departing: the cards leave with whatever face they
+   * had (§7), and once the reducer is in `Leaving` the presentation they left
+   * from is no longer recoverable from the state.
+   */
+  readonly leavingFaceUp: boolean;
+  /**
+   * The committed pair for as long as its flight is still running, or `null`.
+   *
+   * The flight is **fire-and-forget, on its own ~280ms schedule and not gated
+   * on the round trip** (§7) — which cuts *both* ways. On a LAN the
+   * acknowledgement lands tens of milliseconds in and takes `cards` away with
+   * it, so without this the departure the player was promised would be a blink
+   * (story 20). The pair renders from here once the props no longer carry it.
+   */
+  readonly departing: readonly [Card, Card] | null;
   /** A gesture Check landed and is still being confirmed (story 31). */
   readonly checkConfirmed: boolean;
 }
+
+/**
+ * A spring rather than a duration: the cards were being *carried*, and letting
+ * go of something you are carrying has weight and a little overshoot. Carried
+ * forward from the prototype.
+ */
+const RETURN_SPRING = { type: "spring", stiffness: 480, damping: 36 } as const;
 
 /**
  * Binds the pure lifecycle to React: prop changes and pointer events in,
@@ -79,7 +115,19 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
 
   const bend = useMotionValue(0);
   const bendAxis = useMotionValue<BendAxis>("left");
+  const foldOffset = useMotionValue(0);
+  const foldFade = useMotionValue(1);
   const session = useRef<GestureSession | null>(null);
+  /**
+   * React state rather than refs, because both are read during render — but
+   * both are only ever written in the same event as the commit, so they land in
+   * the same render as `Leaving` and no frame shows the wrong face or an empty
+   * seat where the departure should be.
+   */
+  const [leavingFaceUp, setLeavingFaceUp] = useState(false);
+  const [departing, setDeparting] = useState<readonly [Card, Card] | null>(
+    null,
+  );
   /**
    * §16: `preventDefault` at a lower level does not suppress the later `click`
    * consistently across browsers, so suppression is handled here, at the
@@ -152,6 +200,83 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
       bend.set(0);
     }
   }, [state.presentation, bend]);
+
+  /**
+   * Whether the pair is on its way to the muck **right now**.
+   *
+   * `Leaving` alone is not enough: an acknowledgement resolves the reducer to
+   * `Absent` within milliseconds on a LAN, and the flight is explicitly not
+   * gated on that round trip. A rejection is the opposite — it takes the pair
+   * out of the air immediately, from wherever it has got to.
+   */
+  const inFlight =
+    state.presentation === "Leaving" ||
+    (departing !== null && state.presentation === "Absent");
+
+  // The flight itself. Deliberately depends on nothing but `inFlight`, so the
+  // acknowledgement arriving mid-departure neither restarts the animation nor
+  // interrupts it — it simply does not reach this effect at all.
+  useEffect(() => {
+    if (!inFlight) return;
+    const seconds = FOLD_FLIGHT_MS / 1000;
+    const flight = animate(
+      foldOffset,
+      -foldFlightDistance(window.innerHeight),
+      {
+        duration: seconds,
+        ease: [0.4, 0, 1, 1],
+      },
+    );
+    const fade = animate(foldFade, 0, { duration: seconds, ease: "linear" });
+    // Stopping on cleanup is what makes a rejection **interrupt** the departure
+    // rather than complete it first (§7). The flight is a *prediction* of
+    // server truth; when the server contradicts it, finishing the animation
+    // would actively lie to the player.
+    return () => {
+      flight.stop();
+      fade.stop();
+    };
+  }, [inFlight, foldOffset, foldFade]);
+
+  // Coming to rest: the counterpart, and the only thing that puts the pair back
+  // where it belongs. Keyed on the discrete facts that decide where that is —
+  // whether the pair is in the air, and whether a finger is still carrying it.
+  useEffect(() => {
+    if (inFlight) return;
+
+    if (state.presentation === "Absent") {
+      // Nothing is rendered to see the snap, and the next hand must deal in
+      // from rest rather than sliding down from wherever the flight got to.
+      foldOffset.set(0);
+      foldFade.set(1);
+      return;
+    }
+
+    // A finger still on the glass owns the offset; this effect must not fight
+    // it. Every way a drag can end — release, cancellation, a §9 reset out from
+    // under it — clears the recognizer, which is what brings the pair home.
+    if (state.recognizer !== "Idle") return;
+    if (foldOffset.get() === 0 && foldFade.get() === 1) return;
+    const home = animate(foldOffset, 0, RETURN_SPRING);
+    const restore = animate(foldFade, 1, RETURN_SPRING);
+    return () => {
+      home.stop();
+      restore.stop();
+    };
+  }, [inFlight, state.presentation, state.recognizer, foldOffset, foldFade]);
+
+  // The departure outlives the cards prop by exactly one flight, and no longer:
+  // a pair the player is holding again after a rejection renders from `cards`,
+  // and this only has to stop standing in for one that is genuinely gone.
+  useEffect(() => {
+    if (departing === null) return;
+    const timer = setTimeout(() => {
+      setDeparting(null);
+    }, FOLD_FLIGHT_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [departing]);
 
   // The one disturbance that is not a prop change (§8): the app leaving the
   // foreground resets the pair face-down, cancelling any gesture in flight.
@@ -230,8 +355,40 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     // that already crossed the threshold is exempt: it committed on crossing,
     // and the turn is mid-flight with the peel under its control.
     if (!active.crossed) bend.set(0);
+    // **The commitment, and the only one a pointer lift makes** (§10). Decided
+    // off the session, which is a ref and therefore exactly as current as the
+    // events the reducer has been given — the state this hook renders with can
+    // lag a threshold crossed one pointer event ago, and a fast flick is the
+    // commonest way to fold, not an edge case.
+    const { events, commitsFold } = endGesture(active, { cancelled });
+    // Fold legality is sampled once, at classification (§4), so a drag can
+    // outlive the turn that made it legal. §6's answer is that such a drag
+    // **disarms** — the release commits nothing, and there is no rejection
+    // message, because the turn banner already explains it.
+    //
+    // Re-sampled here as well as on the prop change that #146 will watch,
+    // because a release can beat the view that would have disarmed it. `pending`
+    // rides along for the same reason: a Fold cannot go out on top of an Action
+    // already in flight, and a departure the player watches and then has undone
+    // is worse than one that never starts.
+    //
+    // This is arming input, exactly as §2 licenses; `canAct` inside
+    // `intent.fold` remains the single gate on whether the Action is sent.
+    const commits =
+      commitsFold && props.actions.foldLegal && !props.actions.pending;
+    if (commitsFold && !commits) dispatch({ type: "FOLD_DISARMED" });
+    // The pair leaves with whatever face it had (§7). Read off presentation
+    // rather than the session, because a keyboard reveal committed before the
+    // press can land during the drag — and `Turning` is a point of no return,
+    // so a pair mid-flip is a pair that is going to be face-up.
+    if (commits) {
+      setLeavingFaceUp(
+        state.presentation === "Revealed" || state.presentation === "Turning",
+      );
+      setDeparting(props.cards);
+    }
     let tapped = false;
-    for (const cardEvent of endGesture(active, { cancelled })) {
+    for (const cardEvent of events) {
       if (cardEvent.type !== "TAPPED") {
         dispatch(cardEvent);
         continue;
@@ -256,6 +413,14 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     // failure here that costs money, so the window is closed rather than left
     // open on a technicality of what the middle gesture happened to be.
     if (!tapped) tapWindow.current = null;
+    // Sent after the dispatch, so the cards are already on their way to the
+    // muck when the Action goes: the departure is the player's own answer
+    // rather than the server's. `fold` **is** `intent.fold` — gesture and
+    // button enter the identical function, and `canAct` on the latest view
+    // stays the single legality gate, so an armed release the server would
+    // refuse sends nothing, and the pending Action it is waiting behind
+    // resolves the pair back to `FaceDown` as any rejection would.
+    if (commits) props.actions.fold();
   };
 
   const handlers: PairHandlers = {
@@ -289,17 +454,32 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
       const step = moveGesture(
         active,
         { x: event.clientX, y: event.clientY },
-        { foldLegal: props.actions.foldLegal },
+        {
+          foldLegal: props.actions.foldLegal,
+          // Measured per move rather than once: the threshold scales with the
+          // viewport, and a phone keyboard or a rotation changes it under a
+          // gesture that is already running.
+          foldThresholdPx: foldThreshold(window.innerHeight),
+        },
       );
       session.current = step.session;
       if (step.bend !== null) {
         bend.set(step.bend.progress);
         bendAxis.set(step.bend.axis);
       }
+      // The cards track the finger, so the player can feel how far they are
+      // from committing — continuous, and therefore never React state (§13).
+      if (step.fold !== null) foldOffset.set(step.fold.offset);
       // Once the drag belongs to the recognizer, the browser must not also
       // treat it as a pan or a selection.
       if (step.session.classification !== null) event.preventDefault();
-      for (const cardEvent of step.events) dispatch(cardEvent);
+      for (const cardEvent of step.events) {
+        // Optional, best-effort polish and **never** semantic feedback: the
+        // arming signal proper is the card motion and the in-gesture text, both
+        // of which the iPhone/Safari path has and this pulse it does not (§16).
+        if (cardEvent.type === "FOLD_ARMED") pulse(HAPTIC_PULSE_MS);
+        dispatch(cardEvent);
+      }
     },
 
     onPointerUp: (event) => {
@@ -319,6 +499,10 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     handlers,
     bend,
     bendAxis,
+    foldOffset,
+    foldFade,
+    leavingFaceUp,
+    departing,
     checkConfirmed: checkConfirmedAt !== null,
   };
 }

--- a/packages/player-client/src/holecards/viewEvents.test.ts
+++ b/packages/player-client/src/holecards/viewEvents.test.ts
@@ -165,6 +165,57 @@ describe("eventsForPropChange", () => {
     ).toEqual([]);
   });
 
+  describe("a resolving Action", () => {
+    const pending = { ...actions, pending: true };
+    /** The pair mid-flight to the muck, waiting on the server's answer. */
+    const leaving: CardState = {
+      presentation: "Leaving",
+      recognizer: "Idle",
+      armed: false,
+      locked: false,
+    };
+
+    it("acknowledges the Fold: the cards are gone and stay gone", () => {
+      expect(
+        eventsForPropChange(
+          props({ cards: queenJack, actions: pending }),
+          props(),
+          leaving,
+        ),
+      ).toEqual([
+        { type: "CARDS_GONE" },
+        { type: "PENDING_RESOLVED", hasCards: false },
+      ]);
+    });
+
+    it("rejects the Fold: the cards are still in hand, so they come back", () => {
+      expect(
+        eventsForPropChange(
+          props({ cards: queenJack, actions: pending }),
+          props({ cards: queenJack }),
+          leaving,
+        ),
+      ).toEqual([{ type: "PENDING_RESOLVED", hasCards: true }]);
+    });
+
+    it("produces nothing while the Action is still in flight", () => {
+      const before = props({ cards: queenJack, actions: pending });
+      expect(eventsForPropChange(before, { ...before }, leaving)).toEqual([]);
+    });
+
+    it("produces nothing when an Action *starts* — sending is not a lifecycle event", () => {
+      // The pair moved itself to `Leaving` on the release that sent the Fold;
+      // the prop going true afterwards has nothing left to say.
+      expect(
+        eventsForPropChange(
+          props({ cards: queenJack }),
+          props({ cards: queenJack, actions: pending }),
+          leaving,
+        ),
+      ).toEqual([]);
+    });
+  });
+
   describe("showdown", () => {
     it("reveals when locked goes false → true", () => {
       expect(

--- a/packages/player-client/src/holecards/viewEvents.ts
+++ b/packages/player-client/src/holecards/viewEvents.ts
@@ -25,36 +25,47 @@ function samePair(
  * exactly what you do while others act — so a new street, a new board card,
  * another player's bet and a changed `toAct` must all produce nothing.
  *
- * `state` is the current lifecycle state, which the later arms
- * (`FOLD_DISARMED`, `PENDING_RESOLVED`) consult; of the events derived so far
- * only `CARDS_GONE` does.
+ * `state` is the current lifecycle state; of the events derived here only
+ * `CARDS_GONE` consults it. `FOLD_DISARMED` — fold legality disappearing under
+ * a live drag — is the one §8 row still to arrive (#146).
  */
 export function eventsForPropChange(
   prev: HoleCardPairProps,
   next: HoleCardPairProps,
   state: CardState,
 ): readonly CardEvent[] {
+  const events: CardEvent[] = [];
+
   if (next.cards === null) {
     // An event is a transition, never a restatement: a pair already showing
     // nothing has nothing to be told.
-    if (prev.cards === null || state.presentation === "Absent") return [];
-    return [{ type: "CARDS_GONE" }];
+    if (prev.cards !== null && state.presentation !== "Absent") {
+      events.push({ type: "CARDS_GONE" });
+    }
+  } else {
+    // Card identity, not reference: `PlayerView` carries no hand id, so cards
+    // arriving is the deal signal — with a value comparison as the defensive
+    // second signal for a betting→betting view that swaps cards without an
+    // intervening empty one.
+    if (!samePair(prev.cards, next.cards)) events.push({ type: "DEALT" });
+
+    // Ordered after the deal deliberately: a seat whose cards only arrive at
+    // showdown must be dealt in before it is revealed, or the reveal lands on a
+    // pair that is still `Absent`. Losing the lock produces nothing — showdown
+    // does not un-reveal, and the next hand's `DEALT` is what turns the cards
+    // back over.
+    if (!prev.locked && next.locked) events.push({ type: "SHOWDOWN_REVEAL" });
   }
 
-  const events: CardEvent[] = [];
-
-  // Card identity, not reference: `PlayerView` carries no hand id, so cards
-  // arriving is the deal signal — with a value comparison as the defensive
-  // second signal for a betting→betting view that swaps cards without an
-  // intervening empty one.
-  if (!samePair(prev.cards, next.cards)) events.push({ type: "DEALT" });
-
-  // Ordered after the deal deliberately: a seat whose cards only arrive at
-  // showdown must be dealt in before it is revealed, or the reveal lands on a
-  // pair that is still `Absent`. Losing the lock produces nothing — showdown
-  // does not un-reveal, and the next hand's `DEALT` is what turns the cards
-  // back over.
-  if (!prev.locked && next.locked) events.push({ type: "SHOWDOWN_REVEAL" });
+  // Only the falling edge, and only a Fold is waiting on it: the pair moved
+  // itself to `Leaving` on the release that sent the Action, so the prop going
+  // *true* has nothing left to say (§7). Whether the answer was an
+  // acknowledgement or a rejection is read off the cards rather than off any
+  // rejection state — the server taking them is what "acknowledged" means here,
+  // and the reducer needs no second opinion.
+  if (prev.actions.pending && !next.actions.pending) {
+    events.push({ type: "PENDING_RESOLVED", hasCards: next.cards !== null });
+  }
 
   return events;
 }


### PR DESCRIPTION
Closes #145. Part of #138.

The Player swipes the pair upward, away from them. The cards track the finger; past `max(148px, 0.18 × viewport height)` the drag **arms** and the in-gesture text says so, and the **release** commits. Release short of the threshold — or drag back below it — and the pair drops safely back to the face it started from.

All changes are confined to `packages/player-client/src/holecards/`. `ActionBar`, `useActionIntent`, the protocol, the server and the engine are untouched.

## What changed

| File | Change |
| --- | --- |
| `geometry.ts` | `foldThreshold(viewportHeight)`, `foldFlightDistance` |
| `cardState.ts` | `FOLD_ARMED`/`FOLD_DISARMED` arms, armed-`RELEASED` → `Leaving`, `PENDING_RESOLVED` scoped to `Leaving`, exported `releaseCommitsFold` |
| `gesture.ts` | fold tracking in the session, arming both ways, `endGesture` now returns `{ events, commitsFold }` |
| `viewEvents.ts` | `PENDING_RESOLVED` on the falling edge of `actions.pending` |
| `coaching.ts` | "Keep dragging up" / "Release to Fold", never gated on the discovery set |
| `useHoleCards.ts` | fold offset/fade motion values, the flight, the return, the commit |
| `HoleCardPair.tsx`, `BendableCard.tsx` | the departing pair, and the face it leaves with |
| `haptics.ts` *(new)* | best-effort threshold pulse |

## Notes for review

**Arming is deliberately not one-way.** The commitment is on release, never on crossing the line, so pulling the cards back down disarms again — card motion and the permanent prompt can never disagree. There is no rendered threshold marker and browser vibration is Blink-only, so on iPhone/Safari that text *is* the whole arming signal; the pulse is best-effort polish (§16).

**`FOLD_DISARMED` landed here rather than in #146.** A drag pulled back below the threshold needs it. #146 now adds only the `viewEvents` trigger for legality disappearing mid-motion.

**Two guards the spec implies rather than states.**
1. Fold legality and `pending` are re-sampled at release. Without that, a release that beats the view leaves the pair stranded in `Leaving` — invisible and inert — because `canAct` refuses silently and no `PENDING_RESOLVED` ever arrives. §2 licenses both props as arming input, and `canAct` remains the only gate on sending.
2. The commit is decided off the pointer session rather than off rendered state, which can lag a threshold crossed one pointer event ago. A fast flick is the commonest way to fold, not an edge case.

**The flight survives a mid-flight acknowledgement.** The pair renders from the committed cards for the full ~280ms, so the ack landing 20ms later on a LAN does not reduce the departure to a blink (§7, story 20). A rejection interrupts the flight from wherever it has got to and returns the cards face-down, never to `Revealed`.

**`CONTEXT.md` gains a `Muck` entry.** The word carries the whole fold departure in `holecards/` but appeared in the glossary only incidentally, inside `Replay`. The entry says the thing the name hides: the engine models no Muck at all — folding stops the Seat's Hole cards being projected, and that is the entire mechanism, so the word names a direction of travel the player client acts out rather than a place anything is kept. §18 named only the three Hole-card terms, so this is an addition beyond the spec's list.

## Verification

`npm run build`, `npm run lint`, and the full suite (79 files, 625 tests) all pass.

The real-device matrix in #138 — iPhone/Safari, Android/Chrome, and a desktop mouse/keyboard pass — is **still outstanding**, and is the only thing that establishes this actually feels right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvBckA6KRnDgqRN6oqMT5r
