### PR TITLE
feat(table): survive refresh and rejoin the active room

### DIFF
--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -12,6 +12,7 @@ import {
   createRoom,
   endSession,
   evictSeat,
+  fetchRoom,
 } from "./api/rooms.js";
 import { Board } from "./Board.js";
 import { HouseRulesSheet } from "./HouseRulesSheet.js";
@@ -23,6 +24,11 @@ import { ShowdownOverlay } from "./ShowdownOverlay.js";
 import { SettingsToggle } from "./SettingsToggle.js";
 import { StatusBar } from "./StatusBar.js";
 import { TableControls } from "./TableControls.js";
+import {
+  clearHostedRoom,
+  loadHostedRoom,
+  saveHostedRoom,
+} from "./storage/hostedRoom.js";
 import { useTableStore } from "./store/store.js";
 import { useWebSocket } from "./ws/useWebSocket.js";
 
@@ -37,6 +43,26 @@ export function App() {
   const setRoomCreated = useTableStore((state) => state.setRoomCreated);
   const clearRoom = useTableStore((state) => state.clearRoom);
   const clearHand = useTableStore((state) => state.clearHand);
+
+  useEffect(() => {
+    // Silently re-attach to the room this table was hosting on mount (#175) —
+    // a refresh keeps the room alive server-side for the grace window (#130
+    // §7). Confirm the room is still live over HTTP before restoring: the WS
+    // handshake 404s once the room is gone, but the socket can't tell that
+    // from a transient drop and would retry forever, so this check is what
+    // decides the fall-through. A live room restores its code/QR and the
+    // socket reconnects; a gone room (or absent/malformed storage) clears the
+    // stored room and falls through to the create-room screen.
+    const stored = loadHostedRoom(window.localStorage);
+    if (stored === null) return;
+    fetchRoom(stored.code)
+      .then(() => {
+        setRoomCreated(stored);
+      })
+      .catch(() => {
+        clearHostedRoom(window.localStorage);
+      });
+  }, [setRoomCreated]);
 
   const [joinOpen, setJoinOpen] = useState(false);
   const toggleJoin = useCallback(() => {
@@ -69,6 +95,7 @@ export function App() {
   }, [roomCode, menuSeatId]);
 
   const handleRoomEnded = useCallback(() => {
+    clearHostedRoom(window.localStorage);
     setSettingsOpen(false);
     clearRoom();
     clearHand();
@@ -81,7 +108,10 @@ export function App() {
   const [seatCount, setSeatCount] = useState(DEFAULT_SEAT_COUNT);
   const handleCreateRoom = useCallback(() => {
     createRoom(seatCount)
-      .then(setRoomCreated)
+      .then((room) => {
+        saveHostedRoom(window.localStorage, room);
+        setRoomCreated(room);
+      })
       .catch((error: unknown) => {
         console.error(error);
       });
@@ -91,6 +121,7 @@ export function App() {
     if (!roomCode) return;
     endSession(roomCode)
       .then(() => {
+        clearHostedRoom(window.localStorage);
         setSettingsOpen(false);
         clearRoom();
         clearHand();

--- a/packages/table-client/src/api/rooms.ts
+++ b/packages/table-client/src/api/rooms.ts
@@ -1,9 +1,25 @@
-import type { SeatCountChange } from "@table-top-poker/protocol";
+import type { RoomView, SeatCountChange } from "@table-top-poker/protocol";
 
 export interface CreatedRoom {
   readonly code: string;
   readonly joinUrl: string;
   readonly qrCodeDataUrl: string;
+}
+
+/**
+ * Confirms a room is still live before the table re-attaches on refresh
+ * (#175). The WebSocket handshake 404s for a dead room, but a browser socket
+ * can't tell that rejection from a transient drop, so the reconnect loop would
+ * retry forever — this HTTP check decides existence up front, mirroring the
+ * player client's reclaim-on-mount. Rejects on a 404 (grace window elapsed) or
+ * any non-2xx.
+ */
+export async function fetchRoom(code: string): Promise<RoomView> {
+  const response = await fetch(`/rooms/${code}/join`, { method: "POST" });
+  if (!response.ok) {
+    throw new Error(`failed to fetch room: ${String(response.status)}`);
+  }
+  return (await response.json()) as RoomView;
 }
 
 /** `seatCount` is the table size the creator picked — 2-8, re-validated server-side. */

--- a/packages/table-client/src/storage/hostedRoom.test.ts
+++ b/packages/table-client/src/storage/hostedRoom.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  clearHostedRoom,
+  loadHostedRoom,
+  saveHostedRoom,
+} from "./hostedRoom.js";
+
+function fakeStorage(setItem: (key: string, value: string) => void): Storage {
+  const data = new Map<string, string>();
+  return {
+    getItem: (key) => data.get(key) ?? null,
+    setItem: (key, value) => {
+      data.set(key, value);
+      setItem(key, value);
+    },
+    removeItem: (key) => {
+      data.delete(key);
+    },
+    clear: () => {
+      data.clear();
+    },
+    key: () => null,
+    length: 0,
+  };
+}
+
+const room = {
+  code: "ABCD",
+  joinUrl: "http://localhost:3000/join/ABCD",
+  qrCodeDataUrl: "data:image/png;base64,xyz",
+};
+
+describe("saveHostedRoom", () => {
+  it("stores the hosted room as JSON under a namespaced key", () => {
+    const setItem = vi.fn();
+    const storage = fakeStorage(setItem);
+
+    saveHostedRoom(storage, room);
+
+    expect(setItem).toHaveBeenCalledWith(
+      "ttp:hosted-room",
+      JSON.stringify(room),
+    );
+  });
+});
+
+describe("loadHostedRoom", () => {
+  it("reads back a previously saved room", () => {
+    const storage = fakeStorage(() => undefined);
+    saveHostedRoom(storage, room);
+
+    expect(loadHostedRoom(storage)).toEqual(room);
+  });
+
+  it("returns null when nothing is stored", () => {
+    const storage = fakeStorage(() => undefined);
+    expect(loadHostedRoom(storage)).toBeNull();
+  });
+
+  it("returns null for malformed JSON rather than throwing", () => {
+    const storage = fakeStorage(() => undefined);
+    storage.setItem("ttp:hosted-room", "not json");
+    expect(loadHostedRoom(storage)).toBeNull();
+  });
+
+  it("returns null for well-formed JSON missing required fields", () => {
+    const storage = fakeStorage(() => undefined);
+    storage.setItem("ttp:hosted-room", JSON.stringify({ code: "ABCD" }));
+    expect(loadHostedRoom(storage)).toBeNull();
+  });
+});
+
+describe("clearHostedRoom", () => {
+  it("removes the stored room", () => {
+    const storage = fakeStorage(() => undefined);
+    saveHostedRoom(storage, room);
+
+    clearHostedRoom(storage);
+
+    expect(loadHostedRoom(storage)).toBeNull();
+  });
+});

--- a/packages/table-client/src/storage/hostedRoom.ts
+++ b/packages/table-client/src/storage/hostedRoom.ts
@@ -1,0 +1,60 @@
+const KEY = "ttp:hosted-room";
+
+export interface HostedRoom {
+  readonly code: string;
+  readonly joinUrl: string;
+  readonly qrCodeDataUrl: string;
+}
+
+/**
+ * Persists the room this table is hosting so a refresh can re-attach to it
+ * instead of dropping back to the create-room screen (#175). The QR/join URL
+ * are server-derived at creation and absent from `room-view`, so they ride
+ * along here to keep the lobby intact across a reload. Takes an injected
+ * `Storage` so callers pass `window.localStorage` or a test double without
+ * reaching for a global.
+ */
+export function saveHostedRoom(storage: Storage, room: HostedRoom): void {
+  storage.setItem(KEY, JSON.stringify(room));
+}
+
+/**
+ * Reads back a stored hosted room for auto-rejoin on mount. Malformed or
+ * absent storage both read as "nothing to rejoin" — the client then falls
+ * through to the create-room screen.
+ */
+export function loadHostedRoom(storage: Storage): HostedRoom | null {
+  const raw = storage.getItem(KEY);
+  if (raw === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "code" in parsed &&
+      "joinUrl" in parsed &&
+      "qrCodeDataUrl" in parsed
+    ) {
+      const record = parsed as Record<string, unknown>;
+      if (
+        typeof record.code !== "string" ||
+        typeof record.joinUrl !== "string" ||
+        typeof record.qrCodeDataUrl !== "string"
+      ) {
+        return null;
+      }
+      return {
+        code: record.code,
+        joinUrl: record.joinUrl,
+        qrCodeDataUrl: record.qrCodeDataUrl,
+      };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearHostedRoom(storage: Storage): void {
+  storage.removeItem(KEY);
+}


### PR DESCRIPTION
Closes #175.

## Problem

The table client held `roomCode` only in the in-memory Zustand store, so a reload re-initialised to the create-room screen even though the room was still live server-side for the grace window (#130 §7) — forcing every connected player to rejoin a brand-new room.

## Change

Mirror the player client's reclaim-on-mount pattern (`storage/seatToken.ts`):

- **`storage/hostedRoom.ts`** (+ unit tests) — persist the hosted room to `localStorage`. Stores `code` plus the server-derived `joinUrl`/`qrCodeDataUrl`, which `room-view` omits, so the lobby QR survives a reload.
- **`api/rooms.ts`** — `fetchRoom(code)`, a side-effect-free existence check against `POST /rooms/:code/join`.
- **`App.tsx`** — persist on create, clear in both teardown paths (`handleEndSession`, `handleRoomEnded`), and on mount confirm the room is still live over HTTP before restoring.

### Why the HTTP existence check

The WebSocket handshake 404s once the room is gone, but a browser socket can't tell that rejection from a transient drop — the reconnect loop would retry forever and never fall back to create-room. The HTTP check decides existence up front: a live room restores its code/QR and the socket reconnects; a gone room (or absent/malformed storage) clears the stored room and falls through to create-room. This is the fall-through the issue's triage called out, and it caught a bug in the first cut during review.

## Triage decisions honoured

- No table-role reconnect token — the room code alone re-attaches a table socket.
- Stored room ended → silent fall-back to create-room (no notice).

## Testing

- `tsc -b packages/table-client` clean; eslint + prettier clean on changed files.
- 100 table-client tests pass; the storage module is fully covered (save/load/clear + malformed input).
- **Coverage gap:** the mount-restore wiring isn't unit-tested because `App.test.tsx` renders via `renderToStaticMarkup` (no effects) — the same limitation under which the player client's equivalent reclaim is untested. The logic mirrors that proven pattern and is covered by typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R84qeRS69vzPpg9qmrkJdf