### PR TITLE
test(player-client): extract finish sequencing into planFinish

### DIFF
--- a/packages/player-client/src/holecards/finishPlan.test.ts
+++ b/packages/player-client/src/holecards/finishPlan.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import type { Classification } from "./classify.js";
+import { DOUBLE_TAP_MS } from "./constants.js";
+import { endGesture, type GestureSession } from "./gesture.js";
+import { planFinish, type FinishEffect } from "./finishPlan.js";
+import type { CardActions } from "./ports.js";
+
+/**
+ * These exercise the seam #156 identified: the composition from a completed
+ * gesture to a *sent* poker Action, which the pure-function tests below #155
+ * could not reach without a pointer. `end` comes through the real `endGesture`
+ * so the event lists are the ones the hook actually replays.
+ */
+
+function session(over: Partial<GestureSession>): GestureSession {
+  return {
+    pointerId: 1,
+    originX: 0,
+    originY: 0,
+    fromBendZone: false,
+    startedRevealed: false,
+    classification: null,
+    crossed: false,
+    armed: false,
+    ...over,
+  };
+}
+
+const armedFold = session({
+  classification: "FoldDragging" satisfies Classification,
+  armed: true,
+});
+
+const tap = session({ classification: null });
+
+/** All flags open: on turn, Check and Fold both legal, nothing in flight. */
+const open: Pick<CardActions, "foldLegal" | "checkLegal" | "pending"> = {
+  foldLegal: true,
+  checkLegal: true,
+  pending: false,
+};
+
+const dispatched = (effects: readonly FinishEffect[]) =>
+  effects.flatMap((e) => (e.kind === "dispatch" ? [e.event.type] : []));
+
+const sent = (effects: readonly FinishEffect[]) =>
+  effects.flatMap((e) => (e.kind === "send" ? [e.action] : []));
+
+describe("planFinish — Fold", () => {
+  it("commits the Fold when the release is armed and Fold is legal", () => {
+    const plan = planFinish({
+      end: endGesture(armedFold, { cancelled: false }),
+      actions: open,
+      presentation: "FaceDown",
+      tapWindow: null,
+      now: 1000,
+    });
+
+    expect(sent(plan.effects)).toEqual(["fold"]);
+    expect(plan.leaving).toEqual({ faceUp: false });
+  });
+
+  it("departs before the Fold leaves the module (§7)", () => {
+    const { effects } = planFinish({
+      end: endGesture(armedFold, { cancelled: false }),
+      actions: open,
+      presentation: "FaceDown",
+      tapWindow: null,
+      now: 1000,
+    });
+
+    const released = effects.findIndex(
+      (e) => e.kind === "dispatch" && e.event.type === "RELEASED",
+    );
+    const fold = effects.findIndex(
+      (e) => e.kind === "send" && e.action === "fold",
+    );
+    expect(released).toBeGreaterThanOrEqual(0);
+    expect(released).toBeLessThan(fold);
+  });
+
+  it.each([
+    ["Revealed" as const, true],
+    ["Turning" as const, true],
+    ["FaceDown" as const, false],
+    ["Peeking" as const, false],
+  ])("leaves face-up from %s: %s", (presentation, faceUp) => {
+    const plan = planFinish({
+      end: endGesture(armedFold, { cancelled: false }),
+      actions: open,
+      presentation,
+      tapWindow: null,
+      now: 1000,
+    });
+    expect(plan.leaving).toEqual({ faceUp });
+  });
+
+  it("disarms rather than sending when Fold turned illegal under the drag (§6)", () => {
+    const plan = planFinish({
+      end: endGesture(armedFold, { cancelled: false }),
+      actions: { ...open, foldLegal: false },
+      presentation: "FaceDown",
+      tapWindow: null,
+      now: 1000,
+    });
+
+    expect(sent(plan.effects)).toEqual([]);
+    expect(plan.leaving).toBeNull();
+    // Disarm is announced before the release, matching the reducer's order.
+    expect(dispatched(plan.effects)).toEqual(["FOLD_DISARMED", "RELEASED"]);
+  });
+
+  it("does not send a Fold on top of an Action already in flight", () => {
+    const plan = planFinish({
+      end: endGesture(armedFold, { cancelled: false }),
+      actions: { ...open, pending: true },
+      presentation: "FaceDown",
+      tapWindow: null,
+      now: 1000,
+    });
+
+    expect(sent(plan.effects)).toEqual([]);
+    expect(dispatched(plan.effects)).toEqual(["FOLD_DISARMED", "RELEASED"]);
+  });
+
+  it("commits nothing on a cancelled release, however far it was carried", () => {
+    const plan = planFinish({
+      end: endGesture(armedFold, { cancelled: true }),
+      actions: open,
+      presentation: "FaceDown",
+      tapWindow: null,
+      now: 1000,
+    });
+
+    expect(sent(plan.effects)).toEqual([]);
+    expect(plan.leaving).toBeNull();
+    expect(dispatched(plan.effects)).toEqual(["CANCELLED"]);
+  });
+});
+
+describe("planFinish — Check", () => {
+  it("opens the tap window on the first tap and sends nothing", () => {
+    const plan = planFinish({
+      end: endGesture(tap, { cancelled: false }),
+      actions: open,
+      presentation: "FaceDown",
+      tapWindow: null,
+      now: 1000,
+    });
+
+    expect(sent(plan.effects)).toEqual([]);
+    expect(dispatched(plan.effects)).toEqual(["RELEASED", "TAPPED"]);
+    expect(plan.nextTapWindow).toBe(1000);
+  });
+
+  it("sends the Check on a second tap inside the window", () => {
+    const plan = planFinish({
+      end: endGesture(tap, { cancelled: false }),
+      actions: open,
+      presentation: "FaceDown",
+      tapWindow: 1000,
+      now: 1000 + DOUBLE_TAP_MS,
+    });
+
+    expect(sent(plan.effects)).toEqual(["check"]);
+    expect(plan.nextTapWindow).toBeNull();
+    expect(plan.confirmCheck).toBe(true);
+  });
+
+  it("conceals before the Check leaves the module (story 31)", () => {
+    const { effects } = planFinish({
+      end: endGesture(tap, { cancelled: false }),
+      actions: open,
+      presentation: "FaceDown",
+      tapWindow: 1000,
+      now: 1000 + DOUBLE_TAP_MS,
+    });
+
+    const doubleTapped = effects.findIndex(
+      (e) => e.kind === "dispatch" && e.event.type === "DOUBLE_TAPPED",
+    );
+    const check = effects.findIndex(
+      (e) => e.kind === "send" && e.action === "check",
+    );
+    expect(doubleTapped).toBeGreaterThanOrEqual(0);
+    expect(doubleTapped).toBeLessThan(check);
+  });
+
+  it("still sends the Check off-turn but claims nothing (canAct is the gate)", () => {
+    const plan = planFinish({
+      end: endGesture(tap, { cancelled: false }),
+      actions: { ...open, checkLegal: false },
+      presentation: "FaceDown",
+      tapWindow: 1000,
+      now: 1000 + DOUBLE_TAP_MS,
+    });
+
+    expect(sent(plan.effects)).toEqual(["check"]);
+    expect(plan.confirmCheck).toBe(false);
+  });
+
+  it("claims nothing while an Action is already in flight", () => {
+    const plan = planFinish({
+      end: endGesture(tap, { cancelled: false }),
+      actions: { ...open, pending: true },
+      presentation: "FaceDown",
+      tapWindow: 1000,
+      now: 1000 + DOUBLE_TAP_MS,
+    });
+
+    expect(sent(plan.effects)).toEqual(["check"]);
+    expect(plan.confirmCheck).toBe(false);
+  });
+});
+
+describe("planFinish — the tap window closes on any non-tap ending (§5)", () => {
+  it("closes an open window on a bend, so tap → peek → tap composes no Check", () => {
+    const bend = session({ classification: "Bending" });
+    const plan = planFinish({
+      end: endGesture(bend, { cancelled: false }),
+      actions: open,
+      presentation: "Peeking",
+      tapWindow: 1000,
+      now: 1100,
+    });
+
+    expect(sent(plan.effects)).toEqual([]);
+    expect(plan.nextTapWindow).toBeNull();
+  });
+
+  it("closes an open window on a committed Fold", () => {
+    const plan = planFinish({
+      end: endGesture(armedFold, { cancelled: false }),
+      actions: open,
+      presentation: "FaceDown",
+      tapWindow: 1000,
+      now: 1100,
+    });
+
+    expect(plan.nextTapWindow).toBeNull();
+  });
+
+  it("closes an open window on a cancelled press", () => {
+    const plan = planFinish({
+      end: endGesture(tap, { cancelled: true }),
+      actions: open,
+      presentation: "FaceDown",
+      tapWindow: 1000,
+      now: 1100,
+    });
+
+    expect(plan.nextTapWindow).toBeNull();
+  });
+});

