### PR TITLE
feat(player): add leave-game behind a burger side menu

### DIFF
--- a/docs/adr/0005-players-can-release-their-own-seat.md
+++ b/docs/adr/0005-players-can-release-their-own-seat.md
@@ -1,0 +1,65 @@
+# 0005 — Players release their own seat via a token-authenticated leave endpoint
+
+## Status
+
+Accepted. Complements [ADR-0003](0003-eviction-is-a-manual-table-action.md):
+the table's manual evict frees *someone else's* seat; this adds a player
+freeing *their own*. Neither revives the automatic eviction ADR-0003 removed.
+
+## Context
+
+A player could sit out (skip hands while keeping their seat) but had no way
+to give the seat up — only the table device could free it, via the manual
+evict action (ADR-0003). "I'm done, take my seat back" had to be done by
+someone else at the table.
+
+Two constraints shaped the mechanism:
+
+- **It must work while disconnected.** The most common reason to want out is
+  a flaky or dead connection, which is precisely when a WebSocket command
+  (the transport `sitOut`/`sitIn` use) cannot be sent. A leave that only
+  works while connected would fail in the case that motivates it most.
+- **It must not reintroduce an automatic timer.** ADR-0003 deliberately
+  removed auto-eviction so the human at the table — not a clock — decides
+  when a disconnected player is *gone* versus merely *away*. Cleaning up a
+  ghost seat left by a leave that never reached the server is still that
+  human's job, via manual evict; nothing here changes that.
+
+## Decision
+
+Leaving is a player-initiated seat release exposed as
+`POST /rooms/:code/seats/:seatId/leave`, authenticated by the seat's own
+token (the same token the client stores for silent reclaim). It reuses the
+existing free-the-seat operation wholesale — the one manual evict already
+uses — so a live in-hand seat is folded first exactly as an eviction is:
+the current actor folds normally, a non-actor is removed from the
+outstanding queue without disturbing whoever is to act. Committed chips
+stay in the pot. The seat's token is invalidated, the claim cleared, and
+the freed seat broadcast to the table.
+
+HTTP rather than a WebSocket command specifically so it works with no live
+socket; the client sends it with a keep-alive fetch so it survives the
+client's own teardown, and tears down optimistically — clearing its seat,
+room, and stored token and returning to the join screen without waiting for
+a reply. The leaving socket is closed server-side without the
+`player-evicted` notice, since a voluntary leave is not an eviction and the
+client has already navigated away.
+
+No timeout, counter, or automatic trigger is added. A leave that never
+reaches the server (the device is fully offline) leaves the seat marked
+disconnected, cleaned up by the table's manual evict — the ADR-0003 status
+quo, unchanged.
+
+## Consequences
+
+- One free-the-seat operation now has two entry points: the table's evict
+  (frees any seat, no token) and the player's leave (frees only the seat
+  whose token is presented). Both fold a live hand identically.
+- Leave is reachable while disconnected; the client offers it
+  unconditionally, unlike `sitOut`/`sitIn`, which stay gated on a live
+  socket because they have nothing to send over otherwise.
+- The residual ghost seat (offline leave) is not new scope — it is the same
+  disconnected-seat cleanup ADR-0003 already assigns to the table operator.
+- Should automatic cleanup of disconnected seats ever be wanted, it remains
+  a separate decision that must supersede ADR-0003 on its own terms, not a
+  side effect of this endpoint.

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -1,7 +1,7 @@
 import type { SeatMove } from "@table-top-poker/protocol";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ActionBar } from "./ActionBar.js";
-import { claimSeat, joinRoom } from "./api/rooms.js";
+import { claimSeat, joinRoom, leaveSeat } from "./api/rooms.js";
 import { useActionIntent } from "./actions/useActionIntent.js";
 import { claimErrorCode } from "./claimError.js";
 import { Hand } from "./Hand.js";
@@ -129,6 +129,28 @@ export function App() {
     if (!playerSeat) return;
     send({ type: playerSeat.sittingOut ? "sitIn" : "sitOut" });
   }, [playerSeat, send]);
