### PR TITLE
fix(table): clear hand view on room teardown

### DIFF
--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -68,31 +68,33 @@ export function App() {
       });
   }, [setRoomView, setSeat]);
 
-  const handleRejected = useCallback(() => {
+  // Drop this player out of their seat locally: forget the stored and in-memory
+  // seat token, and clear the seat and hand slices so no stale seat or hole
+  // cards survive into the next room (#171). Callers that also leave the room
+  // entirely add clearRoom() themselves.
+  const dropSeat = useCallback(() => {
     clearSeatToken(window.localStorage);
     setSeatToken(null);
     clearSeat();
     clearHand();
-    setSeatMoveMessage(null);
   }, [clearSeat, clearHand]);
+
+  const handleRejected = useCallback(() => {
+    dropSeat();
+    setSeatMoveMessage(null);
+  }, [dropSeat]);
 
   const handleEvicted = useCallback(() => {
-    clearSeatToken(window.localStorage);
-    setSeatToken(null);
-    clearSeat();
-    clearHand();
+    dropSeat();
     setEvictionMessage("You have been evicted from the room");
     setSeatMoveMessage(null);
-  }, [clearSeat, clearHand]);
+  }, [dropSeat]);
 
   const handleRoomEnded = useCallback(() => {
-    clearSeatToken(window.localStorage);
-    setSeatToken(null);
-    clearSeat();
+    dropSeat();
     clearRoom();
-    clearHand();
     setSeatMoveMessage(null);
-  }, [clearSeat, clearRoom, clearHand]);
+  }, [dropSeat, clearRoom]);
 
   const handleSeatMoved = useCallback(
     ({ from, to }: SeatMove) => {
@@ -147,14 +149,11 @@ export function App() {
     if (roomCode !== null && seatId !== null && seatToken !== null) {
       leaveSeat(roomCode, seatId, seatToken);
     }
-    clearSeatToken(window.localStorage);
-    setSeatToken(null);
-    clearSeat();
+    dropSeat();
     clearRoom();
-    clearHand();
     setSeatMoveMessage(null);
     setEvictionMessage(null);
-  }, [roomCode, seatId, seatToken, clearSeat, clearRoom, clearHand]);
+  }, [roomCode, seatId, seatToken, dropSeat, clearRoom]);
 
   const intent = useActionIntent(send);
 

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -33,6 +33,7 @@ export function App() {
   const moveSeat = usePlayerStore((state) => state.moveSeat);
   const clearSeat = usePlayerStore((state) => state.clearSeat);
   const clearRoom = usePlayerStore((state) => state.clearRoom);
+  const clearHand = usePlayerStore((state) => state.clearHand);
 
   const [defaultRoomCode] = useState(() =>
     typeof window === "undefined"
@@ -71,24 +72,27 @@ export function App() {
     clearSeatToken(window.localStorage);
     setSeatToken(null);
     clearSeat();
+    clearHand();
     setSeatMoveMessage(null);
-  }, [clearSeat]);
+  }, [clearSeat, clearHand]);
 
   const handleEvicted = useCallback(() => {
     clearSeatToken(window.localStorage);
     setSeatToken(null);
     clearSeat();
+    clearHand();
     setEvictionMessage("You have been evicted from the room");
     setSeatMoveMessage(null);
-  }, [clearSeat]);
+  }, [clearSeat, clearHand]);
 
   const handleRoomEnded = useCallback(() => {
     clearSeatToken(window.localStorage);
     setSeatToken(null);
     clearSeat();
     clearRoom();
+    clearHand();
     setSeatMoveMessage(null);
-  }, [clearSeat, clearRoom]);
+  }, [clearSeat, clearRoom, clearHand]);
 
   const handleSeatMoved = useCallback(
     ({ from, to }: SeatMove) => {
@@ -147,9 +151,10 @@ export function App() {
     setSeatToken(null);
     clearSeat();
     clearRoom();
+    clearHand();
     setSeatMoveMessage(null);
     setEvictionMessage(null);
-  }, [roomCode, seatId, seatToken, clearSeat, clearRoom]);
+  }, [roomCode, seatId, seatToken, clearSeat, clearRoom, clearHand]);
 
   const intent = useActionIntent(send);
 
@@ -159,13 +164,17 @@ export function App() {
         .then((view) => {
           setEvictionMessage(null);
           setSeatMoveMessage(null);
+          // A freshly joined room has no hand for this player yet; drop any
+          // hand view carried over from a previous room so the seat picker
+          // and lobby never show stale hole cards (#171).
+          clearHand();
           setRoomView(view);
         })
         .catch(() => {
           setJoinError("room-not-found");
         });
     },