--- a/packages/player-client/src/holecards/finishPlan.ts
+++ b/packages/player-client/src/holecards/finishPlan.ts
@@ -1,0 +1,140 @@
+import type { CardEvent, Presentation } from "./cardState.js";
+import type { GestureEnd } from "./gesture.js";
+import type { CardActions } from "./ports.js";
+import { confirmsCheck, tapLanded, type TapWindow } from "./taps.js";
+
+/**
+ * One ordered thing a completed gesture does: either advance the reducer, or
+ * leave the module and send a poker Action (§2). The list preserves the
+ * sequence the hook must replay, so the two orderings that cost money are a
+ * property the plan can be asserted on rather than glue only a real pointer
+ * could exercise:
+ *
+ * - **conceal before Check** — the `TAPPED`/`DOUBLE_TAPPED` dispatch precedes
+ *   the `check` send, so the player sees the cards go down, then the
+ *   confirmation, with no timer between them (story 31);
+ * - **depart before Fold** — `leaving` is applied and `RELEASED` dispatched
+ *   before the `fold` send, so the pair is already on its way to the muck when
+ *   the Action goes and the departure is the player's own answer, not the
+ *   server's (§7).
+ */
+export type FinishEffect =
+  | { readonly kind: "dispatch"; readonly event: CardEvent }
+  | { readonly kind: "send"; readonly action: "check" | "fold" };
+
+export interface FinishPlan {
+  /** The dispatches and sends, in the exact order the hook must replay them. */
+  readonly effects: readonly FinishEffect[];
+  /**
+   * The tap window after this release. A gesture that ended as anything but a
+   * tap closes it (`null`), so tap → peek → tap cannot compose a Check out of
+   * two taps the player never meant to pair (§5).
+   */
+  readonly nextTapWindow: TapWindow;
+  /**
+   * Whether a landed Check should claim, visibly, that it went (story 31).
+   * Rendering only, and only ever set alongside a `check` send — a stale prop
+   * can at worst confirm an Action the intent then refuses, never send one.
+   */
+  readonly confirmCheck: boolean;
+  /**
+   * Set when this release commits the Fold: the pair leaves with whatever face
+   * it had (§7). `null` when nothing departs.
+   */
+  readonly leaving: { readonly faceUp: boolean } | null;
+}
+
+export interface FinishInputs {
+  /** The completed gesture, from `endGesture(session, { cancelled })`. */
+  readonly end: GestureEnd;
+  /**
+   * The legality flags, for **arming and rendering only** (§2). `canAct`
+   * inside `intent.fold`/`intent.check` stays the single gate on whether an
+   * Action is actually sent, so a release these flags wave through can still be
+   * refused there and a stale flag can at worst arm a gesture `canAct` denies.
+   */
+  readonly actions: Pick<CardActions, "foldLegal" | "checkLegal" | "pending">;
+  /**
+   * The presentation the pair leaves from. Read here rather than off the
+   * session because a keyboard reveal committed before the press can land
+   * mid-drag, and `Turning` is a point of no return — a pair mid-flip is a pair
+   * that is going to be face-up (§7).
+   */
+  readonly presentation: Presentation;
+  /** The tap window going in, `performance.now()`-based (§5). */
+  readonly tapWindow: TapWindow;
+  /**
+   * A monotonic clock (`performance.now()`), so two unrelated taps cannot be
+   * paired into an Action by a wall clock stepping backwards mid-hand.
+   */
+  readonly now: number;
+}
+
+/**
+ * Decide what a completed gesture does — which reducer events fire, which
+ * Actions leave the module, what happens to the tap window — as a pure
+ * function of the release and the current view.
+ *
+ * This is the seam where a finger movement turns into a sent poker Action, and
+ * #138's strategy is to push that rule out of the renderer so it can be tested
+ * by construction rather than by a simulated pointer (#156). The hook that
+ * calls this owns only the imperative replay: dispatching the events, calling
+ * the named Action functions in order, and seeding the confirmation timer.
+ */
+export function planFinish(inputs: FinishInputs): FinishPlan {
+  const { end, actions, presentation, tapWindow, now } = inputs;
+  const { events, commitsFold } = end;
+
+  // Fold legality is re-sampled here, not only where `eventsForPropChange`
+  // watches it, because a release can beat the view that would have disarmed
+  // it, and `pending` rides along so a Fold cannot go out on top of an Action
+  // already in flight (§6). This is arming, exactly as §2 licenses.
+  const commits = commitsFold && actions.foldLegal && !actions.pending;
+
+  const effects: FinishEffect[] = [];
+  let nextTapWindow: TapWindow = tapWindow;
+  let confirmCheck = false;
+  let leaving: { readonly faceUp: boolean } | null = null;
+
+  // A drag that armed a Fold but outlived the turn that made it legal disarms:
+  // the release commits nothing, and there is no rejection message because the
+  // turn banner already explains it (§6). Emitted before `RELEASED`, matching
+  // the reducer's order.
+  if (commitsFold && !commits) {
+    effects.push({ kind: "dispatch", event: { type: "FOLD_DISARMED" } });
+  }
+
+  if (commits) {
+    leaving = {
+      faceUp: presentation === "Revealed" || presentation === "Turning",
+    };
+  }
+
+  let tapped = false;
+  for (const event of events) {
+    if (event.type !== "TAPPED") {
+      effects.push({ kind: "dispatch", event });
+      continue;
+    }
+    // A tap is only *provisionally* a tap: whether it is one, or the second
+    // half of a Check, is `taps` to decide.
+    const tap = tapLanded(nextTapWindow, now);
+    nextTapWindow = tap.window;
+    tapped = true;
+    // Dispatched first, so the conceal is on screen before the Check goes.
+    effects.push({ kind: "dispatch", event: tap.event });
+    if (tap.event.type === "DOUBLE_TAPPED") {
+      effects.push({ kind: "send", action: "check" });
+      confirmCheck = confirmsCheck(actions);
+    }
+  }
+  // The two taps of a Check must be *consecutive*: any other ending closes the
+  // window rather than leaving it open on a technicality of the middle gesture.
+  if (!tapped) nextTapWindow = null;
+
+  // Sent after the departure is committed, so the pair is already leaving when
+  // the Action goes (§7).
+  if (commits) effects.push({ kind: "send", action: "fold" });
+
+  return { effects, nextTapWindow, confirmCheck, leaving };
+}

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -29,9 +29,10 @@ import {
   moveGesture,
   type GestureSession,
 } from "./gesture.js";