+
+  // A live seat still in the hand — used to warn that leaving forfeits it.
+  const inLiveHand =
+    handView?.phase === "betting" &&
+    handView.seats.some(
+      (snapshot) => snapshot.seatId === handView.yourSeatId && !snapshot.folded,
+    );
+
+  const handleLeave = useCallback(() => {
+    // Optimistic exit (ADR-0005): fire the release, then tear down locally and
+    // land on the join screen. Nulling the ws params cancels the reconnect.
+    if (roomCode !== null && seatId !== null && seatToken !== null) {
+      leaveSeat(roomCode, seatId, seatToken);
+    }
+    clearSeatToken(window.localStorage);
+    setSeatToken(null);
+    clearSeat();
+    clearRoom();
+    setSeatMoveMessage(null);
+    setEvictionMessage(null);
+  }, [roomCode, seatId, seatToken, clearSeat, clearRoom]);
+
   const intent = useActionIntent(send);
 
   const handleJoin = useCallback(
@@ -225,7 +247,9 @@ export function App() {
       <StatusBar
         showBadge={wsParams !== null}
         connectionStatus={connectionStatus}
+        inLiveHand={inLiveHand}
         onToggleSittingOut={handleToggleSittingOut}
+        onLeave={handleLeave}
         seat={
           playerSeat
             ? {

--- a/packages/player-client/src/PlayerMenu.test.tsx
+++ b/packages/player-client/src/PlayerMenu.test.tsx
@@ -1,0 +1,143 @@
+import { color } from "@table-top-poker/ui-shared";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { MenuBody, PlayerMenu, leaveConfirmMessage } from "./PlayerMenu.js";
+
+const noop = () => undefined;
+
+const bodyHandlers = {
+  onClose: noop,
+  onSitOut: noop,
+  onStartConfirm: noop,
+  onCancelConfirm: noop,
+  onConfirmLeave: noop,
+} as const;
+
+describe("PlayerMenu", () => {
+  it("renders a closed burger button with no drawer", () => {
+    const html = renderToStaticMarkup(
+      <PlayerMenu
+        sittingOut={false}
+        sitOutDisabled={false}
+        inLiveHand={false}
+        onToggleSittingOut={noop}
+        onLeave={noop}
+      />,
+    );
+
+    expect(html).toContain('data-testid="player-menu-button"');
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).not.toContain('data-testid="player-menu-drawer"');
+  });
+});
+
+describe("MenuBody", () => {
+  it("offers sit out while active and sit in while sitting out", () => {
+    const active = renderToStaticMarkup(
+      <MenuBody
+        sittingOut={false}
+        sitOutDisabled={false}
+        inLiveHand={false}
+        confirmingLeave={false}
+        {...bodyHandlers}
+      />,
+    );
+    const sittingOut = renderToStaticMarkup(
+      <MenuBody
+        sittingOut={true}
+        sitOutDisabled={false}
+        inLiveHand={false}
+        confirmingLeave={false}
+        {...bodyHandlers}
+      />,
+    );
+
+    expect(active).toContain('data-testid="menu-sit-out"');
+    expect(active).toContain("Sit out");
+    expect(sittingOut).toContain("Sit in");
+  });
+
+  it("disables sit out when the socket is down, but never the leave action", () => {
+    const html = renderToStaticMarkup(
+      <MenuBody
+        sittingOut={false}
+        sitOutDisabled={true}
+        inLiveHand={false}
+        confirmingLeave={false}
+        {...bodyHandlers}
+      />,
+    );
+
+    expect(html).toMatch(/data-testid="menu-sit-out"[^>]*disabled/);
+    // Leave stays available even when disconnected (ADR-0005).
+    expect(html).toContain('data-testid="menu-leave"');
+    expect(html).not.toMatch(/data-testid="menu-leave"[^>]*disabled/);
+  });
+
+  it("shows the leave action, not a confirmation, until leave is chosen", () => {
+    const html = renderToStaticMarkup(
+      <MenuBody
+        sittingOut={false}
+        sitOutDisabled={false}
+        inLiveHand={false}
+        confirmingLeave={false}
+        {...bodyHandlers}
+      />,
+    );
+
+    expect(html).toContain('data-testid="menu-leave"');
+    expect(html).toContain("Leave game");
+    expect(html).not.toContain('data-testid="leave-confirm"');
+  });
+
+  it("swaps in the confirmation with context-aware copy once confirming", () => {
+    const inHand = renderToStaticMarkup(
+      <MenuBody
+        sittingOut={false}
+        sitOutDisabled={false}
+        inLiveHand={true}
+        confirmingLeave={true}
+        {...bodyHandlers}
+      />,
+    );
+    const outOfHand = renderToStaticMarkup(
+      <MenuBody
+        sittingOut={false}
+        sitOutDisabled={false}
+        inLiveHand={false}
+        confirmingLeave={true}
+        {...bodyHandlers}
+      />,
+    );
+
+    expect(inHand).toContain('data-testid="leave-confirm"');
+    expect(inHand).toContain("forfeit the current hand");
+    expect(inHand).toContain('data-testid="leave-confirm-yes"');
+    expect(inHand).toContain('data-testid="leave-confirm-cancel"');
+    expect(inHand).not.toContain('data-testid="menu-leave"');
+    expect(outOfHand).toContain("Leave the game?");
+  });
+
+  it("styles the leave action against the accent, not the neutral fill", () => {
+    const html = renderToStaticMarkup(
+      <MenuBody
+        sittingOut={false}
+        sitOutDisabled={false}
+        inLiveHand={false}
+        confirmingLeave={false}
+        {...bodyHandlers}
+      />,
+    );
+
+    const leaveButton = /<button[^>]*data-testid="menu-leave"[^>]*>/.exec(html);
+    expect(leaveButton?.[0]).toContain(color.accentWash);
+  });
+});
+
+describe("leaveConfirmMessage", () => {
+  it("warns about forfeiting only while in a live hand", () => {
+    expect(leaveConfirmMessage(true)).toContain("forfeit");
+    expect(leaveConfirmMessage(false)).toBe("Leave the game?");
+  });
+});

--- a/packages/player-client/src/PlayerMenu.tsx
+++ b/packages/player-client/src/PlayerMenu.tsx
@@ -1,0 +1,329 @@
+import {
+  PillButton,
+  color,
+  font,
+  fontSize,
+  radius,
+} from "@table-top-poker/ui-shared";
+import { AnimatePresence, motion } from "motion/react";
+import { useEffect, useState, type CSSProperties } from "react";
+
+export interface PlayerMenuProps {
+  readonly sittingOut: boolean;
+  /** Sit out/in needs a live socket to send; leave never does (ADR-0005). */
+  readonly sitOutDisabled: boolean;
+  /** Drives the confirm copy — a live hand is forfeited on leave. */
+  readonly inLiveHand: boolean;
+  readonly onToggleSittingOut: () => void;
+  readonly onLeave: () => void;
+}
+
+/** Context-aware confirm copy — a live hand is forfeited, otherwise a plain exit. */
+export function leaveConfirmMessage(inLiveHand: boolean): string {
+  return inLiveHand
+    ? "Leave now? You'll forfeit the current hand."
+    : "Leave the game?";
+}
+
+/**
+ * The player's burger and the side drawer it opens (ADR-0005). The drawer holds
+ * the seat actions moved out of the crowded top bar — sit out/in, gated on the
+ * socket, and leave, which is always available and asks to confirm first.
+ */
+export function PlayerMenu({
+  sittingOut,
+  sitOutDisabled,
+  inLiveHand,
+  onToggleSittingOut,
+  onLeave,
+}: PlayerMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [confirmingLeave, setConfirmingLeave] = useState(false);
+
+  function close() {
+    setOpen(false);
+    setConfirmingLeave(false);
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") close();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="player-menu-button"
+        aria-label="Open menu"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => {
+          setOpen(true);
+        }}
+        style={menuButtonStyle}
+      >
+        <span style={burgerBarStyle} />
+        <span style={burgerBarStyle} />
+        <span style={burgerBarStyle} />
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            key="player-menu-backdrop"
+            data-testid="player-menu-backdrop"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.18 }}
+            onClick={close}
+            style={{
+              position: "absolute",
+              inset: 0,
+              zIndex: 30,
+              display: "flex",
+              justifyContent: "flex-end",
+              background: color.overlay,
+              backdropFilter: "blur(3px)",
+            }}
+          >
+            <motion.div
+              role="dialog"
+              aria-modal="true"
+              aria-label="Player menu"
+              data-testid="player-menu-drawer"
+              initial={{ x: "100%" }}
+              animate={{ x: 0 }}
+              exit={{ x: "100%" }}
+              transition={{ type: "tween", duration: 0.22 }}
+              onClick={(event) => {
+                event.stopPropagation();
+              }}
+              style={{
+                width: "80%",
+                height: "100%",
+                display: "flex",
+                flexDirection: "column",
+                gap: 14,
+                padding: "18px 18px 24px",
+                background: color.sideMenuGradient,
+                borderLeft: `1px solid ${color.borderStrong}`,
+                boxShadow: "-30px 0 80px -20px rgba(0,0,0,.8)",
+              }}
+            >
+              <MenuBody
+                sittingOut={sittingOut}
+                sitOutDisabled={sitOutDisabled}
+                inLiveHand={inLiveHand}
+                confirmingLeave={confirmingLeave}
+                onClose={close}
+                onSitOut={() => {
+                  onToggleSittingOut();
+                  close();
+                }}
+                onStartConfirm={() => {
+                  setConfirmingLeave(true);
+                }}
+                onCancelConfirm={() => {
+                  setConfirmingLeave(false);
+                }}
+                onConfirmLeave={onLeave}
+              />
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  );
+}
+
+export interface MenuBodyProps {
+  readonly sittingOut: boolean;
+  readonly sitOutDisabled: boolean;
+  readonly inLiveHand: boolean;
+  readonly confirmingLeave: boolean;
+  readonly onClose: () => void;
+  readonly onSitOut: () => void;
+  readonly onStartConfirm: () => void;
+  readonly onCancelConfirm: () => void;
+  readonly onConfirmLeave: () => void;
+}
+
+/** The drawer's contents, split out from its animation shell so it renders flat in tests. */
+export function MenuBody({
+  sittingOut,
+  sitOutDisabled,
+  inLiveHand,
+  confirmingLeave,
+  onClose,
+  onSitOut,
+  onStartConfirm,
+  onCancelConfirm,
+  onConfirmLeave,
+}: MenuBodyProps) {
+  return (
+    <>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <span style={kickerStyle}>Menu</span>
+        <button
+          type="button"
+          aria-label="Close menu"
+          data-testid="player-menu-close"
+          onClick={onClose}
+          style={{
+            width: 34,
+            height: 34,
+            borderRadius: 11,
+            border: `1px solid ${color.border}`,
+            background: "transparent",
+            color: color.textMuted,
+            fontSize: 15,
+            cursor: "pointer",
+          }}
+        >
+          ✕
+        </button>
+      </div>
+
+      <button
+        type="button"
+        data-testid="menu-sit-out"
+        disabled={sitOutDisabled}
+        onClick={onSitOut}
+        style={{
+          ...itemStyle,
+          ...(sitOutDisabled
+            ? { color: color.disabledText, cursor: "default" }
+            : {}),
+        }}
+      >
+        {sittingOut ? "Sit in" : "Sit out"}
+      </button>
+
+      <div style={{ height: 1, background: color.border, margin: "2px 0" }} />
+
+      {confirmingLeave ? (
+        <div
+          data-testid="leave-confirm"
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 12,
+            padding: "16px 18px",
+            borderRadius: radius.control,
+            border: `1px solid ${color.accentBorder}`,
+            background: color.accentWash,
+          }}
+        >
+          <span
+            style={{
+              fontSize: fontSize.md,
+              lineHeight: 1.4,
+              color: color.textBright,
+            }}
+          >
+            {leaveConfirmMessage(inLiveHand)}
+          </span>
+          <div style={{ display: "flex", gap: 10 }}>
+            <PillButton
+              size="md"
+              data-testid="leave-confirm-yes"
+              onClick={onConfirmLeave}
+              style={{
+                flex: 1,
+                padding: "13px 0",
+                background: color.accent,
+                color: color.text,
+                boxShadow: "none",
+              }}
+            >
+              Confirm leave
+            </PillButton>
+            <PillButton
+              size="md"
+              tone="outline"
+              data-testid="leave-confirm-cancel"
+              onClick={onCancelConfirm}
+              style={{ flex: 1, padding: "13px 0" }}
+            >
+              Cancel
+            </PillButton>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          data-testid="menu-leave"
+          onClick={onStartConfirm}
+          style={{
+            ...itemStyle,
+            border: `1px solid ${color.accentBorder}`,
+            background: color.accentWash,
+            color: color.textBright,
+          }}
+        >
+          Leave game
+        </button>
+      )}
+    </>
+  );
+}
+
+const kickerStyle: CSSProperties = {
+  fontFamily: font.mono,
+  fontSize: fontSize.xs,
+  letterSpacing: "0.24em",
+  textTransform: "uppercase",
+  color: color.textMuted,
+};
+
+const itemStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  width: "100%",
+  padding: "16px 18px",
+  borderRadius: radius.control,
+  border: `1px solid ${color.border}`,
+  background: color.controlFill,
+  color: color.text,
+  fontFamily: font.body,
+  fontSize: fontSize.md,
+  fontWeight: 600,
+  cursor: "pointer",
+};
+
+const menuButtonStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  gap: 4,
+  width: 34,
+  height: 30,
+  padding: "0 8px",
+  borderRadius: radius.pill,
+  border: `1px solid ${color.border}`,
+  background: color.control,
+  cursor: "pointer",
+};
+
+const burgerBarStyle: CSSProperties = {
+  display: "block",
+  height: 2,
+  width: "100%",
+  borderRadius: 2,
+  background: color.textMuted,
+};