-    [setRoomView, setJoinError],
+    [setRoomView, setJoinError, clearHand],
   );
 
   const handleClaim = useCallback(

--- a/packages/player-client/src/store/handSlice.ts
+++ b/packages/player-client/src/store/handSlice.ts
@@ -4,11 +4,15 @@ import type { StateCreator } from "zustand";
 export interface HandSlice {
   readonly handView: PlayerView | null;
   readonly setHandView: (view: PlayerView) => void;
+  readonly clearHand: () => void;
 }
 
 export const createHandSlice: StateCreator<HandSlice> = (set) => ({
   handView: null,
   setHandView: (view) => {
     set({ handView: view });
+  },
+  clearHand: () => {
+    set({ handView: null });
   },
 });

--- a/packages/player-client/src/store/store.test.ts
+++ b/packages/player-client/src/store/store.test.ts
@@ -115,6 +115,14 @@ describe("usePlayerStore", () => {
     expect(usePlayerStore.getState().seats).toEqual([]);
   });
 
+  it("clears the hand view so a new room starts without stale hole cards", () => {
+    usePlayerStore.getState().setHandView({ phase: "no-hand", button: 0 });
+    expect(usePlayerStore.getState().handView).not.toBeNull();
+
+    usePlayerStore.getState().clearHand();
+    expect(usePlayerStore.getState().handView).toBeNull();
+  });
+
   it("marks an action pending on send, with no rejection yet", () => {
     usePlayerStore.getState().sendStarted("call");
     expect(usePlayerStore.getState().pendingAction).toBe("call");

--- a/packages/player-client/src/store/store.test.ts
+++ b/packages/player-client/src/store/store.test.ts
@@ -123,6 +123,80 @@ describe("usePlayerStore", () => {
     expect(usePlayerStore.getState().handView).toBeNull();
   });
 
+  // Regression for #172: rejoining a new room used to render the previous
+  // room's hand result. The root cause lived in the seam below — clearing the
+  // room slice never touched the hand slice — so a teardown that only called
+  // clearRoom left the old result behind for the next room to display.
+  it("does not clear a stale hand result when only the room is torn down (#172)", () => {
+    usePlayerStore.getState().setRoomView({
+      code: "ABCD",
+      pendingSeatCount: null,
+      seats: [
+        {
+          id: 0,
+          claimed: true,
+          sittingOut: false,
+          sittingOutReason: null,
+          disconnected: false,
+        },
+      ],
+    });
+    usePlayerStore.getState().setSeat({ seatId: 0, sittingOut: false });
+    usePlayerStore.getState().setHandView({
+      phase: "folded-out",
+      button: 0,
+      smallBlind: 0,
+      bigBlind: 0,
+      dealtSeatCount: 1,
+      winner: 0,
+    });
+
+    usePlayerStore.getState().clearRoom();
+
+    // The room is gone but the previous hand result survives — this is exactly
+    // why the teardown/join handlers must clear the hand as well.
+    expect(usePlayerStore.getState().roomCode).toBeNull();
+    expect(usePlayerStore.getState().handView).not.toBeNull();
+  });
+
+  // Regression for #172: the full room-ended reset the handler performs must
+  // leave no residue from the previous room, so a rejoin into the same seat
+  // position renders no prior-room result until a fresh hand-update arrives.
+  it("leaves a clean slate for the next room when the hand is cleared too (#172)", () => {
+    usePlayerStore.getState().setRoomView({
+      code: "ABCD",
+      pendingSeatCount: null,
+      seats: [
+        {
+          id: 0,
+          claimed: true,
+          sittingOut: false,
+          sittingOutReason: null,
+          disconnected: false,
+        },
+      ],
+    });
+    usePlayerStore.getState().setSeat({ seatId: 0, sittingOut: false });
+    usePlayerStore.getState().setHandView({
+      phase: "folded-out",
+      button: 0,
+      smallBlind: 0,
+      bigBlind: 0,
+      dealtSeatCount: 1,
+      winner: 0,
+    });
+
+    // The room-ended teardown the handler runs: drop the seat and hand, then
+    // the room.
+    usePlayerStore.getState().clearSeat();
+    usePlayerStore.getState().clearHand();
+    usePlayerStore.getState().clearRoom();
+
+    expect(usePlayerStore.getState().roomCode).toBeNull();
+    expect(usePlayerStore.getState().seatId).toBeNull();
+    expect(usePlayerStore.getState().handView).toBeNull();
+  });
+
   it("marks an action pending on send, with no rejection yet", () => {
     usePlayerStore.getState().sendStarted("call");
     expect(usePlayerStore.getState().pendingAction).toBe("call");

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -36,6 +36,7 @@ export function App() {
   const handView = useTableStore((state) => state.handView);
   const setRoomCreated = useTableStore((state) => state.setRoomCreated);
   const clearRoom = useTableStore((state) => state.clearRoom);
+  const clearHand = useTableStore((state) => state.clearHand);
 
   const [joinOpen, setJoinOpen] = useState(false);
   const toggleJoin = useCallback(() => {
@@ -70,7 +71,8 @@ export function App() {
   const handleRoomEnded = useCallback(() => {
     setSettingsOpen(false);
     clearRoom();
-  }, [clearRoom]);
+    clearHand();
+  }, [clearRoom, clearHand]);
 
   const { send } = useWebSocket(roomCode, {
     onRoomEnded: handleRoomEnded,
@@ -91,11 +93,12 @@ export function App() {
       .then(() => {
         setSettingsOpen(false);
         clearRoom();
+        clearHand();
       })
       .catch((error: unknown) => {
         console.error(error);
       });
-  }, [roomCode, clearRoom]);
+  }, [roomCode, clearRoom, clearHand]);
 
   const handleChangeSeatCount = useCallback(
     (seatCount: number) => {

--- a/packages/table-client/src/store/handSlice.ts
+++ b/packages/table-client/src/store/handSlice.ts
@@ -4,11 +4,15 @@ import type { StateCreator } from "zustand";
 export interface HandSlice {
   readonly handView: TableView | null;
   readonly setHandView: (view: TableView) => void;
+  readonly clearHand: () => void;
 }
 
 export const createHandSlice: StateCreator<HandSlice> = (set) => ({
   handView: null,
   setHandView: (view) => {
     set({ handView: view });
+  },
+  clearHand: () => {
+    set({ handView: null });
   },
 });

--- a/packages/table-client/src/store/store.test.ts
+++ b/packages/table-client/src/store/store.test.ts
@@ -73,6 +73,14 @@ describe("useTableStore", () => {
     expect(useTableStore.getState().pendingSeatCount).toBe(4);
   });
 
+  it("clears the hand view so a new room starts without stale hand state", () => {
+    useTableStore.getState().setHandView({ phase: "no-hand", button: 0 });
+    expect(useTableStore.getState().handView).not.toBeNull();
+
+    useTableStore.getState().clearHand();
+    expect(useTableStore.getState().handView).toBeNull();
+  });
+
   it("clears the room slice back to its initial state", () => {
     useTableStore.getState().setRoomView({
       code: "ABCD",


### PR DESCRIPTION
## Summary

Fixes #171 and #172 — ending a session left the previous hand in state for the next room. The stale state showed up in **both** clients, so this fixes both.

The root cause is the same in each: `handView` lives in its own store slice that the room/seat teardown paths never cleared, so a freshly created/joined room kept showing the prior hand until (and unless) it received its own hand update. In particular, `clearRoom()` never touched the hand slice.

### Table client

- `clearRoom()` reset the room slice (code, join URL, seats) but not `handView`, so **End session** (or a server `room-ended`) left the prior hand/showdown/board on the felt.
- Added a `clearHand` action to the hand slice and call it alongside `clearRoom()` in both teardown paths (`handleEndSession`, `handleRoomEnded`).

### Player client (also fixes #172)

The table-only fix wasn't enough — the **players** still showed the previous hand (hole cards, "You're to act — preflop", or a prior-room result) after rejoining a new room and reclaiming their seats.

- The seat/room teardown handlers (`room-ended`, evicted, rejected, leave) all cleared seat/room but left `handView` intact, so after reclaiming a seat the stale `PlayerView` rendered.
- Added a `clearHand` action to the player hand slice and call it in every path that drops the player out of a hand, and on a fresh join — so a newly joined room shows no stale hole cards or result before the server pushes this player's own view.
- Extracted the shared seat-teardown sequence (forget the stored and in-memory seat token, clear the seat and hand slices) into a `dropSeat` helper, since reject/evicted/room-ended/leave all repeated it; callers that also leave the room keep `clearRoom()` at the call site.

### Not in scope

- #173 (coaching hint absent on a fresh coarse-pointer profile) is **not** downstream of this stale-state fix. The teaching hint it expects isn't implemented yet — `quiet` is hardcoded `false` and `selectHint` has no teaching-hint branch (both land with the #147 discovery-set wiring). Left open for re-test once that lands.

## Testing

- `npx vitest run packages/table-client/src/store/store.test.ts packages/table-client/src/App.test.tsx` — pass
- `npx vitest run packages/player-client/src/store/store.test.ts packages/player-client/src/App.test.tsx` — pass (incl. new #172 regression tests)
- `npm run build` (typecheck) — pass
- `eslint` + `prettier --check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R84qeRS69vzPpg9qmrkJdf
