### PR TITLE
feat(player-client): teach the Hole-card gestures with retiring hints

### DIFF
--- a/packages/player-client/src/holecards/BendableCard.tsx
+++ b/packages/player-client/src/holecards/BendableCard.tsx
@@ -8,7 +8,7 @@ import {
   suitSymbols,
 } from "@table-top-poker/ui-shared";
 import { type MotionValue } from "motion/react";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type CSSProperties } from "react";
 import {
   PeelBack,
   PeelBottom,
@@ -17,7 +17,7 @@ import {
   type PeelRef,
 } from "react-peel";
 import type { Presentation } from "./cardState.js";
-import { REVEAL_THRESHOLD } from "./constants.js";
+import { BEND_CORNER, REVEAL_THRESHOLD } from "./constants.js";
 
 /**
  * The player-side wrapper around the shared `Card` (Phase 3 spec #138 §14).
@@ -235,6 +235,15 @@ function CurlIndex({
 const CURL_TRAVEL = 0.86;
 
 /**
+ * The two sides the affordance is pinned to, from the one constant the coaching
+ * copy also names its corner from — so the zone and the words that describe it
+ * cannot drift apart.
+ */
+function cornerOffsets(inset: string | number): CSSProperties {
+  return { [BEND_CORNER.vertical]: inset, [BEND_CORNER.horizontal]: inset };
+}
+
+/**
  * The affordance the whole gesture hangs off: a corner that looks liftable.
  * `data-bend-zone` is what the recognizer hit-tests against, so the classifier
  * never needs to know where the corner is drawn — and the coaching copy can
@@ -247,8 +256,7 @@ function BendZone() {
       aria-hidden="true"
       style={{
         position: "absolute",
-        right: 0,
-        bottom: 0,
+        ...cornerOffsets(0),
         width: "1.5em",
         height: "1.5em",
         borderBottomRightRadius: "0.2em",
@@ -257,8 +265,7 @@ function BendZone() {
       <span
         style={{
           position: "absolute",
-          right: "0.18em",
-          bottom: "0.18em",
+          ...cornerOffsets("0.18em"),
           width: "0.5em",
           height: "0.5em",
           borderRight: "2px solid rgba(255,236,226,.72)",

--- a/packages/player-client/src/holecards/HoleCardPair.test.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.test.tsx
@@ -2,7 +2,14 @@ import type { Card } from "@table-top-poker/protocol";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { HoleCardPair } from "./HoleCardPair.js";
+import type { CardState } from "./cardState.js";
+import {
+  selectHint,
+  type HintContext,
+  type TeachableGesture,
+} from "./coaching.js";
+import type { BendAxis } from "./geometry.js";
+import { HintBlock, HoleCardPair } from "./HoleCardPair.js";
 import type { CardActions } from "./ports.js";
 
 const actions: CardActions = {
@@ -111,6 +118,104 @@ describe("HoleCardPair", () => {
     );
 
     expect(html).not.toContain('data-testid="hole-cards-hint"');
+  });
+
+  it("renders the words the selector chose, for every hint it can choose", () => {
+    // The copy lives in the selector and this is the only thing that prints it,
+    // so the surface can never teach a gesture in different words from the ones
+    // the §11 table settles.
+    const cases: readonly {
+      readonly state: Partial<CardState & { bendAxis: BendAxis }>;
+      readonly ctx?: Partial<HintContext>;
+      readonly discovered?: readonly TeachableGesture[];
+    }[] = [
+      { state: {}, ctx: { checkConfirmed: true } },
+      { state: { presentation: "Peeking", recognizer: "Bending" } },
+      {
+        state: {
+          presentation: "Peeking",
+          recognizer: "Bending",
+          bendAxis: "up",
+        },
+      },
+      { state: { recognizer: "FoldDragging" } },
+      { state: { recognizer: "FoldDragging", armed: true } },
+      { state: {} },
+      { state: { presentation: "Revealed" }, discovered: ["bend"] },
+      { state: {}, discovered: ["bend", "conceal"] },
+      { state: {}, discovered: ["bend", "conceal", "check"] },
+    ];
+
+    const rendered = cases.map(({ state, ctx, discovered }) => {
+      const hint = selectHint(
+        {
+          presentation: "FaceDown",
+          recognizer: "Idle",
+          armed: false,
+          locked: false,
+          bendAxis: "left",
+          ...state,
+        },
+        new Set(discovered ?? []),
+        {
+          checkLegal: true,
+          foldLegal: true,
+          pending: false,
+          locked: false,
+          coarsePointer: true,
+          quiet: true,
+          checkConfirmed: false,
+          ...ctx,
+        },
+      );
+      if (hint === null) throw new Error("the selector chose no hint");
+      const html = renderToStaticMarkup(<HintBlock hint={hint} />);
+
+      expect(html).toContain(`data-hint="${hint.id}"`);
+      expect(html).toContain(hint.line1);
+      if (hint.line2 !== null) expect(html).toContain(hint.line2);
+      return hint.id;
+    });
+
+    // All nine of them, each rendered by the same block.
+    expect(new Set(rendered).size).toBe(9);
+  });
+
+  it("names the corner the bend affordance is actually drawn in", () => {
+    // "bottom-right" tracks the rendered zone rather than being hard-coded: if
+    // the overlapped layout ever mirrors, the copy follows it.
+    const html = renderToStaticMarkup(
+      <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
+    );
+    const zone = /<span data-bend-zone="true"[^>]*style="([^"]*)"/.exec(html);
+    const zoneStyle = zone?.[1];
+    if (zoneStyle === undefined) throw new Error("no bend zone rendered");
+    const sides = ["top", "bottom", "left", "right"].filter((side) =>
+      new RegExp(`(^|;)${side}:`).test(zoneStyle),
+    );
+
+    const bendHint = selectHint(
+      {
+        presentation: "FaceDown",
+        recognizer: "Idle",
+        armed: false,
+        locked: false,
+        bendAxis: "left",
+      },
+      new Set(),
+      {
+        checkLegal: true,
+        foldLegal: true,
+        pending: false,
+        locked: false,
+        coarsePointer: true,
+        quiet: true,
+        checkConfirmed: false,
+      },
+    );
+
+    expect(sides).toHaveLength(2);
+    for (const side of sides) expect(bendHint?.line1).toContain(side);
   });
 
   it("mounts the live region empty, before there is any news to put in it", () => {

--- a/packages/player-client/src/holecards/HoleCardPair.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.tsx
@@ -4,12 +4,7 @@ import { motion, useTransform, type MotionValue } from "motion/react";
 import type { CSSProperties } from "react";
 import { BendableCard } from "./BendableCard.js";
 import type { Presentation } from "./cardState.js";
-import {
-  selectHint,
-  type Hint,
-  type HintContext,
-  type TeachableGesture,
-} from "./coaching.js";
+import { selectHint, type Hint } from "./coaching.js";
 import { DEAL_IN_MS } from "./constants.js";
 import type { BendAxis } from "./geometry.js";
 import type { CardActions } from "./ports.js";
@@ -122,7 +117,7 @@ function Absent() {
  * bend to peek, tap to conceal, double-tap to Check, and swipe up to Fold.
  */
 export function HoleCardPair(props: HoleCardPairProps) {
-  const { cards, actions } = props;
+  const { cards } = props;
   const {
     state,
     activate,
@@ -133,7 +128,8 @@ export function HoleCardPair(props: HoleCardPairProps) {
     foldFade,
     leavingFaceUp,
     departing,
-    checkConfirmed,
+    hintContext,
+    discovered,
   } = useHoleCards(props);
   // The lifecycle's lock, not the prop: the prop is the *input* the adapter
   // turns into `SHOWDOWN_REVEAL`, and once locked the pair stays locked until
@@ -161,27 +157,17 @@ export function HoleCardPair(props: HoleCardPairProps) {
         ? "FaceDown"
         : state.presentation;
 
-  const hintContext: HintContext = {
-    checkLegal: actions.checkLegal,
-    foldLegal: actions.foldLegal,
-    pending: actions.pending,
-    locked,
-    // The quiet interval only gates the teaching hints, which arrive with the
-    // discovery set they retire against (#147). In-gesture prompts never wait.
-    quiet: false,
-    checkConfirmed,
-  };
   // Both variants of the live hint, because the axis they swap on is a
   // **continuous** value: choosing between them in React would re-render the
   // pair every time a bend wandered across the diagonal (§13).
   const hintDragLeft = selectHint(
     { ...state, presentation, bendAxis: "left" },
-    nothingDiscovered,
+    discovered,
     hintContext,
   );
   const hintDragUp = selectHint(
     { ...state, presentation, bendAxis: "up" },
-    nothingDiscovered,
+    discovered,
     hintContext,
   );
   // An announced hint is news, and news does not depend on which way a finger
@@ -308,8 +294,6 @@ const visuallyHidden: CSSProperties = {
   whiteSpace: "nowrap",
 };
 
-const nothingDiscovered: ReadonlySet<TeachableGesture> = new Set();
-
 function preventDefault(event: { preventDefault: () => void }) {
   event.preventDefault();
 }
@@ -360,7 +344,13 @@ function GestureHint({
   );
 }
 
-function HintBlock({ hint }: { readonly hint: Hint }) {
+/**
+ * One hint, as it appears under the pair. Exported **within the module** so the
+ * component test can assert that what is rendered is what the selector chose —
+ * the copy lives in `coaching.ts` and this block is the only thing that prints
+ * it, so the two cannot say different things.
+ */
+export function HintBlock({ hint }: { readonly hint: Hint }) {
   return (
     <p
       data-testid="hole-cards-hint"

--- a/packages/player-client/src/holecards/coaching.test.ts
+++ b/packages/player-client/src/holecards/coaching.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
-import type { CardState, Presentation, Recognizer } from "./cardState.js";
+import type {
+  CardEvent,
+  CardState,
+  Presentation,
+  Recognizer,
+} from "./cardState.js";
 import {
+  discoveredBy,
+  nextTeachable,
   selectHint,
   type HintContext,
   type TeachableGesture,
@@ -41,6 +48,7 @@ function ctx(overrides: Partial<HintContext> = {}): HintContext {
     foldLegal: true,
     pending: false,
     locked: false,
+    coarsePointer: true,
     quiet: true,
     checkConfirmed: false,
     ...overrides,
@@ -210,10 +218,10 @@ describe("selectHint", () => {
     });
   });
 
-  it("shows nothing when no gesture is running", () => {
+  it("shows nothing when no gesture is running and there is nothing left to teach", () => {
     for (const presentation of ["FaceDown", "Revealed", "Turning"] as const) {
       expect(
-        selectHint(idle(presentation), nothingDiscovered, ctx()),
+        selectHint(idle(presentation), everythingDiscovered, ctx()),
       ).toBeNull();
     }
   });
@@ -222,5 +230,232 @@ describe("selectHint", () => {
     expect(
       selectHint(idle("FaceDown", "Ignored"), nothingDiscovered, ctx()),
     ).toBeNull();
+  });
+});
+
+describe("selectHint, teaching hints", () => {
+  const discovered = (...gestures: TeachableGesture[]) =>
+    new Set<TeachableGesture>(gestures);
+
+  it("teaches the bend first, both outcomes on one line", () => {
+    expect(selectHint(idle("FaceDown"), nothingDiscovered, ctx())).toEqual({
+      id: "teach-bend",
+      line1: "Bend the bottom-right corner",
+      line2: "release to peek · keep bending to reveal",
+      announce: false,
+    });
+  });
+
+  it("teaches the conceal tap next, and only while the pair is face-up", () => {
+    expect(selectHint(idle("Revealed"), discovered("bend"), ctx())).toEqual({
+      id: "teach-conceal",
+      line1: "Tap to hide your cards",
+      line2: "one tap is enough",
+      announce: false,
+    });
+    expect(selectHint(idle("FaceDown"), discovered("bend"), ctx())?.id).toBe(
+      "teach-check",
+    );
+  });
+
+  it("teaches the double-tap Check next", () => {
+    expect(
+      selectHint(idle("FaceDown"), discovered("bend", "conceal"), ctx()),
+    ).toEqual({
+      id: "teach-check",
+      line1: "Double-tap to Check",
+      line2: "passes your turn to the next player",
+      announce: false,
+    });
+  });
+
+  it("teaches the fold swipe last", () => {
+    expect(
+      selectHint(
+        idle("FaceDown"),
+        discovered("bend", "conceal", "check"),
+        ctx(),
+      ),
+    ).toEqual({
+      id: "teach-fold",
+      line1: "Swipe your cards up to Fold",
+      line2: "release once they lift away",
+      announce: false,
+    });
+  });
+
+  it("puts the bend above the conceal where both are eligible", () => {
+    expect(selectHint(idle("Revealed"), nothingDiscovered, ctx())?.id).toBe(
+      "teach-bend",
+    );
+  });
+
+  it("puts Check above Fold in the overlap", () => {
+    // Quieter than it looks: a legal Check means no bet to face, and teaching
+    // someone to fold for free is bad advice.
+    expect(
+      selectHint(idle("FaceDown"), discovered("bend", "conceal"), ctx())?.id,
+    ).toBe("teach-check");
+  });
+
+  it("offers Check and Fold only where the Action is legal", () => {
+    const known = discovered("bend", "conceal");
+    expect(
+      selectHint(idle("FaceDown"), known, ctx({ checkLegal: false }))?.id,
+    ).toBe("teach-fold");
+    expect(
+      selectHint(
+        idle("FaceDown"),
+        known,
+        ctx({ checkLegal: false, foldLegal: false }),
+      ),
+    ).toBeNull();
+  });
+
+  it("offers the bend and the conceal off-turn, where neither Action is legal", () => {
+    // They are local presentation, and off-turn is most of the time a player is
+    // holding cards.
+    const offTurn = ctx({ checkLegal: false, foldLegal: false });
+    expect(selectHint(idle("FaceDown"), nothingDiscovered, offTurn)?.id).toBe(
+      "teach-bend",
+    );
+    expect(selectHint(idle("Revealed"), discovered("bend"), offTurn)?.id).toBe(
+      "teach-conceal",
+    );
+  });
+
+  it("never re-offers a gesture the player has already found", () => {
+    for (const presentation of ["FaceDown", "Revealed"] as const) {
+      expect(
+        selectHint(idle(presentation), everythingDiscovered, ctx()),
+      ).toBeNull();
+    }
+  });
+
+  it("shows nothing at all where the primary pointer is not coarse", () => {
+    // A keyboard player is not told to bend corners; the pair is a focusable
+    // button and every Action keeps its own.
+    expect(
+      selectHint(
+        idle("FaceDown"),
+        nothingDiscovered,
+        ctx({ coarsePointer: false }),
+      ),
+    ).toBeNull();
+  });
+
+  it("shows nothing before the quiet interval", () => {
+    // The player gets the chance to find the gesture themselves first, and a
+    // hint yields the instant a finger lands.
+    expect(
+      selectHint(idle("FaceDown"), nothingDiscovered, ctx({ quiet: false })),
+    ).toBeNull();
+  });
+
+  it("shows nothing while an Action is pending, at showdown, or with no cards", () => {
+    expect(
+      selectHint(idle("FaceDown"), nothingDiscovered, ctx({ pending: true })),
+    ).toBeNull();
+    expect(
+      selectHint(idle("FaceDown"), nothingDiscovered, ctx({ locked: true })),
+    ).toBeNull();
+    expect(selectHint(idle("Absent"), nothingDiscovered, ctx())).toBeNull();
+  });
+
+  it("yields to a gesture already underway, and to the pair leaving", () => {
+    // Instruction about a different gesture must never outrank feedback on the
+    // motion a finger is making right now.
+    expect(selectHint(bending("left"), nothingDiscovered, ctx())?.id).toBe(
+      "bending-left",
+    );
+    expect(
+      selectHint(idle("FaceDown", "Pressing"), nothingDiscovered, ctx()),
+    ).toBeNull();
+    expect(selectHint(idle("Leaving"), nothingDiscovered, ctx())).toBeNull();
+    expect(selectHint(idle("Turning"), nothingDiscovered, ctx())).toBeNull();
+  });
+});
+
+describe("nextTeachable", () => {
+  it("names the gesture whose eligibility the quiet interval is measured from", () => {
+    // The identity the hint timer restarts on: it is what makes the wait an
+    // interval rather than a one-time delay, so Fold does not appear the
+    // instant a turn makes it legal.
+    const legal = { checkLegal: true, foldLegal: true };
+    expect(nextTeachable(idle("FaceDown"), nothingDiscovered, legal)).toBe(
+      "bend",
+    );
+    expect(
+      nextTeachable(
+        idle("Revealed"),
+        new Set<TeachableGesture>(["bend"]),
+        legal,
+      ),
+    ).toBe("conceal");
+    expect(
+      nextTeachable(idle("FaceDown"), everythingDiscovered, legal),
+    ).toBeNull();
+  });
+
+  it("skips the Actions that are not legal right now", () => {
+    const known = new Set<TeachableGesture>(["bend", "conceal"]);
+    expect(
+      nextTeachable(idle("FaceDown"), known, {
+        checkLegal: false,
+        foldLegal: true,
+      }),
+    ).toBe("fold");
+    expect(
+      nextTeachable(idle("FaceDown"), known, {
+        checkLegal: false,
+        foldLegal: false,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("discoveredBy", () => {
+  const faceDown = idle("FaceDown");
+
+  it("counts a bend, a fold swipe, a conceal tap and a double-tap Check", () => {
+    expect(discoveredBy({ type: "CLASSIFIED", as: "Bending" }, faceDown)).toBe(
+      "bend",
+    );
+    expect(
+      discoveredBy({ type: "CLASSIFIED", as: "FoldDragging" }, faceDown),
+    ).toBe("fold");
+    expect(discoveredBy({ type: "TAPPED" }, idle("Revealed"))).toBe("conceal");
+    expect(discoveredBy({ type: "DOUBLE_TAPPED" }, faceDown)).toBe("check");
+  });
+
+  it("counts a tap only where it actually hides the cards", () => {
+    // The conceal hint is only ever offered on a face-up pair, so a tap on a
+    // face-down one retires a hint the player has not seen do anything.
+    expect(discoveredBy({ type: "TAPPED" }, faceDown)).toBeNull();
+  });
+
+  it("does not count a drag the recognizer ignored", () => {
+    expect(
+      discoveredBy({ type: "CLASSIFIED", as: "Ignored" }, faceDown),
+    ).toBeNull();
+  });
+
+  it("does not count an Action taken from a button", () => {
+    // Discovery is on-pair, never on a button: pressing Fold or Check in the
+    // `ActionBar` reaches this module only as a prop change, and the hint
+    // exists to move the player off the button in the first place.
+    const fromButtons: readonly CardEvent[] = [
+      { type: "PENDING_RESOLVED", hasCards: false },
+      { type: "PENDING_RESOLVED", hasCards: true },
+      { type: "CARDS_GONE" },
+      { type: "DEALT" },
+      { type: "SHOWDOWN_REVEAL" },
+      // Enter, Space or a mouse click on the pair: a semantic activation, not
+      // the tap gesture the conceal hint teaches.
+      { type: "ACTIVATED" },
+    ];
+    for (const event of fromButtons) {
+      expect(discoveredBy(event, idle("Revealed"))).toBeNull();
+    }
   });
 });

--- a/packages/player-client/src/holecards/coaching.ts
+++ b/packages/player-client/src/holecards/coaching.ts
@@ -1,12 +1,19 @@
-import type { CardState } from "./cardState.js";
+import type { CardEvent, CardState } from "./cardState.js";
+import { BEND_CORNER } from "./constants.js";
 import type { BendAxis } from "./geometry.js";
 
 /**
- * The gestures the surface teaches, and the keys the discovery set is written
- * with. Bend is Peek *and* Reveal — one gesture at two depths — which is why
- * there are four of these and not five.
+ * The gestures the surface teaches, **in teaching order** (§11). Bend is Peek
+ * *and* Reveal — one gesture at two depths — which is why there are four of
+ * these and not five.
+ *
+ * The order is the list: the selector offers the first gesture the player has
+ * not found yet, so "at most one hint" and "Bend before Conceal before Check
+ * before Fold" are the same fact rather than two rules that could disagree.
  */
-export type TeachableGesture = "bend" | "conceal" | "check" | "fold";
+export const TEACHABLE_GESTURES = ["bend", "conceal", "check", "fold"] as const;
+
+export type TeachableGesture = (typeof TEACHABLE_GESTURES)[number];
 
 /**
  * Line 1 is an imperative; line 2 is the consequence (Phase 3 spec #138 §11).
@@ -32,6 +39,12 @@ export interface HintContext {
   readonly foldLegal: boolean;
   readonly pending: boolean;
   readonly locked: boolean;
+  /**
+   * Whether the *primary* pointer is coarse — a finger rather than a mouse.
+   * Gates the teaching hints only: instruction about bending corners is noise
+   * to a player who cannot act on it.
+   */
+  readonly coarsePointer: boolean;
   /** ~2s since the last contact with the pair. */
   readonly quiet: boolean;
   /** A gesture Check landed moments ago and is still being confirmed (§5). */
@@ -50,19 +63,14 @@ export interface HintContext {
  * only the persisted discovery set cross the seam — is what holds the module's
  * public surface at two names.
  *
- * The in-gesture prompts are complete: the bend's two, and the fold drag's
- * armed and unarmed lines. The four *teaching* hints arrive with #147,
- * extending this same function rather than paralleling it — which is when the
- * discovery set starts being read.
- *
- * The `(pointer: coarse)` gate arrives with those teaching hints (#147), and
- * applies to them: it exists so a keyboard player is not told to bend corners.
- * An in-gesture prompt is feedback on a motion already underway, so it belongs
- * to whoever is making it — including the desktop player dragging with a mouse.
+ * The `(pointer: coarse)` gate applies to the teaching hints alone: it exists
+ * so a keyboard player is not told to bend corners. An in-gesture prompt is
+ * feedback on a motion already underway, so it belongs to whoever is making it
+ * — including the desktop player dragging with a mouse.
  */
 export function selectHint(
   state: CardState & { readonly bendAxis: BendAxis },
-  _discovered: ReadonlySet<TeachableGesture>,
+  discovered: ReadonlySet<TeachableGesture>,
   ctx: HintContext,
 ): Hint | null {
   // Outranks every gate below, including the pending one it necessarily trips:
@@ -91,8 +99,154 @@ export function selectHint(
     return state.armed ? foldArmedHint : foldDraggingHint;
   }
 
-  return null;
+  // Everything below is instruction rather than feedback, and every gate on it
+  // is the same gate: teach only where the advice can be taken.
+  if (!ctx.coarsePointer) return null;
+  // A finger is already on the glass — pressing, or dragging something the
+  // recognizer ignored. Instruction yields to whatever it is doing, even before
+  // the quiet interval has a chance to say so.
+  if (state.recognizer !== "Idle") return null;
+  if (!ctx.quiet) return null;
+  // The two presentations a player is *holding* the pair in. A peek is held
+  // open by a finger, a turn is a flip mid-flight, and a departing pair is on
+  // its way to the muck: none of them is a moment to start teaching in.
+  if (state.presentation !== "FaceDown" && state.presentation !== "Revealed") {
+    return null;
+  }
+
+  const teachable = nextTeachable(state, discovered, ctx);
+  return teachable === null ? null : TEACHING[teachable].hint;
 }
+
+/**
+ * The gesture the surface would teach next, ignoring the timing gates — the
+ * first one in the teaching order the player has not found and *could* act on.
+ *
+ * Separate from `selectHint` because the quiet interval is measured **from the
+ * moment eligibility becomes true** (§11): the caller has to know which gesture
+ * is up before deciding whether it has waited long enough to say so. Without
+ * that, only the first hint of a session would ever observe the interval, and
+ * Fold would appear the instant a turn made it legal.
+ */
+export function nextTeachable(
+  state: CardState,
+  discovered: ReadonlySet<TeachableGesture>,
+  ctx: Pick<HintContext, "checkLegal" | "foldLegal">,
+): TeachableGesture | null {
+  const teaching = TEACHABLE_GESTURES.find(
+    (gesture) =>
+      !discovered.has(gesture) && TEACHING[gesture].eligible(state, ctx),
+  );
+  return teaching ?? null;
+}
+
+/**
+ * Which gesture, if any, a card event proves the player has found (§11).
+ *
+ * Discovery is **on-pair, never on a button**: every event this answers comes
+ * from the recognizer, and pressing Fold or Check in the `ActionBar` reaches
+ * this module only as a prop change. That is the whole point — the hint exists
+ * to move the player off the button, so the button must not retire it.
+ *
+ * A pure function rather than a line in the pointer handlers, so what counts as
+ * having found a gesture is a tested rule rather than four scattered ones.
+ */
+export function discoveredBy(
+  event: CardEvent,
+  state: CardState,
+): TeachableGesture | null {
+  switch (event.type) {
+    case "CLASSIFIED":
+      // The classification, not the release: the player has made the motion,
+      // whether or not they carried it far enough to commit anything. An
+      // `Ignored` drag is not a gesture at all and teaches them nothing.
+      if (event.as === "Bending") return "bend";
+      if (event.as === "FoldDragging") return "fold";
+      return null;
+    case "TAPPED":
+      // Only where the tap actually hides something. A tap on a face-down pair
+      // does nothing by design (§5, which is what makes the first tap of a
+      // Check free), and retiring the hint for it would retire advice the
+      // player has never seen take effect.
+      return state.presentation === "Revealed" ? "conceal" : null;
+    case "DOUBLE_TAPPED":
+      return "check";
+    default:
+      // `ACTIVATED` included: Enter, Space or a mouse click is the semantic
+      // path (§12), not the tap gesture the conceal hint teaches.
+      return null;
+  }
+}
+
+/**
+ * The four teaching hints: what each one says, and when it is worth saying.
+ * Touch only, and each retires permanently the first time its gesture is used.
+ *
+ * Copy and eligibility live in the same entry so a gesture is defined once —
+ * `TEACHABLE_GESTURES` supplies the order, and this supplies everything else.
+ *
+ * Bend and Conceal are local presentation and eligible **off-turn**, which is
+ * most of the time a player is holding cards. Check and Fold are advice about
+ * an Action, and advice you cannot take is worse than silence. Check sits above
+ * Fold in the overlap, which is quieter than it looks: a legal Check means no
+ * bet to face, and teaching someone to fold for free is bad advice. Where a bet
+ * *is* faced, Check is illegal and Fold is the only eligible hint left — so the
+ * irreversible, money-losing Action is never the one pushed at a player two
+ * hands into their first session.
+ *
+ * The bend's corner is **derived from the rendered affordance** rather than
+ * written into the copy, so if the overlapped layout ever mirrors, the words
+ * follow it.
+ */
+const TEACHING: Record<
+  TeachableGesture,
+  {
+    readonly hint: Hint;
+    readonly eligible: (
+      state: CardState,
+      ctx: Pick<HintContext, "checkLegal" | "foldLegal">,
+    ) => boolean;
+  }
+> = {
+  bend: {
+    hint: {
+      id: "teach-bend",
+      line1: `Bend the ${BEND_CORNER.vertical}-${BEND_CORNER.horizontal} corner`,
+      // Both outcomes on one line, because they are one gesture at two depths.
+      line2: "release to peek · keep bending to reveal",
+      announce: false,
+    },
+    eligible: () => true,
+  },
+  conceal: {
+    hint: {
+      id: "teach-conceal",
+      line1: "Tap to hide your cards",
+      line2: "one tap is enough",
+      announce: false,
+    },
+    // Nothing to hide from a pair that is already face-down.
+    eligible: (state) => state.presentation === "Revealed",
+  },
+  check: {
+    hint: {
+      id: "teach-check",
+      line1: "Double-tap to Check",
+      line2: "passes your turn to the next player",
+      announce: false,
+    },
+    eligible: (_state, ctx) => ctx.checkLegal,
+  },
+  fold: {
+    hint: {
+      id: "teach-fold",
+      line1: "Swipe your cards up to Fold",
+      line2: "release once they lift away",
+      announce: false,
+    },
+    eligible: (_state, ctx) => ctx.foldLegal,
+  },
+};
 
 /**
  * The visible confirmation a gesture Check lands with (story 31). It says the

--- a/packages/player-client/src/holecards/constants.ts
+++ b/packages/player-client/src/holecards/constants.ts
@@ -40,6 +40,14 @@ export const FOLD_FLIGHT_MS = 280;
 export const HINT_QUIET_MS = 2000;
 
 /**
+ * Which corner of a card the bend affordance is drawn in — and therefore the
+ * corner the coaching copy names (§11). Stated once, here, because "bend the
+ * bottom-right corner" must **track the rendered zone** rather than be
+ * hard-coded: if the overlapped layout ever mirrors, the words follow it.
+ */
+export const BEND_CORNER = { vertical: "bottom", horizontal: "right" } as const;
+
+/**
  * How long after a classified gesture a synthetic `click` is disowned, in ms.
  * Not a §15 constant — §16 requires the suppression but sets no window.
  *

--- a/packages/player-client/src/holecards/hintStorage.test.ts
+++ b/packages/player-client/src/holecards/hintStorage.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import type { TeachableGesture } from "./coaching.js";
+import { loadDiscovered, saveDiscovered } from "./hintStorage.js";
+
+function fakeStorage(seed: Record<string, string> = {}): Storage {
+  const data = new Map(Object.entries(seed));
+  return {
+    getItem: (key) => data.get(key) ?? null,
+    setItem: (key, value) => {
+      data.set(key, value);
+    },
+    removeItem: (key) => {
+      data.delete(key);
+    },
+    clear: () => {
+      data.clear();
+    },
+    key: () => null,
+    length: 0,
+  };
+}
+
+describe("saveDiscovered", () => {
+  it("stores the discovery set as JSON under a namespaced key", () => {
+    const storage = fakeStorage();
+    const setItem = vi.spyOn(storage, "setItem");
+
+    saveDiscovered(storage, new Set<TeachableGesture>(["bend", "check"]));
+
+    expect(setItem).toHaveBeenCalledWith(
+      "ttp:discovered-gestures",
+      JSON.stringify(["bend", "check"]),
+    );
+  });
+
+  it("survives a storage that refuses to write", () => {
+    // Safari in private browsing throws from `setItem`. Losing the record of a
+    // discovered gesture costs the player a hint they have already outgrown;
+    // losing the Fold it was written during would cost them the hand.
+    const storage = fakeStorage();
+    vi.spyOn(storage, "setItem").mockImplementation(() => {
+      throw new DOMException("QuotaExceededError");
+    });
+
+    expect(() => {
+      saveDiscovered(storage, new Set<TeachableGesture>(["fold"]));
+    }).not.toThrow();
+  });
+});
+
+describe("loadDiscovered", () => {
+  it("round-trips a saved discovery set", () => {
+    const storage = fakeStorage();
+    const discovered = new Set<TeachableGesture>(["bend", "conceal", "fold"]);
+
+    saveDiscovered(storage, discovered);
+
+    expect(loadDiscovered(storage)).toEqual(discovered);
+  });
+
+  it("reads absent storage as nothing discovered", () => {
+    expect(loadDiscovered(fakeStorage())).toEqual(new Set());
+  });
+
+  it("reads malformed storage as nothing discovered", () => {
+    // A cleared or corrupted localStorage re-teaches the gestures rather than
+    // guessing: an extra hint is a small cost, and there is nothing else the
+    // set could honestly be.
+    for (const raw of ["", "not json", "{}", '"bend"', "null", "42"]) {
+      expect(
+        loadDiscovered(fakeStorage({ "ttp:discovered-gestures": raw })),
+      ).toEqual(new Set());
+    }
+  });
+
+  it("keeps the gestures it recognises and drops everything else", () => {
+    // A key written by a later version of the surface, or by hand: the set is
+    // an allow-list, so an unknown name never reaches the selector.
+    const storage = fakeStorage({
+      "ttp:discovered-gestures": JSON.stringify(["bend", "shuffle", 7, null]),
+    });
+
+    expect(loadDiscovered(storage)).toEqual(new Set(["bend"]));
+  });
+});

--- a/packages/player-client/src/holecards/hintStorage.ts
+++ b/packages/player-client/src/holecards/hintStorage.ts
@@ -1,0 +1,55 @@
+import { TEACHABLE_GESTURES, type TeachableGesture } from "./coaching.js";
+
+const KEY = "ttp:discovered-gestures";
+
+/**
+ * The one thing the coaching hints persist: which gestures this device has
+ * already found (Phase 3 spec #138 §11). Per-device, permanent, never
+ * re-taught — a returning player is not re-shown a hint weeks later.
+ *
+ * Takes an injected `Storage` exactly as `storage/seatToken.ts` does, so tests
+ * pass a double rather than reaching for a global. This is also the only thing
+ * in the coaching path that crosses a seam at all: the selector itself stays
+ * module-internal, because every in-gesture hint depends on recognizer state
+ * nothing outside the module may see.
+ */
+export function saveDiscovered(
+  storage: Storage,
+  discovered: ReadonlySet<TeachableGesture>,
+): void {
+  // Ordered by the teaching order rather than by insertion, so the stored value
+  // is the same for a device that folded before it checked.
+  const ordered = TEACHABLE_GESTURES.filter((gesture) =>
+    discovered.has(gesture),
+  );
+  try {
+    storage.setItem(KEY, JSON.stringify(ordered));
+  } catch {
+    // Safari in private browsing throws rather than storing. The write happens
+    // in the same handler as a Fold or a Check, and an Action must not be lost
+    // over a hint that will simply be offered again next time.
+  }
+}
+
+/**
+ * Reads the discovery set back on mount. Absent and malformed storage both read
+ * as "nothing discovered": there is nothing else the set could honestly be, and
+ * an extra hint is the cheapest possible way to be wrong.
+ */
+export function loadDiscovered(
+  storage: Storage,
+): ReadonlySet<TeachableGesture> {
+  const raw = storage.getItem(KEY);
+  if (raw === null) return new Set();
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    // An allow-list, so a name written by a later version of this surface — or
+    // by hand — never reaches the selector as a gesture it cannot teach.
+    return new Set(
+      TEACHABLE_GESTURES.filter((gesture) => parsed.includes(gesture)),
+    );
+  } catch {
+    return new Set();
+  }
+}

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -9,12 +9,24 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
 } from "react";
-import { initialCardState, reduce, type CardState } from "./cardState.js";
+import {
+  initialCardState,
+  reduce,
+  type CardEvent,
+  type CardState,
+} from "./cardState.js";
+import {
+  discoveredBy,
+  nextTeachable,
+  type HintContext,
+  type TeachableGesture,
+} from "./coaching.js";
 import {
   CHECK_CONFIRM_MS,
   CLICK_DISOWN_MS,
   FOLD_FLIGHT_MS,
   HAPTIC_PULSE_MS,
+  HINT_QUIET_MS,
   REVEAL_FINISH_MS,
 } from "./constants.js";
 import {
@@ -29,6 +41,7 @@ import {
   type GestureSession,
 } from "./gesture.js";
 import { pulse } from "./haptics.js";
+import { loadDiscovered, saveDiscovered } from "./hintStorage.js";
 import type { HoleCardPairProps } from "./HoleCardPair.js";
 import { confirmsCheck, tapLanded, type TapWindow } from "./taps.js";
 import { eventsForPropChange, eventsForVisibility } from "./viewEvents.js";
@@ -81,8 +94,41 @@ export interface HoleCards {
    * (story 20). The pair renders from here once the props no longer carry it.
    */
   readonly departing: readonly [Card, Card] | null;
-  /** A gesture Check landed and is still being confirmed (story 31). */
-  readonly checkConfirmed: boolean;
+  /**
+   * Everything the hint selector needs from outside the card lifecycle,
+   * assembled here rather than in the component: the Action port, the pointer
+   * kind, the quiet interval and the Check confirmation are all things this
+   * hook already holds or watches, and passing them out one at a time only to
+   * be re-bundled would put the same seven fields in two places.
+   */
+  readonly hintContext: HintContext;
+  /** The gestures this device has already found, for the teaching hints. */
+  readonly discovered: ReadonlySet<TeachableGesture>;
+}
+
+/**
+ * `window.localStorage`, or `null` where there is none to reach: server
+ * rendering, and the browsers that throw on the property itself when storage is
+ * disabled. A player without it is simply taught the gestures again next time.
+ */
+function localStorageOrNull(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The touch gate (§11): the **primary** pointer, subscribed rather than read
+ * once, so a tablet that gains or loses a trackpad follows the pointer the
+ * player is actually using. `any-pointer: coarse` is deliberately not asked —
+ * it is true for any touchscreen laptop, exactly the case the gate excludes.
+ */
+function coarsePointerQuery(): MediaQueryList | null {
+  if (typeof window === "undefined") return null;
+  return window.matchMedia("(pointer: coarse)");
 }
 
 /**
@@ -151,6 +197,32 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
    * one landing silently inside the first one's window.
    */
   const [checkConfirmedAt, setCheckConfirmedAt] = useState<number | null>(null);
+  /**
+   * The teaching hints' two live inputs and their memory (§11).
+   *
+   * `contact` is a finger on the pair; `quiet` is the ~2s of stillness a hint
+   * waits for. They are separate because a hint hides the *instant* a pointer
+   * lands and only returns after the interval — an aborted half-touch does not
+   * buy silence for the rest of the hand.
+   */
+  const [discovered, setDiscovered] = useState<ReadonlySet<TeachableGesture>>(
+    () => {
+      const storage = localStorageOrNull();
+      return storage === null ? new Set() : loadDiscovered(storage);
+    },
+  );
+  /**
+   * Every pointer currently down on the pair, not just the one the recognizer
+   * is answering. A stray second thumb is ignored as a *gesture* (§4), but it
+   * is still a finger on the cards, and lifting it must not restart the quiet
+   * interval underneath the finger that is still there.
+   */
+  const pointersDown = useRef<Set<number>>(new Set());
+  const [contact, setContact] = useState(false);
+  const [quiet, setQuiet] = useState(false);
+  const [coarsePointer, setCoarsePointer] = useState(
+    () => coarsePointerQuery()?.matches ?? false,
+  );
 
   const previous = useRef(props);
   // Deliberately un-keyed: the adapter compares the props itself and returns
@@ -313,6 +385,63 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     };
   }, [checkConfirmedAt]);
 
+  // Which gesture is up for teaching, if any. Only its *identity* is used here
+  // — to know when the interval below should start over — so a legality prop
+  // flapping without changing the answer costs nothing.
+  const teachable = nextTeachable(state, discovered, props.actions);
+
+  /**
+   * The quiet interval: ~2s of no contact with the pair **after the hint became
+   * eligible** (§11).
+   *
+   * Keyed on the eligible gesture as well as on contact, which is what makes it
+   * an interval rather than a one-time delay: a hint the player half-reached for
+   * comes back after another quiet moment, and Fold does not appear the instant
+   * a turn makes it legal.
+   */
+  useEffect(() => {
+    setQuiet(false);
+    if (contact) return;
+    const timer = setTimeout(() => {
+      setQuiet(true);
+    }, HINT_QUIET_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [contact, teachable]);
+
+  // Subscribed, not read once (§11): a tablet that gains or loses a trackpad
+  // follows the pointer the player is holding it with now.
+  useEffect(() => {
+    const query = coarsePointerQuery();
+    if (query === null) return;
+    const onChange = (event: MediaQueryListEvent) => {
+      setCoarsePointer(event.matches);
+    };
+    setCoarsePointer(query.matches);
+    query.addEventListener("change", onChange);
+    return () => {
+      query.removeEventListener("change", onChange);
+    };
+  }, []);
+
+  /**
+   * A card event on its way to the reducer, checked for what it teaches on the
+   * way past. Discovery is decided by `discoveredBy` — a pure rule — and every
+   * event that reaches here came from a finger on the pair, which is what makes
+   * "never on a button" true by construction rather than by discipline.
+   */
+  const dispatchFromPointer = (event: CardEvent): void => {
+    const found = discoveredBy(event, state);
+    if (found !== null && !discovered.has(found)) {
+      const next = new Set(discovered).add(found);
+      const storage = localStorageOrNull();
+      if (storage !== null) saveDiscovered(storage, next);
+      setDiscovered(next);
+    }
+    dispatch(event);
+  };
+
   const activate = useCallback(() => {
     if (Date.now() < disownClicksUntil.current) return;
     dispatch({ type: "ACTIVATED" });
@@ -390,7 +519,7 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     let tapped = false;
     for (const cardEvent of events) {
       if (cardEvent.type !== "TAPPED") {
-        dispatch(cardEvent);
+        dispatchFromPointer(cardEvent);
         continue;
       }
       // A tap is only *provisionally* a tap: whether it is one, or the second
@@ -400,7 +529,7 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
       const tap = tapLanded(tapWindow.current, performance.now());
       tapWindow.current = tap.window;
       tapped = true;
-      dispatch(tap.event);
+      dispatchFromPointer(tap.event);
       // Dispatched first, so the Action is sent against a pair that has
       // already taken the conceal — the player sees the cards go down, then the
       // confirmation, in that order and with no timer between them.
@@ -423,8 +552,28 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     if (commits) props.actions.fold();
   };
 
+  /**
+   * Contact with the pair, tracked for the hint timer alone — separately from
+   * `finish`, which answers only the pointer that owns the gesture. A hint must
+   * not reappear under a second finger the recognizer is ignoring, so the pair
+   * is being touched until *every* pointer has left it.
+   */
+  const contacted = (event: ReactPointerEvent<HTMLElement>): void => {
+    pointersDown.current.add(event.pointerId);
+    setContact(true);
+    setQuiet(false);
+  };
+
+  const released = (event: ReactPointerEvent<HTMLElement>): void => {
+    pointersDown.current.delete(event.pointerId);
+    if (pointersDown.current.size === 0) setContact(false);
+  };
+
   const handlers: PairHandlers = {
     onPointerDown: (event) => {
+      // Before every guard below: instruction yields to a finger on the glass
+      // whether or not the recognizer takes any interest in this one.
+      contacted(event);
       // A second finger landing mid-gesture is ignored until the first one
       // releases or cancels: a stray thumb must not silently retarget a drag.
       if (session.current !== null || event.button !== 0) return;
@@ -478,17 +627,20 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
         // arming signal proper is the card motion and the in-gesture text, both
         // of which the iPhone/Safari path has and this pulse it does not (§16).
         if (cardEvent.type === "FOLD_ARMED") pulse(HAPTIC_PULSE_MS);
-        dispatch(cardEvent);
+        dispatchFromPointer(cardEvent);
       }
     },
 
     onPointerUp: (event) => {
+      released(event);
       finish(event, false);
     },
     onPointerCancel: (event) => {
+      released(event);
       finish(event, true);
     },
     onLostPointerCapture: (event) => {
+      released(event);
       finish(event, true);
     },
   };
@@ -503,6 +655,17 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     foldFade,
     leavingFaceUp,
     departing,
-    checkConfirmed: checkConfirmedAt !== null,
+    hintContext: {
+      checkLegal: props.actions.checkLegal,
+      foldLegal: props.actions.foldLegal,
+      pending: props.actions.pending,
+      // The lifecycle's lock rather than the prop, so the hints fall silent at
+      // exactly the moment the cards stop listening.
+      locked: state.locked,
+      coarsePointer,
+      quiet,
+      checkConfirmed: checkConfirmedAt !== null,
+    },
+    discovered,
   };
 }


### PR DESCRIPTION
Closes #147.

On a touch device the phone teaches itself: a small hint near the cards names the one gesture the Player has not found yet — **Bend → Conceal → Check → Fold** — and each retires permanently once that gesture is used. A Player on a laptop or keyboard sees none of it.

## What's here

- **`coaching.ts`** — the four teaching hints extend the module-internal `selectHint` rather than paralleling it, so "at most one hint" and "in-gesture outranks every teaching hint" stay one rule. One ordered table carries each gesture's copy *and* its eligibility, so a gesture is defined once. Two new pure functions: `nextTeachable` (which gesture is up) and `discoveredBy` (what an event proves the Player found).
- **`hintStorage.ts`** — the discovery set through an injected `Storage`, mirroring `storage/seatToken.ts`. Absent, malformed and unknown-name storage all read as "nothing discovered"; a `setItem` that throws (Safari private browsing) never takes an Action down with it.
- **`useHoleCards.ts`** — `matchMedia("(pointer: coarse)")` subscribed to `change`, the quiet interval, and discovery recorded on the pointer path only.
- **`BendableCard.tsx` / `constants.ts`** — `BEND_CORNER` positions the rendered bend zone *and* words the bend hint, so "bottom-right" tracks the layout if it ever mirrors.

## Decisions worth a second look

- **The quiet interval is measured from the moment a hint becomes eligible**, not just from the last contact — otherwise only the first hint of a session would wait, and Fold would appear the instant a turn made it legal. That is why `nextTeachable` is its own name: the hook needs to know which gesture is up before it can time it.
- **Discovery is on-pair, never on a button, by construction.** Every event `discoveredBy` answers comes from the recognizer, so pressing Fold or Check in the `ActionBar` cannot retire the hint the gesture exists to move the Player off.
- **A classified fold drag retires the Fold hint even if aborted** — §11 says "swipe on the pair clear a hint", and the motion was made.
- **The `coarsePointer` gate sits below the in-gesture branches**, so a mouse bend still gets its prompt: §11 makes in-gesture hints permanent for every Player, and the gate exists so a keyboard Player is not told to bend corners.

## Base branch

Based on `feat/145-swipe-up-to-fold` rather than `main`: this extends the `selectHint` that #145 landed, and #145 is not merged yet.

## Verification

`npm run build`, `npm run lint`, and the full `packages/player-client` suite (306 tests) pass locally. Per CLAUDE.md the full monorepo suite is left to CI.

Per #147, `matchMedia` subscription behaviour is **not** covered automatically — it belongs to the real-device acceptance run, along with hint appearance and retirement across a fresh device profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvBckA6KRnDgqRN6oqMT5r