--- a/packages/player-client/src/SeatPanel.test.tsx
+++ b/packages/player-client/src/SeatPanel.test.tsx
@@ -1,22 +1,13 @@
-import { color } from "@table-top-poker/ui-shared";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { SeatPanel } from "./SeatPanel.js";
 import { playerTopPillStyle } from "./topPillStyle.js";
 
-const noop = () => undefined;
-
 describe("SeatPanel", () => {
   it("shows the player's name while retaining the seat number", () => {
     const html = renderToStaticMarkup(
-      <SeatPanel
-        seatId={2}
-        displayName="Avery"
-        sittingOut={false}
-        toggleDisabled={false}
-        onToggleSittingOut={noop}
-      />,
+      <SeatPanel seatId={2} displayName="Avery" sittingOut={false} />,
     );
 
     expect(html).toContain("Avery · Seat 3");
@@ -24,12 +15,7 @@ describe("SeatPanel", () => {
 
   it("shows the claimed seat", () => {
     const html = renderToStaticMarkup(
-      <SeatPanel
-        seatId={2}
-        sittingOut={false}
-        toggleDisabled={false}
-        onToggleSittingOut={noop}
-      />,
+      <SeatPanel seatId={2} sittingOut={false} />,
     );
     expect(html).toContain('data-testid="claimed-seat"');
     expect(html).toContain("Seat 3");
@@ -42,30 +28,22 @@ describe("SeatPanel", () => {
         seatId={2}
         sittingOut={true}
         sittingOutReason="waiting-for-next-hand"
-        toggleDisabled={false}
-        onToggleSittingOut={noop}
       />,
     );
     expect(html).toContain('data-testid="sitting-out-badge"');
     expect(html).toContain("Waiting for next hand");
   });
 
-  it("uses the same pill height for the seat, sit-out, and toggle controls", () => {
+  it("uses the same pill height for the seat and status chips", () => {
     const html = renderToStaticMarkup(
       <SeatPanel
         seatId={0}
         sittingOut={true}
         sittingOutReason="waiting-for-next-hand"
-        toggleDisabled={false}
-        onToggleSittingOut={noop}
       />,
     );
 
-    for (const testId of [
-      "claimed-seat",
-      "sitting-out-badge",
-      "sitting-out-toggle",
-    ]) {
+    for (const testId of ["claimed-seat", "sitting-out-badge"]) {
       const element = new RegExp(`<[a-z]+[^>]*data-testid="${testId}"[^>]*>`);
       expect(element.exec(html)?.[0], testId).toContain(
         `height:${String(playerTopPillStyle.height ?? "")}px`,
@@ -73,64 +51,21 @@ describe("SeatPanel", () => {
     }
   });
 
-  it("offers sit out while active and sit in while sitting out", () => {
-    const active = renderToStaticMarkup(
-      <SeatPanel
-        seatId={0}
-        sittingOut={false}
-        toggleDisabled={false}
-        onToggleSittingOut={noop}
-      />,
-    );
-    const sittingOut = renderToStaticMarkup(
-      <SeatPanel
-        seatId={0}
-        sittingOut={true}
-        toggleDisabled={false}
-        onToggleSittingOut={noop}
-      />,
+  it("carries no seat controls — those live behind the menu", () => {
+    const html = renderToStaticMarkup(
+      <SeatPanel seatId={0} sittingOut={false} />,
     );
 
-    expect(active).toContain('data-testid="sitting-out-toggle"');
-    expect(active).toContain("Sit out");
-    expect(sittingOut).toContain("Sit in");
+    expect(html).not.toContain("<button");
+    expect(html).not.toContain("Sit out");
   });
 
-  it("styles the sit-out control as an action rather than a status badge", () => {
+  it("shows the sitting-out label for a voluntary opt-out", () => {
     const html = renderToStaticMarkup(
-      <SeatPanel
-        seatId={0}
-        sittingOut={false}
-        toggleDisabled={false}
-        onToggleSittingOut={noop}
-      />,
+      <SeatPanel seatId={0} sittingOut={true} sittingOutReason="voluntary" />,
     );
 
-    const buttonMatch =
-      /<button[^>]*data-testid="sitting-out-toggle"[^>]*>/.exec(html);
-    expect(buttonMatch?.[0]).toContain("background:rgba(229,68,60,.07)");
-    expect(buttonMatch?.[0]).toContain("border:1px solid rgba(229,68,60,.32)");
-    expect(buttonMatch?.[0]).toContain("cursor:pointer");
-  });
-
-  it("disables the toggle while the socket is reconnecting", () => {
-    const html = renderToStaticMarkup(
-      <SeatPanel
-        seatId={0}
-        sittingOut={false}
-        toggleDisabled={true}
-        onToggleSittingOut={noop}
-      />,
-    );
-
-    expect(html).toMatch(/data-testid="sitting-out-toggle"[^>]*disabled/);
-
-    // The disabled fill comes from PillButton, not from SeatPanel — the accent
-    // treatment must not survive into the disabled state.
-    const buttonMatch =
-      /<button[^>]*data-testid="sitting-out-toggle"[^>]*>/.exec(html);
-    expect(buttonMatch?.[0]).toContain(`background:${color.controlFill}`);
-    expect(buttonMatch?.[0]).toContain(`color:${color.disabledText}`);
-    expect(buttonMatch?.[0]).not.toContain("cursor:pointer");
+    expect(html).toContain('data-testid="sitting-out-badge"');
+    expect(html).toContain("Sitting out");
   });
 });

--- a/packages/player-client/src/SeatPanel.tsx
+++ b/packages/player-client/src/SeatPanel.tsx
@@ -1,39 +1,24 @@
-import { PillButton, color } from "@table-top-poker/ui-shared";
+import { color } from "@table-top-poker/ui-shared";
 import type { SittingOutReason } from "@table-top-poker/protocol";
-import type { CSSProperties } from "react";
 import { playerTopPillStyle } from "./topPillStyle.js";
-
-/**
- * Geometry only while disabled — `PillButton` owns the disabled fill, ink and
- * cursor, and anything passed here would win over it.
- */
-function sittingOutToggleStyle(disabled: boolean): CSSProperties {
-  if (disabled) return playerTopPillStyle;
-  return {
-    ...playerTopPillStyle,
-    background: color.accentWash,
-    border: `1px solid ${color.accentBorder}`,
-    color: color.textBright,
-    cursor: "pointer",
-  };
-}
 
 export interface SeatPanelProps {
   readonly seatId: number;
   readonly displayName?: string | null;
   readonly sittingOut: boolean;
   readonly sittingOutReason?: SittingOutReason | null;
-  readonly toggleDisabled: boolean;
-  readonly onToggleSittingOut: () => void;
 }
 
+/**
+ * The player's identity at the top of the screen: their seat (and name) plus a
+ * presence-only sitting-out badge. The seat actions — sit out and leave — live
+ * behind the menu (ADR-0005), so this panel carries state, never controls.
+ */
 export function SeatPanel({
   seatId,
   displayName,
   sittingOut,
   sittingOutReason = null,
-  toggleDisabled,
-  onToggleSittingOut,
 }: SeatPanelProps) {
   return (
     <div
@@ -72,16 +57,6 @@ export function SeatPanel({
             : "Sitting out"}
         </div>
       )}
-      <PillButton
-        size="md"
-        tone="outline"
-        data-testid="sitting-out-toggle"
-        disabled={toggleDisabled}
-        onClick={onToggleSittingOut}
-        style={sittingOutToggleStyle(toggleDisabled)}
-      >
-        {sittingOut ? "Sit in" : "Sit out"}
-      </PillButton>
     </div>
   );
 }

--- a/packages/player-client/src/StatusBar.test.tsx
+++ b/packages/player-client/src/StatusBar.test.tsx
@@ -5,13 +5,19 @@ import { StatusBar } from "./StatusBar.js";
 
 const noop = () => undefined;
 
+const handlers = {
+  inLiveHand: false,
+  onToggleSittingOut: noop,
+  onLeave: noop,
+} as const;
+
 describe("StatusBar", () => {
   it("hides the connection badge before a seat is claimed", () => {
     const html = renderToStaticMarkup(
       <StatusBar
         showBadge={false}
         connectionStatus="disconnected"
-        onToggleSittingOut={noop}
+        {...handlers}
         seat={null}
       />,
     );
@@ -23,7 +29,7 @@ describe("StatusBar", () => {
       <StatusBar
         showBadge={true}
         connectionStatus="connected"
-        onToggleSittingOut={noop}
+        {...handlers}
         seat={null}
       />,
     );
@@ -32,34 +38,36 @@ describe("StatusBar", () => {
     expect(html).toContain("height:30px");
   });
 
-  it("shows the seat chip alongside the connection badge, on the same row", () => {
+  it("shows the seat chip, badge, and menu together on the same row", () => {
     const html = renderToStaticMarkup(
       <StatusBar
         showBadge={true}
         connectionStatus="connected"
-        onToggleSittingOut={noop}
+        {...handlers}
         seat={{ seatId: 0, sittingOut: false, sittingOutReason: null }}
       />,
     );
 
     expect(html).toContain('data-testid="seat-panel"');
     expect(html).toContain("Seat 1");
-    // Both live in the same header row, not stacked in separate blocks.
+    // Seat chip, connection badge and menu button all live in the header row.
     const headerMatch = /<header[^>]*>[\s\S]*<\/header>/.exec(html);
     expect(headerMatch).not.toBeNull();
     expect(headerMatch?.[0]).toContain('data-testid="seat-panel"');
     expect(headerMatch?.[0]).toContain('data-testid="connection-status"');
+    expect(headerMatch?.[0]).toContain('data-testid="player-menu-button"');
   });
 
-  it("omits the seat chip before a seat is claimed", () => {
+  it("omits the seat chip and menu before a seat is claimed", () => {
     const html = renderToStaticMarkup(
       <StatusBar
         showBadge={false}
         connectionStatus="disconnected"
-        onToggleSittingOut={noop}
+        {...handlers}
         seat={null}
       />,
     );
     expect(html).not.toContain('data-testid="seat-panel"');
+    expect(html).not.toContain('data-testid="player-menu-button"');
   });
 });

--- a/packages/player-client/src/StatusBar.tsx
+++ b/packages/player-client/src/StatusBar.tsx
@@ -1,6 +1,7 @@
 import { color, font, fontSize } from "@table-top-poker/ui-shared";
 import type { SittingOutReason } from "@table-top-poker/protocol";
 import type { CSSProperties } from "react";
+import { PlayerMenu } from "./PlayerMenu.js";
 import { SeatPanel } from "./SeatPanel.js";
 import { playerTopPillStyle } from "./topPillStyle.js";
 import type { ConnectionStatus } from "./store/connectionSlice.js";
@@ -8,7 +9,9 @@ import type { ConnectionStatus } from "./store/connectionSlice.js";
 export interface StatusBarProps {
   readonly showBadge: boolean;
   readonly connectionStatus: ConnectionStatus;
+  readonly inLiveHand: boolean;
   readonly onToggleSittingOut: () => void;
+  readonly onLeave: () => void;
   readonly seat: {
     readonly seatId: number;
     readonly displayName?: string | null;
@@ -37,7 +40,9 @@ const badgeStyle: CSSProperties = {
 export function StatusBar({
   showBadge,
   connectionStatus,
+  inLiveHand,
   onToggleSittingOut,
+  onLeave,
   seat,
 }: StatusBarProps) {
   const tone = badgeTone[connectionStatus];
@@ -57,39 +62,48 @@ export function StatusBar({
           displayName={seat.displayName ?? null}
           sittingOut={seat.sittingOut}
           sittingOutReason={seat.sittingOutReason}
-          toggleDisabled={connectionStatus !== "connected"}
-          onToggleSittingOut={onToggleSittingOut}
         />
       )}
-      {showBadge && (
-        <span
-          data-testid="connection-status"
-          data-status={connectionStatus}
-          style={badgeStyle}
-        >
+      <div style={{ display: "flex", alignItems: "center", gap: "0.6em" }}>
+        {showBadge && (
           <span
-            style={{
-              width: "0.5em",
-              height: "0.5em",
-              borderRadius: "50%",
-              flex: "none",
-              background: tone.dot,
-            }}
-          />
-          <span
-            style={{
-              fontFamily: font.mono,
-              fontSize: fontSize.xs,
-              fontWeight: 600,
-              letterSpacing: "0.16em",
-              textTransform: "uppercase",
-              color: tone.text,
-            }}
+            data-testid="connection-status"
+            data-status={connectionStatus}
+            style={badgeStyle}
           >
-            {connectionStatus}
+            <span
+              style={{
+                width: "0.5em",
+                height: "0.5em",
+                borderRadius: "50%",
+                flex: "none",
+                background: tone.dot,
+              }}
+            />
+            <span
+              style={{
+                fontFamily: font.mono,
+                fontSize: fontSize.xs,
+                fontWeight: 600,
+                letterSpacing: "0.16em",
+                textTransform: "uppercase",
+                color: tone.text,
+              }}
+            >
+              {connectionStatus}
+            </span>
           </span>
-        </span>
-      )}
+        )}
+        {seat && (
+          <PlayerMenu
+            sittingOut={seat.sittingOut}
+            sitOutDisabled={connectionStatus !== "connected"}
+            inLiveHand={inLiveHand}
+            onToggleSittingOut={onToggleSittingOut}
+            onLeave={onLeave}
+          />
+        )}
+      </div>
     </header>
   );
 }

--- a/packages/player-client/src/api/rooms.test.ts
+++ b/packages/player-client/src/api/rooms.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { claimSeat, joinRoom } from "./rooms.js";
+import { claimSeat, joinRoom, leaveSeat } from "./rooms.js";
 
 describe("joinRoom", () => {
   beforeEach(() => {
@@ -76,5 +76,36 @@ describe("claimSeat", () => {
     await expect(claimSeat("ABCD", 2, "Avery")).rejects.toThrow(
       "duplicate-display-name",
     );
+  });
+});
+
+describe("leaveSeat", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts the seat token to the leave endpoint with keepalive", () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 204 }));
+
+    leaveSeat("ABCD", 2, "tok");
+
+    expect(fetch).toHaveBeenCalledWith("/rooms/ABCD/seats/2/leave", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token: "tok" }),
+      keepalive: true,
+    });
+  });
+
+  it("never throws when the request fails — teardown proceeds regardless", () => {
+    vi.mocked(fetch).mockRejectedValue(new Error("offline"));
+
+    expect(() => {
+      leaveSeat("ABCD", 2, "tok");
+    }).not.toThrow();
   });
 });

--- a/packages/player-client/src/api/rooms.ts
+++ b/packages/player-client/src/api/rooms.ts
@@ -40,3 +40,17 @@ export async function claimSeat(
   }
   return (await response.json()) as SeatClaim;
 }
+
+/**
+ * Releases the player's own seat (ADR-0005). Fire-and-forget with `keepalive`
+ * so it survives the client's optimistic teardown, and never throws — the
+ * client returns to the join screen regardless of whether this lands.
+ */
+export function leaveSeat(code: string, seatId: number, token: string): void {
+  void fetch(`/rooms/${code}/seats/${String(seatId)}/leave`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ token }),
+    keepalive: true,
+  }).catch(() => undefined);
+}

--- a/packages/player-client/src/app-shell.css
+++ b/packages/player-client/src/app-shell.css
@@ -28,6 +28,8 @@ body {
   max-width: 480px;
   height: 100%;
   overflow: hidden;
+  /* Anchors the player menu drawer to the phone column, not the viewport. */
+  position: relative;
   display: flex;
   flex-direction: column;
   background: radial-gradient(520px 380px at 50% -6%, #2a1518, #0b0708 70%);

--- a/packages/player-client/src/topPillStyle.ts
+++ b/packages/player-client/src/topPillStyle.ts
@@ -3,11 +3,11 @@ import type { CSSProperties } from "react";
 
 /**
  * The geometry every pill along the top of the player screen shares — name,
- * seat number, sit-out and connection. One height and one padding, so the row
- * reads as a set of chips rather than four controls that happen to be adjacent.
+ * seat number and connection. One height and one padding, so the row reads as a
+ * set of chips rather than controls that happen to be adjacent. The seat
+ * actions now live behind the menu button (ADR-0005), which matches this height.
  *
- * Colour is deliberately absent: each pill carries its own, and the sit-out
- * control is a `PillButton` whose disabled state must stay PillButton's to set.
+ * Colour is deliberately absent: each pill carries its own.
  */
 export const playerTopPillStyle: CSSProperties = {
   display: "flex",

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -45,6 +45,13 @@ export const ClaimSeatRequestSchema = z.strictObject({
 
 export type ClaimSeatRequest = z.infer<typeof ClaimSeatRequestSchema>;
 
+/** Body of a player releasing their own seat (ADR-0005) — the seat's token. */
+export const LeaveSeatRequestSchema = z.strictObject({
+  token: z.string().min(1),
+});
+
+export type LeaveSeatRequest = z.infer<typeof LeaveSeatRequestSchema>;
+
 /** Body of the table-only room settings request (issue #77). */
 export const ChangeSeatCountRequestSchema = z.strictObject({
   seatCount: SeatCountSchema,

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -485,6 +485,59 @@ describe("seat claim/evict routes", () => {
     });
     expect(reclaimed.statusCode).toBe(200);
   });
+
+  it("lets a player leave with their own token, freeing the seat (ADR-0005)", async () => {
+    const code = await createRoom();
+    const claim = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/claim`,
+      ...claimPayload("Avery"),
+    });
+    const { token } = claim.json<SeatClaimBody>();
+
+    const left = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/leave`,
+      payload: { token },
+    });
+    expect(left.statusCode).toBe(204);
+
+    const reclaimed = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/claim`,
+      ...claimPayload("Avery"),
+    });
+    expect(reclaimed.statusCode).toBe(200);
+  });
+
+  it("rejects a leave whose token does not match the seat", async () => {
+    const code = await createRoom();
+    await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/claim`,
+      ...claimPayload("Avery"),
+    });
+
+    const left = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/leave`,
+      payload: { token: "not-the-token" },
+    });
+    expect(left.statusCode).toBe(403);
+    expect(left.json()).toEqual({ error: "not-permitted" });
+  });
+
+  it("rejects a leave with no token in the body", async () => {
+    const code = await createRoom();
+
+    const left = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/seats/0/leave`,
+      payload: {},
+    });
+    expect(left.statusCode).toBe(400);
+    expect(left.json()).toEqual({ error: "invalid-request-body" });
+  });
 });
 
 describe("seat-count settings route", () => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -3,6 +3,7 @@ import fastifyWebsocket from "@fastify/websocket";
 import {
   ChangeSeatCountRequestSchema,
   ClaimSeatRequestSchema,
+  LeaveSeatRequestSchema,
   ClientCommandSchema,
   CreateRoomRequestSchema,
   view,
@@ -284,15 +285,20 @@ export async function buildApp(
    * A seat token only protects the next connection attempt. Remove all
    * currently open sockets for an evicted seat too, otherwise that socket
    * could keep issuing commands until it disconnected on its own.
+   *
+   * `notify` sends the `player-evicted` notice; a voluntary leave (ADR-0005)
+   * passes `false`, since it isn't an eviction and its client has already
+   * torn itself down. Either way the socket is flagged so its own close
+   * handler skips the disconnected-presence toggle on the freed seat.
    */
-  function closeSeatSockets(code: string, seatId: SeatId): void {
+  function closeSeatSockets(code: string, seatId: SeatId, notify = true): void {
     const sockets = roomSockets.get(code);
     if (!sockets) return;
 
     for (const socket of [...sockets]) {
       if (socketIdentity.get(socket) !== seatId) continue;
       evictedSockets.add(socket);
-      send(socket, { type: "player-evicted" });
+      if (notify) send(socket, { type: "player-evicted" });
       sockets.delete(socket);
       socketIdentity.delete(socket);
       socketRoomCode.delete(socket);
@@ -627,6 +633,45 @@ export async function buildApp(
       }
       broadcastRoomView(request.params.code);
       closeSeatSockets(request.params.code, seatId);
+      return reply.code(204).send();
+    },
+  );
+
+  /** A player releasing their own seat (ADR-0005) — the token-gated twin of evict. */
+  app.post<RoomSeatRoute>(
+    "/rooms/:code/seats/:seatId/leave",
+    (request, reply) => {
+      const seatId = parseSeatId(request.params.seatId);
+      if (seatId === undefined) {
+        return reply.code(400).send({ error: "invalid-seat-id" });
+      }
+      const body = LeaveSeatRequestSchema.safeParse(request.body);
+      if (!body.success) {
+        return reply.code(400).send({ error: "invalid-request-body" });
+      }
+      const result = rooms.leaveSeat(
+        request.params.code,
+        seatId,
+        body.data.token,
+      );
+      if ("error" in result) {
+        return reply
+          .code(result.error === "room-not-found" ? 404 : 403)
+          .send({ error: result.error });
+      }
+      if (result.dispatch !== undefined) {
+        publishDispatch(request.params.code, result.dispatch, {
+          // Same fold/queue handling as evict: a non-actor leave preserves the
+          // current actor's clock, a current-actor leave folds and reschedules.
+          actionClock:
+            result.dispatch.command.type === "evict"
+              ? "preserve"
+              : "reschedule",
+        });
+      }
+      broadcastRoomView(request.params.code);
+      // Voluntary leave, not an eviction — close the socket without the notice.
+      closeSeatSockets(request.params.code, seatId, false);
       return reply.code(204).send();
     },
   );

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -257,6 +257,82 @@ describe("RoomStore", () => {
     });
   });
 
+  describe("ADR-0005: player self-leave", () => {
+    function claimWithToken(store: RoomStore, code: string, seatId: number) {
+      const result = store.claimSeat(code, seatId, `P${String(seatId)}`);
+      if (!("seat" in result)) throw new Error("expected a claimed seat");
+      const { token } = result.seat;
+      if (token === null) throw new Error("expected a token");
+      return token;
+    }
+
+    it("frees the seat back to the pool when the token matches", () => {
+      const store = new RoomStore();
+      const room = store.create();
+      const token = claimWithToken(store, room.code, 0);
+
+      const result = store.leaveSeat(room.code, 0, token);
+
+      expect(result).not.toHaveProperty("error");
+      expect(room.seats[0]).toEqual({
+        id: 0,
+        claimed: false,
+        token: null,
+        sittingOut: false,
+        disconnected: false,
+      });
+    });
+
+    it("rejects a mismatched token and leaves the seat untouched", () => {
+      const store = new RoomStore();
+      const room = store.create();
+      claimWithToken(store, room.code, 0);
+
+      const result = store.leaveSeat(room.code, 0, "not-the-token");
+
+      expect(result).toEqual({ error: "not-permitted" });
+      expect(room.seats[0]).toMatchObject({ claimed: true });
+    });
+
+    it("rejects leaving an unclaimed seat", () => {
+      const store = new RoomStore();
+      const room = store.create();
+
+      expect(store.leaveSeat(room.code, 0, "any")).toEqual({
+        error: "not-permitted",
+      });
+    });
+
+    it("reports room-not-found for an unknown room", () => {
+      const store = new RoomStore();
+      expect(store.leaveSeat("ZZZZ", 0, "any")).toEqual({
+        error: "room-not-found",
+      });
+    });
+
+    it("folds the current actor mid-hand, exactly as an eviction does", () => {
+      const store = new RoomStore();
+      const room = store.create();
+      const tokens = [0, 1, 2].map((seatId) =>
+        claimWithToken(store, room.code, seatId),
+      );
+      store.dispatch(room.code, "table", "startHand");
+      const actor = store.currentActor(room.code);
+      if (actor === undefined) throw new Error("expected a current actor");
+
+      const result = store.leaveSeat(room.code, actor, tokens[actor] ?? "");
+
+      if ("error" in result) throw new Error("expected the leave to dispatch");
+      expect(result.dispatch?.steps.at(-1)?.event).toMatchObject({
+        type: "ActionTaken",
+        seatId: actor,
+        action: "fold",
+      });
+      expect(room.seats[actor]).toMatchObject({ claimed: false });
+      expect(store.currentActor(room.code)).not.toBe(actor);
+    });
+  });
+
   describe("seat-count changes", () => {
     function claimSeats(store: RoomStore, room: Room, ids: readonly number[]) {
       for (const seatId of ids) {

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -459,6 +459,25 @@ export class RoomStore {
   }
 
   /**
+   * A player releasing their own seat (ADR-0005) — the free-the-seat
+   * operation of {@link evictSeat}, gated on the caller presenting the
+   * seat's own token rather than on being the table device. Frees only the
+   * seat that token owns; a mismatched or stale token is `not-permitted`.
+   */
+  leaveSeat(
+    code: string,
+    seatId: SeatId,
+    token: string,
+  ): EvictSeatResult | { readonly error: "room-not-found" | "not-permitted" } {
+    const room = this.#rooms.get(code);
+    if (!room) return { error: "room-not-found" };
+    const seat = room.seats[seatId];
+    if (!seat?.claimed || seat.token !== token)
+      return { error: "not-permitted" };
+    return this.evictSeat(code, seatId);
+  }
+
+  /**
    * Changes the room's physical seat count. Growing is always safe and
    * immediate. A shrink would renumber the live engine ring, so it is queued
    * until the next deal-in recompute; outside a live hand it applies


### PR DESCRIPTION
## What

Adds a player-initiated **Leave game** alongside the existing **Sit out**, and moves both controls off the crowded top bar into a **burger-triggered side drawer**.

## Behaviour

- **Leave = self-service seat release.** Reuses the exact free-the-seat operation manual evict already uses — the seat returns to the pool, and a live in-hand seat is folded identically (current actor folds; a non-actor is removed from the queue without disturbing whoever is to act). Committed chips stay in the pot.
- **Transport: token-authed HTTP** — `POST /rooms/:code/seats/:seatId/leave` with the seat's own token. HTTP rather than a WebSocket command specifically so it works **while disconnected**, which is the case that most motivates leaving. The client tears down optimistically (clear seat/room/token → join screen, reconnect cancelled) and fires the release with a keep-alive fetch.
- **No auto-cleanup timeout.** Deliberately does **not** revive the automatic eviction ADR-0003 removed; the offline-ghost-seat case stays the table's manual evict.

## UI

- Burger sits far right in the top bar; identity pill, presence-only sitting-out badge, and connection badge stay put.
- Right-side overlay drawer (~80%, dimmed backdrop; dismiss via backdrop / ✕ / Escape) holding **Sit out/Sit in** (keeps its connection gating) → divider → **Leave game** (accent-styled), with an **inline two-step confirm** using context-aware copy ("…forfeit the current hand" only mid-hand). Leave is available even when disconnected.

## Decisions

Recorded in **ADR-0005**. The design was stress-tested up front — notably, the disconnected-leave requirement is what drove HTTP over a WebSocket command, and a proposed disconnected-player timeout was dropped because it would contradict ADR-0003.

## Tests

New coverage for the leave endpoint (happy path, token-mismatch → 403, missing token → 400, mid-hand fold), the `leaveSeat` domain method, the `MenuBody` drawer states, and the client `leaveSeat` wrapper; `SeatPanel`/`StatusBar` suites updated for the relocated controls. Whole-workspace typecheck, lint, and the touched test suites all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)