### PR TITLE
fix(player): keep the join URL and prefill on the active room

### DIFF
--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -7,7 +7,10 @@ import { useActionIntent } from "./actions/useActionIntent.js";
 import { claimErrorCode } from "./claimError.js";
 import { Hand } from "./Hand.js";
 import { JoinForm } from "./JoinForm.js";
-import { parseRoomCodeFromPath } from "./join/parseRoomCodeFromPath.js";
+import {
+  joinPathForCode,
+  parseRoomCodeFromPath,
+} from "./join/parseRoomCodeFromPath.js";
 import { SeatPicker } from "./SeatPicker.js";
 import { SeatMovedNotice } from "./SeatMovedNotice.js";
 import { StatusBar } from "./StatusBar.js";
@@ -36,7 +39,7 @@ export function App() {
   const clearRoom = usePlayerStore((state) => state.clearRoom);
   const clearHand = usePlayerStore((state) => state.clearHand);
 
-  const [defaultRoomCode] = useState(() =>
+  const [defaultRoomCode, setDefaultRoomCode] = useState(() =>
     typeof window === "undefined"
       ? ""
       : (parseRoomCodeFromPath(window.location.pathname) ?? ""),
@@ -68,6 +71,19 @@ export function App() {
         clearSeatToken(window.localStorage);
       });
   }, [setRoomView, setSeat]);
+
+  // Keep the browser URL and the join-form prefill pointing at the room the
+  // player is actually in. Without this the address bar stays pinned to the
+  // first `/join/:code` it loaded, so a player who joins several rooms in one
+  // session keeps landing back on the join screen prefilled with the *first*
+  // code rather than the one they last used. `replaceState` (not push) so this
+  // never adds back-button history. We only rewrite on an active room; leaving
+  // keeps the last room's path, which is what the prefill should offer next.
+  useEffect(() => {
+    if (typeof window === "undefined" || roomCode === null) return;
+    window.history.replaceState(null, "", joinPathForCode(roomCode));
+    setDefaultRoomCode(roomCode);
+  }, [roomCode]);
 
   // Drop this player out of their seat locally: forget the stored and in-memory
   // seat token, and clear the seat and hand slices so no stale seat or hole

--- a/packages/player-client/src/join/parseRoomCodeFromPath.test.ts
+++ b/packages/player-client/src/join/parseRoomCodeFromPath.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { parseRoomCodeFromPath } from "./parseRoomCodeFromPath.js";
+import {
+  joinPathForCode,
+  parseRoomCodeFromPath,
+} from "./parseRoomCodeFromPath.js";
 
 describe("parseRoomCodeFromPath", () => {
   it("extracts and upper-cases a room code from a /join/:code path", () => {
@@ -12,5 +15,15 @@ describe("parseRoomCodeFromPath", () => {
 
   it("returns null for a code of the wrong length", () => {
     expect(parseRoomCodeFromPath("/join/abc")).toBeNull();
+  });
+});
+
+describe("joinPathForCode", () => {
+  it("builds the /join/:code path for a room", () => {
+    expect(joinPathForCode("AB3D")).toBe("/join/AB3D");
+  });
+
+  it("round-trips with parseRoomCodeFromPath", () => {
+    expect(parseRoomCodeFromPath(joinPathForCode("AB3D"))).toBe("AB3D");
   });
 });

--- a/packages/player-client/src/join/parseRoomCodeFromPath.ts
+++ b/packages/player-client/src/join/parseRoomCodeFromPath.ts
@@ -5,3 +5,13 @@ export function parseRoomCodeFromPath(pathname: string): string | null {
   const code = JOIN_PATH.exec(pathname)?.[1];
   return code ? code.toUpperCase() : null;
 }
+
+/**
+ * The player-client URL path that names a joined room — the inverse of
+ * `parseRoomCodeFromPath`. The server only serves the SPA at `/join/:code`
+ * (the site root serves the table client), so a joined player always lives on
+ * one of these paths.
+ */
+export function joinPathForCode(code: string): string {
+  return `/join/${code}`;
+}


### PR DESCRIPTION
## Problem

A player joins via `/join/<code>`. If they're later removed (e.g. the room closed while their tab was open), they return to the room-code picker. They enter a *new* code and join a different room — but the browser URL still shows the **first** code, and when they're removed again the picker is prefilled with that stale first code. The URL never changes across rooms.

## Cause

`App` read the code from `/join/:code` **once** at mount into a frozen `defaultRoomCode`, and never rewrote the browser URL afterwards. So both the address bar and the prefill stayed pinned to the first room for the whole session.

## Fix

- Sync the browser URL to the store's active `roomCode` via `history.replaceState` whenever it changes, and refresh the prefill state to match. `replaceState` (not `push`) keeps the back button clean. The player client is only ever served at `/join/:code` (the site root serves the *table* client), so we keep the last room's path when the player leaves — that's the sensible code to offer next.
- Add `joinPathForCode` as the inverse of `parseRoomCodeFromPath`, with round-trip test coverage.

## Testing

- `npx vitest run` on the join + App + JoinForm test files (13 passing)
- `tsc -b packages/player-client` clean
- `npm run lint` (eslint + prettier) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEVAwgEo59V53rF8JiWeeZ