### PR TITLE
feat(table): small and big blind markers, sized like the button

### DIFF
--- a/packages/engine/src/apply.ts
+++ b/packages/engine/src/apply.ts
@@ -4,6 +4,7 @@ import {
   nextButtonAfter,
   requeueAfterRaise,
   rotateFromButton,
+  smallBlindSeat,
 } from "./table.js";
 import type { BettingHandState, EngineState, HandEvent } from "./types.js";
 import { must } from "./util.js";
@@ -17,6 +18,21 @@ function asBetting(state: EngineState): BettingHandState {
 
 function seatState(hand: BettingHandState, seat: number) {
   return must(hand.players.get(seat), `unknown seat ${String(seat)}`);
+}
+
+/**
+ * The positional facts a completed hand has to keep once `ring` is dropped:
+ * both blind seats and the size of the field they were dealt from. Resolved
+ * here, while `ring` is still in scope, so `view` reports the same ids in
+ * every phase — and so the button's rotation on `HandComplete` can't reach
+ * back and change what the finished hand says about itself.
+ */
+function resolvedBlinds(hand: BettingHandState) {
+  return {
+    smallBlind: smallBlindSeat(hand.ring, hand.button),
+    bigBlind: bigBlindSeat(hand.ring, hand.button),
+    dealtSeatCount: hand.ring.length,
+  };
 }
 
 /** Pure reducer: folds one event into state. Never mutates its input. */
@@ -132,6 +148,7 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
           reason: "folded-out",
           seed: hand.seed,
           button: hand.button,
+          ...resolvedBlinds(hand),
           winner: event.winner,
         },
       };
@@ -153,6 +170,7 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
           reason: "showdown",
           seed: hand.seed,
           button: hand.button,
+          ...resolvedBlinds(hand),
           board: hand.board,
           results,
           winners: event.winners,