+import { planFinish } from "./finishPlan.js";
 import { pulse } from "./haptics.js";
 import type { HoleCardPairProps } from "./HoleCardPair.js";
-import { confirmsCheck, tapLanded, type TapWindow } from "./taps.js";
+import type { TapWindow } from "./taps.js";
 import { eventsForPropChange, eventsForVisibility } from "./viewEvents.js";
 
 /**
@@ -322,24 +323,6 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     dispatch({ type: "ACTIVATED" });
   }, []);
 
-  /**
-   * The double-tap Action (§5, stories 27 and 28). `check` **is**
-   * `intent.check`, so the gesture and the ActionBar button reach the Action
-   * by the identical route and `canAct` — inside the intent, on the latest
-   * view — is the single gate deciding whether it may be sent. An off-turn or
-   * illegal double-tap therefore needs no guard here to be a no-op.
-   *
-   * `checkLegal` and `pending` are read for **rendering only**, exactly as the
-   * port promises: they decide whether to claim the Check landed. A stale prop
-   * can at worst show a confirmation for an Action the intent then refuses —
-   * never send one.
-   */
-  const sendCheck = (): void => {
-    const confirm = confirmsCheck(props.actions);
-    props.actions.check();
-    if (confirm) setCheckConfirmedAt(Date.now());
-  };
-
   const finish = (
     event: ReactPointerEvent<HTMLElement>,
     cancelled: boolean,
@@ -359,72 +342,46 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     // that already crossed the threshold is exempt: it committed on crossing,
     // and the turn is mid-flight with the peel under its control.
     if (!active.crossed) bend.set(0);
-    // **The commitment, and the only one a pointer lift makes** (§10). Decided
-    // off the session, which is a ref and therefore exactly as current as the
-    // events the reducer has been given — the state this hook renders with can
-    // lag a threshold crossed one pointer event ago, and a fast flick is the
-    // commonest way to fold, not an edge case.
-    const { events, commitsFold } = endGesture(active, { cancelled });
-    // Fold legality is sampled once, at classification (§4), so a drag can
-    // outlive the turn that made it legal. §6's answer is that such a drag
-    // **disarms** — the release commits nothing, and there is no rejection
-    // message, because the turn banner already explains it.
-    //
-    // Re-sampled here as well as on the prop change `eventsForPropChange`
-    // watches, because a release can beat the view that would have disarmed it.
-    // `pending` rides along for the same reason: a Fold cannot go out on top of
-    // an Action already in flight, and a departure the player watches and then
-    // has undone is worse than one that never starts.
-    //
-    // This is arming input, exactly as §2 licenses; `canAct` inside
-    // `intent.fold` remains the single gate on whether the Action is sent.
-    const commits =
-      commitsFold && props.actions.foldLegal && !props.actions.pending;
-    if (commitsFold && !commits) dispatch({ type: "FOLD_DISARMED" });
-    // The pair leaves with whatever face it had (§7). Read off presentation
-    // rather than the session, because a keyboard reveal committed before the
-    // press can land during the drag — and `Turning` is a point of no return,
-    // so a pair mid-flip is a pair that is going to be face-up.
-    if (commits) {
-      setLeavingFaceUp(
-        state.presentation === "Revealed" || state.presentation === "Turning",
-      );
+    // Everything a pointer lift decides — which events fire, which Actions
+    // leave the module, what the tap window becomes — is `planFinish`'s to
+    // answer (§156). Decided off the session, which is a ref and therefore
+    // exactly as current as the events the reducer has been given: the state
+    // this hook renders with can lag a threshold crossed one pointer event ago,
+    // and a fast flick is the commonest way to fold, not an edge case.
+    const plan = planFinish({
+      end: endGesture(active, { cancelled }),
+      actions: props.actions,
+      presentation: state.presentation,
+      tapWindow: tapWindow.current,
+      // The clock is monotonic, because a wall clock stepping backwards
+      // mid-hand would turn two unrelated taps into a Check (§5).
+      now: performance.now(),
+    });
+    tapWindow.current = plan.nextTapWindow;
+    // The pair leaves with whatever face it had (§7). Set here, before the
+    // effects replay, so it lands in the same commit as the `RELEASED` that
+    // moves the reducer into `Leaving`.
+    if (plan.leaving !== null) {
+      setLeavingFaceUp(plan.leaving.faceUp);
       setDeparting(props.cards);
     }
-    let tapped = false;
-    for (const cardEvent of events) {
-      if (cardEvent.type !== "TAPPED") {
-        dispatch(cardEvent);
-        continue;
+    // The hook owns only the imperative replay: the plan already fixed the
+    // order, and the two orderings that cost money — conceal before Check, and
+    // depart before Fold — are carried by the effect list, not by this loop.
+    // `fold`/`check` **are** `intent.fold`/`intent.check`, so gesture and
+    // button enter the identical function and `canAct` on the latest view stays
+    // the single legality gate: an armed release the server would refuse sends
+    // nothing here that the intent does not then drop.
+    for (const effect of plan.effects) {
+      if (effect.kind === "dispatch") {
+        dispatch(effect.event);
+      } else if (effect.action === "check") {
+        props.actions.check();
+      } else {
+        props.actions.fold();
       }
-      // A tap is only *provisionally* a tap: whether it is one, or the second
-      // half of a Check, is `taps` to decide. The clock is monotonic, because
-      // a wall clock stepping backwards mid-hand would turn two unrelated taps
-      // into an Action.
-      const tap = tapLanded(tapWindow.current, performance.now());
-      tapWindow.current = tap.window;
-      tapped = true;
-      dispatch(tap.event);
-      // Dispatched first, so the Action is sent against a pair that has
-      // already taken the conceal — the player sees the cards go down, then the
-      // confirmation, in that order and with no timer between them.
-      if (tap.event.type === "DOUBLE_TAPPED") sendCheck();
     }
-    // The two taps of a Check must be *consecutive*. A gesture that ended as
-    // anything else — a bend, a cancelled press — closes the window, so
-    // tap → quick peek → tap cannot compose an Action out of two taps the
-    // player never meant to pair. Sending a Check nobody asked for is the one
-    // failure here that costs money, so the window is closed rather than left
-    // open on a technicality of what the middle gesture happened to be.
-    if (!tapped) tapWindow.current = null;
-    // Sent after the dispatch, so the cards are already on their way to the
-    // muck when the Action goes: the departure is the player's own answer
-    // rather than the server's. `fold` **is** `intent.fold` — gesture and
-    // button enter the identical function, and `canAct` on the latest view
-    // stays the single legality gate, so an armed release the server would
-    // refuse sends nothing, and the pending Action it is waiting behind
-    // resolves the pair back to `FaceDown` as any rejection would.
-    if (commits) props.actions.fold();
+    if (plan.confirmCheck) setCheckConfirmedAt(Date.now());
   };
 
   const handlers: PairHandlers = {


### PR DESCRIPTION
## What

Resolves the decision in #156. After #155 landed the double-tap Check, the seam where a completed hole-card gesture **leaves the module** — `useHoleCards.finish` turning a pointer lift into `actions.check()` / `actions.fold()` — was reachable only through a real pointer sequence, which the repo's node-only, `renderToStaticMarkup` test strategy (#138) cannot raise.

Rather than reverse #138 and stand up jsdom + testing-library for one package (option 2), this takes option 3: push the sequencing rule into a pure function.

## How

- **`finishPlan.ts`** — `planFinish(inputs)` takes the `endGesture` result plus the current view (legality flags, presentation, tap window, clock) and returns an ordered `effects` list of `dispatch` / `send` steps, plus `nextTapWindow`, `confirmCheck` and `leaving`. The two orderings that cost money — **conceal before Check**, **depart before Fold** — are carried by the effect order, so they become assertions rather than glue only a pointer could exercise.
- **`useHoleCards.finish`** now owns only the imperative replay: motion values, refs, applying `leaving`, and walking the effects in order. No behaviour change.
- **`finishPlan.test.ts`** — 17 cases driving `end` through the real `endGesture`: Fold commit / disarm on illegal / disarm on pending / cancel, the leaving face per presentation, first-tap window open, second-tap Check send + confirm, off-turn Check still sends but claims nothing, and the tap window closing on every non-tap ending.

## Verification

- `npx vitest run packages/player-client/src/holecards` — 217 passed
- `npm run build --workspace @table-top-poker/player-client` (tsc) — clean
- `eslint` + `prettier --check` on the touched files — clean

Closes #156. Refs #138, #144, #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)