### PR TITLE
feat(sound): split action cues out of the cards category

### DIFF
--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -70,15 +70,17 @@ export type SeatCountChangeError =
 
 /**
  * The room-wide tactile-sound settings (#182), owned by the table and pushed to
- * every surface on `room-view`. `sounds` is the master switch; `cards` and
- * `notifications` are the two cue categories under it (cards = the tactile card
- * foley — deal, board, fold, flip, check-knock; notifications = the your-turn
- * prompt). A cue plays only when the master and its category are both on. Phones
- * hold no local override in this cut — they obey these settings verbatim.
+ * every surface on `room-view`. `sounds` is the master switch; `cards`,
+ * `actions` and `notifications` are the three cue categories under it (cards =
+ * the tactile card foley — deal, board, flip; actions = player actions —
+ * fold, check; notifications = the your-turn prompt). A cue plays only when the
+ * master and its category are both on. Phones hold no local override in this
+ * cut — they obey these settings verbatim.
  */
 export interface SoundSettings {
   readonly sounds: boolean;
   readonly cards: boolean;
+  readonly actions: boolean;
   readonly notifications: boolean;
 }
 
@@ -86,17 +88,19 @@ export interface SoundSettings {
 export const DEFAULT_SOUND_SETTINGS: SoundSettings = {
   sounds: true,
   cards: true,
+  actions: true,
   notifications: true,
 };
 
 /**
- * Body of the table-only sound-settings request (#182). The whole triple is
- * sent every time, so the master and both categories stay a single atomic
+ * Body of the table-only sound-settings request (#182). The whole set is
+ * sent every time, so the master and all categories stay a single atomic
  * write — no partial-update ordering to reason about.
  */
 export const ChangeSoundSettingsRequestSchema = z.strictObject({
   sounds: z.boolean(),
   cards: z.boolean(),
+  actions: z.boolean(),
   notifications: z.boolean(),
 });
 

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -238,7 +238,12 @@ describe("POST /rooms/:code/sound", () => {
 
   it("persists the settings on the room view", async () => {
     const code = await createRoom();
-    const settings = { sounds: true, cards: false, notifications: true };
+    const settings = {
+      sounds: true,
+      cards: false,
+      actions: true,
+      notifications: true,
+    };
 
     const response = await app.inject({
       method: "POST",
@@ -269,7 +274,12 @@ describe("POST /rooms/:code/sound", () => {
     const response = await app.inject({
       method: "POST",
       url: "/rooms/ZZZZ/sound",
-      payload: { sounds: true, cards: true, notifications: true },
+      payload: {
+        sounds: true,
+        cards: true,
+        actions: true,
+        notifications: true,
+      },
     });
     expect(response.statusCode).toBe(404);
   });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -567,8 +567,9 @@ export async function buildApp(
   app.post<RoomCodeRoute>("/rooms/:code/seats/count", changeSeatCount);
 
   /**
-   * Table-device sound settings (#182): the room-wide master/cards/notifications
-   * toggles. Same ungated table-action boundary as `/seats/count` — the table
+   * Table-device sound settings (#182): the room-wide
+   * master/cards/actions/notifications toggles. Same ungated table-action
+   * boundary as `/seats/count` — the table
    * owns these and pushes them to every surface via the broadcast `room-view`.
    */
   app.post<RoomCodeRoute>("/rooms/:code/sound", (request, reply) => {

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -1013,7 +1013,12 @@ describe("changeSoundSettings", () => {
   it("replaces the whole triple atomically", () => {
     const store = new RoomStore();
     const room = store.create();
-    const settings = { sounds: true, cards: false, notifications: true };
+    const settings = {
+      sounds: true,
+      cards: false,
+      actions: true,
+      notifications: true,
+    };
 
     const result = store.changeSoundSettings(room.code, settings);
 

--- a/packages/table-client/src/HouseRulesSheet.test.tsx
+++ b/packages/table-client/src/HouseRulesSheet.test.tsx
@@ -140,7 +140,12 @@ describe("HouseRulesSheet", () => {
         pendingSeatCount={null}
         seats={seats.slice(0, 4)}
         handInProgress
-        soundSettings={{ sounds: true, cards: false, notifications: true }}
+        soundSettings={{
+          sounds: true,
+          cards: false,
+          actions: true,
+          notifications: true,
+        }}
         onApply={noop}
         onChangeSoundSettings={noop}
         onClose={noop}
@@ -156,6 +161,9 @@ describe("HouseRulesSheet", () => {
       'aria-checked="false" aria-label="Cards" data-testid="sound-cards-toggle" style=',
     );
     expect(html).toContain(
+      'aria-checked="true" aria-label="Actions" data-testid="sound-actions-toggle" style=',
+    );
+    expect(html).toContain(
       'aria-checked="true" aria-label="Notifications" data-testid="sound-notifications-toggle" style=',
     );
   });
@@ -167,7 +175,12 @@ describe("HouseRulesSheet", () => {
         pendingSeatCount={null}
         seats={seats.slice(0, 4)}
         handInProgress
-        soundSettings={{ sounds: false, cards: true, notifications: true }}
+        soundSettings={{
+          sounds: false,
+          cards: true,
+          actions: true,
+          notifications: true,
+        }}
         onApply={noop}
         onChangeSoundSettings={noop}
         onClose={noop}
@@ -175,6 +188,7 @@ describe("HouseRulesSheet", () => {
     );
 
     expect(html).toContain('data-testid="sound-cards-toggle" disabled=""');
+    expect(html).toContain('data-testid="sound-actions-toggle" disabled=""');
     expect(html).toContain(
       'data-testid="sound-notifications-toggle" disabled=""',
     );

--- a/packages/table-client/src/HouseRulesSheet.tsx
+++ b/packages/table-client/src/HouseRulesSheet.tsx
@@ -388,6 +388,16 @@ export function HouseRulesSheet({
               }}
             />
             <Toggle
+              label="Actions"
+              nested
+              checked={soundSettings.actions}
+              disabled={!soundSettings.sounds}
+              testId="sound-actions-toggle"
+              onChange={(actions) => {
+                onChangeSoundSettings({ ...soundSettings, actions });
+              }}
+            />
+            <Toggle
               label="Notifications"
               nested
               checked={soundSettings.notifications}

--- a/packages/ui-shared/src/sound/cues.ts
+++ b/packages/ui-shared/src/sound/cues.ts
@@ -61,27 +61,36 @@ export function cueSettleMs(cue: CueName): number {
 
 /**
  * Which room-level category (#182) each cue belongs to. `cards` is the tactile
- * card foley; `notifications` is the your-turn prompt. A cue plays only when
- * the room's master switch and its category are both on — see `cueAllowed`.
+ * card foley (deal, board, flip); `actions` is player actions (fold, check);
+ * `notifications` is the your-turn prompt. A cue plays only when the room's
+ * master switch and its category are both on — see `cueAllowed`.
  */
-export const CUE_CATEGORY: Record<CueName, "cards" | "notifications"> = {
+export const CUE_CATEGORY: Record<
+  CueName,
+  "cards" | "actions" | "notifications"
+> = {
   deal: "cards",
   board: "cards",
-  fold: "cards",
-  check: "cards",
+  fold: "actions",
+  check: "actions",
   flip: "cards",
   yourTurn: "notifications",
 };
 
 /**
  * Whether the room's settings (#182) currently allow this cue: the master
- * switch on, and the cue's category (cards / notifications) on. This is the
- * real mute path — the table owns it and it reaches every surface via
+ * switch on, and the cue's category (cards / actions / notifications) on. This
+ * is the real mute path — the table owns it and it reaches every surface via
  * `room-view`.
  */
 export function cueAllowed(settings: SoundSettings, cue: CueName): boolean {
   if (!settings.sounds) return false;
-  return CUE_CATEGORY[cue] === "cards"
-    ? settings.cards
-    : settings.notifications;
+  switch (CUE_CATEGORY[cue]) {
+    case "cards":
+      return settings.cards;
+    case "actions":
+      return settings.actions;
+    case "notifications":
+      return settings.notifications;
+  }
 }

--- a/packages/ui-shared/src/sound/engine.test.ts
+++ b/packages/ui-shared/src/sound/engine.test.ts
@@ -12,6 +12,7 @@ import { createSoundEngine, type SoundEngine, TIMINGS } from "./engine.js";
 const ALL_ON: SoundSettings = {
   sounds: true,
   cards: true,
+  actions: true,
   notifications: true,
 };
 
@@ -250,7 +251,12 @@ describe("event → cue mapping", () => {
 
 describe("room-settings gate", () => {
   it("silences everything when the master switch is off", () => {
-    const r = rig({ sounds: false, cards: true, notifications: true });
+    const r = rig({
+      sounds: false,
+      cards: true,
+      actions: true,
+      notifications: true,
+    });
     r.engine.onHandUpdate({
       surface: "table",
       event: holeCardsDealt([0]),
@@ -262,7 +268,12 @@ describe("room-settings gate", () => {
   });
 
   it("silences card cues but not notifications when cards is off", () => {
-    const r = rig({ sounds: true, cards: false, notifications: true });
+    const r = rig({
+      sounds: true,
+      cards: false,
+      actions: true,
+      notifications: true,
+    });
     r.engine.playRevealFlip();
     r.flush();
     expect(r.played).toEqual([]);
@@ -284,8 +295,36 @@ describe("room-settings gate", () => {
     expect(r.played).toEqual(["yourTurn"]);
   });
 
+  it("silences action cues but not card cues when actions is off", () => {
+    const r = rig({
+      sounds: true,
+      cards: true,
+      actions: false,
+      notifications: true,
+    });
+    // A fold/check on the acting player's own phone is silenced.
+    r.engine.onHandUpdate({
+      surface: "player",
+      seatId: 1,
+      event: actionTaken(1, "fold"),
+      view: noHandView,
+    });
+    r.flush();
+    expect(r.played).toEqual([]);
+
+    // A card cue (reveal flip) still passes.
+    r.engine.playRevealFlip();
+    r.flush();
+    expect(r.played).toEqual(["flip"]);
+  });
+
   it("silences the your-turn prompt when notifications is off", () => {
-    const r = rig({ sounds: true, cards: true, notifications: false });
+    const r = rig({
+      sounds: true,
+      cards: true,
+      actions: true,
+      notifications: false,
+    });
     r.engine.onHandUpdate({
       surface: "player",
       seatId: 0,
@@ -301,6 +340,7 @@ describe("room-settings gate", () => {
     r.engine.applyRoomSoundSettings({
       sounds: true,
       cards: false,
+      actions: true,
       notifications: true,
     });
     r.engine.playRevealFlip();


### PR DESCRIPTION
## What

Makes the room's sound toggles more granular. They were **Cards** + **Notifications**; now they are **Cards** + **Actions** + **Notifications**:

- **Cards** — card foley only: deal, board, flip
- **Actions** — player moves: fold, check
- **Notifications** — the your-turn prompt

Previously fold/check lived under `cards`, so muting card foley also silenced action voicing. They now have their own switch.

## Changes

- `protocol`: add `actions` to `SoundSettings`, `DEFAULT_SOUND_SETTINGS`, and `ChangeSoundSettingsRequestSchema`.
- `ui-shared`: re-map `CUE_CATEGORY` (fold/check → `actions`) and switch `cueAllowed` to a per-category lookup.
- `table-client`: add the **Actions** toggle to the sound settings sheet.
- Tests updated across ui-shared / table-client / server, plus a new engine test that Actions-off silences fold/check while card cues still play.

## Verification

- Targeted tests: `engine.test.ts`, `HouseRulesSheet.test.tsx`, `app.test.ts`, `rooms.test.ts` — all pass.
- `npm run build` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QEVAwgEo59V53rF8JiWeeZ