### PR TITLE
feat(sound): ship tactile-sound audio layer across both clients

### DIFF
--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -1,4 +1,5 @@
 import type { SeatMove } from "@table-top-poker/protocol";
+import { unlockAudio } from "@table-top-poker/ui-shared";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ActionBar } from "./ActionBar.js";
 import { claimSeat, joinRoom, leaveSeat } from "./api/rooms.js";
@@ -179,6 +180,9 @@ export function App() {
   const handleClaim = useCallback(
     (seat: number, name: string) => {
       if (roomCode === null) return;
+      // The seat tap is this phone's audio-unlock gesture (#178): resume the
+      // context and warm the buffers now, while we're inside the user gesture.
+      void unlockAudio();
       claimSeat(roomCode, seat, name)
         .then((claim) => {
           setClaimError(null);

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -1,4 +1,5 @@
 import type { Card } from "@table-top-poker/protocol";
+import { playRevealFlip } from "@table-top-poker/ui-shared";
 import { animate, useMotionValue, type MotionValue } from "motion/react";
 import {
   useCallback,
@@ -204,6 +205,20 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
       bend.set(0);
     }
   }, [state.presentation, bend]);
+
+  // A card-flip cue on reveal/conceal (#186). Entering `Turning` is every
+  // reveal (keyboard, bend-peel, showdown); `Revealed → FaceDown` is a
+  // conceal. A fresh deal reaches `FaceDown` from elsewhere and keeps its own
+  // deal cue instead.
+  const prevPresentation = useRef(state.presentation);
+  useEffect(() => {
+    const from = prevPresentation.current;
+    const to = state.presentation;
+    prevPresentation.current = to;
+    if (to === "Turning" || (from === "Revealed" && to === "FaceDown")) {
+      playRevealFlip();
+    }
+  }, [state.presentation]);
 
   /**
    * Whether the pair is on its way to the muck **right now**.

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -4,6 +4,10 @@ import type {
   SeatMove,
   ServerMessage,
 } from "@table-top-poker/protocol";
+import {
+  applyRoomSoundSettings,
+  onHandUpdate,
+} from "@table-top-poker/ui-shared";
 import { useCallback, useEffect, useRef } from "react";
 import { usePlayerStore } from "../store/store.js";
 import { getWebSocketUrl } from "./getWebSocketUrl.js";
@@ -142,6 +146,9 @@ export function useWebSocket(
         switch (message.type) {
           case "room-view":
             setRoomView(message.view);
+            // Phones obey the table's sound settings (#182); mirror them into
+            // the audio engine's gate so cue playback honours the room.
+            applyRoomSoundSettings(message.view.soundSettings);
             {
               const seat = message.view.seats.find(
                 (candidate) => candidate.id === activeConnection.seatId,
@@ -160,6 +167,14 @@ export function useWebSocket(
             // The server only ever sends a seat's socket its own `view(state, seatId)`.
             setHandView(message.view as PlayerView);
             viewSnapshotReceived();
+            // Cues fire on the live event only, never on the `view-snapshot`
+            // below — so a reconnect/refresh can't replay a burst (#175).
+            onHandUpdate({
+              surface: "player",
+              event: message.event,
+              view: message.view,
+              seatId: activeConnection.seatId,
+            });
             break;
           case "view-snapshot":
             setHandView(message.view as PlayerView);

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -6,7 +6,7 @@ import {
   MIN_SEAT_COUNT,
   type SoundSettings,
 } from "@table-top-poker/protocol";
-import { color } from "@table-top-poker/ui-shared";
+import { color, unlockAudio } from "@table-top-poker/ui-shared";
 import { useCallback, useEffect, useState } from "react";
 import {
   changeSeatCount,
@@ -110,6 +110,8 @@ export function App() {
 
   const [seatCount, setSeatCount] = useState(DEFAULT_SEAT_COUNT);
   const handleCreateRoom = useCallback(() => {
+    // Hosting the table is the kiosk's audio-unlock gesture (#178).
+    void unlockAudio();
     createRoom(seatCount)
       .then((room) => {
         saveHostedRoom(window.localStorage, room);
@@ -161,10 +163,14 @@ export function App() {
   );
 
   const handleStartHand = useCallback(() => {
+    // Also an unlock gesture, so a table that rejoined after a refresh (with no
+    // fresh create-room tap) still wakes its audio before the deal.
+    void unlockAudio();
     send({ type: "startHand" });
   }, [send]);
 
   const handleNextHand = useCallback(() => {
+    void unlockAudio();
     send({ type: "nextHand" });
   }, [send]);
 

--- a/packages/table-client/src/ws/useWebSocket.ts
+++ b/packages/table-client/src/ws/useWebSocket.ts
@@ -1,4 +1,8 @@
 import type { ClientCommand, ServerMessage } from "@table-top-poker/protocol";
+import {
+  applyRoomSoundSettings,
+  onHandUpdate,
+} from "@table-top-poker/ui-shared";
 import { useCallback, useEffect, useRef } from "react";
 import { useTableStore } from "../store/store.js";
 import { getWebSocketUrl } from "./getWebSocketUrl.js";
@@ -72,9 +76,19 @@ export function useWebSocket(
         const message: ServerMessage = JSON.parse(event.data) as ServerMessage;
         if (message.type === "room-view") {
           setRoomView(message.view);
+          // Mirror the room's sound settings (#182) into the audio engine's
+          // gate so cue playback honours the table-controlled master/category.
+          applyRoomSoundSettings(message.view.soundSettings);
         } else if (message.type === "hand-update") {
           // The server only ever sends a table-role socket a `view(state, 'table')`.
           setHandView(message.view);
+          // Cues fire on the live event only, never on the `view-snapshot`
+          // below — so a reconnect can't replay a burst (#175).
+          onHandUpdate({
+            surface: "table",
+            event: message.event,
+            view: message.view,
+          });
         } else if (message.type === "view-snapshot") {
           setHandView(message.view);
         } else if (message.type === "room-ended") {

--- a/packages/table-client/src/ws/useWebSocket.ts
+++ b/packages/table-client/src/ws/useWebSocket.ts
@@ -7,6 +7,7 @@ import {
   applyRoomSoundSettings,
   createBeatQueue,
   onHandUpdate,
+  realClock,
   tableBeatDuration,
 } from "@table-top-poker/ui-shared";
 import { useCallback, useEffect, useRef } from "react";
@@ -66,10 +67,7 @@ export function useWebSocket(
     // the closing action's sound instead of landing on top of it (#186). Each
     // beat applies its view (the animation) and fires its sound together.
     const beats = createBeatQueue<TableView>({
-      now: () => Date.now(),
-      schedule: (fn, delayMs) => {
-        setTimeout(fn, delayMs);
-      },
+      ...realClock,
       apply: (beat) => {
         if (!active) return;
         setHandView(beat.view);

--- a/packages/table-client/src/ws/useWebSocket.ts
+++ b/packages/table-client/src/ws/useWebSocket.ts
@@ -1,7 +1,13 @@
-import type { ClientCommand, ServerMessage } from "@table-top-poker/protocol";
+import type {
+  ClientCommand,
+  ServerMessage,
+  TableView,
+} from "@table-top-poker/protocol";
 import {
   applyRoomSoundSettings,
+  createBeatQueue,
   onHandUpdate,
+  tableBeatDuration,
 } from "@table-top-poker/ui-shared";
 import { useCallback, useEffect, useRef } from "react";
 import { useTableStore } from "../store/store.js";
@@ -55,6 +61,23 @@ export function useWebSocket(
     let active = true;
     let retryTimer: ReturnType<typeof setTimeout> | undefined;
 
+    // The table reveals hand updates as serial beats — a player action, then
+    // the board deal it triggers — so the board's animation and taps wait out
+    // the closing action's sound instead of landing on top of it (#186). Each
+    // beat applies its view (the animation) and fires its sound together.
+    const beats = createBeatQueue<TableView>({
+      now: () => Date.now(),
+      schedule: (fn, delayMs) => {
+        setTimeout(fn, delayMs);
+      },
+      apply: (beat) => {
+        if (!active) return;
+        setHandView(beat.view);
+        onHandUpdate({ surface: "table", event: beat.event, view: beat.view });
+      },
+      duration: tableBeatDuration,
+    });
+
     function connect(): void {
       if (!active) return;
       setConnectionStatus("connecting");
@@ -81,15 +104,14 @@ export function useWebSocket(
           applyRoomSoundSettings(message.view.soundSettings);
         } else if (message.type === "hand-update") {
           // The server only ever sends a table-role socket a `view(state, 'table')`.
-          setHandView(message.view);
-          // Cues fire on the live event only, never on the `view-snapshot`
-          // below — so a reconnect can't replay a burst (#175).
-          onHandUpdate({
-            surface: "table",
-            event: message.event,
-            view: message.view,
-          });
+          // Queue it as a beat; the queue applies the view and fires the cue,
+          // paced so a board deal clears the action that closed the street.
+          beats.push({ event: message.event, view: message.view });
         } else if (message.type === "view-snapshot") {
+          // A snapshot (fresh join/reconnect) is not a beat: drop any pending
+          // ones so a reconnect can't replay a delayed burst (#175), and show
+          // the authoritative state at once, silently.
+          beats.clear();
           setHandView(message.view);
         } else if (message.type === "room-ended") {
           optionsRef.current.onRoomEnded?.();
@@ -101,6 +123,7 @@ export function useWebSocket(
 
     return () => {
       active = false;
+      beats.clear();
       if (retryTimer !== undefined) clearTimeout(retryTimer);
       socketRef.current?.close();
       socketRef.current = null;

--- a/packages/ui-shared/src/index.ts
+++ b/packages/ui-shared/src/index.ts
@@ -15,3 +15,10 @@ export type {
 export { Panel } from "./Panel.js";
 export type { PanelProps } from "./Panel.js";
 export { color, font, fontSize, radius, shadow } from "./theme.js";
+export {
+  applyRoomSoundSettings,
+  onHandUpdate,
+  playRevealFlip,
+  unlockAudio,
+} from "./sound/webAudio.js";
+export type { HandUpdateArgs, Surface } from "./sound/webAudio.js";

--- a/packages/ui-shared/src/index.ts
+++ b/packages/ui-shared/src/index.ts
@@ -24,3 +24,4 @@ export {
 export type { HandUpdateArgs, Surface } from "./sound/webAudio.js";
 export { createBeatQueue, tableBeatDuration } from "./sound/beatQueue.js";
 export type { Beat, BeatEffects, BeatQueue } from "./sound/beatQueue.js";
+export { realClock } from "./sound/realClock.js";

--- a/packages/ui-shared/src/index.ts
+++ b/packages/ui-shared/src/index.ts
@@ -22,3 +22,5 @@ export {
   unlockAudio,
 } from "./sound/webAudio.js";
 export type { HandUpdateArgs, Surface } from "./sound/webAudio.js";
+export { createBeatQueue, tableBeatDuration } from "./sound/beatQueue.js";
+export type { Beat, BeatEffects, BeatQueue } from "./sound/beatQueue.js";

--- a/packages/ui-shared/src/sound/beatQueue.test.ts
+++ b/packages/ui-shared/src/sound/beatQueue.test.ts
@@ -1,7 +1,7 @@
 import type { HandEvent } from "@table-top-poker/protocol";
 import { describe, expect, it } from "vitest";
 import { type Beat, createBeatQueue, tableBeatDuration } from "./beatQueue.js";
-import { CUE_DURATIONS_MS } from "./cues.js";
+import { CUE_DURATIONS_MS, cueSettleMs } from "./cues.js";
 
 // Beats carry a view in production; the queue never inspects it, so the tests
 // use the event alone as the payload.
@@ -65,7 +65,7 @@ function rig() {
   };
 }
 
-const KNOCK = CUE_DURATIONS_MS.check + 90;
+const KNOCK = cueSettleMs("check");
 
 describe("beat queue", () => {
   it("applies an idle beat immediately", () => {

--- a/packages/ui-shared/src/sound/beatQueue.test.ts
+++ b/packages/ui-shared/src/sound/beatQueue.test.ts
@@ -1,0 +1,132 @@
+import type { HandEvent } from "@table-top-poker/protocol";
+import { describe, expect, it } from "vitest";
+import { type Beat, createBeatQueue, tableBeatDuration } from "./beatQueue.js";
+import { CUE_DURATIONS_MS } from "./cues.js";
+
+// Beats carry a view in production; the queue never inspects it, so the tests
+// use the event alone as the payload.
+type TestBeat = Beat<null>;
+
+const beat = (event: HandEvent): TestBeat => ({ event, view: null });
+
+const check = (seatId: number): HandEvent => ({
+  type: "ActionTaken",
+  seatId,
+  action: "check",
+});
+const call = (seatId: number): HandEvent => ({
+  type: "ActionTaken",
+  seatId,
+  action: "call",
+});
+const board = (): HandEvent => ({
+  type: "BoardDealt",
+  street: "flop",
+  cards: [],
+});
+const streetStarted = (): HandEvent => ({
+  type: "StreetStarted",
+  street: "flop",
+  actor: 0,
+});
+
+/**
+ * A test rig with a hand-cranked clock and a timer list, so a test can advance
+ * time deterministically and see exactly when each beat was applied.
+ */
+function rig() {
+  let clock = 0;
+  const timers: { fn: () => void; at: number }[] = [];
+  const applied: { event: HandEvent; at: number }[] = [];
+  const queue = createBeatQueue<null>({
+    now: () => clock,
+    schedule: (fn, delayMs) => {
+      timers.push({ fn, at: clock + Math.max(0, delayMs) });
+    },
+    apply: (b) => applied.push({ event: b.event, at: clock }),
+    duration: tableBeatDuration,
+  });
+  return {
+    queue,
+    applied,
+    /** Advance to `t`, firing every timer due by then in chronological order. */
+    advanceTo(t: number) {
+      for (;;) {
+        const due = timers
+          .filter((x) => x.at <= t)
+          .sort((a, b) => a.at - b.at)[0];
+        if (!due) break;
+        timers.splice(timers.indexOf(due), 1);
+        clock = due.at;
+        due.fn();
+      }
+      clock = t;
+    },
+  };
+}
+
+const KNOCK = CUE_DURATIONS_MS.check + 90;
+
+describe("beat queue", () => {
+  it("applies an idle beat immediately", () => {
+    const r = rig();
+    r.queue.push(beat(streetStarted()));
+    r.advanceTo(0);
+    expect(r.applied.map((a) => a.at)).toEqual([0]);
+  });
+
+  it("holds the board beat until the check knock has finished", () => {
+    const r = rig();
+    r.queue.push(beat(check(1)));
+    r.queue.push(beat(board()));
+    r.advanceTo(5000);
+    expect(r.applied.map((a) => [a.event.type, a.at])).toEqual([
+      ["ActionTaken", 0],
+      ["BoardDealt", KNOCK],
+    ]);
+  });
+
+  it("keeps beats behind a held board in arrival order", () => {
+    const r = rig();
+    r.queue.push(beat(check(1)));
+    r.queue.push(beat(board()));
+    r.queue.push(beat(streetStarted()));
+    r.advanceTo(10000);
+    expect(r.applied.map((a) => [a.event.type, a.at])).toEqual([
+      ["ActionTaken", 0],
+      ["BoardDealt", KNOCK],
+      ["StreetStarted", KNOCK + CUE_DURATIONS_MS.board],
+    ]);
+  });
+
+  it("does not block on a call (no cue yet)", () => {
+    const r = rig();
+    r.queue.push(beat(call(1)));
+    r.queue.push(beat(board()));
+    r.advanceTo(5000);
+    expect(r.applied.map((a) => a.at)).toEqual([0, 0]);
+  });
+
+  it("drops pending beats when cleared (a snapshot supersedes them)", () => {
+    const r = rig();
+    r.queue.push(beat(check(1)));
+    r.queue.push(beat(board()));
+    r.advanceTo(0); // check applied; board deferred behind the knock
+    r.queue.clear();
+    r.advanceTo(5000);
+    expect(r.applied.map((a) => a.event.type)).toEqual(["ActionTaken"]);
+  });
+
+  it("resets the clock after a clear so the next beat is immediate", () => {
+    const r = rig();
+    r.queue.push(beat(check(1)));
+    r.advanceTo(0);
+    r.queue.clear();
+    r.queue.push(beat(board()));
+    r.advanceTo(0);
+    expect(r.applied.map((a) => [a.event.type, a.at])).toEqual([
+      ["ActionTaken", 0],
+      ["BoardDealt", 0],
+    ]);
+  });
+});

--- a/packages/ui-shared/src/sound/beatQueue.ts
+++ b/packages/ui-shared/src/sound/beatQueue.ts
@@ -16,24 +16,26 @@
 // Pure over injected effects (`now`, `schedule`, `apply`, `duration`) so the
 // ordering and the gaps are unit-testable without timers or a DOM.
 import type { HandEvent } from "@table-top-poker/protocol";
-import { CUE_DURATIONS_MS } from "./cues.js";
-
-/** A small breath after a beat's sound tail before the next beat opens. */
-const BEAT_GAP_MS = 90;
+import { CUE_DURATIONS_MS, cueSettleMs } from "./cues.js";
 
 /**
  * The table's execution time for each event — how long it blocks the next
  * beat. Only the sounded moments hold: a check knock and a fold muck (heard on
  * a player's phone, but the table must wait them out before dealing), and a
- * board deal (so a multi-card run-out spaces itself). `call`/`raise` have no
- * cue yet, and view-only events (street/showdown transitions) don't block —
- * they ride out immediately behind whatever beat precedes them.
+ * board deal (so a multi-card run-out spaces itself). View-only events
+ * (street/showdown transitions) don't block — they ride out immediately behind
+ * whatever beat precedes them.
  */
 export function tableBeatDuration(event: HandEvent): number {
   switch (event.type) {
     case "ActionTaken":
-      if (event.action === "check") return CUE_DURATIONS_MS.check + BEAT_GAP_MS;
-      if (event.action === "fold") return CUE_DURATIONS_MS.fold + BEAT_GAP_MS;
+      if (event.action === "check") return cueSettleMs("check");
+      if (event.action === "fold") return cueSettleMs("fold");
+      // A call closes a street too, but has no chip cue yet (#186 leaves
+      // call/raise unallocated), so there is no sound for the board to wait
+      // out — it blocks for nothing. Wired here so it isn't forgotten: when a
+      // chip asset lands, give `call` a duration and return its `cueSettleMs`.
+      if (event.action === "call") return 0;
       return 0;
     case "BoardDealt":
       return CUE_DURATIONS_MS.board;

--- a/packages/ui-shared/src/sound/beatQueue.ts
+++ b/packages/ui-shared/src/sound/beatQueue.ts
@@ -1,0 +1,121 @@
+// A serial presentation queue for the table surface (#186). The table shows
+// the deal as a run of "beats" — a player action, a board deal — each with its
+// own animation, its own sound, and an execution time that blocks the next
+// beat. Without this, the board deal that a closing check triggers reveals its
+// cards (and plays its taps) on top of the ~1.3s check knock still sounding on
+// the acting player's phone. Holding the whole board reveal — animation and
+// sound together — until the action beat finishes keeps the two in step and
+// spaces them by a sensible beat.
+//
+// Beats are applied strictly in arrival order. Each is applied at
+// `max(now, busyUntil)`, then `busyUntil` advances by the beat's execution
+// time, so everything queued behind a sounded action waits it out. A
+// view-snapshot is not a beat (a reconnect must not replay a delayed burst):
+// it flushes the queue and is applied immediately by the caller.
+//
+// Pure over injected effects (`now`, `schedule`, `apply`, `duration`) so the
+// ordering and the gaps are unit-testable without timers or a DOM.
+import type { HandEvent } from "@table-top-poker/protocol";
+import { CUE_DURATIONS_MS } from "./cues.js";
+
+/** A small breath after a beat's sound tail before the next beat opens. */
+const BEAT_GAP_MS = 90;
+
+/**
+ * The table's execution time for each event — how long it blocks the next
+ * beat. Only the sounded moments hold: a check knock and a fold muck (heard on
+ * a player's phone, but the table must wait them out before dealing), and a
+ * board deal (so a multi-card run-out spaces itself). `call`/`raise` have no
+ * cue yet, and view-only events (street/showdown transitions) don't block —
+ * they ride out immediately behind whatever beat precedes them.
+ */
+export function tableBeatDuration(event: HandEvent): number {
+  switch (event.type) {
+    case "ActionTaken":
+      if (event.action === "check") return CUE_DURATIONS_MS.check + BEAT_GAP_MS;
+      if (event.action === "fold") return CUE_DURATIONS_MS.fold + BEAT_GAP_MS;
+      return 0;
+    case "BoardDealt":
+      return CUE_DURATIONS_MS.board;
+    default:
+      return 0;
+  }
+}
+
+/** One queued update: the raw event plus the per-recipient view it produced. */
+export interface Beat<View> {
+  readonly event: HandEvent;
+  readonly view: View;
+}
+
+export interface BeatEffects<View> {
+  /** Current epoch ms. */
+  readonly now: () => number;
+  /** Run `fn` after `delayMs`; fire-and-forget. */
+  readonly schedule: (fn: () => void, delayMs: number) => void;
+  /** Reveal a beat: apply its view (animation) and fire its sound. */
+  readonly apply: (beat: Beat<View>) => void;
+  /** A beat's execution time in ms — how long it blocks the next beat. */
+  readonly duration: (event: HandEvent) => number;
+}
+
+export interface BeatQueue<View> {
+  /** Enqueue a `hand-update` beat; it plays when the queue reaches it. */
+  readonly push: (beat: Beat<View>) => void;
+  /** Drop every pending beat and reset the clock (a snapshot supersedes them). */
+  readonly clear: () => void;
+}
+
+/**
+ * A backlog can never grow beyond this far ahead: a burst of sounded actions
+ * (e.g. a rapid fold-out) collapses toward real time here rather than stacking
+ * an ever-longer delay. Comfortably past the longest single beat.
+ */
+const MAX_LOOKAHEAD_MS = 2500;
+
+export function createBeatQueue<View>(
+  effects: BeatEffects<View>,
+): BeatQueue<View> {
+  const pending: Beat<View>[] = [];
+  /** When the current beat finishes and the next may start (ms epoch). */
+  let busyUntil = 0;
+  /** A drain is already scheduled; don't stack a second timer. */
+  let draining = false;
+
+  function scheduleDrain(): void {
+    draining = true;
+    effects.schedule(
+      () => {
+        draining = false;
+        drain();
+      },
+      Math.max(0, busyUntil - effects.now()),
+    );
+  }
+
+  function drain(): void {
+    while (pending.length > 0) {
+      const now = effects.now();
+      const start = Math.min(Math.max(now, busyUntil), now + MAX_LOOKAHEAD_MS);
+      if (start > now) {
+        scheduleDrain();
+        return;
+      }
+      const beat = pending.shift();
+      if (!beat) return;
+      effects.apply(beat);
+      busyUntil = start + effects.duration(beat.event);
+    }
+  }
+
+  return {
+    push(beat) {
+      pending.push(beat);
+      if (!draining) scheduleDrain();
+    },
+    clear() {
+      pending.length = 0;
+      busyUntil = 0;
+    },
+  };
+}

--- a/packages/ui-shared/src/sound/cues.ts
+++ b/packages/ui-shared/src/sound/cues.ts
@@ -21,6 +21,22 @@ export type CueName = keyof typeof CUE_FILES;
 export const CUE_NAMES = Object.keys(CUE_FILES) as CueName[];
 
 /**
+ * The measured length of each cue's AAC asset, in ms (rounded up from the
+ * container duration). The beat queue uses these as an action's execution time
+ * so the next beat — the board deal especially — opens only once the sound it
+ * would collide with has finished. Keep in step with the assets in
+ * `public/sounds/`; the check knock is the long one that drove this (#186).
+ */
+export const CUE_DURATIONS_MS: Record<CueName, number> = {
+  deal: 601,
+  board: 690,
+  fold: 766,
+  check: 1323,
+  flip: 460,
+  yourTurn: 2143,
+};
+
+/**
  * Which room-level category (#182) each cue belongs to. `cards` is the tactile
  * card foley; `notifications` is the your-turn prompt. A cue plays only when
  * the room's master switch and its category are both on — see `cueAllowed`.

--- a/packages/ui-shared/src/sound/cues.ts
+++ b/packages/ui-shared/src/sound/cues.ts
@@ -1,0 +1,48 @@
+import type { SoundSettings } from "@table-top-poker/protocol";
+
+/**
+ * The six production cues, each backed by one canonical AAC `.m4a` asset
+ * (#185) served same-origin from `public/sounds/`. Card foley — deal, board,
+ * fold, flip (reveal/conceal), check-knock — plus the one non-card cue, the
+ * your-turn prompt. `call`/`raise` are deliberately unallocated: no chip asset
+ * exists yet.
+ */
+export const CUE_FILES = {
+  deal: "deal.m4a",
+  board: "board.m4a",
+  fold: "fold.m4a",
+  check: "check.m4a",
+  flip: "flip.m4a",
+  yourTurn: "your-turn.m4a",
+} as const satisfies Record<string, string>;
+
+export type CueName = keyof typeof CUE_FILES;
+
+export const CUE_NAMES = Object.keys(CUE_FILES) as CueName[];
+
+/**
+ * Which room-level category (#182) each cue belongs to. `cards` is the tactile
+ * card foley; `notifications` is the your-turn prompt. A cue plays only when
+ * the room's master switch and its category are both on — see `cueAllowed`.
+ */
+export const CUE_CATEGORY: Record<CueName, "cards" | "notifications"> = {
+  deal: "cards",
+  board: "cards",
+  fold: "cards",
+  check: "cards",
+  flip: "cards",
+  yourTurn: "notifications",
+};
+
+/**
+ * Whether the room's settings (#182) currently allow this cue: the master
+ * switch on, and the cue's category (cards / notifications) on. This is the
+ * real mute path — the table owns it and it reaches every surface via
+ * `room-view`.
+ */
+export function cueAllowed(settings: SoundSettings, cue: CueName): boolean {
+  if (!settings.sounds) return false;
+  return CUE_CATEGORY[cue] === "cards"
+    ? settings.cards
+    : settings.notifications;
+}

--- a/packages/ui-shared/src/sound/cues.ts
+++ b/packages/ui-shared/src/sound/cues.ts
@@ -37,6 +37,24 @@ export const CUE_DURATIONS_MS: Record<CueName, number> = {
 };
 
 /**
+ * The fraction past a cue's measured length to hold the next beat: a tail so
+ * the following beat opens after the sound has clearly finished rather than
+ * clipping its decay. 1.3 = the clip plus 30%.
+ */
+export const CUE_SETTLE_BUFFER = 1.3;
+
+/**
+ * How long a sounded cue should hold the next presentation beat — its measured
+ * length plus the settle buffer, rounded up to whole ms. The one source of
+ * truth for both the table's beat queue (`tableBeatDuration`) and the phone's
+ * your-turn hold (`checkKnockSettleMs`), so retuning an asset's length moves
+ * both in step instead of leaving a hand-copied constant to drift.
+ */
+export function cueSettleMs(cue: CueName): number {
+  return Math.ceil(CUE_DURATIONS_MS[cue] * CUE_SETTLE_BUFFER);
+}
+
+/**
  * Which room-level category (#182) each cue belongs to. `cards` is the tactile
  * card foley; `notifications` is the your-turn prompt. A cue plays only when
  * the room's master switch and its category are both on — see `cueAllowed`.

--- a/packages/ui-shared/src/sound/engine.test.ts
+++ b/packages/ui-shared/src/sound/engine.test.ts
@@ -125,7 +125,7 @@ describe("event → cue mapping", () => {
     expect(r.played).toEqual(["deal", "deal"]);
   });
 
-  it("taps the board per card on the table, led in past the closing action", () => {
+  it("taps the board per card on the table, offset to the card-drop animation", () => {
     const r = rig();
     r.engine.onHandUpdate({
       surface: "table",
@@ -141,9 +141,10 @@ describe("event → cue mapping", () => {
     expect(r.played).toEqual(["board", "board", "board"]);
   });
 
-  it("holds the board past a check knock that closed the street", () => {
+  it("keeps the board lead-in synced to the card animation, not the check knock", () => {
     const r = rig();
-    // The check that closes the street arrives just before the board deal.
+    // Even when a check closed the street, the board stays on its plain lead-in
+    // so the taps track the card-drop animation instead of waiting out the knock.
     r.engine.onHandUpdate({
       surface: "table",
       event: actionTaken(1, "check"),
@@ -154,11 +155,10 @@ describe("event → cue mapping", () => {
       event: boardDealt("flop", 3),
       view: noHandView,
     });
-    // The lead-in stretches to the knock's settle, not the plain 600ms.
     expect(r.scheduled.map((s) => s.delayMs)).toEqual([
-      TIMINGS.checkKnockSettleMs,
-      TIMINGS.checkKnockSettleMs + TIMINGS.boardStaggerMs,
-      TIMINGS.checkKnockSettleMs + 2 * TIMINGS.boardStaggerMs,
+      TIMINGS.boardLeadInMs,
+      TIMINGS.boardLeadInMs + TIMINGS.boardStaggerMs,
+      TIMINGS.boardLeadInMs + 2 * TIMINGS.boardStaggerMs,
     ]);
   });
 

--- a/packages/ui-shared/src/sound/engine.test.ts
+++ b/packages/ui-shared/src/sound/engine.test.ts
@@ -141,6 +141,27 @@ describe("event → cue mapping", () => {
     expect(r.played).toEqual(["board", "board", "board"]);
   });
 
+  it("holds the board past a check knock that closed the street", () => {
+    const r = rig();
+    // The check that closes the street arrives just before the board deal.
+    r.engine.onHandUpdate({
+      surface: "table",
+      event: actionTaken(1, "check"),
+      view: noHandView,
+    });
+    r.engine.onHandUpdate({
+      surface: "table",
+      event: boardDealt("flop", 3),
+      view: noHandView,
+    });
+    // The lead-in stretches to the knock's settle, not the plain 600ms.
+    expect(r.scheduled.map((s) => s.delayMs)).toEqual([
+      TIMINGS.checkKnockSettleMs,
+      TIMINGS.checkKnockSettleMs + TIMINGS.boardStaggerMs,
+      TIMINGS.checkKnockSettleMs + 2 * TIMINGS.boardStaggerMs,
+    ]);
+  });
+
   it("stays silent on the board on the player surface", () => {
     const r = rig();
     r.engine.onHandUpdate({
@@ -297,6 +318,27 @@ describe("your-turn prompt", () => {
     expect(turnPrompt?.delayMs).toBe(
       TIMINGS.dealStaggerMs + TIMINGS.turnAfterDealMs,
     );
+    r.flush();
+    expect(r.played).toContain("yourTurn");
+  });
+
+  it("holds the prompt past a check knock from the player who passed the turn", () => {
+    const r = rig();
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 0,
+      event: { type: "HandStarted", seed: "s", button: 0 },
+      view: noHandView,
+    });
+    // Seat 1 checks mid-hand and the turn passes to me in the same update.
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 0,
+      event: actionTaken(1, "check"),
+      view: bettingView(true),
+    });
+    const turnPrompt = r.scheduled.at(-1);
+    expect(turnPrompt?.delayMs).toBe(TIMINGS.checkKnockSettleMs);
     r.flush();
     expect(r.played).toContain("yourTurn");
   });

--- a/packages/ui-shared/src/sound/engine.test.ts
+++ b/packages/ui-shared/src/sound/engine.test.ts
@@ -1,0 +1,355 @@
+import type {
+  Card,
+  HandEvent,
+  PlayerView,
+  SoundSettings,
+  TableView,
+} from "@table-top-poker/protocol";
+import { describe, expect, it } from "vitest";
+import type { CueName } from "./cues.js";
+import { createSoundEngine, type SoundEngine, TIMINGS } from "./engine.js";
+
+const ALL_ON: SoundSettings = {
+  sounds: true,
+  cards: true,
+  notifications: true,
+};
+
+const CARD: Card = { rank: "A", suit: "spades" };
+const pair = (): [Card, Card] => [CARD, CARD];
+
+/**
+ * A test rig over a sound engine with fully deterministic effects: a `play`
+ * spy, a hand-cranked clock and a scheduler that records callbacks so a test
+ * can inspect the fired delays and flush the timers when it chooses.
+ */
+function rig(settings: SoundSettings = ALL_ON): {
+  engine: SoundEngine;
+  played: CueName[];
+  scheduled: { fn: () => void; delayMs: number }[];
+  setNow: (t: number) => void;
+  flush: () => void;
+} {
+  const played: CueName[] = [];
+  const scheduled: { fn: () => void; delayMs: number }[] = [];
+  let clock = 0;
+  const engine = createSoundEngine(
+    {
+      play: (cue) => played.push(cue),
+      now: () => clock,
+      schedule: (fn, delayMs) => scheduled.push({ fn, delayMs }),
+    },
+    settings,
+  );
+  return {
+    engine,
+    played,
+    scheduled,
+    setNow: (t) => {
+      clock = t;
+    },
+    flush: () => {
+      // Run in scheduled order; drain so re-flush is a no-op.
+      const pending = scheduled.splice(0);
+      for (const { fn } of pending) fn();
+    },
+  };
+}
+
+const holeCardsDealt = (seatIds: number[]): HandEvent => ({
+  type: "HoleCardsDealt",
+  deals: seatIds.map((seatId) => ({ seatId, cards: pair() })),
+});
+
+const boardDealt = (
+  street: "flop" | "turn" | "river",
+  n: number,
+): HandEvent => ({
+  type: "BoardDealt",
+  street,
+  cards: Array.from({ length: n }, () => CARD),
+});
+
+const actionTaken = (
+  seatId: number,
+  action: "fold" | "check" | "call" | "raise",
+): HandEvent => ({ type: "ActionTaken", seatId, action });
+
+/** A player betting view whose turn state is `myTurn`. */
+const bettingView = (myTurn: boolean): PlayerView => ({
+  phase: "betting",
+  street: "preflop",
+  board: [],
+  toAct: myTurn ? [0] : [1],
+  seats: [{ seatId: 0, folded: false }],
+  yourSeatId: 0,
+  yourHoleCards: pair(),
+  legalActions: myTurn ? ["fold", "check"] : [],
+  button: 0,
+  smallBlind: 0,
+  bigBlind: 1,
+  dealtSeatCount: 2,
+});
+
+const noHandView: TableView = { phase: "no-hand", button: 0 };
+
+describe("event → cue mapping", () => {
+  it("sweeps one deal cue per dealt card on the table, spaced by the deal gap", () => {
+    const r = rig();
+    r.engine.onHandUpdate({
+      surface: "table",
+      event: holeCardsDealt([0, 1, 2]),
+      view: noHandView,
+    });
+    expect(r.scheduled.map((s) => s.delayMs)).toEqual([
+      0,
+      TIMINGS.dealStaggerMs,
+      2 * TIMINGS.dealStaggerMs,
+      3 * TIMINGS.dealStaggerMs,
+      4 * TIMINGS.dealStaggerMs,
+      5 * TIMINGS.dealStaggerMs,
+    ]);
+    r.flush();
+    expect(r.played).toEqual(["deal", "deal", "deal", "deal", "deal", "deal"]);
+  });
+
+  it("plays only the phone's own two hole cards, not the whole table's", () => {
+    const r = rig();
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 1,
+      event: holeCardsDealt([0, 1, 2]),
+      view: noHandView,
+    });
+    r.flush();
+    expect(r.played).toEqual(["deal", "deal"]);
+  });
+
+  it("taps the board per card on the table, led in past the closing action", () => {
+    const r = rig();
+    r.engine.onHandUpdate({
+      surface: "table",
+      event: boardDealt("flop", 3),
+      view: noHandView,
+    });
+    expect(r.scheduled.map((s) => s.delayMs)).toEqual([
+      TIMINGS.boardLeadInMs,
+      TIMINGS.boardLeadInMs + TIMINGS.boardStaggerMs,
+      TIMINGS.boardLeadInMs + 2 * TIMINGS.boardStaggerMs,
+    ]);
+    r.flush();
+    expect(r.played).toEqual(["board", "board", "board"]);
+  });
+
+  it("stays silent on the board on the player surface", () => {
+    const r = rig();
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 0,
+      event: boardDealt("turn", 1),
+      view: noHandView,
+    });
+    r.flush();
+    expect(r.played).toEqual([]);
+  });
+
+  it("voices fold and check only on the acting player's own phone", () => {
+    const own = rig();
+    own.engine.onHandUpdate({
+      surface: "player",
+      seatId: 1,
+      event: actionTaken(1, "fold"),
+      view: noHandView,
+    });
+    own.engine.onHandUpdate({
+      surface: "player",
+      seatId: 1,
+      event: actionTaken(1, "check"),
+      view: noHandView,
+    });
+    expect(own.played).toEqual(["fold", "check"]);
+  });
+
+  it("stays silent on another seat's action and on the table surface", () => {
+    const other = rig();
+    other.engine.onHandUpdate({
+      surface: "player",
+      seatId: 2,
+      event: actionTaken(1, "fold"),
+      view: noHandView,
+    });
+    const table = rig();
+    table.engine.onHandUpdate({
+      surface: "table",
+      event: actionTaken(1, "fold"),
+      view: noHandView,
+    });
+    expect(other.played).toEqual([]);
+    expect(table.played).toEqual([]);
+  });
+
+  it("leaves call and raise unallocated", () => {
+    const r = rig();
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 1,
+      event: actionTaken(1, "call"),
+      view: noHandView,
+    });
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 1,
+      event: actionTaken(1, "raise"),
+      view: noHandView,
+    });
+    expect(r.played).toEqual([]);
+  });
+});
+
+describe("room-settings gate", () => {
+  it("silences everything when the master switch is off", () => {
+    const r = rig({ sounds: false, cards: true, notifications: true });
+    r.engine.onHandUpdate({
+      surface: "table",
+      event: holeCardsDealt([0]),
+      view: noHandView,
+    });
+    r.engine.playRevealFlip();
+    r.flush();
+    expect(r.played).toEqual([]);
+  });
+
+  it("silences card cues but not notifications when cards is off", () => {
+    const r = rig({ sounds: true, cards: false, notifications: true });
+    r.engine.playRevealFlip();
+    r.flush();
+    expect(r.played).toEqual([]);
+
+    // A your-turn prompt (notifications) still passes.
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 0,
+      event: { type: "HandStarted", seed: "s", button: 0 },
+      view: noHandView,
+    });
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 0,
+      event: boardDealt("flop", 3),
+      view: bettingView(true),
+    });
+    r.flush();
+    expect(r.played).toEqual(["yourTurn"]);
+  });
+
+  it("silences the your-turn prompt when notifications is off", () => {
+    const r = rig({ sounds: true, cards: true, notifications: false });
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 0,
+      event: boardDealt("flop", 3),
+      view: bettingView(true),
+    });
+    r.flush();
+    expect(r.played).toEqual([]);
+  });
+
+  it("applies a live room-settings change to the gate", () => {
+    const r = rig(ALL_ON);
+    r.engine.applyRoomSoundSettings({
+      sounds: true,
+      cards: false,
+      notifications: true,
+    });
+    r.engine.playRevealFlip();
+    r.flush();
+    expect(r.played).toEqual([]);
+  });
+});
+
+describe("reveal/conceal flip", () => {
+  it("plays the flip cue when cards are allowed", () => {
+    const r = rig();
+    r.engine.playRevealFlip();
+    r.flush();
+    expect(r.played).toEqual(["flip"]);
+  });
+});
+
+describe("your-turn prompt", () => {
+  it("defers the prompt a beat past the last hole card, then fires it", () => {
+    const r = rig();
+    r.setNow(0);
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 0,
+      event: holeCardsDealt([0, 1]),
+      view: noHandView,
+    });
+    // Two hole cards → last lands at (2-1)*dealStagger.
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 0,
+      event: { type: "StreetStarted", street: "preflop", actor: 0 },
+      view: bettingView(true),
+    });
+    const turnPrompt = r.scheduled.at(-1);
+    expect(turnPrompt?.delayMs).toBe(
+      TIMINGS.dealStaggerMs + TIMINGS.turnAfterDealMs,
+    );
+    r.flush();
+    expect(r.played).toContain("yourTurn");
+  });
+
+  it("cancels the deferred prompt if the turn passes before it fires", () => {
+    const r = rig();
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 0,
+      event: { type: "HandStarted", seed: "s", button: 0 },
+      view: noHandView,
+    });
+    // Turn arrives — the prompt is scheduled.
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 0,
+      event: { type: "StreetStarted", street: "preflop", actor: 0 },
+      view: bettingView(true),
+    });
+    // Turn passes (I acted) before the deferral elapses — bumps the token.
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 0,
+      event: actionTaken(0, "check"),
+      view: bettingView(false),
+    });
+    r.flush();
+    expect(r.played).not.toContain("yourTurn");
+  });
+
+  it("fires the prompt once per arrival, not on every view", () => {
+    const r = rig();
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 0,
+      event: { type: "HandStarted", seed: "s", button: 0 },
+      view: noHandView,
+    });
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 0,
+      event: { type: "StreetStarted", street: "preflop", actor: 0 },
+      view: bettingView(true),
+    });
+    // A second identical betting view (e.g. an opponent reconnecting) must not
+    // re-arm the prompt.
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 0,
+      event: { type: "ActionTaken", seatId: 1, action: "call" },
+      view: bettingView(true),
+    });
+    r.flush();
+    expect(r.played.filter((c) => c === "yourTurn")).toEqual(["yourTurn"]);
+  });
+});

