### PR TITLE
fix(table,player): align top-bar pills and lobby controls

### DIFF
--- a/packages/player-client/src/SeatPanel.test.tsx
+++ b/packages/player-client/src/SeatPanel.test.tsx
@@ -1,3 +1,4 @@
+import { color } from "@table-top-poker/ui-shared";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
@@ -113,6 +114,13 @@ describe("SeatPanel", () => {
     );
 
     expect(html).toMatch(/data-testid="sitting-out-toggle"[^>]*disabled/);
-    expect(html).toContain("background:rgba(255,255,255,.04)");
+
+    // The disabled fill comes from PillButton, not from SeatPanel — the accent
+    // treatment must not survive into the disabled state.
+    const buttonMatch =
+      /<button[^>]*data-testid="sitting-out-toggle"[^>]*>/.exec(html);
+    expect(buttonMatch?.[0]).toContain(`background:${color.controlFill}`);
+    expect(buttonMatch?.[0]).toContain(`color:${color.disabledText}`);
+    expect(buttonMatch?.[0]).not.toContain("cursor:pointer");
   });
 });

--- a/packages/player-client/src/SeatPanel.test.tsx
+++ b/packages/player-client/src/SeatPanel.test.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { SeatPanel } from "./SeatPanel.js";
+import { playerTopPillStyle } from "./topPillStyle.js";
 
 const noop = () => undefined;
 
@@ -49,7 +50,7 @@ describe("SeatPanel", () => {
     expect(html).toContain("Waiting for next hand");
   });
 
