### PR TITLE
feat(player-client): disarm the fold drag when the turn is lost

### DIFF
--- a/packages/player-client/src/holecards/gesture.test.ts
+++ b/packages/player-client/src/holecards/gesture.test.ts
@@ -9,8 +9,8 @@ import {
 import { BEND_TRAVEL_PX, MOVE_SLOP_PX, REVEAL_THRESHOLD } from "./constants.js";
 import { foldThreshold } from "./geometry.js";
 import {
+  applyViewEvent,
   beginGesture,
-  disarmGesture,
   endGesture,
   moveGesture,
   type GestureSession,
@@ -283,7 +283,8 @@ describe("the fold drag", () => {
       to(0, -(FOLD_THRESHOLD_PX + 40)),
       onTurn,
     ).session;
-    const disarmed = disarmGesture(armed);
+    const disarmed = applyViewEvent(armed, { type: "FOLD_DISARMED" });
+    if (disarmed === null) throw new Error("expected a live fold drag");
 
     const moved = moveGesture(disarmed, to(0, -(FOLD_THRESHOLD_PX + 80)), {
       ...onTurn,
@@ -292,6 +293,24 @@ describe("the fold drag", () => {
 
     expect(moved.events).toEqual([]);
     expect(moved.session.armed).toBe(false);
+  });
+
+  it("updates or ends the pointer session when the view changes it", () => {
+    const armed = dragging(FOLD_THRESHOLD_PX).session;
+
+    expect(applyViewEvent(armed, { type: "FOLD_DISARMED" })).toEqual({
+      ...armed,
+      armed: false,
+    });
+
+    for (const event of [
+      { type: "CARDS_GONE" },
+      { type: "DEALT" },
+      { type: "RESET" },
+      { type: "SHOWDOWN_REVEAL" },
+    ] as const) {
+      expect(applyViewEvent(armed, event)).toBeNull();
+    }
   });
 
   it("arms in the same move as the classification when the flick is fast enough", () => {

--- a/packages/player-client/src/holecards/gesture.test.ts
+++ b/packages/player-client/src/holecards/gesture.test.ts
@@ -10,6 +10,7 @@ import { BEND_TRAVEL_PX, MOVE_SLOP_PX, REVEAL_THRESHOLD } from "./constants.js";
 import { foldThreshold } from "./geometry.js";
 import {
   beginGesture,
+  disarmGesture,
   endGesture,
   moveGesture,
   type GestureSession,
@@ -274,6 +275,23 @@ describe("the fold drag", () => {
     expect(pulledBack.events).toEqual([{ type: "FOLD_DISARMED" }]);
     expect(pulledBack.session.armed).toBe(false);
     expect(pulledBack.fold).toEqual({ offset: -20 });
+  });
+
+  it("does not re-arm while Fold is illegal after a view disarms the drag", () => {
+    const armed = moveGesture(
+      dragging(FOLD_THRESHOLD_PX).session,
+      to(0, -(FOLD_THRESHOLD_PX + 40)),
+      onTurn,
+    ).session;
+    const disarmed = disarmGesture(armed);
+
+    const moved = moveGesture(disarmed, to(0, -(FOLD_THRESHOLD_PX + 80)), {
+      ...onTurn,
+      foldLegal: false,
+    });
+
+    expect(moved.events).toEqual([]);
+    expect(moved.session.armed).toBe(false);
   });
 
   it("arms in the same move as the classification when the flick is fast enough", () => {

--- a/packages/player-client/src/holecards/gesture.test.ts
+++ b/packages/player-client/src/holecards/gesture.test.ts
@@ -9,7 +9,7 @@ import {
 import { BEND_TRAVEL_PX, MOVE_SLOP_PX, REVEAL_THRESHOLD } from "./constants.js";
 import { foldThreshold } from "./geometry.js";
 import {
-  applyViewEvent,
+  applyCardEvent,
   beginGesture,
   endGesture,
   moveGesture,
@@ -277,58 +277,46 @@ describe("the fold drag", () => {
     expect(pulledBack.fold).toEqual({ offset: -20 });
   });
 
-  it("does not re-arm while Fold is illegal after a view disarms the drag", () => {
+  it("disarms the session on FOLD_DISARMED so the release commits nothing", () => {
     const armed = moveGesture(
       dragging(FOLD_THRESHOLD_PX).session,
       to(0, -(FOLD_THRESHOLD_PX + 40)),
       onTurn,
     ).session;
-    const disarmed = applyViewEvent(armed, { type: "FOLD_DISARMED" });
+    expect(endGesture(armed, { cancelled: false }).commitsFold).toBe(true);
+
+    const disarmed = applyCardEvent(armed, { type: "FOLD_DISARMED" });
     if (disarmed === null) throw new Error("expected a live fold drag");
 
-    const moved = moveGesture(disarmed, to(0, -(FOLD_THRESHOLD_PX + 80)), {
-      ...onTurn,
-      foldLegal: false,
-    });
-
-    expect(moved.events).toEqual([]);
-    expect(moved.session.armed).toBe(false);
+    expect(disarmed).toEqual({ ...armed, armed: false });
+    expect(endGesture(disarmed, { cancelled: false }).commitsFold).toBe(false);
   });
 
-  it("stays disarmed until the pointer crosses the threshold again", () => {
+  it("keeps the cards tracking the finger after a view disarms the drag", () => {
+    // §6: the surface never freezes under the player's hand. The drag is not
+    // ended, only disarmed, so the pair carries on following the finger.
     const armed = moveGesture(
       dragging(FOLD_THRESHOLD_PX).session,
       to(0, -(FOLD_THRESHOLD_PX + 40)),
       onTurn,
     ).session;
-    const disarmed = applyViewEvent(armed, { type: "FOLD_DISARMED" });
+    const disarmed = applyCardEvent(armed, { type: "FOLD_DISARMED" });
     if (disarmed === null) throw new Error("expected a live fold drag");
 
-    const legalAgain = moveGesture(
+    const moved = moveGesture(
       disarmed,
       to(0, -(FOLD_THRESHOLD_PX + 80)),
       onTurn,
     );
-    expect(legalAgain.events).toEqual([]);
-    expect(legalAgain.session.armed).toBe(false);
-
-    const belowThreshold = moveGesture(legalAgain.session, to(0, -20), onTurn);
-    const recrossed = moveGesture(
-      belowThreshold.session,
-      to(0, -FOLD_THRESHOLD_PX),
-      onTurn,
-    );
-    expect(recrossed.events).toEqual([{ type: "FOLD_ARMED" }]);
+    expect(moved.fold).toEqual({ offset: -(FOLD_THRESHOLD_PX + 80) });
+    expect(moved.session.classification).toBe("FoldDragging");
   });
 
-  it("updates or ends the pointer session when the view changes it", () => {
+  it("leaves the session alone for every other lifecycle event", () => {
+    // The pointer is ended by the pointer, and by nothing else: `finish` bails
+    // on a release it has no session for, so a session cleared out from under a
+    // held finger would leave the synthesised click to reveal the next pair.
     const armed = dragging(FOLD_THRESHOLD_PX).session;
-
-    expect(applyViewEvent(armed, { type: "FOLD_DISARMED" })).toEqual({
-      ...armed,
-      armed: false,
-      armingBlocked: true,
-    });
 
     for (const event of [
       { type: "CARDS_GONE" },
@@ -336,8 +324,9 @@ describe("the fold drag", () => {
       { type: "RESET" },
       { type: "SHOWDOWN_REVEAL" },
     ] as const) {
-      expect(applyViewEvent(armed, event)).toBeNull();
+      expect(applyCardEvent(armed, event)).toBe(armed);
     }
+    expect(applyCardEvent(null, { type: "FOLD_DISARMED" })).toBeNull();
   });
 
   it("arms in the same move as the classification when the flick is fast enough", () => {

--- a/packages/player-client/src/holecards/gesture.test.ts
+++ b/packages/player-client/src/holecards/gesture.test.ts
@@ -295,12 +295,39 @@ describe("the fold drag", () => {
     expect(moved.session.armed).toBe(false);
   });
 
+  it("stays disarmed until the pointer crosses the threshold again", () => {
+    const armed = moveGesture(
+      dragging(FOLD_THRESHOLD_PX).session,
+      to(0, -(FOLD_THRESHOLD_PX + 40)),
+      onTurn,
+    ).session;
+    const disarmed = applyViewEvent(armed, { type: "FOLD_DISARMED" });
+    if (disarmed === null) throw new Error("expected a live fold drag");
+
+    const legalAgain = moveGesture(
+      disarmed,
+      to(0, -(FOLD_THRESHOLD_PX + 80)),
+      onTurn,
+    );
+    expect(legalAgain.events).toEqual([]);
+    expect(legalAgain.session.armed).toBe(false);
+
+    const belowThreshold = moveGesture(legalAgain.session, to(0, -20), onTurn);
+    const recrossed = moveGesture(
+      belowThreshold.session,
+      to(0, -FOLD_THRESHOLD_PX),
+      onTurn,
+    );
+    expect(recrossed.events).toEqual([{ type: "FOLD_ARMED" }]);
+  });
+
   it("updates or ends the pointer session when the view changes it", () => {
     const armed = dragging(FOLD_THRESHOLD_PX).session;
 
     expect(applyViewEvent(armed, { type: "FOLD_DISARMED" })).toEqual({
       ...armed,
       armed: false,
+      armingBlocked: true,
     });
 
     for (const event of [

--- a/packages/player-client/src/holecards/gesture.ts
+++ b/packages/player-client/src/holecards/gesture.ts
@@ -37,12 +37,6 @@ export interface GestureSession {
    * again, and the player can always change their mind by putting them down.
    */
   readonly armed: boolean;
-  /**
-   * A view-driven disarm blocks re-arming until the pointer comes back below
-   * the threshold, so legality returning under a held finger cannot commit the
-   * old offer without a fresh crossing.
-   */
-  readonly armingBlocked: boolean;
 }
 
 /** Continuous peel values, destined for `MotionValue`s rather than state. */
@@ -88,39 +82,30 @@ export function beginGesture(press: {
     classification: null,
     crossed: false,
     armed: false,
-    armingBlocked: false,
   };
 }
 
 /**
- * Fold legality can disappear while the pointer is still moving. The view
- * event disarms the lifecycle reducer and this keeps the synchronous session
- * used by `endGesture` in agreement without ending the drag.
+ * Apply a lifecycle event to the live pointer session.
+ *
+ * Only `FOLD_DISARMED` has anything to say to a session: fold legality can
+ * disappear while the pointer is still moving, and the session is what
+ * `endGesture` answers `commitsFold` from, so it has to hear the same disarm
+ * the reducer does or the two would disagree on the next release. **The drag
+ * itself is untouched** — the cards keep tracking the finger (§6), and the
+ * session ends where every session ends, on the pointer that lifts it.
+ *
+ * Every other event is the reducer's business alone. Ending the session here
+ * would strand the release: `finish` bails on a pointer it has no session for,
+ * so nothing would disown the click the browser synthesises afterwards, and it
+ * would reveal the pair the event had just dealt or reset.
  */
-function disarmGesture(session: GestureSession): GestureSession {
-  return { ...session, armed: false, armingBlocked: true };
-}
-
-/**
- * Apply a view lifecycle event to the live pointer session. Server events that
- * end or lock the pair invalidate the pointer as well; otherwise a removed
- * button could leave a captured pointer blocking the next hand.
- */
-export function applyViewEvent(
+export function applyCardEvent(
   session: GestureSession | null,
   event: CardEvent,
 ): GestureSession | null {
-  switch (event.type) {
-    case "CARDS_GONE":
-    case "DEALT":
-    case "RESET":
-    case "SHOWDOWN_REVEAL":
-      return null;
-    case "FOLD_DISARMED":
-      return session === null ? null : disarmGesture(session);
-    default:
-      return session;
-  }
+  if (session === null || event.type !== "FOLD_DISARMED") return session;
+  return { ...session, armed: false };
 }
 
 /**
@@ -148,9 +133,10 @@ export function moveGesture(
       alreadyRevealed: session.startedRevealed,
       dx,
       dy,
-      // Fold legality admits the classification. Once a drag exists, the
-      // prop-change adapter disarms it when the view withdraws legality; the
-      // live fold step also gates threshold arming on the latest value.
+      // Fold legality is sampled once, here, and never re-read. A drag that
+      // outlives the player's turn disarms (§6) — through `FOLD_DISARMED` off
+      // the prop change, and `applyCardEvent` on this session; it does not
+      // reclassify.
       foldLegal: ctx.foldLegal,
     });
     return step(
@@ -219,19 +205,11 @@ function foldStep(
   // back below where it started must not shove them down the screen.
   const offset = Math.min(0, dy);
   const fold: FoldMotion = { offset };
-  const aboveThreshold = -offset >= ctx.foldThresholdPx;
-  const armingBlocked =
-    aboveThreshold && (session.armingBlocked || !ctx.foldLegal);
-  const armed = ctx.foldLegal && aboveThreshold && !armingBlocked;
-  if (armed === session.armed && armingBlocked === session.armingBlocked) {
-    return { session, events, bend: null, fold };
-  }
+  const armed = -offset >= ctx.foldThresholdPx;
+  if (armed === session.armed) return { session, events, bend: null, fold };
   return {
-    session: { ...session, armed, armingBlocked },
-    events:
-      armed === session.armed
-        ? events
-        : [...events, { type: armed ? "FOLD_ARMED" : "FOLD_DISARMED" }],
+    session: { ...session, armed },
+    events: [...events, { type: armed ? "FOLD_ARMED" : "FOLD_DISARMED" }],
     bend: null,
     fold,
   };

--- a/packages/player-client/src/holecards/gesture.ts
+++ b/packages/player-client/src/holecards/gesture.ts
@@ -86,6 +86,15 @@ export function beginGesture(press: {
 }
 
 /**
+ * Fold legality can disappear while the pointer is still moving. The view
+ * event disarms the lifecycle reducer and this keeps the synchronous session
+ * used by `endGesture` in agreement without ending the drag.
+ */
+export function disarmGesture(session: GestureSession): GestureSession {
+  return session.armed ? { ...session, armed: false } : session;
+}
+
+/**
  * Advance a gesture to a new pointer position.
  *
  * Nothing is classified below the slop, so a tap with a wobble still reads as
@@ -110,8 +119,9 @@ export function moveGesture(
       alreadyRevealed: session.startedRevealed,
       dx,
       dy,
-      // Fold legality is sampled once, here, and never re-read. A drag that
-      // outlives the player's turn disarms (§6); it does not reclassify.
+      // Fold legality admits the classification. Once a drag exists, the
+      // prop-change adapter disarms it when the view withdraws legality; the
+      // live fold step also gates threshold arming on the latest value.
       foldLegal: ctx.foldLegal,
     });
     return step(
@@ -180,7 +190,7 @@ function foldStep(
   // back below where it started must not shove them down the screen.
   const offset = Math.min(0, dy);
   const fold: FoldMotion = { offset };
-  const armed = -offset >= ctx.foldThresholdPx;
+  const armed = ctx.foldLegal && -offset >= ctx.foldThresholdPx;
   if (armed === session.armed) return { session, events, bend: null, fold };
   return {
     session: { ...session, armed },

--- a/packages/player-client/src/holecards/gesture.ts
+++ b/packages/player-client/src/holecards/gesture.ts
@@ -90,8 +90,30 @@ export function beginGesture(press: {
  * event disarms the lifecycle reducer and this keeps the synchronous session
  * used by `endGesture` in agreement without ending the drag.
  */
-export function disarmGesture(session: GestureSession): GestureSession {
+function disarmGesture(session: GestureSession): GestureSession {
   return session.armed ? { ...session, armed: false } : session;
+}
+
+/**
+ * Apply a view lifecycle event to the live pointer session. Server events that
+ * end or lock the pair invalidate the pointer as well; otherwise a removed
+ * button could leave a captured pointer blocking the next hand.
+ */
+export function applyViewEvent(
+  session: GestureSession | null,
+  event: CardEvent,
+): GestureSession | null {
+  switch (event.type) {
+    case "CARDS_GONE":
+    case "DEALT":
+    case "RESET":
+    case "SHOWDOWN_REVEAL":
+      return null;
+    case "FOLD_DISARMED":
+      return session === null ? null : disarmGesture(session);
+    default:
+      return session;
+  }
 }
 
 /**

--- a/packages/player-client/src/holecards/gesture.ts
+++ b/packages/player-client/src/holecards/gesture.ts
@@ -37,6 +37,12 @@ export interface GestureSession {
    * again, and the player can always change their mind by putting them down.
    */
   readonly armed: boolean;
+  /**
+   * A view-driven disarm blocks re-arming until the pointer comes back below
+   * the threshold, so legality returning under a held finger cannot commit the
+   * old offer without a fresh crossing.
+   */
+  readonly armingBlocked: boolean;
 }
 
 /** Continuous peel values, destined for `MotionValue`s rather than state. */
@@ -82,6 +88,7 @@ export function beginGesture(press: {
     classification: null,
     crossed: false,
     armed: false,
+    armingBlocked: false,
   };
 }
 
@@ -91,7 +98,7 @@ export function beginGesture(press: {
  * used by `endGesture` in agreement without ending the drag.
  */
 function disarmGesture(session: GestureSession): GestureSession {
-  return session.armed ? { ...session, armed: false } : session;
+  return { ...session, armed: false, armingBlocked: true };
 }
 
 /**
@@ -212,11 +219,19 @@ function foldStep(
   // back below where it started must not shove them down the screen.
   const offset = Math.min(0, dy);
   const fold: FoldMotion = { offset };
-  const armed = ctx.foldLegal && -offset >= ctx.foldThresholdPx;
-  if (armed === session.armed) return { session, events, bend: null, fold };
+  const aboveThreshold = -offset >= ctx.foldThresholdPx;
+  const armingBlocked =
+    aboveThreshold && (session.armingBlocked || !ctx.foldLegal);
+  const armed = ctx.foldLegal && aboveThreshold && !armingBlocked;
+  if (armed === session.armed && armingBlocked === session.armingBlocked) {
+    return { session, events, bend: null, fold };
+  }
   return {
-    session: { ...session, armed },
-    events: [...events, { type: armed ? "FOLD_ARMED" : "FOLD_DISARMED" }],
+    session: { ...session, armed, armingBlocked },
+    events:
+      armed === session.armed
+        ? events
+        : [...events, { type: armed ? "FOLD_ARMED" : "FOLD_DISARMED" }],
     bend: null,
     fold,
   };

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -23,8 +23,8 @@ import {
   type BendAxis,
 } from "./geometry.js";
 import {
+  applyViewEvent,
   beginGesture,
-  disarmGesture,
   endGesture,
   moveGesture,
   type GestureSession,
@@ -166,9 +166,7 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     const events = eventsForPropChange(previous.current, props, state);
     previous.current = props;
     for (const event of events) {
-      if (event.type === "FOLD_DISARMED" && session.current !== null) {
-        session.current = disarmGesture(session.current);
-      }
+      session.current = applyViewEvent(session.current, event);
       dispatch(event);
     }
   });

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -24,6 +24,7 @@ import {
 } from "./geometry.js";
 import {
   beginGesture,
+  disarmGesture,
   endGesture,
   moveGesture,
   type GestureSession,
@@ -164,7 +165,12 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
   useIsomorphicLayoutEffect(() => {
     const events = eventsForPropChange(previous.current, props, state);
     previous.current = props;
-    for (const event of events) dispatch(event);
+    for (const event of events) {
+      if (event.type === "FOLD_DISARMED" && session.current !== null) {
+        session.current = disarmGesture(session.current);
+      }
+      dispatch(event);
+    }
   });
 
   // `Turning` is a point of no return: once the flip is committed it finishes

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -23,7 +23,7 @@ import {
   type BendAxis,
 } from "./geometry.js";
 import {
-  applyViewEvent,
+  applyCardEvent,
   beginGesture,
   endGesture,
   moveGesture,
@@ -166,7 +166,7 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     const events = eventsForPropChange(previous.current, props, state);
     previous.current = props;
     for (const event of events) {
-      session.current = applyViewEvent(session.current, event);
+      session.current = applyCardEvent(session.current, event);
       dispatch(event);
     }
   });
@@ -370,11 +370,11 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     // **disarms** — the release commits nothing, and there is no rejection
     // message, because the turn banner already explains it.
     //
-    // Re-sampled here as well as on the prop change that #146 will watch,
-    // because a release can beat the view that would have disarmed it. `pending`
-    // rides along for the same reason: a Fold cannot go out on top of an Action
-    // already in flight, and a departure the player watches and then has undone
-    // is worse than one that never starts.
+    // Re-sampled here as well as on the prop change `eventsForPropChange`
+    // watches, because a release can beat the view that would have disarmed it.
+    // `pending` rides along for the same reason: a Fold cannot go out on top of
+    // an Action already in flight, and a departure the player watches and then
+    // has undone is worse than one that never starts.
     //
     // This is arming input, exactly as §2 licenses; `canAct` inside
     // `intent.fold` remains the single gate on whether the Action is sent.

--- a/packages/player-client/src/holecards/viewEvents.test.ts
+++ b/packages/player-client/src/holecards/viewEvents.test.ts
@@ -55,6 +55,12 @@ const revealed: CardState = {
   armed: false,
   locked: false,
 };
+const foldDragging: CardState = {
+  presentation: "FaceDown",
+  recognizer: "FoldDragging",
+  armed: true,
+  locked: false,
+};
 
 describe("eventsForPropChange", () => {
   it("produces nothing by default — an incoming view is inert unless proven otherwise", () => {
@@ -77,6 +83,36 @@ describe("eventsForPropChange", () => {
       actions: { ...actions, foldLegal: true, checkLegal: true },
     });
     expect(eventsForPropChange(before, after, faceDown)).toEqual([]);
+  });
+
+  it("disarms a fold drag when Fold stops being legal", () => {
+    const before = props({
+      cards: queenJack,
+      actions: { ...actions, foldLegal: true },
+    });
+    const after = props({
+      cards: queenJack,
+      actions: { ...actions, foldLegal: false },
+    });
+
+    expect(eventsForPropChange(before, after, foldDragging)).toEqual([
+      { type: "FOLD_DISARMED" },
+    ]);
+  });
+
+  it("does not disarm a view that is not in a fold drag", () => {
+    const before = props({
+      cards: queenJack,
+      actions: { ...actions, foldLegal: true },
+    });
+    const after = props({
+      cards: queenJack,
+      actions: { ...actions, foldLegal: false },
+    });
+
+    for (const state of [faceDown, peeking, revealed, absent]) {
+      expect(eventsForPropChange(before, after, state)).toEqual([]);
+    }
   });
 
   it("leaves a peek in flight alone when a server update arrives", () => {
@@ -153,6 +189,20 @@ describe("eventsForPropChange", () => {
     expect(
       eventsForPropChange(props({ cards: queenJack }), props(), faceDown),
     ).toEqual([{ type: "CARDS_GONE" }]);
+  });
+
+  it("lets clock expiry empty a fold drag through CARDS_GONE", () => {
+    const before = props({
+      cards: queenJack,
+      actions: { ...actions, foldLegal: true },
+    });
+    const after = props({
+      actions: { ...actions, foldLegal: false },
+    });
+
+    expect(eventsForPropChange(before, after, foldDragging)).toEqual([
+      { type: "CARDS_GONE" },
+    ]);
   });
 
   it("produces nothing while the seat holds no cards at all", () => {

--- a/packages/player-client/src/holecards/viewEvents.ts
+++ b/packages/player-client/src/holecards/viewEvents.ts
@@ -25,9 +25,11 @@ function samePair(
  * exactly what you do while others act — so a new street, a new board card,
  * another player's bet and a changed `toAct` must all produce nothing.
  *
- * `state` is the current lifecycle state; of the events derived here only
- * `CARDS_GONE` consults it. `FOLD_DISARMED` — fold legality disappearing under
- * a live drag — is the one §8 row still to arrive (#146).
+ * `state` is the current lifecycle state; `CARDS_GONE` and `FOLD_DISARMED`
+ * consult it. Fold legality disappearing under a live drag is the one §8
+ * disturbance that must reach an in-progress gesture. If the same view also
+ * removes the cards (clock expiry or eviction), `CARDS_GONE` ends the gesture
+ * and is the only event needed.
  */
 export function eventsForPropChange(
   prev: HoleCardPairProps,
@@ -55,6 +57,18 @@ export function eventsForPropChange(
     // does not un-reveal, and the next hand's `DEALT` is what turns the cards
     // back over.
     if (!prev.locked && next.locked) events.push({ type: "SHOWDOWN_REVEAL" });
+  }
+
+  // A Fold drag keeps following the finger when its legality disappears. The
+  // card removal that accompanies an expiry or eviction ends the gesture
+  // through `CARDS_GONE`, so there is no separate disarm event in that case.
+  if (
+    next.cards !== null &&
+    prev.actions.foldLegal &&
+    !next.actions.foldLegal &&
+    state.recognizer === "FoldDragging"
+  ) {
+    events.push({ type: "FOLD_DISARMED" });
   }
 
   // Only the falling edge, and only a Fold is waiting on it: the pair moved


### PR DESCRIPTION
## Summary

- emit `FOLD_DISARMED` when fold legality disappears during a live drag
- keep the pointer session disarmed until a fresh threshold crossing
- clear stale pointer sessions when cards leave, a new hand deals, or the view resets/locks
- add focused coverage for legality changes, expiry, and session behavior

## Why

A turn expiry or seat eviction can invalidate a Fold while the Player is still holding the cards. The cards continue tracking the finger, but the expired drag cannot commit a Fold or produce a rejection message; expiry resolves through `CARDS_GONE` to the Absent presentation.

Closes #146

## Validation

- `npx vitest run packages/player-client/src/holecards/gesture.test.ts packages/player-client/src/holecards/viewEvents.test.ts packages/player-client/src/holecards/cardState.test.ts` — 3 files, 130 tests
- `npm run build -- --pretty false`
- `npm run lint`
- `npm test` — 79 files, 631 tests
