### PR TITLE
feat(table): showdown reveal as a centred overlay

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ help:
 		'make dev                 Start locally (default)' \
 		'make dev-local           Start on localhost' \
 		'make dev-wsl             Start using the WSL2 IP address' \
-		'make dev-tailscale       Start using the Tailscale address' \
+		'make dev-tailscale       Start using Tailscale HTTPS Serve automatically' \
 		'make dev DEV_PROFILE=wsl Start with a selected profile' \
 		'make dev-stop            Stop all dev servers started by this repo' \
 		'make dev-restart         Restart using DEV_PROFILE' \

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -63,6 +63,41 @@ const completeHand: TableView = {
   winner: 0,
 };
 
+/** A showdown: the reveal overlay owns the result here. */
+const showdownHand: TableView = {
+  phase: "showdown",
+  button: 0,
+  smallBlind: 1,
+  bigBlind: 2,
+  dealtSeatCount: 2,
+  board: [
+    { rank: "A", suit: "spades" },
+    { rank: "K", suit: "hearts" },
+    { rank: "2", suit: "clubs" },
+    { rank: "7", suit: "diamonds" },
+    { rank: "9", suit: "clubs" },
+  ],
+  winners: [0],
+  results: [
+    {
+      seatId: 0,
+      rank: 1,
+      description: "Pair of Aces",
+      holeCards: [
+        { rank: "A", suit: "clubs" },
+        { rank: "3", suit: "hearts" },
+      ],
+      bestHand: [
+        { rank: "A", suit: "spades" },
+        { rank: "A", suit: "clubs" },
+        { rank: "K", suit: "hearts" },
+        { rank: "9", suit: "clubs" },
+        { rank: "7", suit: "diamonds" },
+      ],
+    },
+  ],
+};
+
 /** Puts the table in a room, with the seats claimed and hand state given. */
 function enterRoom(claimedSeats: number, handView: TableView | null) {
   store.overrides = {
@@ -169,6 +204,35 @@ describe("App", () => {
     const html = renderToStaticMarkup(<App />);
 
     expect(html).not.toMatch(/data-testid="next-hand-button"[^>]*disabled/);
+  });
+
+  it("renders the showdown reveal overlay at showdown, gating Next hand on player count", () => {
+    enterRoom(2, showdownHand);
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).toContain('data-testid="showdown-overlay"');
+    expect(html).toContain('data-testid="showdown-player-0"');
+    expect(html).not.toMatch(
+      /data-testid="showdown-next-hand-button"[^>]*disabled/,
+    );
+  });
+
+  it("disables the overlay's Next hand once the table drops below two players", () => {
+    enterRoom(1, showdownHand);
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).toMatch(
+      /data-testid="showdown-next-hand-button"[^>]*disabled/,
+    );
+    expect(html).toContain('data-testid="showdown-next-hand-blocked-hint"');
+  });
+
+  it("does not render the overlay for a fold-out ending", () => {
+    enterRoom(2, completeHand);
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).not.toContain('data-testid="showdown-overlay"');
+    expect(html).toContain('data-testid="hand-complete-banner"');
   });
 
   it("moves the controls to the rail and shows the room code once a hand starts", () => {

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -215,6 +215,10 @@ describe("App", () => {
     expect(html).not.toMatch(
       /data-testid="showdown-next-hand-button"[^>]*disabled/,
     );
+    // The rail offers "View showdown" to reopen the overlay, not "Next hand" —
+    // dealing the next hand lives in the overlay itself.
+    expect(html).toContain('data-testid="view-showdown-button"');
+    expect(html).not.toContain('data-testid="next-hand-button"');
   });
 
   it("disables the overlay's Next hand once the table drops below two players", () => {

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -6,7 +6,7 @@ import {
   MIN_SEAT_COUNT,
 } from "@table-top-poker/protocol";
 import { color } from "@table-top-poker/ui-shared";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   changeSeatCount,
   createRoom,
@@ -19,6 +19,7 @@ import { SeatCountPicker } from "./SeatCountPicker.js";
 import { JoinPanel } from "./JoinPanel.js";
 import { SeatMenu } from "./SeatMenu.js";
 import { Seats } from "./Seats.js";
+import { ShowdownOverlay } from "./ShowdownOverlay.js";
 import { SettingsToggle } from "./SettingsToggle.js";
 import { StatusBar } from "./StatusBar.js";
 import { TableControls } from "./TableControls.js";
@@ -43,6 +44,15 @@ export function App() {
 
   const [menuSeatId, setMenuSeatId] = useState<number | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
+
+  // "View table" collapses the showdown overlay without leaving showdown, so
+  // the felt's controls are reachable; the Showdown chip reopens it. Reset
+  // whenever the table is not at showdown, so each new showdown opens featured.
+  const [showdownCollapsed, setShowdownCollapsed] = useState(false);
+  const atShowdown = handView?.phase === "showdown";
+  useEffect(() => {
+    if (!atShowdown) setShowdownCollapsed(false);
+  }, [atShowdown]);
   const handleSeatClick = useCallback((seatId: number) => {
     setMenuSeatId((current) => (current === seatId ? null : seatId));
   }, []);
@@ -229,6 +239,21 @@ export function App() {
                 onStartHand={handleStartHand}
                 onNextHand={handleNextHand}
                 onEndSession={handleEndSession}
+              />
+            )}
+            {handView?.phase === "showdown" && (
+              <ShowdownOverlay
+                view={handView}
+                seats={seats}
+                collapsed={showdownCollapsed}
+                canDealNextHand={enoughPlayers}
+                onNextHand={handleNextHand}
+                onViewTable={() => {
+                  setShowdownCollapsed(true);
+                }}
+                onReopen={() => {
+                  setShowdownCollapsed(false);
+                }}
               />
             )}
           </div>

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -236,9 +236,13 @@ export function App() {
                 canStartHand={canStartHand}
                 handComplete={handComplete}
                 canDealNextHand={enoughPlayers}
+                atShowdown={atShowdown}
                 onStartHand={handleStartHand}
                 onNextHand={handleNextHand}
                 onEndSession={handleEndSession}
+                onViewShowdown={() => {
+                  setShowdownCollapsed(false);
+                }}
               />
             )}
             {handView?.phase === "showdown" && (
@@ -250,9 +254,6 @@ export function App() {
                 onNextHand={handleNextHand}
                 onViewTable={() => {
                   setShowdownCollapsed(true);
-                }}
-                onReopen={() => {
-                  setShowdownCollapsed(false);
                 }}
               />
             )}

--- a/packages/table-client/src/Board.test.tsx
+++ b/packages/table-client/src/Board.test.tsx
@@ -75,7 +75,7 @@ describe("Board", () => {
     expect(html).not.toContain('data-testid="community-cards"');
   });
 
-  it("names the winner and their hand in a hand-complete banner at showdown, without duplicating any seat's hole cards", () => {
+  it("shows only the community cards at showdown, suppressing the banner the overlay now owns", () => {
     const view: TableView = {
       phase: "showdown",
       button: 0,
@@ -128,65 +128,11 @@ describe("Board", () => {
     const html = renderToStaticMarkup(<Board view={view} />);
 
     expect(html).toMatch(/data-testid="board"[^>]*data-phase="showdown"/);
-    expect(html).toContain('data-testid="hand-complete-banner"');
-    expect(html).toContain("Seat 1 wins — Pair of Aces");
+    // The overlay owns the result now, so the felt drops the banner entirely.
+    expect(html).not.toContain('data-testid="hand-complete-banner"');
+    expect(html).not.toContain("Pair of Aces");
     expect(html).toMatch(/data-testid="community-cards"/);
     // Only the 5 board cards — no seat's hole cards duplicated in the board.
     expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(5);
-  });
-
-  it("names every winner on a split pot", () => {
-    const view: TableView = {
-      phase: "showdown",
-      button: 0,
-      smallBlind: 1,
-      bigBlind: 2,
-      dealtSeatCount: 3,
-      board: [
-        { rank: "A", suit: "spades" },
-        { rank: "K", suit: "hearts" },
-        { rank: "2", suit: "clubs" },
-        { rank: "7", suit: "diamonds" },
-        { rank: "9", suit: "clubs" },
-      ],
-      winners: [0, 1],
-      results: [
-        {
-          seatId: 0,
-          rank: 1,
-          description: "Pair of Aces",
-          holeCards: [
-            { rank: "A", suit: "clubs" },
-            { rank: "3", suit: "hearts" },
-          ],
-          bestHand: [
-            { rank: "A", suit: "spades" },
-            { rank: "A", suit: "clubs" },
-            { rank: "K", suit: "hearts" },
-            { rank: "9", suit: "clubs" },
-            { rank: "7", suit: "diamonds" },
-          ],
-        },
-        {
-          seatId: 1,
-          rank: 1,
-          description: "Pair of Aces",
-          holeCards: [
-            { rank: "A", suit: "diamonds" },
-            { rank: "4", suit: "hearts" },
-          ],
-          bestHand: [
-            { rank: "A", suit: "spades" },
-            { rank: "A", suit: "diamonds" },
-            { rank: "K", suit: "hearts" },
-            { rank: "9", suit: "clubs" },
-            { rank: "7", suit: "diamonds" },
-          ],
-        },
-      ],
-    };
-    const html = renderToStaticMarkup(<Board view={view} />);
-
-    expect(html).toContain("Seat 1 &amp; Seat 2 split — Pair of Aces");
   });
 });

--- a/packages/table-client/src/Board.tsx
+++ b/packages/table-client/src/Board.tsx
@@ -88,24 +88,10 @@ function HandCompleteBanner({ text }: { readonly text: string }) {
   );
 }
 
-/** `winners.join(" & ") wins/split with <description>` — never "everyone folded". */
-function showdownText(
-  winners: readonly number[],
-  description: string | undefined,
-  seats: readonly SeatView[],
-): string {
-  const names = winners.map((winner) => seatLabel(winner, seats)).join(" & ");
-  const verb = winners.length > 1 ? "split" : "wins";
-  return description ? `${names} ${verb} — ${description}` : `${names} ${verb}`;
-}
-
 /**
- * The felt's centre content — community cards and, at showdown, a single
- * "hand complete" line naming the winner(s) and their hand. Each seat's own
- * revealed hole cards live at the seat pod (`Seats`' job), not duplicated
- * here — issue #60's showdown-reveal pass found showing every hand twice
- * (once here, once at the pod) was most of what made the felt unreadable
- * at a full 8-player table.
+ * The felt's centre content — community cards, plus a "hand complete" banner
+ * naming the winner only for the fold-out ending. At showdown the reveal
+ * overlay (issue #169) owns the result, so the felt shows just the board.
  */
 export function Board({ view, seats = [] }: BoardProps) {
   if (view.phase === "no-hand") {
@@ -127,9 +113,10 @@ export function Board({ view, seats = [] }: BoardProps) {
   }
 
   if (view.phase === "showdown") {
-    const winnerResult = view.results.find((result) =>
-      view.winners.includes(result.seatId),
-    );
+    // The reveal overlay (issue #169) owns the showdown result — winner(s),
+    // hands, and hole cards. The felt keeps only the community cards, so that
+    // "View table" reveals them behind the collapsed overlay; the redundant
+    // "Hand complete" banner is suppressed here.
     return (
       <div
         data-testid="board"
@@ -141,9 +128,6 @@ export function Board({ view, seats = [] }: BoardProps) {
           gap: "0.6em",
         }}
       >
-        <HandCompleteBanner
-          text={showdownText(view.winners, winnerResult?.description, seats)}
-        />
         <CommunityCards board={view.board} />
       </div>
     );

--- a/packages/table-client/src/Board.tsx
+++ b/packages/table-client/src/Board.tsx
@@ -5,17 +5,11 @@ import type {
 } from "@table-top-poker/protocol";
 import { Card, color, font } from "@table-top-poker/ui-shared";
 import { motion } from "motion/react";
+import { seatLabel } from "./seatLabel.js";
 
 export interface BoardProps {
   readonly view: TableView;
   readonly seats?: readonly SeatView[];
-}
-
-function seatLabel(seatId: number, seats: readonly SeatView[]): string {
-  return (
-    seats.find((seat) => seat.id === seatId)?.displayName ??
-    `Seat ${String(seatId + 1)}`
-  );
 }
 
 /** The community cards, dealt in one at a time via Motion rather than CSS keyframes. */

--- a/packages/table-client/src/HouseRulesSheet.tsx
+++ b/packages/table-client/src/HouseRulesSheet.tsx
@@ -14,6 +14,7 @@ import {
   shadow,
 } from "@table-top-poker/ui-shared";
 import { useState, type CSSProperties } from "react";
+import { seatLabel } from "./seatLabel.js";
 
 export interface HouseRulesSheetProps {
   readonly seatCount: number;
@@ -60,13 +61,6 @@ const stepperButtonStyle: CSSProperties = {
   color: color.textBright,
   cursor: "pointer",
 };
-
-function seatLabel(seatId: number, seats: readonly SeatView[]): string {
-  return (
-    seats.find((seat) => seat.id === seatId)?.displayName ??
-    `Seat ${String(seatId + 1)}`
-  );
-}
 
 /** The table-device House rules sheet; seat count is its first setting. */
 export function HouseRulesSheet({

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -271,7 +271,9 @@ describe("Seats", () => {
     expect(html).not.toContain('data-testid="seat-pod-0-disconnected"');
   });
 
-  it("marks the winning seat at showdown and reveals its hole cards", () => {
+  it("reveals nothing on the felt at showdown — no hole cards, hand, or winner mark", () => {
+    // The reveal overlay (issue #169) owns who-won and every hand; the seat
+    // pods stay plain so nothing shifts when the hand ends.
     const view: TableView = {
       phase: "showdown",
       button: 0,
@@ -306,13 +308,10 @@ describe("Seats", () => {
       ],
     };
     const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
-    expect(html).toMatch(/data-testid="seat-pod-0"[^>]*data-winner="true"/);
-    expect(html).toContain('data-testid="seat-pod-0-hole-cards"');
-    expect(html).not.toContain('data-testid="seat-pod-1-hole-cards"');
-    // The hand description shows plainly — no "Winner —" prefix, since the
-    // pod's own winner styling and the board's banner already say so.
-    expect(html).toMatch(/data-testid="seat-pod-0-hand"[^>]*>Pair of Aces</);
-    expect(html).not.toContain("Winner");
+    expect(html).toMatch(/data-testid="seat-pod-0"[^>]*data-winner="false"/);
+    expect(html).not.toContain("hole-cards");
+    expect(html).not.toContain('data-testid="seat-pod-0-hand"');
+    expect(html).not.toContain("Pair of Aces");
   });
 
   it("keeps a revealed player in-hand when they sit out for the next hand", () => {
@@ -351,10 +350,10 @@ describe("Seats", () => {
     };
     const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
 
-    expect(html).toMatch(
-      /data-testid="seat-pod-2"[^>]*data-status="in-hand"[^>]*data-winner="true"/,
-    );
-    expect(html).toContain('data-testid="seat-pod-2-hole-cards"');
+    // Reaching showdown keeps the seat in-hand rather than sitting-out, even
+    // though the felt no longer reveals its cards (the overlay does that).
+    expect(html).toMatch(/data-testid="seat-pod-2"[^>]*data-status="in-hand"/);
+    expect(html).not.toContain("hole-cards");
     expect(html).not.toContain('data-testid="seat-pod-2-sitting-out"');
     expect(html).not.toContain('data-testid="seat-pod-2-sitting-out-marker"');
     expect(html).not.toMatch(

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -1,9 +1,5 @@
-import type {
-  Card as CardType,
-  SeatView,
-  TableView,
-} from "@table-top-poker/protocol";
-import { Card, color, font, shadow } from "@table-top-poker/ui-shared";
+import type { SeatView, TableView } from "@table-top-poker/protocol";
+import { color, font, shadow } from "@table-top-poker/ui-shared";
 import { AnimatePresence, motion } from "motion/react";
 import { posFor } from "./table/posFor.js";
 
@@ -47,8 +43,6 @@ interface SeatVisual {
   readonly marker: SeatMarker | null;
   readonly isActor: boolean;
   readonly isWinner: boolean;
-  readonly holeCards: readonly [CardType, CardType] | null;
-  readonly handDescription: string | null;
   readonly avatarBackground: string;
   readonly avatarColor: string;
 }
@@ -130,12 +124,10 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
     }
   }
 
+  // Showdown no longer marks a winning seat on the felt — the reveal overlay
+  // owns who-won (issue #169). Only the fold-out ending still crowns a seat.
   const isWinner =
-    view?.phase === "showdown"
-      ? view.winners.includes(seat.id)
-      : view?.phase === "folded-out"
-        ? view.winner === seat.id
-        : false;
+    view?.phase === "folded-out" ? view.winner === seat.id : false;
 
   const avatarBackground = !seat.claimed
     ? color.seatAvatarOpen
@@ -157,8 +149,6 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
     marker: markerFor(seat.id, view),
     isActor: view?.phase === "betting" && view.toAct[0] === seat.id,
     isWinner,
-    holeCards: showdownResult?.holeCards ?? null,
-    handDescription: showdownResult?.description ?? null,
     avatarBackground,
     avatarColor,
   };
@@ -272,47 +262,6 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
           </div>
         );
 
-        const holeCardsBlock = visual.holeCards && (
-          <div
-            key="cards"
-            data-testid={`seat-pod-${String(seat.id)}-hole-cards`}
-            style={{ display: "flex", gap: "0.15em", fontSize: "1.1em" }}
-          >
-            {visual.holeCards.map((c, i) => (
-              <motion.div
-                key={i}
-                initial={{ opacity: 0, rotateY: -92 }}
-                animate={{ opacity: 1, rotateY: 0 }}
-                transition={{ duration: 0.35, delay: i * 0.08 }}
-              >
-                <Card rank={c.rank} suit={c.suit} />
-              </motion.div>
-            ))}
-          </div>
-        );
-
-        // No "Winner —" prefix here (issue #60 follow-up to #63): the pod's
-        // own border/background already carries that, and so does the
-        // board's "Hand complete" banner — repeating it a third time here
-        // was just noise.
-        const captionBlock = visual.handDescription && (
-          <div
-            key="caption"
-            data-testid={`seat-pod-${String(seat.id)}-hand`}
-            style={{
-              fontFamily: font.mono,
-              fontSize: "0.6em",
-              letterSpacing: "0.03em",
-              textAlign: "center",
-              lineHeight: 1.3,
-              maxWidth: "7em",
-              color: visual.isWinner ? color.textBright : color.textDim,
-            }}
-          >
-            {visual.handDescription}
-          </div>
-        );
-
         const sittingOutBlock = visual.status === "sitting-out" && (
           <div
             key="sitting-out"
@@ -347,28 +296,15 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
           </div>
         );
 
-        // Boundary rule: the avatar is the fixed anchor `posFor` placed —
-        // cards and the hand-description caption only ever grow inward,
-        // toward the felt's centre, never past the seat toward the rail.
-        // Top row reads avatar → name → cards/status → caption top to bottom;
-        // bottom row is the mirror, so the name, status, and caption always
-        // end up on the table-facing side, closest to the centre everyone's
-        // looking at.
+        // Boundary rule: the avatar is the fixed anchor `posFor` placed — the
+        // name and status only ever grow inward, toward the felt's centre,
+        // never past the seat toward the rail. Top row reads avatar → name →
+        // status top to bottom; bottom row is the mirror, so the name and
+        // status always end up on the table-facing side, closest to the centre
+        // everyone's looking at.
         const stack = isTopRow
-          ? [
-              avatarBlock,
-              nameBlock,
-              holeCardsBlock,
-              sittingOutBlock,
-              captionBlock,
-            ]
-          : [
-              captionBlock,
-              sittingOutBlock,
-              holeCardsBlock,
-              nameBlock,
-              avatarBlock,
-            ];
+          ? [avatarBlock, nameBlock, sittingOutBlock]
+          : [sittingOutBlock, nameBlock, avatarBlock];
 
         return (
           <div

--- a/packages/table-client/src/ShowdownOverlay.test.tsx
+++ b/packages/table-client/src/ShowdownOverlay.test.tsx
@@ -1,0 +1,182 @@
+import type { SeatView, TableView } from "@table-top-poker/protocol";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { ShowdownOverlay } from "./ShowdownOverlay.js";
+
+type ShowdownView = Extract<TableView, { phase: "showdown" }>;
+
+function seat(id: number, displayName?: string): SeatView {
+  return {
+    id,
+    claimed: displayName !== undefined,
+    ...(displayName !== undefined ? { displayName } : {}),
+    sittingOut: false,
+    sittingOutReason: null,
+    disconnected: false,
+  };
+}
+
+const seats: SeatView[] = [seat(0, "Mara"), seat(1, "Devin"), seat(2, "Priya")];
+
+/** A two-way showdown: seat 0 wins, seat 1 reached showdown and lost. */
+const showdown: ShowdownView = {
+  phase: "showdown",
+  button: 0,
+  smallBlind: 1,
+  bigBlind: 2,
+  dealtSeatCount: 3,
+  board: [
+    { rank: "A", suit: "spades" },
+    { rank: "K", suit: "hearts" },
+    { rank: "2", suit: "clubs" },
+    { rank: "7", suit: "diamonds" },
+    { rank: "9", suit: "clubs" },
+  ],
+  winners: [0],
+  results: [
+    {
+      seatId: 0,
+      rank: 1,
+      description: "Pair of Aces",
+      holeCards: [
+        { rank: "A", suit: "clubs" },
+        { rank: "3", suit: "hearts" },
+      ],
+      bestHand: [
+        { rank: "A", suit: "spades" },
+        { rank: "A", suit: "clubs" },
+        { rank: "K", suit: "hearts" },
+        { rank: "9", suit: "clubs" },
+        { rank: "7", suit: "diamonds" },
+      ],
+    },
+    {
+      seatId: 1,
+      rank: 2,
+      description: "Ace high",
+      holeCards: [
+        { rank: "Q", suit: "diamonds" },
+        { rank: "4", suit: "hearts" },
+      ],
+      bestHand: [
+        { rank: "A", suit: "spades" },
+        { rank: "K", suit: "hearts" },
+        { rank: "Q", suit: "diamonds" },
+        { rank: "9", suit: "clubs" },
+        { rank: "7", suit: "diamonds" },
+      ],
+    },
+  ],
+};
+
+function render(
+  view: ShowdownView,
+  props: Partial<React.ComponentProps<typeof ShowdownOverlay>> = {},
+) {
+  return renderToStaticMarkup(
+    <ShowdownOverlay
+      view={view}
+      seats={seats}
+      collapsed={false}
+      canDealNextHand
+      onNextHand={() => undefined}
+      onViewTable={() => undefined}
+      onReopen={() => undefined}
+      {...props}
+    />,
+  );
+}
+
+describe("ShowdownOverlay", () => {
+  it("shows the board and every revealed seat's name, cards, and hand", () => {
+    const html = render(showdown);
+
+    expect(html).toContain('data-testid="showdown-overlay"');
+    expect(html).toContain('data-testid="showdown-board"');
+    // Every seat that reached showdown appears, by name and hand description.
+    expect(html).toContain('data-testid="showdown-player-0"');
+    expect(html).toContain('data-testid="showdown-player-1"');
+    expect(html).toContain("Mara");
+    expect(html).toContain("Pair of Aces");
+    expect(html).toContain("Devin");
+    expect(html).toContain("Ace high");
+    // 5 board cards + 2 + 2 hole cards, all face up.
+    expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(9);
+  });
+
+  it("features the winner and leaves the loser unmarked", () => {
+    const html = render(showdown);
+
+    expect(html).toMatch(
+      /data-testid="showdown-player-0"[^>]*data-winner="true"/,
+    );
+    expect(html).toMatch(
+      /data-testid="showdown-player-1"[^>]*data-winner="false"/,
+    );
+    expect(html).toContain("WINS");
+  });
+
+  it("features every winner on a split pot", () => {
+    const split: ShowdownView = {
+      ...showdown,
+      winners: [0, 1],
+      results: showdown.results.map((result) => ({
+        ...result,
+        rank: 1,
+        description: "Pair of Aces",
+      })),
+    };
+    const html = render(split);
+
+    expect(html).toMatch(
+      /data-testid="showdown-player-0"[^>]*data-winner="true"/,
+    );
+    expect(html).toMatch(
+      /data-testid="showdown-player-1"[^>]*data-winner="true"/,
+    );
+  });
+
+  it("falls back to a seat number when a revealed seat has no display name", () => {
+    const html = renderToStaticMarkup(
+      <ShowdownOverlay
+        view={showdown}
+        seats={[seat(1, "Devin")]}
+        collapsed={false}
+        canDealNextHand
+        onNextHand={() => undefined}
+        onViewTable={() => undefined}
+        onReopen={() => undefined}
+      />,
+    );
+
+    expect(html).toContain("Seat 1");
+  });
+
+  it("disables Next hand with the standing hint below two eligible seats", () => {
+    const html = render(showdown, { canDealNextHand: false });
+
+    expect(html).toMatch(
+      /data-testid="showdown-next-hand-button"[^>]*disabled/,
+    );
+    expect(html).toContain('data-testid="showdown-next-hand-blocked-hint"');
+    expect(html).toContain("Waiting for at least two players");
+  });
+
+  it("keeps Next hand live and unblocked when two seats are eligible", () => {
+    const html = render(showdown);
+
+    expect(html).not.toMatch(
+      /data-testid="showdown-next-hand-button"[^>]*disabled/,
+    );
+    expect(html).not.toContain('data-testid="showdown-next-hand-blocked-hint"');
+  });
+
+  it("collapses to a reopen chip, hiding the panel and its actions", () => {
+    const html = render(showdown, { collapsed: true });
+
+    expect(html).toContain('data-testid="showdown-chip"');
+    expect(html).not.toContain('data-testid="showdown-overlay"');
+    expect(html).not.toContain('data-testid="showdown-next-hand-button"');
+  });
+});

--- a/packages/table-client/src/ShowdownOverlay.test.tsx
+++ b/packages/table-client/src/ShowdownOverlay.test.tsx
@@ -82,7 +82,6 @@ function render(
       canDealNextHand
       onNextHand={() => undefined}
       onViewTable={() => undefined}
-      onReopen={() => undefined}
       {...props}
     />,
   );
@@ -146,7 +145,6 @@ describe("ShowdownOverlay", () => {
         canDealNextHand
         onNextHand={() => undefined}
         onViewTable={() => undefined}
-        onReopen={() => undefined}
       />,
     );
 
@@ -172,10 +170,9 @@ describe("ShowdownOverlay", () => {
     expect(html).not.toContain('data-testid="showdown-next-hand-blocked-hint"');
   });
 
-  it("collapses to a reopen chip, hiding the panel and its actions", () => {
+  it("renders nothing when collapsed — the rail reopens it", () => {
     const html = render(showdown, { collapsed: true });
 
-    expect(html).toContain('data-testid="showdown-chip"');
     expect(html).not.toContain('data-testid="showdown-overlay"');
     expect(html).not.toContain('data-testid="showdown-next-hand-button"');
   });

--- a/packages/table-client/src/ShowdownOverlay.tsx
+++ b/packages/table-client/src/ShowdownOverlay.tsx
@@ -6,6 +6,7 @@ import type {
 } from "@table-top-poker/protocol";
 import { Card, color, font } from "@table-top-poker/ui-shared";
 import { AnimatePresence, motion } from "motion/react";
+import { seatLabel } from "./seatLabel.js";
 
 /** The showdown shape of the table view — the only phase this overlay renders. */
 type ShowdownView = Extract<TableView, { phase: "showdown" }>;
@@ -28,13 +29,6 @@ export interface ShowdownOverlayProps {
   readonly onNextHand: () => void;
   readonly onViewTable: () => void;
   readonly onReopen: () => void;
-}
-
-function seatLabel(seatId: number, seats: readonly SeatView[]): string {
-  return (
-    seats.find((seat) => seat.id === seatId)?.displayName ??
-    `Seat ${String(seatId + 1)}`
-  );
 }
 
 /** A row of face-up cards at a given em scale. */

--- a/packages/table-client/src/ShowdownOverlay.tsx
+++ b/packages/table-client/src/ShowdownOverlay.tsx
@@ -15,9 +15,10 @@ export interface ShowdownOverlayProps {
   readonly view: ShowdownView;
   readonly seats: readonly SeatView[];
   /**
-   * `true` once the operator hits "View table": the overlay collapses to a
-   * chip so the felt's own controls are reachable. Reset to `false` on each
-   * new showdown by the caller, so every hand opens featured.
+   * `true` once "View table" is pressed: the overlay animates out so the felt
+   * and its controls are reachable, and the rail's "View showdown" button
+   * brings it back. Reset to `false` on each new showdown by the caller, so
+   * every hand opens featured.
    */
   readonly collapsed: boolean;
   /**
@@ -28,7 +29,6 @@ export interface ShowdownOverlayProps {
   readonly canDealNextHand: boolean;
   readonly onNextHand: () => void;
   readonly onViewTable: () => void;
-  readonly onReopen: () => void;
 }
 
 /** A row of face-up cards at a given em scale. */
@@ -247,49 +247,6 @@ function OverlayButtons({
   );
 }
 
-/** The chip that reopens a collapsed overlay while still at showdown. */
-function ShowdownChip({ onClick }: { readonly onClick: () => void }) {
-  return (
-    <motion.button
-      type="button"
-      data-testid="showdown-chip"
-      onClick={onClick}
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: 8 }}
-      style={{
-        position: "absolute",
-        top: "0.9em",
-        left: "50%",
-        transform: "translateX(-50%)",
-        display: "flex",
-        alignItems: "center",
-        gap: "0.5em",
-        padding: "0.5rem 1.1rem",
-        borderRadius: "999px",
-        border: `1px solid ${color.winBorder}`,
-        cursor: "pointer",
-        background: color.surface,
-        color: color.text,
-        fontFamily: font.mono,
-        fontSize: "0.75rem",
-        letterSpacing: "0.16em",
-        textTransform: "uppercase",
-      }}
-    >
-      <span
-        style={{
-          width: "0.55em",
-          height: "0.55em",
-          borderRadius: "50%",
-          background: color.winBright,
-        }}
-      />
-      Showdown
-    </motion.button>
-  );
-}
-
 /**
  * The showdown reveal: a single centred panel over a dimmed felt (issue #169,
  * prototype variant E). It shows the board, every seat that reached showdown as
@@ -297,10 +254,10 @@ function ShowdownChip({ onClick }: { readonly onClick: () => void }) {
  * pulsing green glow. It supersedes the per-seat reveal and the felt's winner
  * mark — who won lives only here.
  *
- * "View table" collapses the panel to a chip so the felt's own controls (house
- * rules, end session, join QR) are reachable; the chip reopens it. The panel
- * always fits its bounding box — content scales to the viewport and never
- * scrolls, heads-up or full ring.
+ * "View table" animates the panel out so the felt's own controls (house rules,
+ * end session, join QR) are reachable; the rail's "View showdown" button brings
+ * it back. The panel always fits its bounding box — content scales to the
+ * viewport and never scrolls, heads-up or full ring.
  */
 export function ShowdownOverlay({
   view,
@@ -309,7 +266,6 @@ export function ShowdownOverlay({
   canDealNextHand,
   onNextHand,
   onViewTable,
-  onReopen,
 }: ShowdownOverlayProps) {
   const winnerIds = new Set(view.winners);
   const winners = view.results.filter((result) => winnerIds.has(result.seatId));
@@ -317,9 +273,7 @@ export function ShowdownOverlay({
 
   return (
     <AnimatePresence>
-      {collapsed ? (
-        <ShowdownChip key="chip" onClick={onReopen} />
-      ) : (
+      {!collapsed && (
         <motion.div
           key="overlay"
           data-testid="showdown-overlay"

--- a/packages/table-client/src/ShowdownOverlay.tsx
+++ b/packages/table-client/src/ShowdownOverlay.tsx
@@ -6,7 +6,62 @@ import type {
 } from "@table-top-poker/protocol";
 import { Card, color, font } from "@table-top-poker/ui-shared";
 import { AnimatePresence, motion } from "motion/react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { seatLabel } from "./seatLabel.js";
+
+/**
+ * The burger (settings) toggle lives in the top-right of the felt at
+ * `top:20 right:24`, 52px square. The overlay reserves this much clearance at
+ * the top so its panel never creeps under it. Kept in sync with
+ * `SettingsToggle`.
+ */
+const BURGER_CLEARANCE = "5.25rem";
+
+/**
+ * Uniformly scales the measured content down until it fits inside the stage's
+ * padding box, so every element shrinks together rather than the panel
+ * clipping its own overflow. `offset*`/`client*` sizes are layout sizes and
+ * ignore CSS transforms, so applying the returned scale never feeds back into
+ * the measurement — no observer loop. Only ever scales down (never past 1).
+ */
+function useFitToBox() {
+  const stageRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+
+  useLayoutEffect(() => {
+    const stage = stageRef.current;
+    const content = contentRef.current;
+    if (stage === null || content === null) return;
+
+    function measure(): void {
+      if (stage === null || content === null) return;
+      const styles = getComputedStyle(stage);
+      const padX =
+        parseFloat(styles.paddingLeft) + parseFloat(styles.paddingRight);
+      const padY =
+        parseFloat(styles.paddingTop) + parseFloat(styles.paddingBottom);
+      const availWidth = stage.clientWidth - padX;
+      const availHeight = stage.clientHeight - padY;
+      const naturalWidth = content.offsetWidth;
+      const naturalHeight = content.offsetHeight;
+      if (naturalWidth === 0 || naturalHeight === 0) return;
+      setScale(
+        Math.min(1, availWidth / naturalWidth, availHeight / naturalHeight),
+      );
+    }
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(stage);
+    observer.observe(content);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  return { stageRef, contentRef, scale };
+}
 
 /** The showdown shape of the table view — the only phase this overlay renders. */
 type ShowdownView = Extract<TableView, { phase: "showdown" }>;
@@ -270,11 +325,13 @@ export function ShowdownOverlay({
   const winnerIds = new Set(view.winners);
   const winners = view.results.filter((result) => winnerIds.has(result.seatId));
   const rest = view.results.filter((result) => !winnerIds.has(result.seatId));
+  const { stageRef, contentRef, scale } = useFitToBox();
 
   return (
     <AnimatePresence>
       {!collapsed && (
         <motion.div
+          ref={stageRef}
           key="overlay"
           data-testid="showdown-overlay"
           initial={{ opacity: 0 }}
@@ -290,17 +347,26 @@ export function ShowdownOverlay({
             background: "rgba(5,4,4,.6)",
             backdropFilter: "blur(2px)",
             padding: "1.5rem",
+            // Keep the panel out from under the top-right burger menu.
+            paddingTop: BURGER_CLEARANCE,
           }}
         >
+          <div
+            ref={contentRef}
+            style={{
+              width: "min(97%, 92rem)",
+              flexShrink: 0,
+              transform: `scale(${String(scale)})`,
+              transformOrigin: "center center",
+            }}
+          >
           <motion.div
             initial={{ scale: 0.96, opacity: 0 }}
             animate={{ scale: 1, opacity: 1 }}
             exit={{ scale: 0.96, opacity: 0 }}
             transition={{ duration: 0.2, ease: "easeOut" }}
             style={{
-              width: "min(97%, 92rem)",
-              maxHeight: "100%",
-              overflow: "hidden",
+              width: "100%",
               padding: "clamp(1rem, 2.4vh, 1.8rem)",
               borderRadius: "1.2rem",
               background: color.surfaceGradient,
@@ -376,6 +442,7 @@ export function ShowdownOverlay({
               onViewTable={onViewTable}
             />
           </motion.div>
+          </div>
         </motion.div>
       )}
     </AnimatePresence>

--- a/packages/table-client/src/ShowdownOverlay.tsx
+++ b/packages/table-client/src/ShowdownOverlay.tsx
@@ -1,0 +1,435 @@
+import type {
+  Card as CardType,
+  RevealedResult,
+  SeatView,
+  TableView,
+} from "@table-top-poker/protocol";
+import { Card, color, font } from "@table-top-poker/ui-shared";
+import { AnimatePresence, motion } from "motion/react";
+
+/** The showdown shape of the table view — the only phase this overlay renders. */
+type ShowdownView = Extract<TableView, { phase: "showdown" }>;
+
+export interface ShowdownOverlayProps {
+  readonly view: ShowdownView;
+  readonly seats: readonly SeatView[];
+  /**
+   * `true` once the operator hits "View table": the overlay collapses to a
+   * chip so the felt's own controls are reachable. Reset to `false` on each
+   * new showdown by the caller, so every hand opens featured.
+   */
+  readonly collapsed: boolean;
+  /**
+   * Whether enough players are dealt in for the server to accept `nextHand` —
+   * mirrors the rail's own gate. False disables "Next hand" with a reason
+   * rather than dealing into a rejection.
+   */
+  readonly canDealNextHand: boolean;
+  readonly onNextHand: () => void;
+  readonly onViewTable: () => void;
+  readonly onReopen: () => void;
+}
+
+function seatLabel(seatId: number, seats: readonly SeatView[]): string {
+  return (
+    seats.find((seat) => seat.id === seatId)?.displayName ??
+    `Seat ${String(seatId + 1)}`
+  );
+}
+
+/** A row of face-up cards at a given em scale. */
+function CardRow({
+  cards,
+  scale,
+  gap = "0.28em",
+}: {
+  readonly cards: readonly CardType[];
+  readonly scale: string;
+  readonly gap?: string;
+}) {
+  return (
+    <div style={{ display: "flex", gap, fontSize: scale }}>
+      {cards.map((card, i) => (
+        <Card key={i} rank={card.rank} suit={card.suit} />
+      ))}
+    </div>
+  );
+}
+
+/** The community cards, labelled, at the top of the overlay. */
+function BoardStrip({ board }: { readonly board: readonly CardType[] }) {
+  return (
+    <div
+      data-testid="showdown-board"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "clamp(0.35rem, 1vh, 0.6rem)",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: font.mono,
+          fontSize: "0.75rem",
+          letterSpacing: "0.28em",
+          color: color.textMuted,
+        }}
+      >
+        BOARD
+      </span>
+      <CardRow cards={board} scale="min(1.5rem, 2.2vh)" gap="0.4em" />
+    </div>
+  );
+}
+
+/**
+ * One revealed seat: cards, name, and hand description. Winners glow (a gentle
+ * pulse via `.showdown-win-glow`) and, when `featured`, render larger so the
+ * result reads at a glance across the table.
+ */
+function OverlayPlayer({
+  result,
+  name,
+  isWinner,
+  featured = false,
+}: {
+  readonly result: RevealedResult;
+  readonly name: string;
+  readonly isWinner: boolean;
+  readonly featured?: boolean;
+}) {
+  return (
+    <div
+      data-testid={`showdown-player-${String(result.seatId)}`}
+      data-winner={isWinner}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "clamp(0.35rem, 1vh, 0.7rem)",
+      }}
+    >
+      <div
+        className={isWinner ? "showdown-win-glow" : undefined}
+        style={{
+          padding: featured ? "0.5rem" : "0.4rem",
+          borderRadius: "0.6rem",
+          border: `1px solid ${isWinner ? color.winBorder : "transparent"}`,
+          background: isWinner ? color.winPlate : undefined,
+        }}
+      >
+        <CardRow
+          cards={result.holeCards}
+          scale={featured ? "min(2.1rem, 3vh)" : "min(1.2rem, 1.8vh)"}
+        />
+      </div>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: "0.2rem",
+          textAlign: "center",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: "0.5em",
+            fontSize: featured ? "1.3rem" : "1rem",
+            fontWeight: 700,
+            color: isWinner ? color.winText : color.text,
+          }}
+        >
+          {name}
+          {isWinner && (
+            <span
+              style={{
+                fontFamily: font.mono,
+                fontSize: "0.6em",
+                letterSpacing: "0.16em",
+                color: color.winBright,
+              }}
+            >
+              WINS
+            </span>
+          )}
+        </div>
+        <div
+          style={{
+            fontFamily: font.mono,
+            fontSize: featured ? "0.85rem" : "0.72rem",
+            letterSpacing: "0.02em",
+            color: isWinner ? color.winBright : color.textDim,
+          }}
+        >
+          {result.description}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function OverlayButtons({
+  canDealNextHand,
+  onNextHand,
+  onViewTable,
+}: {
+  readonly canDealNextHand: boolean;
+  readonly onNextHand: () => void;
+  readonly onViewTable: () => void;
+}) {
+  return (
+    <div
+      style={{
+        marginTop: "0.4rem",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "0.5rem",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "1rem",
+        }}
+      >
+        <button
+          type="button"
+          data-testid="showdown-view-table-button"
+          onClick={onViewTable}
+          style={{
+            padding: "0.7rem 2.2rem",
+            borderRadius: "999px",
+            border: `1px solid ${color.borderStrong}`,
+            cursor: "pointer",
+            background: "transparent",
+            color: color.textMuted,
+            fontFamily: font.display,
+            fontSize: "1rem",
+            fontWeight: 800,
+            letterSpacing: "0.04em",
+          }}
+        >
+          View table
+        </button>
+        <button
+          type="button"
+          data-testid="showdown-next-hand-button"
+          disabled={!canDealNextHand}
+          onClick={onNextHand}
+          style={{
+            padding: "0.7rem 2.2rem",
+            borderRadius: "999px",
+            border: "none",
+            cursor: canDealNextHand ? "pointer" : "not-allowed",
+            background: color.pillGradient,
+            color: color.pillInk,
+            fontFamily: font.display,
+            fontSize: "1rem",
+            fontWeight: 800,
+            letterSpacing: "0.04em",
+            opacity: canDealNextHand ? 1 : 0.5,
+            boxShadow:
+              "0 16px 40px -14px rgba(229,68,60,.6), inset 0 1px 0 rgba(255,255,255,.5)",
+          }}
+        >
+          Next hand →
+        </button>
+      </div>
+      {!canDealNextHand && (
+        <div
+          data-testid="showdown-next-hand-blocked-hint"
+          style={{ fontSize: "0.8rem", color: color.textDim }}
+        >
+          Waiting for at least two players
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** The chip that reopens a collapsed overlay while still at showdown. */
+function ShowdownChip({ onClick }: { readonly onClick: () => void }) {
+  return (
+    <motion.button
+      type="button"
+      data-testid="showdown-chip"
+      onClick={onClick}
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: 8 }}
+      style={{
+        position: "absolute",
+        top: "0.9em",
+        left: "50%",
+        transform: "translateX(-50%)",
+        display: "flex",
+        alignItems: "center",
+        gap: "0.5em",
+        padding: "0.5rem 1.1rem",
+        borderRadius: "999px",
+        border: `1px solid ${color.winBorder}`,
+        cursor: "pointer",
+        background: color.surface,
+        color: color.text,
+        fontFamily: font.mono,
+        fontSize: "0.75rem",
+        letterSpacing: "0.16em",
+        textTransform: "uppercase",
+      }}
+    >
+      <span
+        style={{
+          width: "0.55em",
+          height: "0.55em",
+          borderRadius: "50%",
+          background: color.winBright,
+        }}
+      />
+      Showdown
+    </motion.button>
+  );
+}
+
+/**
+ * The showdown reveal: a single centred panel over a dimmed felt (issue #169,
+ * prototype variant E). It shows the board, every seat that reached showdown as
+ * name + cards + hand description, and the winner(s) featured larger with a
+ * pulsing green glow. It supersedes the per-seat reveal and the felt's winner
+ * mark — who won lives only here.
+ *
+ * "View table" collapses the panel to a chip so the felt's own controls (house
+ * rules, end session, join QR) are reachable; the chip reopens it. The panel
+ * always fits its bounding box — content scales to the viewport and never
+ * scrolls, heads-up or full ring.
+ */
+export function ShowdownOverlay({
+  view,
+  seats,
+  collapsed,
+  canDealNextHand,
+  onNextHand,
+  onViewTable,
+  onReopen,
+}: ShowdownOverlayProps) {
+  const winnerIds = new Set(view.winners);
+  const winners = view.results.filter((result) => winnerIds.has(result.seatId));
+  const rest = view.results.filter((result) => !winnerIds.has(result.seatId));
+
+  return (
+    <AnimatePresence>
+      {collapsed ? (
+        <ShowdownChip key="chip" onClick={onReopen} />
+      ) : (
+        <motion.div
+          key="overlay"
+          data-testid="showdown-overlay"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            background: "rgba(5,4,4,.6)",
+            backdropFilter: "blur(2px)",
+            padding: "1.5rem",
+          }}
+        >
+          <motion.div
+            initial={{ scale: 0.96, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.96, opacity: 0 }}
+            transition={{ duration: 0.2, ease: "easeOut" }}
+            style={{
+              width: "min(97%, 92rem)",
+              maxHeight: "100%",
+              overflow: "hidden",
+              padding: "clamp(1rem, 2.4vh, 1.8rem)",
+              borderRadius: "1.2rem",
+              background: color.surfaceGradient,
+              border: `1px solid ${color.borderStrong}`,
+              boxShadow: "0 44px 90px -30px rgba(0,0,0,.95)",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: "clamp(0.6rem, 1.6vh, 1.4rem)",
+            }}
+          >
+            <span
+              style={{
+                fontFamily: font.display,
+                fontSize: "clamp(1rem, 2.2vh, 1.3rem)",
+                fontWeight: 800,
+                letterSpacing: "0.06em",
+                color: color.text,
+              }}
+            >
+              Showdown
+            </span>
+
+            <BoardStrip board={view.board} />
+
+            <div
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                justifyContent: "center",
+                gap: "clamp(1rem, 3vw, 2.4rem)",
+              }}
+            >
+              {winners.map((result) => (
+                <OverlayPlayer
+                  key={result.seatId}
+                  result={result}
+                  name={seatLabel(result.seatId, seats)}
+                  isWinner
+                  featured
+                />
+              ))}
+            </div>
+
+            {rest.length > 0 && (
+              <>
+                <div
+                  style={{ width: "100%", height: 1, background: color.border }}
+                />
+                <div
+                  style={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    justifyContent: "center",
+                    gap: "clamp(0.8rem, 2vw, 1.8rem)",
+                  }}
+                >
+                  {rest.map((result) => (
+                    <OverlayPlayer
+                      key={result.seatId}
+                      result={result}
+                      name={seatLabel(result.seatId, seats)}
+                      isWinner={false}
+                    />
+                  ))}
+                </div>
+              </>
+            )}
+
+            <OverlayButtons
+              canDealNextHand={canDealNextHand}
+              onNextHand={onNextHand}
+              onViewTable={onViewTable}
+            />
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/table-client/src/ShowdownOverlay.tsx
+++ b/packages/table-client/src/ShowdownOverlay.tsx
@@ -360,88 +360,92 @@ export function ShowdownOverlay({
               transformOrigin: "center center",
             }}
           >
-          <motion.div
-            initial={{ scale: 0.96, opacity: 0 }}
-            animate={{ scale: 1, opacity: 1 }}
-            exit={{ scale: 0.96, opacity: 0 }}
-            transition={{ duration: 0.2, ease: "easeOut" }}
-            style={{
-              width: "100%",
-              padding: "clamp(1rem, 2.4vh, 1.8rem)",
-              borderRadius: "1.2rem",
-              background: color.surfaceGradient,
-              border: `1px solid ${color.borderStrong}`,
-              boxShadow: "0 44px 90px -30px rgba(0,0,0,.95)",
-              display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              gap: "clamp(0.6rem, 1.6vh, 1.4rem)",
-            }}
-          >
-            <span
+            <motion.div
+              initial={{ scale: 0.96, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              exit={{ scale: 0.96, opacity: 0 }}
+              transition={{ duration: 0.2, ease: "easeOut" }}
               style={{
-                fontFamily: font.display,
-                fontSize: "clamp(1rem, 2.2vh, 1.3rem)",
-                fontWeight: 800,
-                letterSpacing: "0.06em",
-                color: color.text,
-              }}
-            >
-              Showdown
-            </span>
-
-            <BoardStrip board={view.board} />
-
-            <div
-              style={{
+                width: "100%",
+                padding: "clamp(1rem, 2.4vh, 1.8rem)",
+                borderRadius: "1.2rem",
+                background: color.surfaceGradient,
+                border: `1px solid ${color.borderStrong}`,
+                boxShadow: "0 44px 90px -30px rgba(0,0,0,.95)",
                 display: "flex",
-                flexWrap: "wrap",
-                justifyContent: "center",
-                gap: "clamp(1rem, 3vw, 2.4rem)",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: "clamp(0.6rem, 1.6vh, 1.4rem)",
               }}
             >
-              {winners.map((result) => (
-                <OverlayPlayer
-                  key={result.seatId}
-                  result={result}
-                  name={seatLabel(result.seatId, seats)}
-                  isWinner
-                  featured
-                />
-              ))}
-            </div>
+              <span
+                style={{
+                  fontFamily: font.display,
+                  fontSize: "clamp(1rem, 2.2vh, 1.3rem)",
+                  fontWeight: 800,
+                  letterSpacing: "0.06em",
+                  color: color.text,
+                }}
+              >
+                Showdown
+              </span>
 
-            {rest.length > 0 && (
-              <>
-                <div
-                  style={{ width: "100%", height: 1, background: color.border }}
-                />
-                <div
-                  style={{
-                    display: "flex",
-                    flexWrap: "wrap",
-                    justifyContent: "center",
-                    gap: "clamp(0.8rem, 2vw, 1.8rem)",
-                  }}
-                >
-                  {rest.map((result) => (
-                    <OverlayPlayer
-                      key={result.seatId}
-                      result={result}
-                      name={seatLabel(result.seatId, seats)}
-                      isWinner={false}
-                    />
-                  ))}
-                </div>
-              </>
-            )}
+              <BoardStrip board={view.board} />
 
-            <OverlayButtons
-              canDealNextHand={canDealNextHand}
-              onNextHand={onNextHand}
-              onViewTable={onViewTable}
-            />
-          </motion.div>
+              <div
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  justifyContent: "center",
+                  gap: "clamp(1rem, 3vw, 2.4rem)",
+                }}
+              >
+                {winners.map((result) => (
+                  <OverlayPlayer
+                    key={result.seatId}
+                    result={result}
+                    name={seatLabel(result.seatId, seats)}
+                    isWinner
+                    featured
+                  />
+                ))}
+              </div>
+
+              {rest.length > 0 && (
+                <>
+                  <div
+                    style={{
+                      width: "100%",
+                      height: 1,
+                      background: color.border,
+                    }}
+                  />
+                  <div
+                    style={{
+                      display: "flex",
+                      flexWrap: "wrap",
+                      justifyContent: "center",
+                      gap: "clamp(0.8rem, 2vw, 1.8rem)",
+                    }}
+                  >
+                    {rest.map((result) => (
+                      <OverlayPlayer
+                        key={result.seatId}
+                        result={result}
+                        name={seatLabel(result.seatId, seats)}
+                        isWinner={false}
+                      />
+                    ))}
+                  </div>
+                </>
+              )}
+
+              <OverlayButtons
+                canDealNextHand={canDealNextHand}
+                onNextHand={onNextHand}
+                onViewTable={onViewTable}
+              />
+            </motion.div>
           </div>
         </motion.div>
       )}

--- a/packages/table-client/src/TableControls.test.tsx
+++ b/packages/table-client/src/TableControls.test.tsx
@@ -40,6 +40,24 @@ describe("TableControls", () => {
     expect(html).toContain('data-testid="next-hand-button"');
   });
 
+  it("swaps Next hand for View showdown at showdown", () => {
+    const html = renderToStaticMarkup(
+      <TableControls
+        canStartHand={false}
+        handComplete
+        canDealNextHand
+        atShowdown
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+        onViewShowdown={noop}
+      />,
+    );
+    expect(html).toContain('data-testid="view-showdown-button"');
+    expect(html).not.toContain('data-testid="next-hand-button"');
+    expect(html).toContain('data-testid="end-session-button"');
+  });
+
   it("shows neither deal control mid-hand", () => {
     const html = renderToStaticMarkup(
       <TableControls

--- a/packages/table-client/src/TableControls.tsx
+++ b/packages/table-client/src/TableControls.tsx
@@ -55,6 +55,14 @@ export interface TableControlsProps {
   readonly onStartHand: () => void;
   readonly onNextHand: () => void;
   readonly onEndSession: () => void;
+  /**
+   * At showdown the reveal overlay owns "Next hand", so the rail offers "View
+   * showdown" in that slot instead — reopening the overlay the operator
+   * collapsed with "View table". True only at the showdown phase, never at the
+   * fold-out ending, which keeps its own "Next hand".
+   */
+  readonly atShowdown?: boolean;
+  readonly onViewShowdown?: () => void;
   readonly placement?: TableControlsPlacement;
   /**
    * PROTOTYPE (wayfinder #81) — opens the session hand picker. Optional so
@@ -89,6 +97,8 @@ export function TableControls({
   onStartHand,
   onNextHand,
   onEndSession,
+  atShowdown = false,
+  onViewShowdown,
   placement = "rail",
   onReviewHands,
 }: TableControlsProps) {
@@ -107,22 +117,32 @@ export function TableControls({
           Deal hand
         </PillButton>
       )}
-      {handComplete && (
-        <div style={actionButtonStyle}>
-          <PillButton
-            data-testid="next-hand-button"
-            disabled={!canDealNextHand}
-            onClick={onNextHand}
-            style={{ width: "100%" }}
-          >
-            Next hand
-          </PillButton>
-          {!canDealNextHand && (
-            <div data-testid="next-hand-blocked-hint" style={hintStyle}>
-              Waiting for at least two players
-            </div>
-          )}
-        </div>
+      {atShowdown ? (
+        <PillButton
+          data-testid="view-showdown-button"
+          onClick={onViewShowdown}
+          style={actionButtonStyle}
+        >
+          View showdown
+        </PillButton>
+      ) : (
+        handComplete && (
+          <div style={actionButtonStyle}>
+            <PillButton
+              data-testid="next-hand-button"
+              disabled={!canDealNextHand}
+              onClick={onNextHand}
+              style={{ width: "100%" }}
+            >
+              Next hand
+            </PillButton>
+            {!canDealNextHand && (
+              <div data-testid="next-hand-blocked-hint" style={hintStyle}>
+                Waiting for at least two players
+              </div>
+            )}
+          </div>
+        )
       )}
       {onReviewHands && (
         <PillButton

--- a/packages/table-client/src/app-shell.css
+++ b/packages/table-client/src/app-shell.css
@@ -38,3 +38,24 @@ body {
   gap: 12px;
   background: linear-gradient(160deg, #1a1516, #0a0708 60%, #161011);
 }
+
+/* The showdown overlay's winner glow. Its box-shadow gently pulses, so the
+ * win reads across the table without a hard border. The colour is ui-shared's
+ * `color.winBright` (#7bd88f), hard-coded here for the keyframe. */
+@keyframes showdown-win-pulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 2px #7bd88f,
+      0 0 18px 1px rgba(123, 216, 143, 0.28);
+  }
+  50% {
+    box-shadow:
+      0 0 0 2px #7bd88f,
+      0 0 28px 4px rgba(123, 216, 143, 0.42);
+  }
+}
+
+.showdown-win-glow {
+  animation: showdown-win-pulse 2s ease-in-out infinite;
+}

--- a/packages/table-client/src/seatLabel.ts
+++ b/packages/table-client/src/seatLabel.ts
@@ -1,0 +1,14 @@
+import type { SeatView } from "@table-top-poker/protocol";
+
+/**
+ * A seat's human label: its claimed display name, or a 1-based "Seat N"
+ * fallback for open or unnamed seats. The one place the table client turns a
+ * `seatId` into text, shared by the board, the house-rules sheet, and the
+ * showdown overlay so they never drift.
+ */
+export function seatLabel(seatId: number, seats: readonly SeatView[]): string {
+  return (
+    seats.find((seat) => seat.id === seatId)?.displayName ??
+    `Seat ${String(seatId + 1)}`
+  );
+}

--- a/scripts/dev-servers.sh
+++ b/scripts/dev-servers.sh
@@ -6,12 +6,14 @@ state_dir="${DEV_SERVERS_STATE_DIR:-$repo_root/.dev}"
 pid_dir="$state_dir/pids"
 log_dir="$state_dir/logs"
 profile_file="$state_dir/profile"
+tailscale_serve_state_file="$state_dir/tailscale-serve-ports"
 
 server_port=3000
 table_port=5173
 player_port=5174
 
 readonly service_names=(server table player)
+readonly tailscale_service_ports=("$server_port" "$table_port" "$player_port")
 
 usage() {
   cat <<'EOF'
@@ -24,8 +26,9 @@ Usage:
 Profiles:
   local       Bind to localhost.
   wsl         Bind externally and use the detected WSL2 address.
-  tailscale   Bind externally and use TAILSCALE_ADDRESS, .env.local, or the
-              local Tailscale CLI to find the browser-facing address.
+  tailscale   Bind externally, configure Tailscale Serve for the dev ports,
+              and use TAILSCALE_ADDRESS, .env.local, or the local Tailscale
+              CLI to find the browser-facing address.
 
 Overrides:
   WSL2_ADDRESS=...          WSL2 address to advertise.
@@ -119,6 +122,115 @@ detect_tailscale_address() {
 
   [[ -n "$address" ]] || die "could not find a Tailscale address; set TAILSCALE_ADDRESS"
   printf '%s' "$address"
+}
+
+tailscale_serve_routes() {
+  local port
+
+  # Keep the table's established HTTPS URL on 443, while also exposing each
+  # dev service on its own port. A new service only needs its port added to
+  # tailscale_service_ports above; no separate Serve command is needed.
+  printf '443 %s\n' "$table_port"
+  for port in "${tailscale_service_ports[@]}"; do
+    printf '%s %s\n' "$port" "$port"
+  done
+}
+
+tailscale_serve_proxy_for_port() {
+  local command="$1"
+  local public_port="$2"
+  local config
+
+  config="$("$command" serve status --json </dev/null 2>/dev/null || true)"
+  [[ -n "$config" ]] || return 0
+
+  printf '%s' "$config" |
+    node -e '
+      let input = "";
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", (chunk) => {
+        input += chunk;
+      });
+      process.stdin.on("end", () => {
+        try {
+          const config = JSON.parse(input);
+          const port = process.argv[1];
+          const address = Object.keys(config.Web ?? {}).find((value) =>
+            value.endsWith(":" + port),
+          );
+          const proxy = address
+            ? config.Web[address]?.Handlers?.["/"]?.Proxy
+            : undefined;
+          if (proxy) process.stdout.write(proxy);
+        } catch {
+          // An empty or older status response means the port is unconfigured.
+        }
+      });
+    ' "$public_port"
+}
+
+configure_tailscale_serve() {
+  local command public_port target_port existing_proxy
+
+  command="$(tailscale_command)"
+  if [[ -z "$command" ]]; then
+    printf '%s\n' 'dev-servers: Tailscale CLI is required for the tailscale profile.' >&2
+    return 1
+  fi
+
+  mkdir -p "$state_dir"
+  printf '%s\n' 'Configuring Tailscale Serve for the dev ports.'
+  while read -r public_port target_port; do
+    existing_proxy="$(tailscale_serve_proxy_for_port "$command" "$public_port")"
+    if [[ -n "$existing_proxy" ]]; then
+      if [[ "$existing_proxy" != "http://127.0.0.1:$target_port" ]]; then
+        printf 'dev-servers: refusing to overwrite Tailscale Serve port %s (currently %s).\n' \
+          "$public_port" "$existing_proxy" >&2
+        return 1
+      fi
+      printf '  serve  https://%s -> %s (already configured)\n' \
+        "$public_port" "$existing_proxy"
+      continue
+    fi
+
+    "$command" serve \
+      --https="$public_port" \
+      --bg \
+      --yes \
+      "http://127.0.0.1:$target_port" </dev/null >/dev/null
+    if [[ ! -f "$tailscale_serve_state_file" ]] ||
+      ! grep -Fqx "$public_port $target_port" "$tailscale_serve_state_file"; then
+      printf '%s %s\n' "$public_port" "$target_port" >> "$tailscale_serve_state_file"
+    fi
+    printf '  serve  https://%s -> http://127.0.0.1:%s\n' \
+      "$public_port" "$target_port"
+  done < <(tailscale_serve_routes)
+}
+
+remove_tailscale_serve() {
+  local command public_port target_port existing_proxy
+
+  [[ -s "$tailscale_serve_state_file" ]] || return 0
+
+  command="$(tailscale_command)"
+  if [[ -z "$command" ]]; then
+    printf '%s\n' 'dev-servers: could not find Tailscale CLI to remove managed Serve listeners.' >&2
+    return 1
+  fi
+
+  while read -r public_port target_port; do
+    [[ -n "$public_port" && -n "$target_port" ]] || continue
+    existing_proxy="$(tailscale_serve_proxy_for_port "$command" "$public_port")"
+    if [[ "$existing_proxy" == "http://127.0.0.1:$target_port" ]]; then
+      "$command" serve --https="$public_port" off </dev/null >/dev/null
+      printf '  serve  removed HTTPS port %s\n' "$public_port"
+    else
+      printf '  serve  preserved HTTPS port %s (it no longer matches the managed target)\n' \
+        "$public_port"
+    fi
+  done < "$tailscale_serve_state_file"
+
+  rm -f -- "$tailscale_serve_state_file"
 }
 
 resolve_profile() {
@@ -261,12 +373,29 @@ start_servers() {
     return 1
   fi
 
+  if [[ "$profile_name" == "tailscale" ]] && ! configure_tailscale_serve; then
+    stop_servers
+    return 1
+  fi
+
   cat <<EOF
 
 Dev servers are running:
+EOF
+  if [[ "$profile_name" == "tailscale" ]]; then
+    cat <<EOF
+  table:  https://$public_host/
+  table-dev: https://$public_host:$table_port/
+  player: https://$public_host:$player_port/
+  server: https://$public_host:$server_port
+EOF
+  else
+    cat <<EOF
   table:  http://$public_host:$table_port
   player: http://$public_host:$player_port
   server: http://$public_host:$server_port
+EOF
+  fi
 
 Stop them with: make dev-stop
 EOF
@@ -310,6 +439,7 @@ stop_servers() {
     printf '%s\n' 'No tracked dev servers are running.'
   fi
 
+  remove_tailscale_serve || true
   remove_pid_files
 }
 

--- a/scripts/dev-servers.sh
+++ b/scripts/dev-servers.sh
@@ -6,14 +6,12 @@ state_dir="${DEV_SERVERS_STATE_DIR:-$repo_root/.dev}"
 pid_dir="$state_dir/pids"
 log_dir="$state_dir/logs"
 profile_file="$state_dir/profile"
-tailscale_serve_state_file="$state_dir/tailscale-serve-ports"
 
 server_port=3000
 table_port=5173
 player_port=5174
 
 readonly service_names=(server table player)
-readonly tailscale_service_ports=("$server_port" "$table_port" "$player_port")
 
 usage() {
   cat <<'EOF'
@@ -26,9 +24,8 @@ Usage:
 Profiles:
   local       Bind to localhost.
   wsl         Bind externally and use the detected WSL2 address.
-  tailscale   Bind externally, configure Tailscale Serve for the dev ports,
-              and use TAILSCALE_ADDRESS, .env.local, or the local Tailscale
-              CLI to find the browser-facing address.
+  tailscale   Bind externally and use TAILSCALE_ADDRESS, .env.local, or the
+              local Tailscale CLI to find the browser-facing address.
 
 Overrides:
   WSL2_ADDRESS=...          WSL2 address to advertise.
@@ -122,115 +119,6 @@ detect_tailscale_address() {
 
   [[ -n "$address" ]] || die "could not find a Tailscale address; set TAILSCALE_ADDRESS"
   printf '%s' "$address"
-}
-
-tailscale_serve_routes() {
-  local port
-
-  # Keep the table's established HTTPS URL on 443, while also exposing each
-  # dev service on its own port. A new service only needs its port added to
-  # tailscale_service_ports above; no separate Serve command is needed.
-  printf '443 %s\n' "$table_port"
-  for port in "${tailscale_service_ports[@]}"; do
-    printf '%s %s\n' "$port" "$port"
-  done
-}
-
-tailscale_serve_proxy_for_port() {
-  local command="$1"
-  local public_port="$2"
-  local config
-
-  config="$("$command" serve status --json </dev/null 2>/dev/null || true)"
-  [[ -n "$config" ]] || return 0
-
-  printf '%s' "$config" |
-    node -e '
-      let input = "";
-      process.stdin.setEncoding("utf8");
-      process.stdin.on("data", (chunk) => {
-        input += chunk;
-      });
-      process.stdin.on("end", () => {
-        try {
-          const config = JSON.parse(input);
-          const port = process.argv[1];
-          const address = Object.keys(config.Web ?? {}).find((value) =>
-            value.endsWith(":" + port),
-          );
-          const proxy = address
-            ? config.Web[address]?.Handlers?.["/"]?.Proxy
-            : undefined;
-          if (proxy) process.stdout.write(proxy);
-        } catch {
-          // An empty or older status response means the port is unconfigured.
-        }
-      });
-    ' "$public_port"
-}
-
-configure_tailscale_serve() {
-  local command public_port target_port existing_proxy
-
-  command="$(tailscale_command)"
-  if [[ -z "$command" ]]; then
-    printf '%s\n' 'dev-servers: Tailscale CLI is required for the tailscale profile.' >&2
-    return 1
-  fi
-
-  mkdir -p "$state_dir"
-  printf '%s\n' 'Configuring Tailscale Serve for the dev ports.'
-  while read -r public_port target_port; do
-    existing_proxy="$(tailscale_serve_proxy_for_port "$command" "$public_port")"
-    if [[ -n "$existing_proxy" ]]; then
-      if [[ "$existing_proxy" != "http://127.0.0.1:$target_port" ]]; then
-        printf 'dev-servers: refusing to overwrite Tailscale Serve port %s (currently %s).\n' \
-          "$public_port" "$existing_proxy" >&2
-        return 1
-      fi
-      printf '  serve  https://%s -> %s (already configured)\n' \
-        "$public_port" "$existing_proxy"
-      continue
-    fi
-
-    "$command" serve \
-      --https="$public_port" \
-      --bg \
-      --yes \
-      "http://127.0.0.1:$target_port" </dev/null >/dev/null
-    if [[ ! -f "$tailscale_serve_state_file" ]] ||
-      ! grep -Fqx "$public_port $target_port" "$tailscale_serve_state_file"; then
-      printf '%s %s\n' "$public_port" "$target_port" >> "$tailscale_serve_state_file"
-    fi
-    printf '  serve  https://%s -> http://127.0.0.1:%s\n' \
-      "$public_port" "$target_port"
-  done < <(tailscale_serve_routes)
-}
-
-remove_tailscale_serve() {
-  local command public_port target_port existing_proxy
-
-  [[ -s "$tailscale_serve_state_file" ]] || return 0
-
-  command="$(tailscale_command)"
-  if [[ -z "$command" ]]; then
-    printf '%s\n' 'dev-servers: could not find Tailscale CLI to remove managed Serve listeners.' >&2
-    return 1
-  fi
-
-  while read -r public_port target_port; do
-    [[ -n "$public_port" && -n "$target_port" ]] || continue
-    existing_proxy="$(tailscale_serve_proxy_for_port "$command" "$public_port")"
-    if [[ "$existing_proxy" == "http://127.0.0.1:$target_port" ]]; then
-      "$command" serve --https="$public_port" off </dev/null >/dev/null
-      printf '  serve  removed HTTPS port %s\n' "$public_port"
-    else
-      printf '  serve  preserved HTTPS port %s (it no longer matches the managed target)\n' \
-        "$public_port"
-    fi
-  done < "$tailscale_serve_state_file"
-
-  rm -f -- "$tailscale_serve_state_file"
 }
 
 resolve_profile() {
@@ -373,29 +261,12 @@ start_servers() {
     return 1
   fi
 
-  if [[ "$profile_name" == "tailscale" ]] && ! configure_tailscale_serve; then
-    stop_servers
-    return 1
-  fi
-
   cat <<EOF
 
 Dev servers are running:
-EOF
-  if [[ "$profile_name" == "tailscale" ]]; then
-    cat <<EOF
-  table:  https://$public_host/
-  table-dev: https://$public_host:$table_port/
-  player: https://$public_host:$player_port/
-  server: https://$public_host:$server_port
-EOF
-  else
-    cat <<EOF
   table:  http://$public_host:$table_port
   player: http://$public_host:$player_port
   server: http://$public_host:$server_port
-EOF
-  fi
 
 Stop them with: make dev-stop
 EOF
@@ -439,7 +310,6 @@ stop_servers() {
     printf '%s\n' 'No tracked dev servers are running.'
   fi
 
-  remove_tailscale_serve || true
   remove_pid_files
 }
 


### PR DESCRIPTION
Closes #169.

## What changed

At showdown the table device now renders a single centred panel over a dimmed felt (prototype variant E), replacing the per-seat reveal:

- **`ShowdownOverlay`** (new) shows the board, every seat that reached showdown as name + cards + hand description, and the winner(s) featured larger with a pulsing green glow. Fades + scales in/out; collapses to a **Showdown** chip via **View table** and reopens from it.
- **Next hand** is the overlay's primary action, reusing the existing `nextHand` command and disabled below two eligible seats with the standing "Waiting for at least two players" hint.
- **`Seats`** no longer renders hole cards, hand descriptions, or a winner mark at showdown — nothing shifts when a hand ends. The fold-out winner crown is unchanged.
- **`Board`** suppresses its "Hand complete" banner at showdown (the overlay owns the result); `folded-out` keeps its banner.
- Collapsed state resets on each new showdown (`useEffect` on phase).
- Follow-up refactor extracts the duplicated `seatLabel` helper into one shared module.

## Testing

- New `ShowdownOverlay.test.tsx`; updated `Seats`, `Board`, and `App` tests to the new behaviour.
- `packages/table-client` full suite (92 tests) green; `tsc -b`, eslint, and prettier clean.

## Notes for review

The overlay layout — winner-first vertical order, the "Showdown" title, the "WINS" badge, and the fixed rem type sizes — is faithful to the validated prototype (variant E). It uses `overflow: hidden` so it never scrolls; extreme many-way + short-viewport combinations clip rather than scroll, matching the prototype's tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T2yVrqn159RwqEacboWjZ4