--- a/packages/engine/src/blinds.test.ts
+++ b/packages/engine/src/blinds.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { createInitialState } from "./room.js";
+import { bigBlindSeat, smallBlindSeat } from "./table.js";
+import { playAll } from "./test-utils.js";
+import type { EngineState } from "./types.js";
+import { view } from "./view.js";
+
+function bettingView(state: EngineState) {
+  const v = view(state, "table");
+  if (v.phase !== "betting") throw new Error("expected a betting view");
+  return v;
+}
+
+describe("smallBlindSeat", () => {
+  it("is the seat immediately after the button in ring order, not by seat number", () => {
+    // Seat 5 has the button; ring order wraps to seat 1 before seat 3.
+    expect(smallBlindSeat([1, 3, 5], 5)).toBe(1);
+    expect(bigBlindSeat([1, 3, 5], 5)).toBe(3);
+  });
+
+  it("is the button itself heads-up", () => {
+    expect(smallBlindSeat([4, 2], 2)).toBe(2);
+    expect(bigBlindSeat([4, 2], 2)).toBe(4);
+  });
+});
+
+describe("view: blinds during betting", () => {
+  it("reports the blinds by ring order for a three-handed hand", () => {
+    // Seats 2, 5, 7 with the button on 5: ring = [7, 2, 5].
+    let state = createInitialState([2, 5, 7]);
+    state = { ...state, button: 5 };
+    state = playAll(state, [{ type: "startHand", seatId: 2, seed: "blinds" }]);
+
+    const v = bettingView(state);
+    expect(v.button).toBe(5);
+    expect(v.smallBlind).toBe(7);
+    expect(v.bigBlind).toBe(2);
+    expect(v.dealtSeatCount).toBe(3);
+  });
+
+  it("reports the heads-up truth honestly: the button is also the small blind", () => {
+    let state = createInitialState([0, 1]);
+    state = playAll(state, [{ type: "startHand", seatId: 0, seed: "hu" }]);
+
+    const v = bettingView(state);
+    expect(v.button).toBe(0);
+    expect(v.smallBlind).toBe(0);
+    expect(v.bigBlind).toBe(1);
+    expect(v.dealtSeatCount).toBe(2);
+  });
+
+  it("keeps the blinds fixed for the hand when a seat folds", () => {
+    let state = createInitialState([0, 1, 2]);
+    state = playAll(state, [{ type: "startHand", seatId: 0, seed: "fixed" }]);
+    const before = bettingView(state);
+    state = playAll(state, [{ type: "fold", seatId: 1 }]);
+    const after = bettingView(state);
+
+    expect(after.smallBlind).toBe(before.smallBlind);
+    expect(after.bigBlind).toBe(before.bigBlind);
+    expect(after.dealtSeatCount).toBe(before.dealtSeatCount);
+  });
+});
+
+describe("view: blinds on a completed hand", () => {
+  it("a folded-out hand keeps the ids the betting hand had, despite the button rotating", () => {
+    let state = createInitialState([0, 1, 2]);
+    state = playAll(state, [{ type: "startHand", seatId: 0, seed: "foldout" }]);
+    const betting = bettingView(state);
+
+    state = playAll(state, [
+      { type: "fold", seatId: 1 },
+      { type: "fold", seatId: 2 },
+    ]);
+
+    // `HandComplete` has rotated the engine button on to the next seat, but
+    // the completed hand still describes the hand that was just played.
+    expect(state.button).not.toBe(betting.button);
+
+    const v = view(state, "table");
+    if (v.phase !== "folded-out") throw new Error("expected folded-out");
+    expect(v.button).toBe(betting.button);
+    expect(v.smallBlind).toBe(betting.smallBlind);
+    expect(v.bigBlind).toBe(betting.bigBlind);
+    expect(v.dealtSeatCount).toBe(3);
+  });
+
+  it("a showdown hand keeps the ids the betting hand had", () => {
+    let state = createInitialState([0, 1, 2]);
+    state = playAll(state, [{ type: "startHand", seatId: 0, seed: "sd" }]);
+    const betting = bettingView(state);
+
+    state = playAll(state, [
+      { type: "call", seatId: 1 },
+      { type: "check", seatId: 2 },
+      { type: "call", seatId: 0 },
+      { type: "check", seatId: 2 },
+      { type: "check", seatId: 1 },
+      { type: "check", seatId: 2 },
+      { type: "check", seatId: 0 },
+      { type: "check", seatId: 1 },
+      { type: "check", seatId: 2 },
+      { type: "check", seatId: 0 },
+      { type: "check", seatId: 1 },
+      { type: "check", seatId: 2 },
+      { type: "check", seatId: 0 },
+    ]);
+
+    const v = view(state, "table");
+    if (v.phase !== "showdown") throw new Error("expected showdown");
+    expect(v.button).toBe(betting.button);
+    expect(v.smallBlind).toBe(betting.smallBlind);
+    expect(v.bigBlind).toBe(betting.bigBlind);
+    expect(v.dealtSeatCount).toBe(3);
+  });
+
+  it("a heads-up showdown still reports the button as the small blind", () => {
+    let state = createInitialState([0, 1]);
+    state = playAll(state, [{ type: "startHand", seatId: 0, seed: "hu-sd" }]);
+    state = playAll(state, [
+      { type: "call", seatId: 0 },
+      { type: "check", seatId: 1 },
+      { type: "check", seatId: 1 },
+      { type: "check", seatId: 0 },
+      { type: "check", seatId: 1 },
+      { type: "check", seatId: 0 },
+      { type: "check", seatId: 1 },
+      { type: "check", seatId: 0 },
+    ]);
+
+    const v = view(state, "table");
+    if (v.phase !== "showdown") throw new Error("expected showdown");
+    expect(v.smallBlind).toBe(v.button);
+    expect(v.bigBlind).toBe(1);
+    expect(v.dealtSeatCount).toBe(2);
+  });
+});
+
+describe("view: between hands", () => {
+  it("reports only the button — the blinds do not exist without a hand", () => {
+    const state = createInitialState([0, 1, 2]);
+    const v = view(state, "table");
+    expect(v.phase).toBe("no-hand");
+    expect(v).not.toHaveProperty("smallBlind");
+    expect(v).not.toHaveProperty("bigBlind");
+  });
+});

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -14,6 +14,7 @@ export type {
   EngineState,
   FoldedOutCompleteHandState,
   HandEvent,
+  HandPositions,
   HandRank,
   HandState,
   Rank,

--- a/packages/engine/src/table.ts
+++ b/packages/engine/src/table.ts
@@ -63,6 +63,19 @@ export function initialToAct(
 }
 
 /**
+ * The small blind's seat for the whole hand: `ring[0]` (button+1) with 3+
+ * seats; in heads-up the button posts the small blind, so the two coincide.
+ * Ring order, never seat-number arithmetic — seats need not be contiguous.
+ */
+export function smallBlindSeat(
+  ring: readonly SeatId[],
+  button: SeatId,
+): SeatId {
+  if (ring.length === 2) return button;
+  return must(ring[0], "the small blind needs at least 2 seated players");
+}
+
+/**
  * The big blind's seat for the whole hand: `ring[1]` (button+2) with 3+
  * seats; in heads-up (`ring` has exactly 2 seats, `[other, button]`) the
  * non-button seat is the big blind instead.

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -110,32 +110,37 @@ export interface RevealedResult extends ShowdownResult {
   readonly holeCards: readonly [Card, Card];
 }
 
-export interface FoldedOutCompleteHandState {
+/**
+ * Where a hand's three fixed positions sit, plus the size of the field they
+ * were dealt from. Seat ids only — no chips are implied, the blinds are
+ * tracked positionally like the button.
+ *
+ * `smallBlind` is the honest answer, so heads-up it equals `button` (the
+ * button does post the small blind); what to draw from that is a client
+ * decision, not a rules one. `dealtSeatCount` is fixed for the hand — folds
+ * never reduce it — so `2` identifies a heads-up hand in every phase.
+ *
+ * A betting hand can derive all three from `ring`; a completed hand has
+ * dropped `ring`, so it stores them.
+ */
+export interface HandPositions {
+  readonly button: SeatId;
+  readonly smallBlind: SeatId;
+  readonly bigBlind: SeatId;
+  readonly dealtSeatCount: number;
+}
+
+export interface FoldedOutCompleteHandState extends HandPositions {
   readonly status: "complete";
   readonly reason: "folded-out";
   readonly seed: string;
-  readonly button: SeatId;
-  /** Resolved from `ring` at completion — see `dealtSeatCount`. */
-  readonly smallBlind: SeatId;
-  readonly bigBlind: SeatId;
-  /**
-   * How many seats were dealt into this hand. Fixed for the hand (folds
-   * never reduce it), so `2` identifies a heads-up hand in every phase —
-   * which is exactly when `smallBlind === button`.
-   */
-  readonly dealtSeatCount: number;
   readonly winner: SeatId;
 }
 
-export interface ShowdownCompleteHandState {
+export interface ShowdownCompleteHandState extends HandPositions {
   readonly status: "complete";
   readonly reason: "showdown";
   readonly seed: string;
-  readonly button: SeatId;
-  /** Resolved from `ring` at completion — see `FoldedOutCompleteHandState`. */
-  readonly smallBlind: SeatId;
-  readonly bigBlind: SeatId;
-  readonly dealtSeatCount: number;
   readonly board: readonly Card[];
   readonly results: readonly RevealedResult[];
   readonly winners: readonly SeatId[];

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -115,6 +115,15 @@ export interface FoldedOutCompleteHandState {
   readonly reason: "folded-out";
   readonly seed: string;
   readonly button: SeatId;
+  /** Resolved from `ring` at completion — see `dealtSeatCount`. */
+  readonly smallBlind: SeatId;
+  readonly bigBlind: SeatId;
+  /**
+   * How many seats were dealt into this hand. Fixed for the hand (folds
+   * never reduce it), so `2` identifies a heads-up hand in every phase —
+   * which is exactly when `smallBlind === button`.
+   */
+  readonly dealtSeatCount: number;
   readonly winner: SeatId;
 }
 
@@ -123,6 +132,10 @@ export interface ShowdownCompleteHandState {
   readonly reason: "showdown";
   readonly seed: string;
   readonly button: SeatId;
+  /** Resolved from `ring` at completion — see `FoldedOutCompleteHandState`. */
+  readonly smallBlind: SeatId;
+  readonly bigBlind: SeatId;
+  readonly dealtSeatCount: number;
   readonly board: readonly Card[];
   readonly results: readonly RevealedResult[];
   readonly winners: readonly SeatId[];

--- a/packages/engine/src/view.ts
+++ b/packages/engine/src/view.ts
@@ -3,6 +3,7 @@ import type {
   ActionType,
   Card,
   EngineState,
+  HandPositions,
   RevealedResult,
   SeatId,
   Street,
@@ -22,20 +23,6 @@ export interface SeatSnapshot {
 interface NoHandView {
   readonly phase: "no-hand";
   readonly button: SeatId;
-}
-
-/**
- * The positional facts every hand-bearing view carries. `smallBlind` is the
- * engine's honest answer, so heads-up it equals `button` — presentation
- * (which of these to actually draw) is the client's call, not the rules
- * core's. `dealtSeatCount` is how many seats were dealt in, fixed for the
- * hand, so `2` means heads-up in any phase.
- */
-interface HandPositions {
-  readonly button: SeatId;
-  readonly smallBlind: SeatId;
-  readonly bigBlind: SeatId;
-  readonly dealtSeatCount: number;
 }
 
 interface FoldedOutView extends HandPositions {

--- a/packages/engine/src/view.ts
+++ b/packages/engine/src/view.ts
@@ -1,4 +1,4 @@
-import { legalActions } from "./table.js";
+import { bigBlindSeat, legalActions, smallBlindSeat } from "./table.js";
 import type {
   ActionType,
   Card,
@@ -13,28 +13,45 @@ export interface SeatSnapshot {
   readonly folded: boolean;
 }
 
+/**
+ * Between hands there are no blinds: the engine button has already rotated
+ * on, so the `button` reported here is a forecast, and the blinds are far
+ * likelier than the button to move again before the deal (seats can be
+ * claimed, vacated or set to sit out). Deliberately no blind fields.
+ */
 interface NoHandView {
   readonly phase: "no-hand";
   readonly button: SeatId;
 }
 
-interface FoldedOutView {
-  readonly phase: "folded-out";
+/**
+ * The positional facts every hand-bearing view carries. `smallBlind` is the
+ * engine's honest answer, so heads-up it equals `button` — presentation
+ * (which of these to actually draw) is the client's call, not the rules
+ * core's. `dealtSeatCount` is how many seats were dealt in, fixed for the
+ * hand, so `2` means heads-up in any phase.
+ */
+interface HandPositions {
   readonly button: SeatId;
+  readonly smallBlind: SeatId;
+  readonly bigBlind: SeatId;
+  readonly dealtSeatCount: number;
+}
+
+interface FoldedOutView extends HandPositions {
+  readonly phase: "folded-out";
   readonly winner: SeatId;
 }
 
-interface ShowdownView {
+interface ShowdownView extends HandPositions {
   readonly phase: "showdown";
-  readonly button: SeatId;
   readonly board: readonly Card[];
   readonly results: readonly RevealedResult[];
   readonly winners: readonly SeatId[];
 }
 
-export interface PlayerViewBetting {
+export interface PlayerViewBetting extends HandPositions {
   readonly phase: "betting";
-  readonly button: SeatId;
   readonly street: Street;
   readonly board: readonly Card[];
   readonly toAct: readonly SeatId[];
@@ -45,9 +62,8 @@ export interface PlayerViewBetting {
   readonly legalActions: readonly ActionType[];
 }
 
-export interface TableViewBetting {
+export interface TableViewBetting extends HandPositions {
   readonly phase: "betting";
-  readonly button: SeatId;
   readonly street: Street;
   readonly board: readonly Card[];
   readonly toAct: readonly SeatId[];
@@ -82,13 +98,23 @@ export function view(
   }
 
   if (hand.status === "complete" && hand.reason === "folded-out") {
-    return { phase: "folded-out", button: hand.button, winner: hand.winner };
+    return {
+      phase: "folded-out",
+      button: hand.button,
+      smallBlind: hand.smallBlind,
+      bigBlind: hand.bigBlind,
+      dealtSeatCount: hand.dealtSeatCount,
+      winner: hand.winner,
+    };
   }
 
   if (hand.status === "complete") {
     return {
       phase: "showdown",
       button: hand.button,
+      smallBlind: hand.smallBlind,
+      bigBlind: hand.bigBlind,
+      dealtSeatCount: hand.dealtSeatCount,
       board: hand.board,
       winners: hand.winners,
       results: hand.results,
@@ -103,6 +129,9 @@ export function view(
   const tableView: TableViewBetting = {
     phase: "betting",
     button: hand.button,
+    smallBlind: smallBlindSeat(hand.ring, hand.button),
+    bigBlind: bigBlindSeat(hand.ring, hand.button),
+    dealtSeatCount: hand.ring.length,
     street: hand.street,
     board: hand.board,
     toAct: hand.toAct,

--- a/packages/harness/src/fixtures.test.ts
+++ b/packages/harness/src/fixtures.test.ts
@@ -3,7 +3,12 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { Writable } from "node:stream";
 import { describe, expect, it } from "vitest";
-import { createInitialState } from "@table-top-poker/engine";
+import {
+  apply,
+  createInitialState,
+  ENGINE_LOG_VERSION,
+} from "@table-top-poker/engine";
+import type { HandEvent } from "@table-top-poker/engine";
 import { runHarness } from "./harness.js";
 
 const fixturesDir = fileURLToPath(new URL("../fixtures/", import.meta.url));
@@ -33,5 +38,33 @@ describe("hand-1 fixture", () => {
     });
 
     expect(text()).toBe(expected);
+  });
+});
+
+describe("hand-1 fixture: replay through the engine", () => {
+  it("folds the recorded event log into a state carrying the hand's blinds", async () => {
+    // The fixture was recorded before `smallBlind`/`bigBlind` existed on the
+    // completed hand. `HandEvent` shapes are unchanged (ENGINE_LOG_VERSION is
+    // still 3), so the untouched log still replays — and the blinds resolve
+    // from the ring the replay rebuilds, not from anything in the log.
+    const recorded = await readFile(`${fixturesDir}hand-1.expected.jsonl`, {
+      encoding: "utf8",
+    });
+    const events = recorded
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as HandEvent);
+
+    let state = createInitialState([0, 1, 2]);
+    for (const event of events) state = apply(state, event);
+
+    expect(ENGINE_LOG_VERSION).toBe(3);
+    if (state.hand?.status !== "complete") throw new Error("expected complete");
+    // Button on seat 0, so ring order is [1, 2, 0]: seat 1 posts the small
+    // blind and seat 2 the big blind, three-handed.
+    expect(state.hand.button).toBe(0);
+    expect(state.hand.smallBlind).toBe(1);
+    expect(state.hand.bigBlind).toBe(2);
+    expect(state.hand.dealtSeatCount).toBe(3);
   });
 });

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -15,6 +15,9 @@ describe("Hand", () => {
     const view: PlayerView = {
       phase: "betting",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       street: "flop",
       board: [],
       toAct: [1],
@@ -58,6 +61,9 @@ describe("Hand", () => {
     const view: PlayerView = {
       phase: "betting",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       street: "flop",
       board: [
         { rank: "A", suit: "spades" },
@@ -89,6 +95,9 @@ describe("Hand", () => {
     const view: PlayerView = {
       phase: "betting",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       street: "flop",
       board: [],
       toAct: [1],
@@ -111,6 +120,9 @@ describe("Hand", () => {
     const view: PlayerView = {
       phase: "betting",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       street: "flop",
       board: [],
       toAct: [1],
@@ -131,6 +143,9 @@ describe("Hand", () => {
     const view: PlayerView = {
       phase: "betting",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       street: "turn",
       board: [],
       toAct: [0],
@@ -152,6 +167,9 @@ describe("Hand", () => {
     const view: PlayerView = {
       phase: "betting",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       street: "turn",
       board: [],
       toAct: [0],
@@ -176,6 +194,9 @@ describe("Hand", () => {
     const showdownView: PlayerView = {
       phase: "showdown",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       board: [
         { rank: "A", suit: "spades" },
         { rank: "K", suit: "hearts" },
@@ -272,7 +293,14 @@ describe("Hand", () => {
 
   describe("folded-out", () => {
     it("shows a win banner and no hole cards when everyone else folded", () => {
-      const view: PlayerView = { phase: "folded-out", button: 0, winner: 0 };
+      const view: PlayerView = {
+        phase: "folded-out",
+        button: 0,
+        smallBlind: 1,
+        bigBlind: 2,
+        dealtSeatCount: 3,
+        winner: 0,
+      };
       const html = renderToStaticMarkup(<Hand view={view} seatId={0} />);
 
       expect(html).toMatch(/data-testid="hand"[^>]*data-phase="folded-out"/);
@@ -283,7 +311,14 @@ describe("Hand", () => {
     });
 
     it("shows a loss banner naming the winner when this seat folded", () => {
-      const view: PlayerView = { phase: "folded-out", button: 0, winner: 1 };
+      const view: PlayerView = {
+        phase: "folded-out",
+        button: 0,
+        smallBlind: 1,
+        bigBlind: 2,
+        dealtSeatCount: 3,
+        winner: 1,
+      };
       const html = renderToStaticMarkup(<Hand view={view} seatId={0} />);
 
       expect(html).toMatch(/data-testid="turn-banner"[^>]*data-tone="loss"/);
@@ -292,7 +327,14 @@ describe("Hand", () => {
     });
 
     it("never reveals a pair for a seat that folded out — folding is final", () => {
-      const view: PlayerView = { phase: "folded-out", button: 0, winner: 1 };
+      const view: PlayerView = {
+        phase: "folded-out",
+        button: 0,
+        smallBlind: 1,
+        bigBlind: 2,
+        dealtSeatCount: 3,
+        winner: 1,
+      };
       const html = renderToStaticMarkup(<Hand view={view} seatId={0} />);
 
       expect(html).not.toMatch(/data-testid="hole-cards"/);

--- a/packages/player-client/src/actions/legalActionsFromView.test.ts
+++ b/packages/player-client/src/actions/legalActionsFromView.test.ts
@@ -16,6 +16,9 @@ describe("legalActionsFromView", () => {
     const view: PlayerView = {
       phase: "betting",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       street: "preflop",
       board: [],
       toAct: [0],

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -41,6 +41,9 @@ function seat(id: number, claimed: boolean): SeatView {
 const liveHand: TableView = {
   phase: "betting",
   button: 0,
+  smallBlind: 1,
+  bigBlind: 2,
+  dealtSeatCount: 3,
   street: "flop",
   board: [],
   toAct: [1],

--- a/packages/table-client/src/Board.test.tsx
+++ b/packages/table-client/src/Board.test.tsx
@@ -15,6 +15,9 @@ describe("Board", () => {
     const view: TableView = {
       phase: "betting",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       street: "flop",
       board: [
         { rank: "A", suit: "spades" },
@@ -35,7 +38,14 @@ describe("Board", () => {
   });
 
   it("names the winner in a hand-complete banner after everyone else folds", () => {
-    const view: TableView = { phase: "folded-out", button: 0, winner: 1 };
+    const view: TableView = {
+      phase: "folded-out",
+      button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
+      winner: 1,
+    };
     const html = renderToStaticMarkup(
       <Board
         view={view}
@@ -69,6 +79,9 @@ describe("Board", () => {
     const view: TableView = {
       phase: "showdown",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       board: [
         { rank: "A", suit: "spades" },
         { rank: "K", suit: "hearts" },
@@ -126,6 +139,9 @@ describe("Board", () => {
     const view: TableView = {
       phase: "showdown",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       board: [
         { rank: "A", suit: "spades" },
         { rank: "K", suit: "hearts" },

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -112,6 +112,9 @@ describe("Seats", () => {
     const view: TableView = {
       phase: "betting",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       street: "flop",
       board: [],
       toAct: [0],
@@ -145,6 +148,9 @@ describe("Seats", () => {
     const view: TableView = {
       phase: "betting",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       street: "flop",
       board: [],
       toAct: [0],
@@ -190,6 +196,9 @@ describe("Seats", () => {
     const view: TableView = {
       phase: "betting",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       street: "flop",
       board: [],
       toAct: [1],
@@ -218,6 +227,9 @@ describe("Seats", () => {
     const view: TableView = {
       phase: "betting",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       street: "preflop",
       board: [],
       toAct: [0],
@@ -263,6 +275,9 @@ describe("Seats", () => {
     const view: TableView = {
       phase: "showdown",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       board: [
         { rank: "A", suit: "spades" },
         { rank: "K", suit: "hearts" },
@@ -304,6 +319,9 @@ describe("Seats", () => {
     const view: TableView = {
       phase: "showdown",
       button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
       board: [
         { rank: "A", suit: "spades" },
         { rank: "K", suit: "hearts" },
@@ -348,7 +366,14 @@ describe("Seats", () => {
   });
 
   it("marks the sole winner at a fold-out completion, with no reveal", () => {
-    const view: TableView = { phase: "folded-out", button: 0, winner: 1 };
+    const view: TableView = {
+      phase: "folded-out",
+      button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
+      winner: 1,
+    };
     const sittingOutWinnerSeats = seats.map((seat) =>
       seat.id === 1 ? { ...seat, sittingOut: true } : seat,
     );
@@ -373,5 +398,158 @@ describe("Seats", () => {
     expect(html).toMatch(
       /data-testid="seat-pod-3"[^>]*style="(?:(?!cursor).)*"/,
     );
+  });
+});
+
+/** The inline `style` attribute of the span carrying `testid`, if drawn. */
+function styleOf(html: string, testid: string): string | null {
+  const match = new RegExp(`data-testid="${testid}"[^>]*style="([^"]*)"`).exec(
+    html,
+  );
+  return match?.[1] ?? null;
+}
+
+const threeHanded: TableView = {
+  // Seats 3, 0 and 1 are in the hand with the button on 3, so ring order
+  // (3 -> 0 -> 1) runs the opposite way to seat-number order.
+  phase: "betting",
+  button: 3,
+  smallBlind: 0,
+  bigBlind: 1,
+  dealtSeatCount: 3,
+  street: "preflop",
+  board: [],
+  toAct: [0],
+  seats: [
+    { seatId: 3, folded: false },
+    { seatId: 0, folded: false },
+    { seatId: 1, folded: false },
+  ],
+};
+
+const headsUpPositions = {
+  button: 0,
+  smallBlind: 0,
+  bigBlind: 1,
+  dealtSeatCount: 2,
+} as const;
+
+describe("Seats: position markers", () => {
+  it("draws all three markers, on the seats the view names", () => {
+    const html = renderToStaticMarkup(
+      <Seats seats={seats} view={threeHanded} />,
+    );
+
+    expect(html).toContain('data-testid="seat-pod-3-button"');
+    expect(html).toContain('data-testid="seat-pod-0-small-blind"');
+    expect(html).toContain('data-testid="seat-pod-1-big-blind"');
+    expect(html).toMatch(
+      /data-testid="seat-pod-0"[^>]*data-small-blind="true"/,
+    );
+    expect(html).toMatch(/data-testid="seat-pod-1"[^>]*data-big-blind="true"/);
+  });
+
+  it("follows ring order rather than seat-number order", () => {
+    const html = renderToStaticMarkup(
+      <Seats seats={seats} view={threeHanded} />,
+    );
+
+    // Seat 0 is the lowest seat number but sits button+1, so it is the small
+    // blind — seat-number arithmetic from the button would have said seat 4.
+    expect(html).not.toContain('data-testid="seat-pod-0-button"');
+    expect(html).not.toContain('data-testid="seat-pod-3-small-blind"');
+    expect(html).not.toContain('data-testid="seat-pod-0-big-blind"');
+  });
+
+  it("gives no seat more than one marker", () => {
+    const html = renderToStaticMarkup(
+      <Seats seats={seats} view={threeHanded} />,
+    );
+    const markers = html.match(
+      /data-testid="seat-pod-\d+-(?:button|small-blind|big-blind)"/g,
+    );
+    expect(markers).toHaveLength(3);
+    expect(new Set(markers).size).toBe(3);
+  });
+
+  it("draws the button only between hands", () => {
+    const html = renderToStaticMarkup(
+      <Seats seats={seats} view={{ phase: "no-hand", button: 1 }} />,
+    );
+    expect(html).toContain('data-testid="seat-pod-1-button"');
+    expect(html).not.toContain('small-blind"');
+    expect(html).not.toContain('big-blind"');
+  });
+
+  // Issue #160, decision 4: heads-up the button *is* the small blind, and the
+  // client suppresses both blinds rather than doubling up a seat.
+  it.each([
+    [
+      "betting",
+      {
+        ...headsUpPositions,
+        phase: "betting",
+        street: "preflop",
+        board: [],
+        toAct: [0],
+        seats: [
+          { seatId: 0, folded: false },
+          { seatId: 1, folded: false },
+        ],
+      } satisfies TableView,
+    ],
+    [
+      "showdown",
+      {
+        ...headsUpPositions,
+        phase: "showdown",
+        board: [],
+        winners: [0],
+        results: [],
+      } satisfies TableView,
+    ],
+    [
+      "folded-out",
+      {
+        ...headsUpPositions,
+        phase: "folded-out",
+        winner: 0,
+      } satisfies TableView,
+    ],
+  ])("draws the button only in a heads-up hand (%s)", (_phase, view) => {
+    const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
+
+    expect(html).toContain('data-testid="seat-pod-0-button"');
+    expect(html).not.toContain('data-testid="seat-pod-0-small-blind"');
+    expect(html).not.toContain('data-testid="seat-pod-1-big-blind"');
+    expect(html).toMatch(
+      /data-testid="seat-pod-0"[^>]*data-small-blind="false"/,
+    );
+    expect(html).toMatch(/data-testid="seat-pod-1"[^>]*data-big-blind="false"/);
+  });
+
+  it("renders all three markers at one diameter and one font size", () => {
+    const html = renderToStaticMarkup(
+      <Seats seats={seats} view={threeHanded} />,
+    );
+
+    const sizes = [
+      styleOf(html, "seat-pod-3-button"),
+      styleOf(html, "seat-pod-0-small-blind"),
+      styleOf(html, "seat-pod-1-big-blind"),
+    ].map((style) => {
+      expect(style).not.toBeNull();
+      return /width:([^;]+);height:([^;]+);/.exec(style ?? "")?.slice(1, 3);
+    });
+
+    expect(sizes[0]).toBeDefined();
+    expect(sizes[1]).toEqual(sizes[0]);
+    expect(sizes[2]).toEqual(sizes[0]);
+    // The label's font size lives on an inner span, so the diameter resolves
+    // against the pod and not against the marker's own text.
+    expect(sizes[0]?.[0]).toBe(sizes[0]?.[1]);
+
+    const fontSizes = html.match(/font-size:0\.62em/g);
+    expect(fontSizes).toHaveLength(3);
   });
 });

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -18,7 +18,7 @@ type SeatStatus =
   "open" | "sitting-out" | "disconnected" | "folded" | "in-hand";
 
 /** Which positional marker a seat carries, if any. Never more than one. */
-type Position = "button" | "small-blind" | "big-blind";
+type SeatMarker = "button" | "small-blind" | "big-blind";
 
 /**
  * One diameter and one font size for all three markers, resolved against the
@@ -30,13 +30,13 @@ type Position = "button" | "small-blind" | "big-blind";
 const MARKER_DIAMETER = "1.6em";
 const MARKER_FONT_SIZE = "0.62em";
 
-const markerLabel: Record<Position, string> = {
+const markerLabel: Record<SeatMarker, string> = {
   button: "D",
   "small-blind": "SB",
   "big-blind": "BB",
 };
 
-const markerBackground: Record<Position, string> = {
+const markerBackground: Record<SeatMarker, string> = {
   button: color.buttonMarker,
   "small-blind": color.blindSmallMarker,
   "big-blind": color.blindBigMarker,
@@ -44,8 +44,7 @@ const markerBackground: Record<Position, string> = {
 
 interface SeatVisual {
   readonly status: SeatStatus;
-  readonly position: Position | null;
-  readonly isButton: boolean;
+  readonly marker: SeatMarker | null;
   readonly isActor: boolean;
   readonly isWinner: boolean;
   readonly holeCards: readonly [CardType, CardType] | null;
@@ -71,9 +70,12 @@ interface SeatVisual {
  *   that existed before blind markers were added. This is a decision
  *   (issue #160, decision 4), not an oversight.
  */
-function positionFor(seatId: number, view: TableView | null): Position | null {
+function markerFor(seatId: number, view: TableView | null): SeatMarker | null {
   if (view === null) return null;
-  if (view.phase === "no-hand" || view.dealtSeatCount === 2) {
+  // Heads-up is a property of the deal, not of who is still live: folds never
+  // change it, so this reads the same in every phase of the hand.
+  const headsUp = view.phase !== "no-hand" && view.dealtSeatCount === 2;
+  if (view.phase === "no-hand" || headsUp) {
     return seatId === view.button ? "button" : null;
   }
   if (seatId === view.button) return "button";
@@ -152,8 +154,7 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
 
   return {
     status,
-    position: positionFor(seat.id, view),
-    isButton: view !== null && seat.id === view.button,
+    marker: markerFor(seat.id, view),
     isActor: view?.phase === "betting" && view.toAct[0] === seat.id,
     isWinner,
     holeCards: showdownResult?.holeCards ?? null,
@@ -219,9 +220,9 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
                 }}
               />
             )}
-            {visual.position && (
+            {visual.marker && (
               <span
-                data-testid={`seat-pod-${String(seat.id)}-${visual.position}`}
+                data-testid={`seat-pod-${String(seat.id)}-${visual.marker}`}
                 style={{
                   position: "absolute",
                   top: "-0.4em",
@@ -232,7 +233,7 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  background: markerBackground[visual.position],
+                  background: markerBackground[visual.marker],
                   color: color.pillInk,
                   boxShadow: shadow.card,
                 }}
@@ -245,7 +246,7 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
                     lineHeight: 1,
                   }}
                 >
-                  {markerLabel[visual.position]}
+                  {markerLabel[visual.marker]}
                 </span>
               </span>
             )}
@@ -374,9 +375,9 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
             key={seat.id}
             data-testid={`seat-pod-${String(seat.id)}`}
             data-status={visual.status}
-            data-button={visual.isButton}
-            data-small-blind={visual.position === "small-blind"}
-            data-big-blind={visual.position === "big-blind"}
+            data-button={visual.marker === "button"}
+            data-small-blind={visual.marker === "small-blind"}
+            data-big-blind={visual.marker === "big-blind"}
             data-turn={visual.isActor}
             data-winner={visual.isWinner}
             data-disconnected={seat.disconnected}

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -17,8 +17,34 @@ export interface SeatsProps {
 type SeatStatus =
   "open" | "sitting-out" | "disconnected" | "folded" | "in-hand";
 
+/** Which positional marker a seat carries, if any. Never more than one. */
+type Position = "button" | "small-blind" | "big-blind";
+
+/**
+ * One diameter and one font size for all three markers, resolved against the
+ * pod rather than against the marker's own text. The two are set on separate
+ * elements on purpose: `width: 1.6em` and `fontSize: 0.6em` on the *same*
+ * element made the true diameter `1.6 x 0.6em`, which is why the button
+ * marker rendered at roughly a third of the avatar instead of half of it.
+ */
+const MARKER_DIAMETER = "1.6em";
+const MARKER_FONT_SIZE = "0.62em";
+
+const markerLabel: Record<Position, string> = {
+  button: "D",
+  "small-blind": "SB",
+  "big-blind": "BB",
+};
+
+const markerBackground: Record<Position, string> = {
+  button: color.buttonMarker,
+  "small-blind": color.blindSmallMarker,
+  "big-blind": color.blindBigMarker,
+};
+
 interface SeatVisual {
   readonly status: SeatStatus;
+  readonly position: Position | null;
   readonly isButton: boolean;
   readonly isActor: boolean;
   readonly isWinner: boolean;
@@ -26,6 +52,34 @@ interface SeatVisual {
   readonly handDescription: string | null;
   readonly avatarBackground: string;
   readonly avatarColor: string;
+}
+
+/**
+ * Which marker this seat carries. All three come off the same view, so the
+ * trio always moves on one tick and no seat ever carries two.
+ *
+ * Two suppressions, both deliberate:
+ *
+ * - Between hands (`no-hand`) only the button shows. The engine reports no
+ *   blinds without a hand, and the button it does report is already a
+ *   forecast of the next deal.
+ * - **Heads-up (`dealtSeatCount === 2`) only the button shows — no `SB` on
+ *   the button seat, and no `BB` on the other seat either.** The engine
+ *   honestly reports `smallBlind === button` heads-up (the button does post
+ *   the small blind), which would put two markers on one seat. Rather than
+ *   stack or combine them, a heads-up hand reverts to exactly the display
+ *   that existed before blind markers were added. This is a decision
+ *   (issue #160, decision 4), not an oversight.
+ */
+function positionFor(seatId: number, view: TableView | null): Position | null {
+  if (view === null) return null;
+  if (view.phase === "no-hand" || view.dealtSeatCount === 2) {
+    return seatId === view.button ? "button" : null;
+  }
+  if (seatId === view.button) return "button";
+  if (seatId === view.smallBlind) return "small-blind";
+  if (seatId === view.bigBlind) return "big-blind";
+  return null;
 }
 
 /**
@@ -98,6 +152,7 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
 
   return {
     status,
+    position: positionFor(seat.id, view),
     isButton: view !== null && seat.id === view.button,
     isActor: view?.phase === "betting" && view.toAct[0] === seat.id,
     isWinner,
@@ -164,28 +219,34 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
                 }}
               />
             )}
-            {visual.isButton && (
+            {visual.position && (
               <span
-                data-testid={`seat-pod-${String(seat.id)}-button`}
+                data-testid={`seat-pod-${String(seat.id)}-${visual.position}`}
                 style={{
                   position: "absolute",
                   top: "-0.4em",
                   right: "-0.4em",
-                  width: "1.6em",
-                  height: "1.6em",
+                  width: MARKER_DIAMETER,
+                  height: MARKER_DIAMETER,
                   borderRadius: "50%",
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  fontFamily: font.mono,
-                  fontSize: "0.6em",
-                  fontWeight: 700,
-                  background: color.buttonMarker,
+                  background: markerBackground[visual.position],
                   color: color.pillInk,
                   boxShadow: shadow.card,
                 }}
               >
-                D
+                <span
+                  style={{
+                    fontFamily: font.mono,
+                    fontSize: MARKER_FONT_SIZE,
+                    fontWeight: 700,
+                    lineHeight: 1,
+                  }}
+                >
+                  {markerLabel[visual.position]}
+                </span>
               </span>
             )}
           </div>
@@ -314,6 +375,8 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
             data-testid={`seat-pod-${String(seat.id)}`}
             data-status={visual.status}
             data-button={visual.isButton}
+            data-small-blind={visual.position === "small-blind"}
+            data-big-blind={visual.position === "big-blind"}
             data-turn={visual.isActor}
             data-winner={visual.isWinner}
             data-disconnected={seat.disconnected}

--- a/packages/ui-shared/src/theme.ts
+++ b/packages/ui-shared/src/theme.ts
@@ -2,11 +2,10 @@
  * Design tokens for the felt/night palette. `table-client` and
  * `player-client` both style against these rather than hard-coding values.
  *
- * These tokens — not the design prototype
- * (`docs/design/table-top-poker-prototype.dc.html`) — are the palette's
- * source of truth. The prototype seeded the original values but has since
- * drifted, and features built from it are now closed off; do not reconcile
- * new tokens against it.
+ * The design prototype (`docs/design/table-top-poker-prototype.dc.html`)
+ * seeded these values but is no longer the palette's source of truth: it has
+ * since drifted from what ships. These tokens are. Don't reconcile a new
+ * token against the prototype (issue #160, decision 9).
  */
 
 const feltGradient =

--- a/packages/ui-shared/src/theme.ts
+++ b/packages/ui-shared/src/theme.ts
@@ -1,7 +1,12 @@
 /**
- * Design tokens for the felt/night palette used by the design prototype
- * (`docs/design/table-top-poker-prototype.dc.html`). `table-client` and
+ * Design tokens for the felt/night palette. `table-client` and
  * `player-client` both style against these rather than hard-coding values.
+ *
+ * These tokens — not the design prototype
+ * (`docs/design/table-top-poker-prototype.dc.html`) — are the palette's
+ * source of truth. The prototype seeded the original values but has since
+ * drifted, and features built from it are now closed off; do not reconcile
+ * new tokens against it.
  */
 
 const feltGradient =
@@ -67,6 +72,13 @@ export const color = {
   seatWinnerBackground: "rgba(250,234,231,.14)",
   seatActorBackground: "rgba(20,7,8,.72)",
   buttonMarker: "#faf6f0",
+  /**
+   * Saturated enough that it never reads as "the white button marker,
+   * slightly tinted" from a couple of metres away.
+   */
+  blindSmallMarker: "#5aa9f0",
+  /** Amber rather than lemon, so it sits inside the warm felt palette. */
+  blindBigMarker: "#f2c14e",
 } as const;
 
 export const font = {


### PR DESCRIPTION
Closes #160.

Adds `SB` and `BB` markers beside the table's existing `D`, and fixes the button marker's size. All three render at one diameter and one font size.

## Source of truth is the engine view

`smallBlindSeat` joins `bigBlindSeat` in `packages/engine/src/table.ts`, and the hand-bearing views gain `smallBlind`, `bigBlind` and `dealtSeatCount` (hoisted into a shared `HandPositions`). The client renders what it is told — no client-side re-derivation of the heads-up rule or the live-seat filter.

`FoldedOutCompleteHandState` and `ShowdownCompleteHandState` resolve both blind seats from `ring` at completion, while `ring` is still in scope, so the button's rotation on `HandComplete` cannot reach back and change what a finished hand says about itself. `NoHandView` gains no fields: between hands, only `D` shows.

No `HandEvent` shape changes, so **`ENGINE_LOG_VERSION` stays at 3**. Proven, not assumed: the existing `hand-1` fixture still replays byte-for-byte, and a new test folds that untouched recorded log through `apply` and checks the blinds resolve correctly from the ring the replay rebuilds.

## Heads-up shows the Button only — deliberate

**In a heads-up hand only `D` is drawn: no `SB` on the button seat, and no `BB` on the other seat either, in `betting`, `showdown` and `folded-out` alike.** Heads-up the button genuinely does post the small blind, so `smallBlind === button` and that seat would otherwise carry two markers. Rather than stack or combine them, a heads-up hand reverts to exactly the display that existed before this change.

The engine reports the heads-up truth honestly — suppression is purely client-side, so the rules core carries no presentation decision and the player client and replay tooling get the truth later. The rule is recorded at the suppression site in `Seats.tsx` as well as here, so it doesn't read as a bug to whoever finds it next.

The mechanism for detecting heads-up outside `betting` is `dealtSeatCount`: how many seats were dealt into the hand, fixed for the hand. A count is a fact where a `headsUp` boolean would be an interpretation.

## Sizing

`Seats.tsx` set `width`/`height: 1.6em` **and** `fontSize: 0.6em` on the same element. `width`'s `em` resolves against the element's own computed font-size, so the true diameter was `1.6 x 0.6 = 0.96em` of the pod, where the code read as `1.6em`. The diameter now sits on the outer span and the label's font size on an inner one, at the target `1.6em` / `0.62em`.

Note the avatar next door has the same em-nesting (`3em` with `fontSize: 1.1em`, so `3.3em` true), which puts the marker at ~48% of the avatar rather than the ~53% the issue quoted. Left alone here — changing it would resize the avatar, which is outside this issue — and the constants are provisional pending a look on the real device anyway.

## Also

Per decision 9, the `theme.ts` doc comment no longer cites the design prototype as the palette's source of truth; the prototype has drifted (it disagrees with every decision above) and is not updated. The wider repo-wide sweep is tracked separately.

## Testing

- Engine tests first (TDD): ring order not seat arithmetic; heads-up honesty; completed states unaffected by the button rotation; between-hands has no blind fields.
- Table-client: markers on the right seats, ring order, never two on one seat, button-only between hands, button-only heads-up in all three phases, and one diameter/font size across the trio.
- Full suite: 80 files, 658 tests, all passing. `npm run build` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KogYGpUWdN9nmm4DAbNbsA