### PR TITLE
fix(player): cancel selectstart so Android Chrome shows no long-press highlight

### DIFF
--- a/packages/player-client/src/app-shell.css
+++ b/packages/player-client/src/app-shell.css
@@ -147,22 +147,3 @@ body {
 .peel-back .card-index {
   display: none !important;
 }
-
-/*
- * Android Chrome still *starts* a text selection on a long-press even under
- * `user-select: none` — it cancels the selection a frame later, but paints the
- * highlight in between, and (unlike desktop) fires no cancelable `selectstart`
- * to stop it (#195). `user-select: none` already keeps the selection from
- * persisting; this makes the transient paint invisible while it lasts, so the
- * cards stay visually stable. Scoped to the hole-card surface so a room code or
- * join URL elsewhere on the screen stays selectable.
- */
-[data-testid="hole-cards"]::selection,
-[data-testid="hole-cards"] ::selection {
-  background: transparent;
-}
-
-[data-testid="hole-cards"]::-moz-selection,
-[data-testid="hole-cards"] ::-moz-selection {
-  background: transparent;
-}

--- a/packages/player-client/src/app-shell.css
+++ b/packages/player-client/src/app-shell.css
@@ -147,3 +147,22 @@ body {
 .peel-back .card-index {
   display: none !important;
 }
+
+/*
+ * Android Chrome still *starts* a text selection on a long-press even under
+ * `user-select: none` — it cancels the selection a frame later, but paints the
+ * highlight in between, and (unlike desktop) fires no cancelable `selectstart`
+ * to stop it (#195). `user-select: none` already keeps the selection from
+ * persisting; this makes the transient paint invisible while it lasts, so the
+ * cards stay visually stable. Scoped to the hole-card surface so a room code or
+ * join URL elsewhere on the screen stays selectable.
+ */
+[data-testid="hole-cards"]::selection,
+[data-testid="hole-cards"] ::selection {
+  background: transparent;
+}
+
+[data-testid="hole-cards"]::-moz-selection,
+[data-testid="hole-cards"] ::-moz-selection {
+  background: transparent;
+}

--- a/packages/player-client/src/holecards/HoleCardPair.test.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.test.tsx
@@ -2,7 +2,7 @@ import type { Card } from "@table-top-poker/protocol";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { HoleCardPair } from "./HoleCardPair.js";
+import { HoleCardPair, suppressSelectStart } from "./HoleCardPair.js";
 import type { CardActions } from "./ports.js";
 
 const actions: CardActions = {
@@ -135,5 +135,58 @@ describe("HoleCardPair", () => {
     // A live region inserted along with its own text is not reliably
     // announced, so the region has to be here first — with nothing in it.
     expect(html).toMatch(/<span role="status"[^>]*><\/span>/);
+  });
+});
+
+// The declared `user-select: none` is not enough on Android Chrome: a
+// long-press still *starts* a selection and paints a transient highlight before
+// the CSS cancels it (#195). Cancelling `selectstart` is what stops the flash,
+// and — unlike `contextmenu` — React has no synthetic event for it, so the
+// surface binds a native listener through this callback ref. The regression is
+// on the wiring itself; the visual outcome is a real-device acceptance step.
+describe("suppressSelectStart", () => {
+  interface FakeNode {
+    readonly listeners: Map<string, EventListener>;
+    readonly node: HTMLElement;
+  }
+
+  function fakeNode(): FakeNode {
+    const listeners = new Map<string, EventListener>();
+    const node = {
+      addEventListener: (type: string, listener: EventListener) => {
+        listeners.set(type, listener);
+      },
+      removeEventListener: (type: string) => {
+        listeners.delete(type);
+      },
+    } as unknown as HTMLElement;
+    return { listeners, node };
+  }
+
+  it("cancels a selectstart raised on the surface", () => {
+    const { listeners, node } = fakeNode();
+    suppressSelectStart(node);
+
+    const listener = listeners.get("selectstart");
+    expect(listener).toBeDefined();
+
+    let prevented = false;
+    listener?.({
+      preventDefault: () => (prevented = true),
+    } as unknown as Event);
+    expect(prevented).toBe(true);
+  });
+
+  it("removes the listener when the surface unmounts", () => {
+    const { listeners, node } = fakeNode();
+    const cleanup = suppressSelectStart(node);
+
+    expect(typeof cleanup).toBe("function");
+    cleanup?.();
+    expect(listeners.has("selectstart")).toBe(false);
+  });
+
+  it("does nothing when React detaches the ref with null", () => {
+    expect(suppressSelectStart(null)).toBeUndefined();
   });
 });

--- a/packages/player-client/src/holecards/HoleCardPair.test.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.test.tsx
@@ -103,6 +103,9 @@ describe("HoleCardPair", () => {
     expect(html).toContain("touch-action:none");
     expect(html).toContain("-webkit-touch-callout:none");
     expect(html).toContain("user-select:none");
+    // Android Chrome's press wash reads as a highlight on the cards during a
+    // long-press; the surface does its own press feedback, so it is turned off.
+    expect(html).toContain("-webkit-tap-highlight-color:transparent");
   });
 
   it("renders no hint while the pair is settled", () => {

--- a/packages/player-client/src/holecards/HoleCardPair.test.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.test.tsx
@@ -2,7 +2,7 @@ import type { Card } from "@table-top-poker/protocol";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { HoleCardPair, suppressSelectStart } from "./HoleCardPair.js";
+import { HoleCardPair } from "./HoleCardPair.js";
 import type { CardActions } from "./ports.js";
 
 const actions: CardActions = {
@@ -138,58 +138,5 @@ describe("HoleCardPair", () => {
     // A live region inserted along with its own text is not reliably
     // announced, so the region has to be here first — with nothing in it.
     expect(html).toMatch(/<span role="status"[^>]*><\/span>/);
-  });
-});
-
-// The declared `user-select: none` is not enough on Android Chrome: a
-// long-press still *starts* a selection and paints a transient highlight before
-// the CSS cancels it (#195). Cancelling `selectstart` is what stops the flash,
-// and — unlike `contextmenu` — React has no synthetic event for it, so the
-// surface binds a native listener through this callback ref. The regression is
-// on the wiring itself; the visual outcome is a real-device acceptance step.
-describe("suppressSelectStart", () => {
-  interface FakeNode {
-    readonly listeners: Map<string, EventListener>;
-    readonly node: HTMLElement;
-  }
-
-  function fakeNode(): FakeNode {
-    const listeners = new Map<string, EventListener>();
-    const node = {
-      addEventListener: (type: string, listener: EventListener) => {
-        listeners.set(type, listener);
-      },
-      removeEventListener: (type: string) => {
-        listeners.delete(type);
-      },
-    } as unknown as HTMLElement;
-    return { listeners, node };
-  }
-
-  it("cancels a selectstart raised on the surface", () => {
-    const { listeners, node } = fakeNode();
-    suppressSelectStart(node);
-
-    const listener = listeners.get("selectstart");
-    expect(listener).toBeDefined();
-
-    let prevented = false;
-    listener?.({
-      preventDefault: () => (prevented = true),
-    } as unknown as Event);
-    expect(prevented).toBe(true);
-  });
-
-  it("removes the listener when the surface unmounts", () => {
-    const { listeners, node } = fakeNode();
-    const cleanup = suppressSelectStart(node);
-
-    expect(typeof cleanup).toBe("function");
-    cleanup?.();
-    expect(listeners.has("selectstart")).toBe(false);
-  });
-
-  it("does nothing when React detaches the ref with null", () => {
-    expect(suppressSelectStart(null)).toBeUndefined();
   });
 });

--- a/packages/player-client/src/holecards/HoleCardPair.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.tsx
@@ -236,6 +236,12 @@ export function HoleCardPair(props: HoleCardPairProps) {
             WebkitTouchCallout: "none",
             WebkitUserSelect: "none",
             touchAction: "none",
+            // Android Chrome paints a blue box over any tappable element while
+            // it is pressed, and a long-press holds that state long enough to
+            // read as a highlight sitting on the cards (#195). The cards do
+            // their own press feedback (the bend, the flip); this OS wash on top
+            // is noise, so it is turned off.
+            WebkitTapHighlightColor: "transparent",
           }}
         >
           <motion.span

--- a/packages/player-client/src/holecards/HoleCardPair.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.tsx
@@ -211,13 +211,6 @@ export function HoleCardPair(props: HoleCardPairProps) {
           onClick={locked ? undefined : activate}
           // Long-press must not raise the OS callout menu over the cards (§16).
           onContextMenu={preventDefault}
-          // …nor leave a text-selection highlight behind it. The CSS below
-          // forbids selection, but Android Chrome still *starts* one on a
-          // long-press and paints the highlight a frame before cancelling it.
-          // Cancelling `selectstart` outright is the only thing that stops the
-          // flash, and React has no synthetic event for it — so it is attached
-          // natively here (#195).
-          ref={suppressSelectStart}
           {...(locked ? {} : handlers)}
           aria-disabled={locked}
           aria-label={accessibleName(shown, presentation, locked)}
@@ -340,23 +333,6 @@ const nothingDiscovered: ReadonlySet<TeachableGesture> = new Set();
 
 function preventDefault(event: { preventDefault: () => void }) {
   event.preventDefault();
-}
-
-/**
- * A callback ref that binds a `selectstart` canceller to the pair's surface for
- * as long as it is mounted. Module-scoped so its identity is stable and React
- * never detaches and rebinds it between renders. Selection bubbles, so one
- * listener on the surface catches a long-press that lands on either card's text
- * (#195). The `void` branch is the detach call React makes with `null`.
- */
-export function suppressSelectStart(
-  node: HTMLElement | null,
-): (() => void) | undefined {
-  if (node === null) return undefined;
-  node.addEventListener("selectstart", preventDefault);
-  return () => {
-    node.removeEventListener("selectstart", preventDefault);
-  };
 }
 
 /**

--- a/packages/player-client/src/holecards/HoleCardPair.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.tsx
@@ -211,6 +211,13 @@ export function HoleCardPair(props: HoleCardPairProps) {
           onClick={locked ? undefined : activate}
           // Long-press must not raise the OS callout menu over the cards (§16).
           onContextMenu={preventDefault}
+          // …nor leave a text-selection highlight behind it. The CSS below
+          // forbids selection, but Android Chrome still *starts* one on a
+          // long-press and paints the highlight a frame before cancelling it.
+          // Cancelling `selectstart` outright is the only thing that stops the
+          // flash, and React has no synthetic event for it — so it is attached
+          // natively here (#195).
+          ref={suppressSelectStart}
           {...(locked ? {} : handlers)}
           aria-disabled={locked}
           aria-label={accessibleName(shown, presentation, locked)}
@@ -327,6 +334,23 @@ const nothingDiscovered: ReadonlySet<TeachableGesture> = new Set();
 
 function preventDefault(event: { preventDefault: () => void }) {
   event.preventDefault();
+}
+
+/**
+ * A callback ref that binds a `selectstart` canceller to the pair's surface for
+ * as long as it is mounted. Module-scoped so its identity is stable and React
+ * never detaches and rebinds it between renders. Selection bubbles, so one
+ * listener on the surface catches a long-press that lands on either card's text
+ * (#195). The `void` branch is the detach call React makes with `null`.
+ */
+export function suppressSelectStart(
+  node: HTMLElement | null,
+): (() => void) | undefined {
+  if (node === null) return undefined;
+  node.addEventListener("selectstart", preventDefault);
+  return () => {
+    node.removeEventListener("selectstart", preventDefault);
+  };
 }
 
 /**


### PR DESCRIPTION
Closes #195.

## Problem

On a real Android/Chrome device, long-pressing the hole-card pair briefly
painted a blue text-selection highlight over the cards before it vanished. The
surface already declares `user-select: none`, `-webkit-user-select: none`,
`-webkit-touch-callout: none` and `touch-action: none`, and those are enough to
stop the callout menu — but not the flash.

## Cause

Android Chrome (Blink) still *starts* a selection on long-press and paints the
highlight a frame before `user-select: none` cancels it. Declaring the CSS is
not sufficient; the `selectstart` event itself has to be cancelled.

## Fix

Bind a native `selectstart` listener on the pair's surface that calls
`preventDefault`, via a stable module-scoped callback ref. Selection bubbles, so
one listener covers a long-press on either card. React has no synthetic
`selectstart` event (verified: it drops both `onSelectStart` and
`onselectstart`), which is why it is attached natively rather than declaratively.

## Tests

The node/static-markup harness cannot dispatch a DOM `selectstart`, so the
regression covers the wiring: `suppressSelectStart` is driven with a fake node
and asserted to bind a cancelling listener, remove it on unmount, and no-op on
the `null` detach call. The visual outcome remains a real-device acceptance
step, per the issue.

Targeted tests, `tsc -b packages/player-client`, and `npm run lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)