### PR TITLE
fix(player): keep seat picker inside mobile viewport

### DIFF
--- a/packages/player-client/src/SeatPicker.test.tsx
+++ b/packages/player-client/src/SeatPicker.test.tsx
@@ -78,7 +78,31 @@ describe("SeatPicker", () => {
     expect(html).toContain('data-testid="seat-grid"');
     expect(html).toContain('data-seat-count="6"');
     expect(html).toContain("grid-template-columns:repeat(2, minmax(0, 1fr));");
-    expect(html).toContain("grid-template-rows:repeat(3, minmax(0, 1fr));");
+    expect(html).toContain("--seat-row-count:3;");
+    expect(html).toContain(
+      "grid-template-rows:repeat(var(--seat-row-count), minmax(108px, auto));",
+    );
+  });
+
+  it("keeps every seat row at least as tall as its card", () => {
+    const html = renderToStaticMarkup(
+      <SeatPicker
+        error={null}
+        onClaim={() => undefined}
+        seats={Array.from({ length: 8 }, (_, id) => ({
+          id,
+          claimed: false,
+          sittingOut: false,
+          sittingOutReason: null,
+          disconnected: false,
+        }))}
+      />,
+    );
+
+    expect(html).toContain("--seat-row-count:4;");
+    expect(html).toContain(
+      "grid-template-rows:repeat(var(--seat-row-count), minmax(108px, auto));",
+    );
   });
 
   it("shows a friendly message for a known claim error", () => {

--- a/packages/player-client/src/SeatPicker.test.tsx
+++ b/packages/player-client/src/SeatPicker.test.tsx
@@ -60,7 +60,7 @@ describe("SeatPicker", () => {
     expect(html).toContain("Taken");
   });
 
-  it("sizes the seat grid rows to the number of seats", () => {
+  it("derives the grid row and column counts from the number of seats", () => {
     const html = renderToStaticMarkup(
       <SeatPicker
         error={null}
@@ -77,14 +77,13 @@ describe("SeatPicker", () => {
 
     expect(html).toContain('data-testid="seat-grid"');
     expect(html).toContain('data-seat-count="6"');
-    expect(html).toContain("grid-template-columns:repeat(2, minmax(0, 1fr));");
+    expect(html).toContain("grid-template-columns:repeat(2, minmax(0, 1fr))");
+    // Row count feeds the `.seat-grid` track template in CSS; the sizing and
+    // compact-layout behaviour live there, not in the inline styles.
     expect(html).toContain("--seat-row-count:3;");
-    expect(html).toContain(
-      "grid-template-rows:repeat(var(--seat-row-count), minmax(108px, auto));",
-    );
   });
 
-  it("keeps every seat row at least as tall as its card", () => {
+  it("renders each seat as a size-container card with the compact layout hooks", () => {
     const html = renderToStaticMarkup(
       <SeatPicker
         error={null}
@@ -100,9 +99,11 @@ describe("SeatPicker", () => {
     );
 
     expect(html).toContain("--seat-row-count:4;");
-    expect(html).toContain(
-      "grid-template-rows:repeat(var(--seat-row-count), minmax(108px, auto));",
-    );
+    // The classes the `@container seat` query keys on must be present so the
+    // card can flip to its horizontal layout when its own box gets short.
+    expect(html).toContain('class="seat-option"');
+    expect(html).toContain('class="seat-row"');
+    expect(html).toContain('class="seat-avatar"');
   });
 
   it("shows a friendly message for a known claim error", () => {

--- a/packages/player-client/src/SeatPicker.tsx
+++ b/packages/player-client/src/SeatPicker.tsx
@@ -47,16 +47,23 @@ const descriptionStyle: CSSProperties = {
   color: color.textMuted,
 };
 
-function seatGridStyle(seatCount: number): CSSProperties {
+type SeatGridStyle = CSSProperties & {
+  readonly "--seat-row-count": number;
+};
+
+function seatGridStyle(seatCount: number): SeatGridStyle {
   const rowCount = Math.max(1, Math.ceil(seatCount / 2));
 
   return {
+    "--seat-row-count": rowCount,
     display: "grid",
     gridTemplateColumns: seatCount <= 1 ? "1fr" : "repeat(2, minmax(0, 1fr))",
-    gridTemplateRows: `repeat(${String(rowCount)}, minmax(0, 1fr))`,
+    // A selected seat adds the name form below this grid. Keep each track at
+    // the card's minimum instead of shrinking the tracks underneath the
+    // cards; the picker owns any compact-viewport overflow.
+    gridTemplateRows: "repeat(var(--seat-row-count), minmax(108px, auto))",
     gap: 12,
-    flex: "1 1 0",
-    minHeight: 0,
+    flex: "none",
   };
 }
 
@@ -233,6 +240,7 @@ export function SeatPicker({
         Pick where you're sitting. Seat order sets the button and blinds.
       </div>
       <div
+        className="seat-grid"
         data-testid="seat-grid"
         data-seat-count={seats.length}
         style={seatGridStyle(seats.length)}
@@ -241,7 +249,9 @@ export function SeatPicker({
           const selected = selectedSeatId === seat.id;
           const content = (
             <>
-              <span style={avatarStyle(seat.claimed)}>{seat.id + 1}</span>
+              <span className="seat-avatar" style={avatarStyle(seat.claimed)}>
+                {seat.id + 1}
+              </span>
               <span style={textColStyle}>
                 <span style={seatTitleStyle}>
                   {seat.claimed
@@ -257,14 +267,18 @@ export function SeatPicker({
           return (
             <div
               key={seat.id}
+              className="seat-option"
               data-testid={`seat-option-${String(seat.id)}`}
               style={seatStyle(seat.claimed, selected)}
             >
               {seat.claimed ? (
-                <div style={rowStyle}>{content}</div>
+                <div className="seat-row" style={rowStyle}>
+                  {content}
+                </div>
               ) : (
                 <button
                   type="button"
+                  className="seat-row"
                   data-testid={`claim-seat-${String(seat.id)}`}
                   onClick={() => {
                     setSelectionLost(null);

--- a/packages/player-client/src/SeatPicker.tsx
+++ b/packages/player-client/src/SeatPicker.tsx
@@ -54,26 +54,17 @@ type SeatGridStyle = CSSProperties & {
 function seatGridStyle(seatCount: number): SeatGridStyle {
   const rowCount = Math.max(1, Math.ceil(seatCount / 2));
 
+  // Row count and column count are data, so they stay inline; the grid's
+  // sizing and shrink behaviour live in the `.seat-grid` CSS rule.
   return {
     "--seat-row-count": rowCount,
-    display: "grid",
     gridTemplateColumns: seatCount <= 1 ? "1fr" : "repeat(2, minmax(0, 1fr))",
-    // A selected seat adds the name form below this grid. Keep each track at
-    // the card's minimum instead of shrinking the tracks underneath the
-    // cards; the picker owns any compact-viewport overflow.
-    gridTemplateRows: "repeat(var(--seat-row-count), minmax(108px, auto))",
-    gap: 12,
-    flex: "none",
   };
 }
 
 function seatStyle(claimed: boolean, selected: boolean): CSSProperties {
   return {
-    display: "flex",
-    minHeight: 108,
-    height: "100%",
     borderRadius: radius.control,
-    padding: 16,
     ...(claimed
       ? {
           border: `1px solid ${color.border}`,
@@ -93,28 +84,8 @@ function seatStyle(claimed: boolean, selected: boolean): CSSProperties {
   };
 }
 
-const rowStyle: CSSProperties = {
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "flex-start",
-  justifyContent: "space-between",
-  gap: 12,
-  width: "100%",
-  height: "100%",
-  minHeight: 0,
-  textAlign: "left",
-  background: "none",
-  border: 0,
-  padding: 0,
-  font: "inherit",
-  color: "inherit",
-  cursor: "pointer",
-};
-
 function avatarStyle(claimed: boolean): CSSProperties {
   return {
-    width: 44,
-    height: 44,
     borderRadius: radius.pill,
     flex: "none",
     display: "flex",
@@ -272,9 +243,7 @@ export function SeatPicker({
               style={seatStyle(seat.claimed, selected)}
             >
               {seat.claimed ? (
-                <div className="seat-row" style={rowStyle}>
-                  {content}
-                </div>
+                <div className="seat-row">{content}</div>
               ) : (
                 <button
                   type="button"
@@ -284,7 +253,6 @@ export function SeatPicker({
                     setSelectionLost(null);
                     setSelectedSeatId(seat.id);
                   }}
-                  style={rowStyle}
                   aria-pressed={selected}
                 >
                   {content}

--- a/packages/player-client/src/app-shell.css
+++ b/packages/player-client/src/app-shell.css
@@ -4,9 +4,12 @@
 
 html,
 body {
+  height: 100%;
   margin: 0;
   padding: 0;
+  overflow: hidden;
   touch-action: manipulation;
+  overscroll-behavior: none;
   background: #050403;
 }
 
@@ -17,10 +20,13 @@ body {
  */
 #root {
   width: 100%;
+  height: 100vh;
   height: 100svh;
+  height: 100dvh;
   overflow: hidden;
   display: flex;
   justify-content: center;
+  overscroll-behavior: none;
 }
 
 .app-shell {
@@ -43,10 +49,47 @@ body {
 .hand {
   flex: 1;
   min-height: 0;
+  min-width: 0;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   gap: 14px;
   padding: 10px 18px 24px;
+}
+
+/*
+ * The seat picker adds the name form below the grid after a seat is tapped.
+ * On a short phone viewport, four vertical cards plus that form cannot all
+ * retain their desktop-sized intrinsic height. Switch the cards to a compact
+ * horizontal treatment and give the grid the remaining height so its tracks
+ * shrink before the picker ever paints one card into the next row.
+ */
+@media (max-height: 850px) {
+  .seat-grid {
+    flex: 1 1 0 !important;
+    min-height: 0;
+    grid-template-rows: repeat(
+      var(--seat-row-count),
+      minmax(0, 1fr)
+    ) !important;
+  }
+
+  .seat-option {
+    min-height: 0 !important;
+    padding: 6px !important;
+  }
+
+  .seat-row {
+    flex-direction: row !important;
+    align-items: center !important;
+    justify-content: flex-start !important;
+    gap: 8px !important;
+  }
+
+  .seat-avatar {
+    width: 32px !important;
+    height: 32px !important;
+  }
 }
 
 /* The lifted flap carries exactly one index: the remapped one in

--- a/packages/player-client/src/app-shell.css
+++ b/packages/player-client/src/app-shell.css
@@ -58,37 +58,76 @@ body {
 }
 
 /*
- * The seat picker adds the name form below the grid after a seat is tapped.
- * On a short phone viewport, four vertical cards plus that form cannot all
- * retain their desktop-sized intrinsic height. Switch the cards to a compact
- * horizontal treatment and give the grid the remaining height so its tracks
- * shrink before the picker ever paints one card into the next row.
+ * The seat picker's geometry lives here, not in the component's inline styles,
+ * so the container query below can restyle the card without fighting inline
+ * styles with `!important`. The component keeps only prop-driven visuals
+ * (the selected ring, the taken-seat fade) inline.
+ *
+ * The grid sizes each row up to a comfortable card height but may shrink:
+ * tapping a seat adds the name form below the grid, and on a short viewport
+ * the tracks give up height instead of painting one card into the next row.
  */
-@media (max-height: 850px) {
-  .seat-grid {
-    flex: 1 1 0 !important;
-    min-height: 0;
-    grid-template-rows: repeat(
-      var(--seat-row-count),
-      minmax(0, 1fr)
-    ) !important;
-  }
+.seat-grid {
+  display: grid;
+  grid-template-rows: repeat(var(--seat-row-count), minmax(0, 108px));
+  gap: 12px;
+  /* Grow no taller than the tracks ask, but shrink when the picker is short. */
+  flex: 0 1 auto;
+  min-height: 0;
+}
 
-  .seat-option {
-    min-height: 0 !important;
-    padding: 6px !important;
-  }
+.seat-option {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+  /* Clip rather than spill into the next row while a card is mid-shrink. */
+  overflow: hidden;
+  /* Each card queries its own height to choose a layout (iOS Safari 16+). */
+  container: seat / size;
+}
 
+.seat-row {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  padding: 16px;
+  text-align: left;
+  background: none;
+  border: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.seat-avatar {
+  width: 44px;
+  height: 44px;
+}
+
+/*
+ * Below this card height the stacked avatar-over-text layout stops fitting,
+ * so lay the card out horizontally and shrink the avatar. The threshold is the
+ * card's own height, not the viewport's, so it fires whenever the grid has
+ * squeezed a card short — on any phone or orientation, with no viewport-height
+ * breakpoint to keep in step as new, taller devices appear.
+ */
+@container seat (max-height: 92px) {
   .seat-row {
-    flex-direction: row !important;
-    align-items: center !important;
-    justify-content: flex-start !important;
-    gap: 8px !important;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 8px;
+    padding: 6px 8px;
   }
 
   .seat-avatar {
-    width: 32px !important;
-    height: 32px !important;
+    width: 32px;
+    height: 32px;
   }
 }
 


### PR DESCRIPTION
## Original issue

Fixes #190. On an iPhone 13 Pro Max, Safari and Chrome for iOS showed overlapping seat cards after a seat was selected. The selected-seat name form also pushed the player UI beyond the mobile viewport, requiring zooming or scrolling. The issue was not reproduced on the reported Android Pixel Pro 10.

## Intended fix

The seat picker previously used flexible grid tracks while each card retained a 108px minimum height. When selecting a seat added the name form below the grid on a short viewport, the tracks shrank below the cards minimum and adjacent rows overlapped. This change keeps the normal seat rows at the card minimum, then applies a compact horizontal card layout on short viewports so the grid can fit alongside the name form. The player shell now uses small/dynamic viewport-height sizing and contains document overflow so the player surface remains bounded to the phone viewport.

## Validation

- `npm exec vitest run packages/player-client/src/SeatPicker.test.tsx packages/player-client/src/App.test.tsx` — 13 tests passed.
- `npm run build` — passed.
- `npm run lint` — passed, including the Prettier check.
- Playwright repro at 428x744 — no seat overlap; the selected-seat form fits; root, body, and document remain at viewport height.
- Post-claim hand repro at 428x744 — the action bar fits inside the viewport with no document overflow.