--- a/packages/ui-shared/src/sound/engine.ts
+++ b/packages/ui-shared/src/sound/engine.ts
@@ -82,10 +82,19 @@ export const TIMINGS = {
   /**
    * A board deal always follows the action that closed the street (a check or
    * call), so its sound would otherwise land right on top of that closing
-   * action's — the check knock especially. Hold the board cue this long so the
-   * closing sound clears first and the two never overlap.
+   * action's. Hold the board cue at least this long so a short closing sound
+   * clears first; a check knock overrides it with `checkKnockSettleMs` below.
    */
   boardLeadInMs: 600,
+  /**
+   * The check knock is the longest cue at ~1.32s, and both the board deal that
+   * a closing check triggers and the next player's your-turn prompt would
+   * otherwise start on top of it (on other devices, but heard in the same
+   * room). Every surface sees the broadcast `ActionTaken` check event, so each
+   * independently holds the following cue this long — the knock's length plus a
+   * small gap — so the knock is heard out first.
+   */
+  checkKnockSettleMs: 1400,
 } as const;
 
 /**
@@ -116,6 +125,14 @@ export function createSoundEngine(
    * well in the past, so a mid-hand turn prompts without the pause.
    */
   let lastHoleCardAt = 0;
+  /**
+   * When the most recent check knock will have finished sounding (ms epoch),
+   * so the board deal it closes and the next player's your-turn prompt can be
+   * held until the knock clears. Set from any seat's check on every surface —
+   * the event is broadcast, so all devices agree on when the knock ends —
+   * reset each hand, and naturally stale once a knock's worth of time passes.
+   */
+  let checkKnockUntil = 0;
 
   function playCue(cue: CueName): void {
     if (cueAllowed(settings, cue)) effects.play(cue);
@@ -145,6 +162,7 @@ export function createSoundEngine(
       case "HandStarted":
         lastMyTurn = false;
         lastHoleCardAt = 0;
+        checkKnockUntil = 0;
         break;
 
       case "HoleCardsDealt": {
@@ -167,19 +185,29 @@ export function createSoundEngine(
         // one each on the turn and river. Table only (the center voice, #180).
         // Led in so it doesn't collide with the check/call that closed the street.
         if (surface === "table") {
+          // Hold the board past whichever is longer: the plain lead-in, or a
+          // check knock still ringing out from the action that closed the street.
+          const leadIn = Math.max(
+            TIMINGS.boardLeadInMs,
+            checkKnockUntil - effects.now(),
+          );
           staggeredCue(
             "board",
             event.cards.length,
             TIMINGS.boardStaggerMs,
-            TIMINGS.boardLeadInMs,
+            leadIn,
           );
         }
         break;
 
       case "ActionTaken":
-        // Only the acting player's own phone voices its fold muck / check
-        // knock; the table stays silent (#180). call/raise are unallocated
-        // (no chip asset yet).
+        // A check is heard on every surface's clock (the event is broadcast),
+        // so each engine notes when the knock will clear even though only the
+        // acting player's own phone actually voices it. call/raise are
+        // unallocated (no chip asset yet); the table stays silent (#180).
+        if (event.action === "check") {
+          checkKnockUntil = effects.now() + TIMINGS.checkKnockSettleMs;
+        }
         if (surface === "player" && event.seatId === seatId) {
           if (event.action === "fold") playCue("fold");
           else if (event.action === "check") playCue("check");
@@ -207,9 +235,12 @@ export function createSoundEngine(
       if (myTurn !== lastMyTurn) turnToken++;
       if (myTurn && !lastMyTurn) {
         const token = turnToken;
+        // Hold the prompt past the deal-sweep beat and past any check knock
+        // still sounding from the previous player's move that passed the turn.
         const wait = Math.max(
           0,
           lastHoleCardAt + TIMINGS.turnAfterDealMs - effects.now(),
+          checkKnockUntil - effects.now(),
         );
         effects.schedule(() => {
           // Still this same turn when the deferral elapses? A newer turn-state

--- a/packages/ui-shared/src/sound/engine.ts
+++ b/packages/ui-shared/src/sound/engine.ts
@@ -1,0 +1,233 @@
+// The production tactile-sound layer (#186), ported from the tuned logic in
+// `proto/sound-181`'s throwaway prototype — minus its A/B tuning store and
+// on-screen panel. Turns the live `HandEvent` stream into heard, tactile card
+// cues, gated by the room settings (#184) and playing the canonical AAC assets
+// (#185).
+//
+// Design decisions baked in here (per the map, #177, and its decisions):
+//  - Cue ownership (#180): the TABLE is the dealer/center voice (the whole
+//    hole-card deal sweep, the board); each PHONE is its own player (its own
+//    two hole cards, own fold, own check knock, own reveal/conceal flip, own
+//    your-turn prompt).
+//  - Multi-card deals sound per card: the flop is three distinct board taps
+//    (board gap), a phone's hole cards are two distinct slides (the wider hole
+//    gap) — one scheduled play per card. The your-turn prompt is held a beat
+//    past the last hole card so cards land first, then the prompt.
+//  - Sounds fire ONLY from `hand-update` (which carries the raw event), never
+//    from `view-snapshot` — so a reconnect/refresh mid-hand can't replay a
+//    burst of cues (the map's rejoin worry, #175). That gate lives in the WS
+//    hooks that call `onHandUpdate`; this module never sees a snapshot.
+//
+// The engine is a pure state machine over injected effects (`play`, `now`,
+// `schedule`) so the event→cue mapping, the settings gate and the your-turn
+// cancellation are all unit-testable without Web Audio. The production wiring
+// (AudioContext, buffers, unlock) lives in `webAudio.ts`.
+import {
+  DEFAULT_SOUND_SETTINGS,
+  type HandEvent,
+  type PlayerView,
+  type SoundSettings,
+  type TableView,
+} from "@table-top-poker/protocol";
+import { type CueName, cueAllowed } from "./cues.js";
+
+export type Surface = "table" | "player";
+
+/** The single `hand-update` payload the WS hooks hand to the engine. */
+export interface HandUpdateArgs {
+  readonly surface: Surface;
+  readonly event: HandEvent;
+  readonly view: PlayerView | TableView;
+  /** The phone's own seat; omitted on the table surface. */
+  readonly seatId?: number;
+}
+
+/**
+ * The side effects the engine drives, injected so the mapping is testable.
+ * `play` is the raw sink — the engine only ever calls it for a cue that has
+ * already passed the room-settings gate.
+ */
+export interface SoundEffects {
+  /** Emit a single already-gated cue now. */
+  readonly play: (cue: CueName) => void;
+  /** Current epoch ms. */
+  readonly now: () => number;
+  /** Run `fn` after `delayMs`; fire-and-forget (cancellation is via token). */
+  readonly schedule: (fn: () => void, delayMs: number) => void;
+}
+
+export interface SoundEngine {
+  /** Called on every `hand-update` (never `view-snapshot`). */
+  readonly onHandUpdate: (args: HandUpdateArgs) => void;
+  /** Mirror the room-view sound settings (#182) — the WS hooks call this. */
+  readonly applyRoomSoundSettings: (settings: SoundSettings) => void;
+  /**
+   * The reveal/conceal flip cue — a client-side presentation change on the
+   * player surface, not a wire event, so the hole-card hook calls it directly.
+   */
+  readonly playRevealFlip: () => void;
+}
+
+/** The tuned timings the prototype settled on, in ms. */
+export const TIMINGS = {
+  /**
+   * Gap between hole cards in the dealer's sweep — wider than the board gap so
+   * each dealt card is obvious as the deal reaches around the table.
+   */
+  dealStaggerMs: 600,
+  /** Gap between board cards (the flop's three taps). */
+  boardStaggerMs: 250,
+  /** The deliberate beat between the last hole card and the your-turn prompt. */
+  turnAfterDealMs: 700,
+  /**
+   * A board deal always follows the action that closed the street (a check or
+   * call), so its sound would otherwise land right on top of that closing
+   * action's — the check knock especially. Hold the board cue this long so the
+   * closing sound clears first and the two never overlap.
+   */
+  boardLeadInMs: 600,
+} as const;
+
+/**
+ * Create a sound engine over the given effects. One instance is a stateful
+ * singleton shared across a surface's WS hook and hole-card hook; the
+ * production instance lives in `webAudio.ts`, tests construct their own with
+ * spy effects.
+ */
+export function createSoundEngine(
+  effects: SoundEffects,
+  initialSettings: SoundSettings = DEFAULT_SOUND_SETTINGS,
+): SoundEngine {
+  let settings = initialSettings;
+
+  /** Edge-detect "it just became my turn" so the prompt fires once, not per view. */
+  let lastMyTurn = false;
+  /**
+   * Bumped every time the turn state changes. A deferred your-turn prompt
+   * captures the token when scheduled and only plays if it still matches when
+   * the timer fires — so acting (or the hand ending) before the deferral
+   * elapses cancels the stale prompt instead of firing it after the fact.
+   */
+  let turnToken = 0;
+  /**
+   * When the current hand's last hole card lands (ms epoch). The your-turn
+   * prompt is deferred to this plus `turnAfterDealMs`, so a player hears their
+   * cards settle and a clear beat before the prompt. Later streets leave this
+   * well in the past, so a mid-hand turn prompts without the pause.
+   */
+  let lastHoleCardAt = 0;
+
+  function playCue(cue: CueName): void {
+    if (cueAllowed(settings, cue)) effects.play(cue);
+  }
+
+  /** Fire a cue once per card, staggered so multi-card deals read as distinct. */
+  function staggeredCue(
+    cue: CueName,
+    count: number,
+    gapMs: number,
+    startDelayMs = 0,
+  ): void {
+    for (let i = 0; i < count; i++) {
+      effects.schedule(
+        () => {
+          playCue(cue);
+        },
+        startDelayMs + i * gapMs,
+      );
+    }
+  }
+
+  function onHandUpdate(args: HandUpdateArgs): void {
+    const { surface, event, seatId } = args;
+
+    switch (event.type) {
+      case "HandStarted":
+        lastMyTurn = false;
+        lastHoleCardAt = 0;
+        break;
+
+      case "HoleCardsDealt": {
+        // A dealer's sweep, one distinct slide per card, spaced by the wider
+        // hole-deal gap so each dealt card is obvious. The table hears the
+        // whole table dealt; each phone hears only its own two cards (#180).
+        // The your-turn cue below is held until this sweep ends.
+        const count =
+          surface === "table"
+            ? event.deals.reduce((n, d) => n + d.cards.length, 0)
+            : (event.deals.find((d) => d.seatId === seatId)?.cards.length ?? 0);
+        lastHoleCardAt =
+          effects.now() + Math.max(0, count - 1) * TIMINGS.dealStaggerMs;
+        staggeredCue("deal", count, TIMINGS.dealStaggerMs);
+        break;
+      }
+
+      case "BoardDealt":
+        // One tap per board card, staggered — three distinct taps on the flop,
+        // one each on the turn and river. Table only (the center voice, #180).
+        // Led in so it doesn't collide with the check/call that closed the street.
+        if (surface === "table") {
+          staggeredCue(
+            "board",
+            event.cards.length,
+            TIMINGS.boardStaggerMs,
+            TIMINGS.boardLeadInMs,
+          );
+        }
+        break;
+
+      case "ActionTaken":
+        // Only the acting player's own phone voices its fold muck / check
+        // knock; the table stays silent (#180). call/raise are unallocated
+        // (no chip asset yet).
+        if (surface === "player" && event.seatId === seatId) {
+          if (event.action === "fold") playCue("fold");
+          else if (event.action === "check") playCue("check");
+        }
+        break;
+
+      case "StreetStarted":
+      case "StreetClosed":
+      case "ShowdownReached":
+      case "HandFoldedOut":
+      case "HandComplete":
+        // No dedicated cue (your-turn is derived from the view below).
+        break;
+    }
+
+    // "Action on you": derived from the phone's view, edge-detected so it fires
+    // once when the turn arrives, and held until the deal sweep has finished so
+    // the player hears their cards land first, then the prompt.
+    if (surface === "player") {
+      const { view } = args;
+      const myTurn =
+        view.phase === "betting" &&
+        "legalActions" in view &&
+        view.legalActions.length > 0;
+      if (myTurn !== lastMyTurn) turnToken++;
+      if (myTurn && !lastMyTurn) {
+        const token = turnToken;
+        const wait = Math.max(
+          0,
+          lastHoleCardAt + TIMINGS.turnAfterDealMs - effects.now(),
+        );
+        effects.schedule(() => {
+          // Still this same turn when the deferral elapses? A newer turn-state
+          // change (I acted, or the hand ended) bumps the token and cancels it.
+          if (token === turnToken) playCue("yourTurn");
+        }, wait);
+      }
+      lastMyTurn = myTurn;
+    }
+  }
+
+  return {
+    onHandUpdate,
+    applyRoomSoundSettings(next: SoundSettings): void {
+      settings = next;
+    },
+    playRevealFlip(): void {
+      playCue("flip");
+    },
+  };
+}

--- a/packages/ui-shared/src/sound/engine.ts
+++ b/packages/ui-shared/src/sound/engine.ts
@@ -80,19 +80,20 @@ export const TIMINGS = {
   /** The deliberate beat between the last hole card and the your-turn prompt. */
   turnAfterDealMs: 700,
   /**
-   * A board deal always follows the action that closed the street (a check or
-   * call), so its sound would otherwise land right on top of that closing
-   * action's. Hold the board cue at least this long so a short closing sound
-   * clears first; a check knock overrides it with `checkKnockSettleMs` below.
+   * A small offset from the board beat opening to its first tap, so the tap
+   * lands as the card-drop animation settles rather than the instant it starts.
+   * The big gap that keeps the board clear of the closing action's sound is the
+   * beat queue's job now (`tableBeatDuration`), not this lead-in — so this stays
+   * short and the tap never detaches from the card.
    */
-  boardLeadInMs: 600,
+  boardLeadInMs: 150,
   /**
-   * The check knock is the longest cue at ~1.32s, and both the board deal that
-   * a closing check triggers and the next player's your-turn prompt would
-   * otherwise start on top of it (on other devices, but heard in the same
-   * room). Every surface sees the broadcast `ActionTaken` check event, so each
-   * independently holds the following cue this long — the knock's length plus a
-   * small gap — so the knock is heard out first.
+   * The check knock is the longest cue at ~1.32s, so the next player's your-turn
+   * prompt would otherwise start on top of it (on another device, but heard in
+   * the same room). Every surface sees the broadcast `ActionTaken` check event,
+   * so each independently holds the prompt this long — the knock's length plus a
+   * small gap — so the knock is heard out first. This is the phone's equivalent
+   * of the table's beat queue, which the phone has no part in.
    */
   checkKnockSettleMs: 1400,
 } as const;
@@ -126,11 +127,11 @@ export function createSoundEngine(
    */
   let lastHoleCardAt = 0;
   /**
-   * When the most recent check knock will have finished sounding (ms epoch),
-   * so the board deal it closes and the next player's your-turn prompt can be
-   * held until the knock clears. Set from any seat's check on every surface —
-   * the event is broadcast, so all devices agree on when the knock ends —
-   * reset each hand, and naturally stale once a knock's worth of time passes.
+   * When the most recent check knock will have finished sounding (ms epoch), so
+   * the next player's your-turn prompt can be held until the knock clears. Set
+   * from any seat's check on every surface — the event is broadcast, so all
+   * devices agree on when the knock ends — reset each hand, and naturally stale
+   * once a knock's worth of time passes.
    */
   let checkKnockUntil = 0;
 
@@ -183,19 +184,15 @@ export function createSoundEngine(
       case "BoardDealt":
         // One tap per board card, staggered — three distinct taps on the flop,
         // one each on the turn and river. Table only (the center voice, #180).
-        // Led in so it doesn't collide with the check/call that closed the street.
+        // The lead-in keeps the taps in step with the card-drop animation and
+        // clear of a short closing action; it deliberately does NOT wait out a
+        // long check knock, so the tap never detaches from the card landing.
         if (surface === "table") {
-          // Hold the board past whichever is longer: the plain lead-in, or a
-          // check knock still ringing out from the action that closed the street.
-          const leadIn = Math.max(
-            TIMINGS.boardLeadInMs,
-            checkKnockUntil - effects.now(),
-          );
           staggeredCue(
             "board",
             event.cards.length,
             TIMINGS.boardStaggerMs,
-            leadIn,
+            TIMINGS.boardLeadInMs,
           );
         }
         break;

--- a/packages/ui-shared/src/sound/engine.ts
+++ b/packages/ui-shared/src/sound/engine.ts
@@ -29,7 +29,7 @@ import {
   type SoundSettings,
   type TableView,
 } from "@table-top-poker/protocol";
-import { type CueName, cueAllowed } from "./cues.js";
+import { type CueName, cueAllowed, cueSettleMs } from "./cues.js";
 
 export type Surface = "table" | "player";
 
@@ -91,11 +91,12 @@ export const TIMINGS = {
    * The check knock is the longest cue at ~1.32s, so the next player's your-turn
    * prompt would otherwise start on top of it (on another device, but heard in
    * the same room). Every surface sees the broadcast `ActionTaken` check event,
-   * so each independently holds the prompt this long — the knock's length plus a
-   * small gap — so the knock is heard out first. This is the phone's equivalent
-   * of the table's beat queue, which the phone has no part in.
+   * so each independently holds the prompt for the knock's settle time — its
+   * length plus the shared buffer (`cueSettleMs`), the same figure the table's
+   * beat queue uses — so the knock is heard out first. This is the phone's
+   * equivalent of the table's beat queue, which the phone has no part in.
    */
-  checkKnockSettleMs: 1400,
+  checkKnockSettleMs: cueSettleMs("check"),
 } as const;
 
 /**

--- a/packages/ui-shared/src/sound/realClock.ts
+++ b/packages/ui-shared/src/sound/realClock.ts
@@ -1,0 +1,12 @@
+// The production clock/scheduler pair shared by the Web Audio engine and the
+// table's beat queue, so both drive off one real-timer implementation instead
+// of each repeating `Date.now()`/`setTimeout` at its own call site. Tests
+// inject their own hand-cranked clock in its place.
+export const realClock = {
+  /** Current epoch ms. */
+  now: (): number => Date.now(),
+  /** Run `fn` after `delayMs`; fire-and-forget. */
+  schedule: (fn: () => void, delayMs: number): void => {
+    setTimeout(fn, delayMs);
+  },
+};

--- a/packages/ui-shared/src/sound/webAudio.ts
+++ b/packages/ui-shared/src/sound/webAudio.ts
@@ -11,6 +11,7 @@ import {
   type HandUpdateArgs,
   type SoundEngine,
 } from "./engine.js";
+import { realClock } from "./realClock.js";
 
 // Pin the context, buffer cache and engine to `globalThis`. This module is a
 // stateful singleton shared by the WS hook and the hole-card hook; a partial
@@ -69,10 +70,7 @@ function playCueSound(cue: CueName): void {
 
 const engine = (soundGlobal.__ttpSoundEngine ??= createSoundEngine({
   play: playCueSound,
-  now: () => Date.now(),
-  schedule: (fn, delayMs) => {
-    setTimeout(fn, delayMs);
-  },
+  ...realClock,
 }));
 
 export type { HandUpdateArgs, Surface } from "./engine.js";

--- a/packages/ui-shared/src/sound/webAudio.ts
+++ b/packages/ui-shared/src/sound/webAudio.ts
@@ -1,0 +1,176 @@
+// Production Web Audio effects for the tactile-sound layer (#186): one
+// `AudioContext` singleton, a warm-decoded buffer per cue, gesture unlock and
+// the iOS silent-switch workaround. This is the thin, browser-bound half — the
+// tuned event→cue logic lives in the pure `engine.ts`. Both clients import the
+// bound API (`onHandUpdate`, `applyRoomSoundSettings`, `playRevealFlip`,
+// `unlockAudio`) from here.
+import type { SoundSettings } from "@table-top-poker/protocol";
+import { CUE_FILES, CUE_NAMES, type CueName } from "./cues.js";
+import {
+  createSoundEngine,
+  type HandUpdateArgs,
+  type SoundEngine,
+} from "./engine.js";
+
+// Pin the context, buffer cache and engine to `globalThis`. This module is a
+// stateful singleton shared by the WS hook and the hole-card hook; a partial
+// HMR update can otherwise leave those importers on different module instances,
+// each with its own suspended context, so a cue plays through a context the
+// gesture never unlocked. One instance on the global keeps every importer —
+// however HMR splits them — driving the same audio.
+const soundGlobal = globalThis as unknown as {
+  __ttpAudioCtx?: AudioContext | null;
+  __ttpAudioBuffers?: Map<CueName, AudioBuffer>;
+  __ttpSoundEngine?: SoundEngine;
+  __ttpSilentKeepAlive?: HTMLAudioElement | null;
+};
+
+const buffers = (soundGlobal.__ttpAudioBuffers ??= new Map<
+  CueName,
+  AudioBuffer
+>());
+
+function context(): AudioContext {
+  return (soundGlobal.__ttpAudioCtx ??= new AudioContext());
+}
+
+/** Whether Web Audio exists — false under jsdom/SSR, where the layer is inert. */
+function audioAvailable(): boolean {
+  return typeof AudioContext !== "undefined";
+}
+
+async function loadBuffer(cue: CueName): Promise<AudioBuffer | undefined> {
+  const cached = buffers.get(cue);
+  if (cached) return cached;
+  const response = await fetch(`/sounds/${CUE_FILES[cue]}`);
+  const bytes = await response.arrayBuffer();
+  const buffer = await context().decodeAudioData(bytes);
+  buffers.set(cue, buffer);
+  return buffer;
+}
+
+/**
+ * The engine's `play` sink: fire a cue's warm-decoded buffer. Inert without
+ * Web Audio (jsdom under vitest, SSR) so importing the layer never throws on
+ * `new AudioContext()`. Cues are warmed on unlock, so by playtime the buffer is
+ * cached and this resolves without a decode gap.
+ */
+function playCueSound(cue: CueName): void {
+  if (!audioAvailable()) return;
+  void loadBuffer(cue).then((buffer) => {
+    if (!buffer) return;
+    const c = context();
+    const source = c.createBufferSource();
+    source.buffer = buffer;
+    source.connect(c.destination);
+    source.start();
+  });
+}
+
+const engine = (soundGlobal.__ttpSoundEngine ??= createSoundEngine({
+  play: playCueSound,
+  now: () => Date.now(),
+  schedule: (fn, delayMs) => {
+    setTimeout(fn, delayMs);
+  },
+}));
+
+export type { HandUpdateArgs, Surface } from "./engine.js";
+
+/** Called on every `hand-update` (never `view-snapshot`) — see `engine.ts`. */
+export function onHandUpdate(args: HandUpdateArgs): void {
+  engine.onHandUpdate(args);
+}
+
+/** Mirror the room-view sound settings (#182) into the engine's gate. */
+export function applyRoomSoundSettings(settings: SoundSettings): void {
+  engine.applyRoomSoundSettings(settings);
+}
+
+/** The reveal/conceal flip cue — the player's hole-card hook calls this. */
+export function playRevealFlip(): void {
+  engine.playRevealFlip();
+}
+
+/**
+ * Unlock audio from a user gesture (#178: an `AudioContext` starts
+ * `suspended`, and mobile browsers refuse to start one outside a gesture).
+ * Resumes the context, arms the iOS silent-switch workaround and warm-decodes
+ * every cue buffer so the first real cue has no decode gap. Idempotent — safe
+ * to call from every gesture that might be the first.
+ */
+export async function unlockAudio(): Promise<void> {
+  if (!audioAvailable()) return;
+  armSilentKeepAlive();
+  await context().resume();
+  // Warm every cue so the first real one plays without a decode gap.
+  await Promise.all(
+    CUE_NAMES.map((cue) => loadBuffer(cue).catch(() => undefined)),
+  );
+}
+
+// --- iOS silent-switch workaround (#178) ------------------------------------
+//
+// On iOS the hardware ringer/silent switch mutes Web Audio, so a phone with the
+// ringer off would hear nothing. A silently-looping HTMLMediaElement plays
+// through the media channel, which the switch does not gate, and keeping one
+// active routes Web Audio to that same channel — so the cues survive the switch
+// being off. Armed on the unlock gesture (media playback needs a gesture too).
+
+/** A fraction of a second of 8-bit mono PCM silence, as a `data:` WAV URL. */
+function silentWavDataUrl(): string {
+  const sampleRate = 8000;
+  const numSamples = Math.floor(sampleRate * 0.25);
+  const buffer = new ArrayBuffer(44 + numSamples);
+  const dv = new DataView(buffer);
+  const writeAscii = (offset: number, text: string): void => {
+    for (let i = 0; i < text.length; i++)
+      dv.setUint8(offset + i, text.charCodeAt(i));
+  };
+  writeAscii(0, "RIFF");
+  dv.setUint32(4, 36 + numSamples, true);
+  writeAscii(8, "WAVE");
+  writeAscii(12, "fmt ");
+  dv.setUint32(16, 16, true); // PCM chunk size
+  dv.setUint16(20, 1, true); // PCM format
+  dv.setUint16(22, 1, true); // mono
+  dv.setUint32(24, sampleRate, true);
+  dv.setUint32(28, sampleRate, true); // byte rate (8-bit mono)
+  dv.setUint16(32, 1, true); // block align
+  dv.setUint16(34, 8, true); // bits per sample
+  writeAscii(36, "data");
+  dv.setUint32(40, numSamples, true);
+  // 8-bit PCM silence is the mid-point 128, not 0.
+  for (let i = 0; i < numSamples; i++) dv.setUint8(44 + i, 128);
+  let binary = "";
+  const bytes = new Uint8Array(buffer);
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return `data:audio/wav;base64,${btoa(binary)}`;
+}
+
+/** Nudge the keep-alive element back to playing; a no-op if it isn't armed. */
+function nudgeKeepAlive(): void {
+  void soundGlobal.__ttpSilentKeepAlive?.play().catch(() => undefined);
+}
+
+function armSilentKeepAlive(): void {
+  if (typeof document === "undefined") return;
+  if (!soundGlobal.__ttpSilentKeepAlive) {
+    const el = document.createElement("audio");
+    el.loop = true;
+    el.setAttribute("playsinline", "");
+    el.src = silentWavDataUrl();
+    soundGlobal.__ttpSilentKeepAlive = el;
+  }
+  nudgeKeepAlive();
+}
+
+// Returning to a backgrounded tab (a phone waking) can leave the context
+// suspended; re-resume on visibility and nudge the keep-alive back to playing.
+if (typeof document !== "undefined") {
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState !== "visible") return;
+    if (soundGlobal.__ttpAudioCtx) void soundGlobal.__ttpAudioCtx.resume();
+    nudgeKeepAlive();
+  });
+}


### PR DESCRIPTION
Implements #186 — the production tactile-sound audio layer, reused by both clients, gated by the room sound settings (#184) and playing the canonical AAC assets (#185). Ports the tuned logic from `proto/sound-181`, dropping the A/B tuning store and `PrototypeSoundPanel`. No server change — cues fire off the existing `HandEvent` on `hand-update`.

## What's here

- **`ui-shared/src/sound/engine.ts`** — a pure state machine over injected effects (`play`/`now`/`schedule`): event→cue mapping, the settings gate, and the deferred your-turn prompt with token-based cancellation. Unit-testable without Web Audio.
- **`ui-shared/src/sound/webAudio.ts`** — the browser-bound half: one `AudioContext` singleton, warm-decode of the six buffers on unlock, `visibilitychange` resume, and the **iOS silent-switch workaround** (a looping silent `<audio>` element).
- **`ui-shared/src/sound/cues.ts`** — the six canonical cues, their `cards`/`notifications` category, the `cueAllowed` gate, and measured asset durations (`CUE_DURATIONS_MS`).
- **`ui-shared/src/sound/beatQueue.ts`** — the table's serial presentation queue (see Timing below).
- **Wiring** — both WS hooks call `applyRoomSoundSettings` on `room-view`; the player hook fires cues on `hand-update`; the table hook routes hand-updates through the beat queue. The player hole-card hook plays the reveal/conceal flip; audio unlocks on the seat-tap (player) and host/start/next-hand gestures (table).

Cue ownership per #180: the table is the dealer/center voice (deal sweep, per-card board taps); each phone is its own player (own hole cards, fold, check, flip, your-turn). `call`/`raise` left unallocated.

## Timing / pacing (follow-up from testing)

The board deal a closing **check** triggers was landing on top of the ~1.3s check knock still sounding on the acting player's phone, and simply delaying the board *sound* detached it from the card-drop animation. Resolved by pacing the table's whole reveal as **serial beats**:

- Each `hand-update` is a beat with an execution time — a check ~1.4s, a fold ~0.85s, view-only events 0 — applied at `max(now, busyUntil)` with its **animation and sound together**, then `busyUntil` advances by the beat's duration.
- The board beat opens only once the closing action's sound has finished; everything queued behind it stays in order.
- A `view-snapshot` (reconnect) is not a beat: it flushes the queue and applies at once, silently — so a rejoin can't replay a delayed burst (#175). A 2.5s look-ahead cap stops a rapid burst stacking an ever-longer delay.
- The phone's your-turn prompt holds until the knock clears as the cross-device equivalent (phones have no queue).

Known trade-off: on the table, a second player action within ~1.4s of the first is now spaced by a beat (the atomic-action serialisation).

## Acceptance criteria

- [x] Shared module plays cues from `hand-update`, never `view-snapshot`
- [x] Table plays the deal sweep + per-card board taps and nothing on per-player actions
- [x] Each phone plays its own hole cards, fold, check, reveal/conceal flip, and a deferred your-turn prompt that cancels if the turn passes first
- [x] Every cue is silenced by the matching room toggle (master / cards / notifications)
- [x] Audio unlocks on a gesture on both surfaces, resumes on `visibilitychange`, warms buffers on unlock
- [x] iOS silent-switch workaround coded (silent looping `<audio>` element)
- [ ] **iOS silent-switch _verified_ on an iPhone with the ringer off** — manual on-device check, outstanding
- [x] No `prototype-sound/` folder, A/B store, or tuning panel; unit tests cover mapping / gate / cancellation (+ beat-queue ordering); lint + typecheck green

## Verification

`tsc --build` clean; 23 sound tests + 102 table-client tests pass; eslint + prettier green. Full suite left to CI per `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R84qeRS69vzPpg9qmrkJdf