### PR TITLE
fix(table): disable Next hand below two players

### DIFF
--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -113,6 +113,24 @@ export interface SeatView {
   readonly disconnected: boolean;
 }
 
+/**
+ * Whether a seat joins the next deal-in — the client-side mirror of the
+ * server's `eligibleSeats` (ADR-0002): claimed, connected, and not
+ * voluntarily sitting out. A `waiting-for-next-hand` seat sets `sittingOut`
+ * on the view but *is* dealt in next hand, so the reason, not the flag, is
+ * what excludes a seat here.
+ */
+export function isDealtInNextHand(seat: SeatView): boolean {
+  return (
+    seat.claimed && !seat.disconnected && seat.sittingOutReason !== "voluntary"
+  );
+}
+
+/** How many seats the next `startHand`/`nextHand` would deal in. */
+export function countDealInSeats(seats: readonly SeatView[]): number {
+  return seats.filter(isDealtInNextHand).length;
+}
+
 export interface RoomView {
   readonly code: string;
   readonly seats: readonly SeatView[];

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -53,6 +53,16 @@ const liveHand: TableView = {
   ],
 };
 
+/** A finished hand: the rail offers "Next hand" in this state. */
+const completeHand: TableView = {
+  phase: "folded-out",
+  button: 0,
+  smallBlind: 1,
+  bigBlind: 2,
+  dealtSeatCount: 2,
+  winner: 0,
+};
+
 /** Puts the table in a room, with the seats claimed and hand state given. */
 function enterRoom(claimedSeats: number, handView: TableView | null) {
   store.overrides = {
@@ -114,6 +124,51 @@ describe("App", () => {
 
     expect(html).toMatch(/data-testid="start-hand-button"[^>]*disabled/);
     expect(html).toContain('data-testid="end-session-button"');
+  });
+
+  it("offers Next hand on the rail while two players remain", () => {
+    enterRoom(2, completeHand);
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).toContain('data-testid="next-hand-button"');
+    expect(html).not.toMatch(/data-testid="next-hand-button"[^>]*disabled/);
+  });
+
+  it("disables Next hand once the table drops below two players", () => {
+    enterRoom(1, completeHand);
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).toMatch(/data-testid="next-hand-button"[^>]*disabled/);
+    expect(html).toContain("Waiting for at least two players");
+  });
+
+  it("disables Next hand when a seated player has dropped off the network", () => {
+    enterRoom(2, completeHand);
+    store.overrides = {
+      ...store.overrides,
+      seats: [seat(0, true), { ...seat(1, true), disconnected: true }],
+    };
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).toMatch(/data-testid="next-hand-button"[^>]*disabled/);
+  });
+
+  it("counts a seat waiting for the next hand as a player, since the deal will include it", () => {
+    enterRoom(2, completeHand);
+    store.overrides = {
+      ...store.overrides,
+      seats: [
+        seat(0, true),
+        {
+          ...seat(1, true),
+          sittingOut: true,
+          sittingOutReason: "waiting-for-next-hand",
+        },
+      ],
+    };
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).not.toMatch(/data-testid="next-hand-button"[^>]*disabled/);
   });
 
   it("moves the controls to the rail and shows the room code once a hand starts", () => {

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -1,7 +1,9 @@
 import {
+  countDealInSeats,
   DEFAULT_SEAT_COUNT,
   isHandComplete,
   isHandLive,
+  MIN_SEAT_COUNT,
 } from "@table-top-poker/protocol";
 import { color } from "@table-top-poker/ui-shared";
 import { useCallback, useState } from "react";
@@ -109,12 +111,15 @@ export function App() {
 
   const claimedSeatCount = seats.filter((seat) => seat.claimed).length;
   const handInProgress = handView !== null;
-  const canStartHand = !handInProgress && claimedSeatCount >= 2;
+  // The server rejects startHand/nextHand below two deal-in seats, so both
+  // controls key off the same count rather than a raw claimed-seat tally.
+  const enoughPlayers = countDealInSeats(seats) >= MIN_SEAT_COUNT;
+  const canStartHand = !handInProgress && enoughPlayers;
   const handComplete = isHandComplete(handView);
   const showJoinPanel = !handInProgress || joinOpen;
   const lobbyHint = handInProgress
     ? "New players are dealt in from the next hand"
-    : claimedSeatCount >= 2
+    : enoughPlayers
       ? `${String(claimedSeatCount)} seated — deal when ready`
       : "Waiting for at least two players";
 
@@ -189,6 +194,7 @@ export function App() {
                       placement="join-panel"
                       canStartHand={canStartHand}
                       handComplete={handComplete}
+                      canDealNextHand={enoughPlayers}
                       onStartHand={handleStartHand}
                       onNextHand={handleNextHand}
                       onEndSession={handleEndSession}
@@ -219,6 +225,7 @@ export function App() {
               <TableControls
                 canStartHand={canStartHand}
                 handComplete={handComplete}
+                canDealNextHand={enoughPlayers}
                 onStartHand={handleStartHand}
                 onNextHand={handleNextHand}
                 onEndSession={handleEndSession}

--- a/packages/table-client/src/TableControls.test.tsx
+++ b/packages/table-client/src/TableControls.test.tsx
@@ -14,6 +14,7 @@ describe("TableControls", () => {
       <TableControls
         canStartHand
         handComplete={false}
+        canDealNextHand
         onStartHand={noop}
         onNextHand={noop}
         onEndSession={noop}
@@ -29,6 +30,7 @@ describe("TableControls", () => {
       <TableControls
         canStartHand={false}
         handComplete
+        canDealNextHand
         onStartHand={noop}
         onNextHand={noop}
         onEndSession={noop}
@@ -43,6 +45,7 @@ describe("TableControls", () => {
       <TableControls
         canStartHand={false}
         handComplete={false}
+        canDealNextHand
         onStartHand={noop}
         onNextHand={noop}
         onEndSession={noop}
@@ -59,6 +62,7 @@ describe("TableControls", () => {
         placement="join-panel"
         canStartHand
         handComplete={false}
+        canDealNextHand
         onStartHand={noop}
         onNextHand={noop}
         onEndSession={noop}
@@ -78,6 +82,7 @@ describe("TableControls", () => {
         placement="join-panel"
         canStartHand={false}
         handComplete={false}
+        canDealNextHand
         onStartHand={noop}
         onNextHand={noop}
         onEndSession={noop}
@@ -87,5 +92,38 @@ describe("TableControls", () => {
     expect(html).toMatch(/data-testid="start-hand-button"[^>]*disabled/);
     expect(html).toContain(`background:${color.controlFill}`);
     expect(html).toContain('data-testid="end-session-button"');
+  });
+
+  it("keeps Next hand enabled while enough players are dealt in", () => {
+    const html = renderToStaticMarkup(
+      <TableControls
+        canStartHand={false}
+        handComplete
+        canDealNextHand
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+      />,
+    );
+
+    expect(html).not.toMatch(/data-testid="next-hand-button"[^>]*disabled/);
+    expect(html).not.toContain('data-testid="next-hand-blocked-hint"');
+  });
+
+  it("disables Next hand and says why below two players", () => {
+    const html = renderToStaticMarkup(
+      <TableControls
+        canStartHand={false}
+        handComplete
+        canDealNextHand={false}
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+      />,
+    );
+
+    expect(html).toMatch(/data-testid="next-hand-button"[^>]*disabled/);
+    expect(html).toContain(`background:${color.controlFill}`);
+    expect(html).toContain("Waiting for at least two players");
   });
 });

--- a/packages/table-client/src/TableControls.tsx
+++ b/packages/table-client/src/TableControls.tsx
@@ -1,4 +1,4 @@
-import { PillButton } from "@table-top-poker/ui-shared";
+import { color, fontSize, PillButton } from "@table-top-poker/ui-shared";
 import type { CSSProperties } from "react";
 
 export type TableControlsPlacement = "rail" | "join-panel";
@@ -31,9 +31,27 @@ const actionButtonStyles: Record<TableControlsPlacement, CSSProperties> = {
   "join-panel": { flex: "1 1 0", minWidth: 0 },
 };
 
+/**
+ * The reason under a disabled "Next hand". A greyed pill says the action is
+ * off but not why, and the lobby hint that carries the same message is hidden
+ * once a hand exists — so the rail has to say it itself.
+ */
+const hintStyle: CSSProperties = {
+  marginTop: "0.4em",
+  textAlign: "center",
+  fontSize: fontSize.sm,
+  color: color.textDim,
+};
+
 export interface TableControlsProps {
   readonly canStartHand: boolean;
   readonly handComplete: boolean;
+  /**
+   * Whether enough players are dealt in for the server to accept `nextHand`.
+   * False leaves the button in place but disabled with a reason, rather than
+   * live-looking and inert — the server rejects it either way.
+   */
+  readonly canDealNextHand: boolean;
   readonly onStartHand: () => void;
   readonly onNextHand: () => void;
   readonly onEndSession: () => void;
@@ -67,6 +85,7 @@ export interface TableControlsProps {
 export function TableControls({
   canStartHand,
   handComplete,
+  canDealNextHand,
   onStartHand,
   onNextHand,
   onEndSession,
@@ -89,13 +108,21 @@ export function TableControls({
         </PillButton>
       )}
       {handComplete && (
-        <PillButton
-          data-testid="next-hand-button"
-          onClick={onNextHand}
-          style={actionButtonStyle}
-        >
-          Next hand
-        </PillButton>
+        <div style={actionButtonStyle}>
+          <PillButton
+            data-testid="next-hand-button"
+            disabled={!canDealNextHand}
+            onClick={onNextHand}
+            style={{ width: "100%" }}
+          >
+            Next hand
+          </PillButton>
+          {!canDealNextHand && (
+            <div data-testid="next-hand-blocked-hint" style={hintStyle}>
+              Waiting for at least two players
+            </div>
+          )}
+        </div>
       )}
       {onReviewHands && (
         <PillButton


### PR DESCRIPTION
## Problem

When a room has started a game and the number of players drops below two, the rail's **Next hand** button still rendered as a live primary action. The server rejects `nextHand` with `not-enough-players`, so tapping it did nothing — with no visual signal that the action was unavailable.

## Change

- `Next hand` is now `disabled` when the table can't deal, picking up `PillButton`'s existing disabled treatment, with a short "Waiting for at least two players" line underneath. The lobby hint that normally carries that message is hidden once a hand exists, so the rail says it itself.
- Both deal controls key off one count — new `countDealInSeats` / `isDealtInNextHand` helpers in `protocol` that mirror the server's `eligibleSeats` rule (claimed, connected, not *voluntarily* sitting out). Previously the client used a raw claimed-seat tally, which also read as enabled-but-inert when a seated player was disconnected. A `waiting-for-next-hand` seat still counts, since the next deal includes it.

## Testing

`vitest run packages/table-client/src/{App,TableControls}.test.tsx` (17 passing, 6 new), `npm run build`, `npm run lint`. Lint reports two pre-existing Prettier warnings under `.claude/worktrees/`, untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RvmYsH2fdM4x9rHW9k35k