-  it("uses the same 30px pill height for the seat, sit-out, and toggle controls", () => {
+  it("uses the same pill height for the seat, sit-out, and toggle controls", () => {
     const html = renderToStaticMarkup(
       <SeatPanel
         seatId={0}
@@ -60,7 +61,16 @@ describe("SeatPanel", () => {
       />,
     );
 
-    expect(html.match(/height:30px/g)).toHaveLength(3);
+    for (const testId of [
+      "claimed-seat",
+      "sitting-out-badge",
+      "sitting-out-toggle",
+    ]) {
+      const element = new RegExp(`<[a-z]+[^>]*data-testid="${testId}"[^>]*>`);
+      expect(element.exec(html)?.[0], testId).toContain(
+        `height:${String(playerTopPillStyle.height ?? "")}px`,
+      );
+    }
   });
 
   it("offers sit out while active and sit in while sitting out", () => {

--- a/packages/player-client/src/SeatPanel.test.tsx
+++ b/packages/player-client/src/SeatPanel.test.tsx
@@ -48,6 +48,20 @@ describe("SeatPanel", () => {
     expect(html).toContain("Waiting for next hand");
   });
 
+  it("uses the same 30px pill height for the seat, sit-out, and toggle controls", () => {
+    const html = renderToStaticMarkup(
+      <SeatPanel
+        seatId={0}
+        sittingOut={true}
+        sittingOutReason="waiting-for-next-hand"
+        toggleDisabled={false}
+        onToggleSittingOut={noop}
+      />,
+    );
+
+    expect(html.match(/height:30px/g)).toHaveLength(3);
+  });
+
   it("offers sit out while active and sit in while sitting out", () => {
     const active = renderToStaticMarkup(
       <SeatPanel
@@ -71,6 +85,23 @@ describe("SeatPanel", () => {
     expect(sittingOut).toContain("Sit in");
   });
 
+  it("styles the sit-out control as an action rather than a status badge", () => {
+    const html = renderToStaticMarkup(
+      <SeatPanel
+        seatId={0}
+        sittingOut={false}
+        toggleDisabled={false}
+        onToggleSittingOut={noop}
+      />,
+    );
+
+    const buttonMatch =
+      /<button[^>]*data-testid="sitting-out-toggle"[^>]*>/.exec(html);
+    expect(buttonMatch?.[0]).toContain("background:rgba(229,68,60,.07)");
+    expect(buttonMatch?.[0]).toContain("border:1px solid rgba(229,68,60,.32)");
+    expect(buttonMatch?.[0]).toContain("cursor:pointer");
+  });
+
   it("disables the toggle while the socket is reconnecting", () => {
     const html = renderToStaticMarkup(
       <SeatPanel
@@ -82,5 +113,6 @@ describe("SeatPanel", () => {
     );
 
     expect(html).toMatch(/data-testid="sitting-out-toggle"[^>]*disabled/);
+    expect(html).toContain("background:rgba(255,255,255,.04)");
   });
 });

--- a/packages/player-client/src/SeatPanel.tsx
+++ b/packages/player-client/src/SeatPanel.tsx
@@ -21,13 +21,18 @@ export const playerTopPillStyle: CSSProperties = {
   textTransform: "uppercase",
 };
 
+/**
+ * Geometry only while disabled — `PillButton` owns the disabled fill, ink and
+ * cursor, and anything passed here would win over it.
+ */
 function sittingOutToggleStyle(disabled: boolean): CSSProperties {
+  if (disabled) return playerTopPillStyle;
   return {
     ...playerTopPillStyle,
-    background: disabled ? color.controlFill : color.accentWash,
-    border: `1px solid ${disabled ? color.border : color.accentBorder}`,
-    color: disabled ? color.disabledText : color.textBright,
-    cursor: disabled ? "default" : "pointer",
+    background: color.accentWash,
+    border: `1px solid ${color.accentBorder}`,
+    color: color.textBright,
+    cursor: "pointer",
   };
 }
 

--- a/packages/player-client/src/SeatPanel.tsx
+++ b/packages/player-client/src/SeatPanel.tsx
@@ -1,25 +1,7 @@
-import {
-  PillButton,
-  color,
-  font,
-  fontSize,
-  radius,
-} from "@table-top-poker/ui-shared";
+import { PillButton, color } from "@table-top-poker/ui-shared";
 import type { SittingOutReason } from "@table-top-poker/protocol";
 import type { CSSProperties } from "react";
-
-export const playerTopPillStyle: CSSProperties = {
-  display: "flex",
-  alignItems: "center",
-  height: 30,
-  padding: "0 12px",
-  borderRadius: radius.pill,
-  fontFamily: font.mono,
-  fontSize: fontSize.xs,
-  fontWeight: 600,
-  letterSpacing: "0.16em",
-  textTransform: "uppercase",
-};
+import { playerTopPillStyle } from "./topPillStyle.js";
 
 /**
  * Geometry only while disabled — `PillButton` owns the disabled fill, ink and

--- a/packages/player-client/src/SeatPanel.tsx
+++ b/packages/player-client/src/SeatPanel.tsx
@@ -6,6 +6,30 @@ import {
   radius,
 } from "@table-top-poker/ui-shared";
 import type { SittingOutReason } from "@table-top-poker/protocol";
+import type { CSSProperties } from "react";
+
+export const playerTopPillStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  height: 30,
+  padding: "0 12px",
+  borderRadius: radius.pill,
+  fontFamily: font.mono,
+  fontSize: fontSize.xs,
+  fontWeight: 600,
+  letterSpacing: "0.16em",
+  textTransform: "uppercase",
+};
+
+function sittingOutToggleStyle(disabled: boolean): CSSProperties {
+  return {
+    ...playerTopPillStyle,
+    background: disabled ? color.controlFill : color.accentWash,
+    border: `1px solid ${disabled ? color.border : color.accentBorder}`,
+    color: disabled ? color.disabledText : color.textBright,
+    cursor: disabled ? "default" : "pointer",
+  };
+}
 
 export interface SeatPanelProps {
   readonly seatId: number;
@@ -37,18 +61,10 @@ export function SeatPanel({
       <div
         data-testid="claimed-seat"
         style={{
-          display: "flex",
-          alignItems: "center",
+          ...playerTopPillStyle,
           gap: "0.5em",
-          padding: "0.4em 0.85em",
-          borderRadius: radius.pill,
           background: color.control,
           border: `1px solid ${color.border}`,
-          fontFamily: font.mono,
-          fontSize: fontSize.xs,
-          fontWeight: 600,
-          letterSpacing: "0.16em",
-          textTransform: "uppercase",
           color: color.textMuted,
         }}
       >
@@ -58,15 +74,9 @@ export function SeatPanel({
         <div
           data-testid="sitting-out-badge"
           style={{
-            padding: "0.4em 0.85em",
-            borderRadius: radius.pill,
+            ...playerTopPillStyle,
             background: "rgba(255,255,255,.04)",
             border: `1px solid ${color.border}`,
-            fontFamily: font.mono,
-            fontSize: fontSize.xs,
-            fontWeight: 600,
-            letterSpacing: "0.16em",
-            textTransform: "uppercase",
             color: color.textFaint,
           }}
         >
@@ -81,7 +91,7 @@ export function SeatPanel({
         data-testid="sitting-out-toggle"
         disabled={toggleDisabled}
         onClick={onToggleSittingOut}
-        style={{ padding: "8px 12px", fontSize: fontSize.xs }}
+        style={sittingOutToggleStyle(toggleDisabled)}
       >
         {sittingOut ? "Sit in" : "Sit out"}
       </PillButton>

--- a/packages/player-client/src/StatusBar.test.tsx
+++ b/packages/player-client/src/StatusBar.test.tsx
@@ -29,6 +29,7 @@ describe("StatusBar", () => {
     );
     expect(html).toContain('data-testid="connection-status"');
     expect(html).toContain("connected");
+    expect(html).toContain("height:30px");
   });
 
   it("shows the seat chip alongside the connection badge, on the same row", () => {

--- a/packages/player-client/src/StatusBar.tsx
+++ b/packages/player-client/src/StatusBar.tsx
@@ -1,7 +1,8 @@
 import { color, font, fontSize } from "@table-top-poker/ui-shared";
 import type { SittingOutReason } from "@table-top-poker/protocol";
 import type { CSSProperties } from "react";
-import { SeatPanel, playerTopPillStyle } from "./SeatPanel.js";
+import { SeatPanel } from "./SeatPanel.js";
+import { playerTopPillStyle } from "./topPillStyle.js";
 import type { ConnectionStatus } from "./store/connectionSlice.js";
 
 export interface StatusBarProps {

--- a/packages/player-client/src/StatusBar.tsx
+++ b/packages/player-client/src/StatusBar.tsx
@@ -1,7 +1,7 @@
-import { color, font, fontSize, radius } from "@table-top-poker/ui-shared";
+import { color, font, fontSize } from "@table-top-poker/ui-shared";
 import type { SittingOutReason } from "@table-top-poker/protocol";
 import type { CSSProperties } from "react";
-import { SeatPanel } from "./SeatPanel.js";
+import { SeatPanel, playerTopPillStyle } from "./SeatPanel.js";
 import type { ConnectionStatus } from "./store/connectionSlice.js";
 
 export interface StatusBarProps {
@@ -26,11 +26,8 @@ const badgeTone: Record<
 };
 
 const badgeStyle: CSSProperties = {
-  display: "flex",
-  alignItems: "center",
+  ...playerTopPillStyle,
   gap: "0.5em",
-  padding: "0.45em 0.9em",
-  borderRadius: radius.pill,
   background: color.control,
   border: `1px solid ${color.border}`,
 };

--- a/packages/player-client/src/topPillStyle.ts
+++ b/packages/player-client/src/topPillStyle.ts
@@ -1,0 +1,23 @@
+import { font, fontSize, radius } from "@table-top-poker/ui-shared";
+import type { CSSProperties } from "react";
+
+/**
+ * The geometry every pill along the top of the player screen shares — name,
+ * seat number, sit-out and connection. One height and one padding, so the row
+ * reads as a set of chips rather than four controls that happen to be adjacent.
+ *
+ * Colour is deliberately absent: each pill carries its own, and the sit-out
+ * control is a `PillButton` whose disabled state must stay PillButton's to set.
+ */
+export const playerTopPillStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  height: 30,
+  padding: "0 12px",
+  borderRadius: radius.pill,
+  fontFamily: font.mono,
+  fontSize: fontSize.xs,
+  fontWeight: 600,
+  letterSpacing: "0.16em",
+  textTransform: "uppercase",
+};

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -1,10 +1,72 @@
 import { DEFAULT_SEAT_COUNT } from "@table-top-poker/protocol";
+import type { SeatView, TableView } from "@table-top-poker/protocol";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App.js";
+import type { TableStore } from "./store/store.js";
+
+/**
+ * These tests render on the server, and zustand serves `getInitialState` to
+ * `useSyncExternalStore` there — a plain `setState` would never reach the
+ * markup. So the hook reads a per-test override instead; the real slices still
+ * supply every value the test does not name, including the setters
+ * `useWebSocket` reads.
+ */
+const store = vi.hoisted((): { overrides: Partial<TableStore> } => ({
+  overrides: {},
+}));
+
+vi.mock("./store/store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./store/store.js")>();
+  const initial = actual.useTableStore.getInitialState();
+  const useTableStore = (selector: (state: TableStore) => unknown) =>
+    selector({ ...initial, ...store.overrides });
+  return {
+    ...actual,
+    useTableStore: Object.assign(useTableStore, actual.useTableStore),
+  };
+});
+
+function seat(id: number, claimed: boolean): SeatView {
+  return {
+    id,
+    claimed,
+    sittingOut: false,
+    sittingOutReason: null,
+    disconnected: false,
+  };
+}
+
+const liveHand: TableView = {
+  phase: "betting",
+  button: 0,
+  street: "flop",
+  board: [],
+  toAct: [1],
+  seats: [
+    { seatId: 0, folded: false },
+    { seatId: 1, folded: false },
+  ],
+};
+
+/** Puts the table in a room, with the seats claimed and hand state given. */
+function enterRoom(claimedSeats: number, handView: TableView | null) {
+  store.overrides = {
+    roomCode: "ABCD",
+    joinUrl: "http://localhost:3000/join/ABCD",
+    qrCodeDataUrl: "data:image/png;base64,xyz",
+    seats: [0, 1].map((id) => seat(id, id < claimedSeats)),
+    connectionStatus: "connected",
+    handView,
+  };
+}
 
 describe("App", () => {
+  afterEach(() => {
+    store.overrides = {};
+  });
+
   it("renders the table-client shell", () => {
     const html = renderToStaticMarkup(<App />);
     expect(html).toContain('data-testid="table-client-shell"');
@@ -28,5 +90,37 @@ describe("App", () => {
     expect(html).toContain(
       `data-testid="seat-count-${String(DEFAULT_SEAT_COUNT)}-button" aria-pressed="true"`,
     );
+  });
+
+  it("puts the lobby controls inside the join panel, with no rail and no room-code pill", () => {
+    enterRoom(2, null);
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).toContain('data-testid="join-panel"');
+    expect(html).toContain('data-placement="join-panel"');
+    expect(html).not.toContain('data-placement="rail"');
+    // The join card is the room-join surface in the lobby; a second copy of
+    // the code in the status bar would be redundant.
+    expect(html).not.toContain('data-testid="join-code-toggle"');
+    expect(html).toContain('data-testid="connection-status"');
+  });
+
+  it("keeps Deal hand in the lobby but disabled below two seated players", () => {
+    enterRoom(1, null);
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).toMatch(/data-testid="start-hand-button"[^>]*disabled/);
+    expect(html).toContain('data-testid="end-session-button"');
+  });
+
+  it("moves the controls to the rail and shows the room code once a hand starts", () => {
+    enterRoom(2, liveHand);
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).toContain('data-placement="rail"');
+    expect(html).not.toContain('data-placement="join-panel"');
+    expect(html).not.toContain('data-testid="join-panel"');
+    expect(html).toContain('data-testid="join-code-toggle"');
+    expect(html).toContain('data-testid="connection-status"');
   });
 });

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -184,7 +184,7 @@ export function App() {
                 dismissable={handInProgress}
                 onDismiss={toggleJoin}
                 controls={
-                  !handInProgress ? (
+                  handInProgress ? undefined : (
                     <TableControls
                       placement="join-panel"
                       canStartHand={canStartHand}
@@ -193,7 +193,7 @@ export function App() {
                       onNextHand={handleNextHand}
                       onEndSession={handleEndSession}
                     />
-                  ) : undefined
+                  )
                 }
               />
             )}

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -124,8 +124,7 @@ export function App() {
         roomCode={roomCode}
         connectionStatus={connectionStatus}
         showRoomCode={handInProgress && !joinOpen}
-        joinOpen={joinOpen}
-        onToggleJoin={toggleJoin}
+        onOpenJoin={toggleJoin}
       />
       <main className="felt">
         {roomCode === null ? (

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -14,7 +14,6 @@ import {
 import { Board } from "./Board.js";
 import { HouseRulesSheet } from "./HouseRulesSheet.js";
 import { SeatCountPicker } from "./SeatCountPicker.js";
-import { JoinCodeToggle } from "./JoinCodeToggle.js";
 import { JoinPanel } from "./JoinPanel.js";
 import { SeatMenu } from "./SeatMenu.js";
 import { Seats } from "./Seats.js";
@@ -121,7 +120,13 @@ export function App() {
 
   return (
     <div className="app-shell" data-testid="table-client-shell">
-      <StatusBar roomCode={roomCode} connectionStatus={connectionStatus} />
+      <StatusBar
+        roomCode={roomCode}
+        connectionStatus={connectionStatus}
+        showRoomCode={handInProgress && !joinOpen}
+        joinOpen={joinOpen}
+        onToggleJoin={toggleJoin}
+      />
       <main className="felt">
         {roomCode === null ? (
           <SeatCountPicker
@@ -171,11 +176,6 @@ export function App() {
                 <Board view={handView} seats={seats} />
               </div>
             )}
-            <JoinCodeToggle
-              roomCode={roomCode}
-              open={joinOpen}
-              onToggle={toggleJoin}
-            />
             {showJoinPanel && (
               <JoinPanel
                 roomCode={roomCode}

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -184,6 +184,18 @@ export function App() {
                 lobbyHint={lobbyHint}
                 dismissable={handInProgress}
                 onDismiss={toggleJoin}
+                controls={
+                  !handInProgress ? (
+                    <TableControls
+                      placement="join-panel"
+                      canStartHand={canStartHand}
+                      handComplete={handComplete}
+                      onStartHand={handleStartHand}
+                      onNextHand={handleNextHand}
+                      onEndSession={handleEndSession}
+                    />
+                  ) : undefined
+                }
               />
             )}
             <SettingsToggle
@@ -204,13 +216,15 @@ export function App() {
                 }}
               />
             )}
-            <TableControls
-              canStartHand={canStartHand}
-              handComplete={handComplete}
-              onStartHand={handleStartHand}
-              onNextHand={handleNextHand}
-              onEndSession={handleEndSession}
-            />
+            {handInProgress && (
+              <TableControls
+                canStartHand={canStartHand}
+                handComplete={handComplete}
+                onStartHand={handleStartHand}
+                onNextHand={handleNextHand}
+                onEndSession={handleEndSession}
+              />
+            )}
           </div>
         )}
       </main>

--- a/packages/table-client/src/JoinCodeToggle.test.tsx
+++ b/packages/table-client/src/JoinCodeToggle.test.tsx
@@ -3,16 +3,14 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { JoinCodeToggle } from "./JoinCodeToggle.js";
 
+const noop = () => {
+  /* unused in these tests */
+};
+
 describe("JoinCodeToggle", () => {
-  it("shows the room code and a Room label when closed", () => {
+  it("shows the room code and a Room label", () => {
     const html = renderToStaticMarkup(
-      <JoinCodeToggle
-        roomCode="ABCD"
-        open={false}
-        onToggle={() => {
-          /* unused in this test */
-        }}
-      />,
+      <JoinCodeToggle roomCode="ABCD" onOpen={noop} />,
     );
 
     expect(html).toContain('data-testid="join-code-toggle"');
@@ -20,17 +18,11 @@ describe("JoinCodeToggle", () => {
     expect(html).toContain("Room");
   });
 
-  it("shows a Hide code label when open", () => {
+  it("sits in the status-bar flow rather than positioning itself", () => {
     const html = renderToStaticMarkup(
-      <JoinCodeToggle
-        roomCode="ABCD"
-        open={true}
-        onToggle={() => {
-          /* unused in this test */
-        }}
-      />,
+      <JoinCodeToggle roomCode="ABCD" onOpen={noop} />,
     );
 
-    expect(html).toContain("Hide code");
+    expect(html).not.toContain("position:absolute");
   });
 });

--- a/packages/table-client/src/JoinCodeToggle.tsx
+++ b/packages/table-client/src/JoinCodeToggle.tsx
@@ -3,20 +3,10 @@ import type { CSSProperties } from "react";
 
 export interface JoinCodeToggleProps {
   readonly roomCode: string;
-  readonly open: boolean;
-  readonly onToggle: () => void;
-  readonly placement?: "felt" | "status-bar";
+  readonly onOpen: () => void;
 }
 
-const feltWrapperStyle: CSSProperties = {
-  position: "absolute",
-  left: "50%",
-  top: 22,
-  transform: "translateX(-50%)",
-  zIndex: 11,
-};
-
-const statusBarWrapperStyle: CSSProperties = {
+const wrapperStyle: CSSProperties = {
   flex: "none",
   minWidth: 0,
 };
@@ -34,25 +24,21 @@ const buttonStyle: CSSProperties = {
 };
 
 /**
- * Room pill that stays visible once a room exists, letting the table device
- * peek at the join code/QR mid-hand without losing the board view.
+ * Room pill in the status bar, letting the table device peek at the join
+ * code/QR mid-hand without losing the board view.
+ *
+ * It opens the join card but never closes it: `App` unmounts the pill while
+ * the card is up, so the card's own Hide button is the single close path. A
+ * pill that could also close would need a second label and a second state for
+ * a control that is off-screen whenever that state applies.
  */
-export function JoinCodeToggle({
-  roomCode,
-  open,
-  onToggle,
-  placement = "felt",
-}: JoinCodeToggleProps) {
+export function JoinCodeToggle({ roomCode, onOpen }: JoinCodeToggleProps) {
   return (
-    <div
-      style={
-        placement === "status-bar" ? statusBarWrapperStyle : feltWrapperStyle
-      }
-    >
+    <div style={wrapperStyle}>
       <button
         type="button"
         data-testid="join-code-toggle"
-        onClick={onToggle}
+        onClick={onOpen}
         style={buttonStyle}
       >
         <span
@@ -65,7 +51,7 @@ export function JoinCodeToggle({
             color: color.textDim,
           }}
         >
-          {open ? "Hide code" : "Room"}
+          Room
         </span>
         <span
           style={{

--- a/packages/table-client/src/JoinCodeToggle.tsx
+++ b/packages/table-client/src/JoinCodeToggle.tsx
@@ -5,14 +5,20 @@ export interface JoinCodeToggleProps {
   readonly roomCode: string;
   readonly open: boolean;
   readonly onToggle: () => void;
+  readonly placement?: "felt" | "status-bar";
 }
 
-const wrapperStyle: CSSProperties = {
+const feltWrapperStyle: CSSProperties = {
   position: "absolute",
   left: "50%",
   top: 22,
   transform: "translateX(-50%)",
   zIndex: 11,
+};
+
+const statusBarWrapperStyle: CSSProperties = {
+  flex: "none",
+  minWidth: 0,
 };
 
 const buttonStyle: CSSProperties = {
@@ -28,16 +34,21 @@ const buttonStyle: CSSProperties = {
 };
 
 /**
- * Top-centre pill that stays visible once a room exists, letting the table
- * device peek at the join code/QR mid-hand without losing the board view.
+ * Room pill that stays visible once a room exists, letting the table device
+ * peek at the join code/QR mid-hand without losing the board view.
  */
 export function JoinCodeToggle({
   roomCode,
   open,
   onToggle,
+  placement = "felt",
 }: JoinCodeToggleProps) {
   return (
-    <div style={wrapperStyle}>
+    <div
+      style={
+        placement === "status-bar" ? statusBarWrapperStyle : feltWrapperStyle
+      }
+    >
       <button
         type="button"
         data-testid="join-code-toggle"

--- a/packages/table-client/src/JoinPanel.test.tsx
+++ b/packages/table-client/src/JoinPanel.test.tsx
@@ -71,4 +71,25 @@ describe("JoinPanel", () => {
     expect(dismissableHtml).toContain('data-testid="join-panel-dismiss"');
     expect(pinnedHtml).not.toContain('data-testid="join-panel-dismiss"');
   });
+
+  it("renders optional controls below the join card", () => {
+    const html = renderToStaticMarkup(
+      <JoinPanel
+        roomCode="ABCD"
+        joinUrl="http://localhost:3000/join/ABCD"
+        qrCodeDataUrl="data:image/png;base64,xyz"
+        lobbyHint="Waiting for at least two players"
+        dismissable={false}
+        onDismiss={() => {
+          /* unused in this test */
+        }}
+        controls={<div data-testid="join-panel-controls">Controls</div>}
+      />,
+    );
+
+    expect(html).toContain('data-testid="join-panel-controls"');
+    expect(html.indexOf('data-testid="join-panel-code"')).toBeLessThan(
+      html.indexOf('data-testid="join-panel-controls"'),
+    );
+  });
 });

--- a/packages/table-client/src/JoinPanel.tsx
+++ b/packages/table-client/src/JoinPanel.tsx
@@ -5,7 +5,7 @@ import {
   fontSize,
   radius,
 } from "@table-top-poker/ui-shared";
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 export interface JoinPanelProps {
   readonly roomCode: string;
@@ -14,6 +14,7 @@ export interface JoinPanelProps {
   readonly lobbyHint: string;
   readonly dismissable: boolean;
   readonly onDismiss: () => void;
+  readonly controls?: ReactNode;
 }
 
 const overlayStyle: CSSProperties = {
@@ -28,6 +29,14 @@ const overlayStyle: CSSProperties = {
   // whole felt — without this, its invisible edges swallow clicks on
   // whatever sits behind them, like the "Deal hand" control in the
   // bottom-right rail. Only the panel itself should be clickable.
+  pointerEvents: "none",
+};
+
+const overlayContentStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: "1em",
   pointerEvents: "none",
 };
 
@@ -65,89 +74,93 @@ export function JoinPanel({
   lobbyHint,
   dismissable,
   onDismiss,
+  controls,
 }: JoinPanelProps) {
   return (
     <div style={overlayStyle} data-testid="join-panel">
-      <Panel style={panelStyle}>
-        <div style={qrPlateStyle}>
-          {qrCodeDataUrl && (
-            <img
-              data-testid="join-panel-qr"
-              src={qrCodeDataUrl}
-              alt={`Scan to join at ${joinUrl ?? ""}`}
-              width={140}
-              height={140}
-            />
-          )}
-        </div>
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: 10,
-            alignItems: "flex-start",
-          }}
-        >
-          <span style={{ ...kickerStyle, fontSize: fontSize.sm }}>
-            Scan or enter code
-          </span>
-          <span
-            data-testid="join-panel-code"
+      <div style={overlayContentStyle}>
+        <Panel style={panelStyle}>
+          <div style={qrPlateStyle}>
+            {qrCodeDataUrl && (
+              <img
+                data-testid="join-panel-qr"
+                src={qrCodeDataUrl}
+                alt={`Scan to join at ${joinUrl ?? ""}`}
+                width={140}
+                height={140}
+              />
+            )}
+          </div>
+          <div
             style={{
-              fontFamily: font.mono,
-              fontWeight: 700,
-              fontSize: fontSize.jumbo,
-              lineHeight: 0.92,
-              letterSpacing: "0.1em",
-              color: color.text,
-              textShadow: "0 4px 30px rgba(229,68,60,.4)",
+              display: "flex",
+              flexDirection: "column",
+              gap: 10,
+              alignItems: "flex-start",
             }}
           >
-            {roomCode}
-          </span>
-          {joinUrl && (
+            <span style={{ ...kickerStyle, fontSize: fontSize.sm }}>
+              Scan or enter code
+            </span>
             <span
+              data-testid="join-panel-code"
               style={{
                 fontFamily: font.mono,
-                fontSize: fontSize.sm,
-                color: color.textFaint,
+                fontWeight: 700,
+                fontSize: fontSize.jumbo,
+                lineHeight: 0.92,
+                letterSpacing: "0.1em",
+                color: color.text,
+                textShadow: "0 4px 30px rgba(229,68,60,.4)",
               }}
             >
-              {joinUrl}
+              {roomCode}
             </span>
-          )}
-          <div
-            data-testid="join-panel-hint"
-            style={{
-              marginTop: 8,
-              fontSize: fontSize.md,
-              color: color.textDim,
-            }}
-          >
-            {lobbyHint}
-          </div>
-          {dismissable && (
-            <button
-              type="button"
-              data-testid="join-panel-dismiss"
-              onClick={onDismiss}
+            {joinUrl && (
+              <span
+                style={{
+                  fontFamily: font.mono,
+                  fontSize: fontSize.sm,
+                  color: color.textFaint,
+                }}
+              >
+                {joinUrl}
+              </span>
+            )}
+            <div
+              data-testid="join-panel-hint"
               style={{
-                ...kickerStyle,
-                marginTop: 10,
-                padding: "12px 22px",
-                borderRadius: radius.pill,
-                border: `1px solid ${color.border}`,
-                background: "transparent",
-                fontSize: fontSize.xs,
-                fontWeight: 600,
-                letterSpacing: "0.18em",
+                marginTop: 8,
+                fontSize: fontSize.md,
+                color: color.textDim,
               }}
             >
-              Hide
-            </button>
-          )}
-        </div>
-      </Panel>
+              {lobbyHint}
+            </div>
+            {dismissable && (
+              <button
+                type="button"
+                data-testid="join-panel-dismiss"
+                onClick={onDismiss}
+                style={{
+                  ...kickerStyle,
+                  marginTop: 10,
+                  padding: "12px 22px",
+                  borderRadius: radius.pill,
+                  border: `1px solid ${color.border}`,
+                  background: "transparent",
+                  fontSize: fontSize.xs,
+                  fontWeight: 600,
+                  letterSpacing: "0.18em",
+                }}
+              >
+                Hide
+              </button>
+            )}
+          </div>
+        </Panel>
+        {controls}
+      </div>
     </div>
   );
 }

--- a/packages/table-client/src/StatusBar.test.tsx
+++ b/packages/table-client/src/StatusBar.test.tsx
@@ -3,6 +3,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { StatusBar } from "./StatusBar.js";
 
+const noop = () => {
+  /* unused in these tests */
+};
+
 describe("StatusBar", () => {
   it("hides the connection badge before a room exists", () => {
     const html = renderToStaticMarkup(
@@ -10,10 +14,7 @@ describe("StatusBar", () => {
         roomCode={null}
         connectionStatus="disconnected"
         showRoomCode={false}
-        joinOpen={false}
-        onToggleJoin={() => {
-          /* unused in this test */
-        }}
+        onOpenJoin={noop}
       />,
     );
     expect(html).not.toContain('data-testid="connection-status"');
@@ -26,10 +27,7 @@ describe("StatusBar", () => {
         roomCode="ABCD"
         connectionStatus="connected"
         showRoomCode={true}
-        joinOpen={false}
-        onToggleJoin={() => {
-          /* unused in this test */
-        }}
+        onOpenJoin={noop}
       />,
     );
     expect(html).toContain('data-testid="connection-status"');
@@ -55,10 +53,7 @@ describe("StatusBar", () => {
         roomCode="ABCD"
         connectionStatus="connected"
         showRoomCode={false}
-        joinOpen={false}
-        onToggleJoin={() => {
-          /* unused in this test */
-        }}
+        onOpenJoin={noop}
       />,
     );
     expect(html).not.toContain('data-testid="join-code-toggle"');

--- a/packages/table-client/src/StatusBar.test.tsx
+++ b/packages/table-client/src/StatusBar.test.tsx
@@ -6,16 +6,63 @@ import { StatusBar } from "./StatusBar.js";
 describe("StatusBar", () => {
   it("hides the connection badge before a room exists", () => {
     const html = renderToStaticMarkup(
-      <StatusBar roomCode={null} connectionStatus="disconnected" />,
+      <StatusBar
+        roomCode={null}
+        connectionStatus="disconnected"
+        showRoomCode={false}
+        joinOpen={false}
+        onToggleJoin={() => {
+          /* unused in this test */
+        }}
+      />,
     );
     expect(html).not.toContain('data-testid="connection-status"');
+    expect(html).not.toContain('data-testid="join-code-toggle"');
   });
 
-  it("shows the connection badge once a room exists", () => {
+  it("puts the room code on the left and connection badge on the right", () => {
     const html = renderToStaticMarkup(
-      <StatusBar roomCode="ABCD" connectionStatus="connected" />,
+      <StatusBar
+        roomCode="ABCD"
+        connectionStatus="connected"
+        showRoomCode={true}
+        joinOpen={false}
+        onToggleJoin={() => {
+          /* unused in this test */
+        }}
+      />,
     );
     expect(html).toContain('data-testid="connection-status"');
     expect(html).toContain("connected");
+    expect(html).toContain('data-testid="join-code-toggle"');
+    expect(html).toContain("ABCD");
+
+    const headerMatch = /<header[^>]*>[\s\S]*<\/header>/.exec(html);
+    expect(headerMatch).not.toBeNull();
+    expect(headerMatch?.[0]).toContain('data-testid="join-code-toggle"');
+    expect(headerMatch?.[0]).toContain('data-testid="connection-status"');
+    expect(headerMatch?.[0]).toContain("padding:16px 22px");
+    expect(
+      headerMatch?.[0].indexOf('data-testid="join-code-toggle"'),
+    ).toBeLessThan(
+      headerMatch?.[0].indexOf('data-testid="connection-status"') ?? -1,
+    );
+  });
+
+  it("keeps the connection badge while hiding the room code before the hand starts", () => {
+    const html = renderToStaticMarkup(
+      <StatusBar
+        roomCode="ABCD"
+        connectionStatus="connected"
+        showRoomCode={false}
+        joinOpen={false}
+        onToggleJoin={() => {
+          /* unused in this test */
+        }}
+      />,
+    );
+    expect(html).not.toContain('data-testid="join-code-toggle"');
+    expect(html).toContain('data-testid="connection-status"');
+    expect(html).toContain("margin-left:auto");
   });
 });

--- a/packages/table-client/src/StatusBar.tsx
+++ b/packages/table-client/src/StatusBar.tsx
@@ -7,8 +7,7 @@ export interface StatusBarProps {
   readonly roomCode: string | null;
   readonly connectionStatus: ConnectionStatus;
   readonly showRoomCode: boolean;
-  readonly joinOpen: boolean;
-  readonly onToggleJoin: () => void;
+  readonly onOpenJoin: () => void;
 }
 
 const badgeTone: Record<
@@ -35,8 +34,7 @@ export function StatusBar({
   roomCode,
   connectionStatus,
   showRoomCode,
-  joinOpen,
-  onToggleJoin,
+  onOpenJoin,
 }: StatusBarProps) {
   const tone = badgeTone[connectionStatus];
   return (
@@ -53,12 +51,7 @@ export function StatusBar({
       }}
     >
       {roomCode !== null && showRoomCode && (
-        <JoinCodeToggle
-          roomCode={roomCode}
-          open={joinOpen}
-          onToggle={onToggleJoin}
-          placement="status-bar"
-        />
+        <JoinCodeToggle roomCode={roomCode} onOpen={onOpenJoin} />
       )}
       {roomCode !== null && (
         <span

--- a/packages/table-client/src/StatusBar.tsx
+++ b/packages/table-client/src/StatusBar.tsx
@@ -29,7 +29,13 @@ const badgeStyle: CSSProperties = {
   border: `1px solid ${color.border}`,
 };
 
-/** No connection badge before a room exists — there's nothing to connect to yet. */
+/**
+ * No connection badge before a room exists — there's nothing to connect to yet.
+ *
+ * The badge is pushed right by its own auto margin rather than by the header's
+ * justification, because the room-code pill on the left comes and goes: with
+ * `space-between` alone, a lone badge would sit hard left.
+ */
 export function StatusBar({
   roomCode,
   connectionStatus,
@@ -43,7 +49,6 @@ export function StatusBar({
         flex: "none",
         display: "flex",
         alignItems: "center",
-        justifyContent: "space-between",
         gap: "0.75em",
         width: "100%",
         minWidth: 0,

--- a/packages/table-client/src/StatusBar.tsx
+++ b/packages/table-client/src/StatusBar.tsx
@@ -1,10 +1,14 @@
 import { color, font, fontSize, radius } from "@table-top-poker/ui-shared";
 import type { CSSProperties } from "react";
+import { JoinCodeToggle } from "./JoinCodeToggle.js";
 import type { ConnectionStatus } from "./store/connectionSlice.js";
 
 export interface StatusBarProps {
   readonly roomCode: string | null;
   readonly connectionStatus: ConnectionStatus;
+  readonly showRoomCode: boolean;
+  readonly joinOpen: boolean;
+  readonly onToggleJoin: () => void;
 }
 
 const badgeTone: Record<
@@ -27,22 +31,40 @@ const badgeStyle: CSSProperties = {
 };
 
 /** No connection badge before a room exists — there's nothing to connect to yet. */
-export function StatusBar({ roomCode, connectionStatus }: StatusBarProps) {
+export function StatusBar({
+  roomCode,
+  connectionStatus,
+  showRoomCode,
+  joinOpen,
+  onToggleJoin,
+}: StatusBarProps) {
   const tone = badgeTone[connectionStatus];
   return (
     <header
       style={{
         flex: "none",
         display: "flex",
-        justifyContent: "flex-end",
-        padding: "16px 22px 0",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "0.75em",
+        width: "100%",
+        minWidth: 0,
+        padding: "16px 22px",
       }}
     >
+      {roomCode !== null && showRoomCode && (
+        <JoinCodeToggle
+          roomCode={roomCode}
+          open={joinOpen}
+          onToggle={onToggleJoin}
+          placement="status-bar"
+        />
+      )}
       {roomCode !== null && (
         <span
           data-testid="connection-status"
           data-status={connectionStatus}
-          style={badgeStyle}
+          style={{ ...badgeStyle, flex: "none", marginLeft: "auto" }}
         >
           <span
             style={{

--- a/packages/table-client/src/TableControls.test.tsx
+++ b/packages/table-client/src/TableControls.test.tsx
@@ -51,4 +51,42 @@ describe("TableControls", () => {
     expect(html).not.toContain('data-testid="next-hand-button"');
     expect(html).toContain('data-testid="end-session-button"');
   });
+
+  it("places lobby controls below the join panel", () => {
+    const html = renderToStaticMarkup(
+      <TableControls
+        placement="join-panel"
+        canStartHand
+        handComplete={false}
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+      />,
+    );
+
+    expect(html).toContain('data-placement="join-panel"');
+    expect(html).toContain("flex-direction:row");
+    expect(html).toContain("position:relative");
+    expect(html).toContain("z-index:15");
+    expect(html).not.toContain("position:absolute");
+    expect(html).toContain('data-testid="start-hand-button"');
+    expect(html).toContain('data-testid="end-session-button"');
+  });
+
+  it("keeps Deal hand visible but disabled until enough players are seated", () => {
+    const html = renderToStaticMarkup(
+      <TableControls
+        placement="join-panel"
+        canStartHand={false}
+        handComplete={false}
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+      />,
+    );
+
+    expect(html).toMatch(/data-testid="start-hand-button"[^>]*disabled/);
+    expect(html).toContain("background:rgba(255,255,255,.04)");
+    expect(html).toContain('data-testid="end-session-button"');
+  });
 });

--- a/packages/table-client/src/TableControls.test.tsx
+++ b/packages/table-client/src/TableControls.test.tsx
@@ -1,3 +1,4 @@
+import { color } from "@table-top-poker/ui-shared";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
@@ -66,8 +67,6 @@ describe("TableControls", () => {
 
     expect(html).toContain('data-placement="join-panel"');
     expect(html).toContain("flex-direction:row");
-    expect(html).toContain("position:relative");
-    expect(html).toContain("z-index:15");
     expect(html).not.toContain("position:absolute");
     expect(html).toContain('data-testid="start-hand-button"');
     expect(html).toContain('data-testid="end-session-button"');
@@ -86,7 +85,7 @@ describe("TableControls", () => {
     );
 
     expect(html).toMatch(/data-testid="start-hand-button"[^>]*disabled/);
-    expect(html).toContain("background:rgba(255,255,255,.04)");
+    expect(html).toContain(`background:${color.controlFill}`);
     expect(html).toContain('data-testid="end-session-button"');
   });
 });

--- a/packages/table-client/src/TableControls.tsx
+++ b/packages/table-client/src/TableControls.tsx
@@ -1,4 +1,5 @@
-import { PillButton } from "@table-top-poker/ui-shared";
+import { PillButton, color } from "@table-top-poker/ui-shared";
+import type { CSSProperties } from "react";
 
 export interface TableControlsProps {
   readonly canStartHand: boolean;
@@ -6,6 +7,7 @@ export interface TableControlsProps {
   readonly onStartHand: () => void;
   readonly onNextHand: () => void;
   readonly onEndSession: () => void;
+  readonly placement?: "rail" | "join-panel";
   /**
    * PROTOTYPE (wayfinder #81) — opens the session hand picker. Optional so
    * the live `App` is unaffected; Phase 2 makes it a peer of the other rail
@@ -16,10 +18,11 @@ export interface TableControlsProps {
 }
 
 /**
- * The right-hand control rail — every table action the device offers, as one
- * group. Deal hand / Next hand are mutually exclusive with the felt's hand
- * state; Review hands and End session are always available once a room exists
- * (this component is only mounted then).
+ * The table action group — a right-hand control rail during a hand, or a
+ * group below the join panel while the room is waiting to start. Deal hand /
+ * Next hand are mutually exclusive with the felt's hand state; Review hands
+ * and End session are always available once a room exists (this component is
+ * only mounted then).
  *
  * The rail is a fixed-width column and every button fills it, so the actions
  * share one left and right edge instead of ragging off the right margin at
@@ -37,26 +40,54 @@ export function TableControls({
   onStartHand,
   onNextHand,
   onEndSession,
+  placement = "rail",
   onReviewHands,
 }: TableControlsProps) {
+  const layoutStyle: CSSProperties =
+    placement === "join-panel"
+      ? {
+          position: "relative",
+          zIndex: 15,
+          display: "flex",
+          flexDirection: "row",
+          width: "26em",
+          maxWidth: "calc(100vw - 2em)",
+          gap: "0.6em",
+          pointerEvents: "auto",
+        }
+      : {
+          position: "absolute",
+          right: "1.5em",
+          top: "50%",
+          transform: "translateY(-50%)",
+          display: "flex",
+          flexDirection: "column",
+          width: "13em",
+          gap: "0.6em",
+        };
+  const actionButtonStyle: CSSProperties =
+    placement === "join-panel"
+      ? { flex: "1 1 0", minWidth: 0 }
+      : { width: "100%" };
+  const disabledStartStyle: CSSProperties =
+    placement === "join-panel" && !canStartHand
+      ? {
+          background: color.controlFill,
+          color: color.disabledText,
+          border: `1px solid ${color.border}`,
+          boxShadow: "none",
+          cursor: "default",
+        }
+      : {};
+
   return (
-    <div
-      style={{
-        position: "absolute",
-        right: "1.5em",
-        top: "50%",
-        transform: "translateY(-50%)",
-        display: "flex",
-        flexDirection: "column",
-        width: "13em",
-        gap: "0.6em",
-      }}
-    >
-      {canStartHand && (
+    <div data-placement={placement} style={layoutStyle}>
+      {(placement === "join-panel" || canStartHand) && (
         <PillButton
           data-testid="start-hand-button"
+          disabled={placement === "join-panel" && !canStartHand}
           onClick={onStartHand}
-          style={{ width: "100%" }}
+          style={{ ...actionButtonStyle, ...disabledStartStyle }}
         >
           Deal hand
         </PillButton>
@@ -65,7 +96,7 @@ export function TableControls({
         <PillButton
           data-testid="next-hand-button"
           onClick={onNextHand}
-          style={{ width: "100%" }}
+          style={actionButtonStyle}
         >
           Next hand
         </PillButton>
@@ -75,7 +106,7 @@ export function TableControls({
           tone="outline"
           data-testid="review-hands-button"
           onClick={onReviewHands}
-          style={{ width: "100%" }}
+          style={actionButtonStyle}
         >
           Review hands
         </PillButton>
@@ -84,7 +115,7 @@ export function TableControls({
         tone="outline"
         data-testid="end-session-button"
         onClick={onEndSession}
-        style={{ width: "100%" }}
+        style={actionButtonStyle}
       >
         End session
       </PillButton>

--- a/packages/table-client/src/TableControls.tsx
+++ b/packages/table-client/src/TableControls.tsx
@@ -1,13 +1,43 @@
 import { PillButton } from "@table-top-poker/ui-shared";
 import type { CSSProperties } from "react";
 
+export type TableControlsPlacement = "rail" | "join-panel";
+
+const layoutStyles: Record<TableControlsPlacement, CSSProperties> = {
+  rail: {
+    position: "absolute",
+    right: "1.5em",
+    top: "50%",
+    transform: "translateY(-50%)",
+    display: "flex",
+    flexDirection: "column",
+    width: "13em",
+    gap: "0.6em",
+  },
+  "join-panel": {
+    display: "flex",
+    flexDirection: "row",
+    width: "26em",
+    maxWidth: "calc(100vw - 2em)",
+    gap: "0.6em",
+    // The join overlay turns pointer events off so its invisible edges don't
+    // swallow clicks on the felt; the controls have to turn them back on.
+    pointerEvents: "auto",
+  },
+};
+
+const actionButtonStyles: Record<TableControlsPlacement, CSSProperties> = {
+  rail: { width: "100%" },
+  "join-panel": { flex: "1 1 0", minWidth: 0 },
+};
+
 export interface TableControlsProps {
   readonly canStartHand: boolean;
   readonly handComplete: boolean;
   readonly onStartHand: () => void;
   readonly onNextHand: () => void;
   readonly onEndSession: () => void;
-  readonly placement?: "rail" | "join-panel";
+  readonly placement?: TableControlsPlacement;
   /**
    * PROTOTYPE (wayfinder #81) — opens the session hand picker. Optional so
    * the live `App` is unaffected; Phase 2 makes it a peer of the other rail
@@ -43,30 +73,8 @@ export function TableControls({
   placement = "rail",
   onReviewHands,
 }: TableControlsProps) {
-  const layoutStyle: CSSProperties =
-    placement === "join-panel"
-      ? {
-          display: "flex",
-          flexDirection: "row",
-          width: "26em",
-          maxWidth: "calc(100vw - 2em)",
-          gap: "0.6em",
-          pointerEvents: "auto",
-        }
-      : {
-          position: "absolute",
-          right: "1.5em",
-          top: "50%",
-          transform: "translateY(-50%)",
-          display: "flex",
-          flexDirection: "column",
-          width: "13em",
-          gap: "0.6em",
-        };
-  const actionButtonStyle: CSSProperties =
-    placement === "join-panel"
-      ? { flex: "1 1 0", minWidth: 0 }
-      : { width: "100%" };
+  const layoutStyle = layoutStyles[placement];
+  const actionButtonStyle = actionButtonStyles[placement];
 
   return (
     <div data-placement={placement} style={layoutStyle}>

--- a/packages/table-client/src/TableControls.tsx
+++ b/packages/table-client/src/TableControls.tsx
@@ -1,4 +1,4 @@
-import { PillButton, color } from "@table-top-poker/ui-shared";
+import { PillButton } from "@table-top-poker/ui-shared";
 import type { CSSProperties } from "react";
 
 export interface TableControlsProps {
@@ -46,8 +46,6 @@ export function TableControls({
   const layoutStyle: CSSProperties =
     placement === "join-panel"
       ? {
-          position: "relative",
-          zIndex: 15,
           display: "flex",
           flexDirection: "row",
           width: "26em",
@@ -69,16 +67,6 @@ export function TableControls({
     placement === "join-panel"
       ? { flex: "1 1 0", minWidth: 0 }
       : { width: "100%" };
-  const disabledStartStyle: CSSProperties =
-    placement === "join-panel" && !canStartHand
-      ? {
-          background: color.controlFill,
-          color: color.disabledText,
-          border: `1px solid ${color.border}`,
-          boxShadow: "none",
-          cursor: "default",
-        }
-      : {};
 
   return (
     <div data-placement={placement} style={layoutStyle}>
@@ -87,7 +75,7 @@ export function TableControls({
           data-testid="start-hand-button"
           disabled={placement === "join-panel" && !canStartHand}
           onClick={onStartHand}
-          style={{ ...actionButtonStyle, ...disabledStartStyle }}
+          style={actionButtonStyle}
         >
           Deal hand
         </PillButton>

--- a/packages/ui-shared/src/PillButton.tsx
+++ b/packages/ui-shared/src/PillButton.tsx
@@ -37,6 +37,20 @@ const toneStyle: Record<PillButtonTone, CSSProperties> = {
 };
 
 /**
+ * One disabled look for every pill, whatever its tone. A disabled action still
+ * has to read as the same control it was a moment ago — same size, same
+ * position — so only the fill, the ink and the cursor change. This lives here
+ * rather than at the call sites: three of them had grown their own copy of it.
+ */
+const disabledStyle: CSSProperties = {
+  background: color.controlFill,
+  color: color.disabledText,
+  border: `1px solid ${color.border}`,
+  boxShadow: "none",
+  cursor: "default",
+};
+
+/**
  * The rounded pill used for table/player actions. `tone="solid"` is the
  * cream gradient for primary actions ("Deal hand", "Create room"); `tone="outline"`
  * is the muted mono-label pill used for secondary actions ("End session").
@@ -59,6 +73,7 @@ export function PillButton({
         fontFamily: font.body,
         ...toneStyle[tone],
         ...sizeStyle[size],
+        ...(rest.disabled ? disabledStyle : {}),
         ...style,
       }}
     />


### PR DESCRIPTION
## Intent

This PR is a focused UI polish pass for the table and player interfaces. The goal is to make the top-bar status information fit cleanly within its bounds, keep controls in predictable places as the room moves between lobby and live-game states, and make the one clickable pill look like an action rather than passive status.

## What changed

### Table interface

- Keeps the **Connected** status pill inside the top bar on the far right in every state.
- Places the **room-code** pill on the far left, with equal top and bottom padding.
- Hides the room-code pill while the QR join card is open; shows it only when the game starts and the QR card disappears.
- Shows **Deal hand** and **End session** horizontally below the QR card while the room is in the lobby.
- Keeps **Deal hand** visible but visually and functionally disabled until enough players are seated.
- Returns the lobby controls to the existing right-hand rail once the hand has started.
- Keeps the lobby controls on the same stacking level as the QR card and burger button so they are not obscured by the overlay.

### Player interface

- Gives the name, seat number, sit-out, and connection pills a shared size and geometry.
- Differentiates the **Sit out / Sit in** control with an accent action treatment, pointer cursor, and disabled styling so it is clear that it is clickable rather than an indicator.

## Reviewer focus

The intended behavior is state-dependent placement, not just a spacing adjustment:

1. In the lobby, the QR card is the primary room-join surface; the table top bar shows Connected on the right, while the room-code pill is hidden.
2. Once a hand starts, the QR card disappears and the room-code pill appears on the left; Connected remains on the right.
3. The lobby actions sit beneath the QR card and are usable at the same visual layer. Deal hand remains present but cannot be activated until the player-count requirement is met.
4. On the player interface, all top pills line up consistently, while Sit out / Sit in reads as an action.

## Validation

- Focused table-client tests passed.
- Focused player-client tests passed.
- Table and player type checks and app builds passed.
- Prettier and ESLint checks passed.

