### PR TITLE
feat(engine): pure Replay capability turning a Hand recording into a flipbook

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -160,7 +160,9 @@ The typed value the engine returns when a Command is not valid —
 `{ type: 'Rejection', reason, command }`. Never thrown, never itself an
 Event, never processed by `apply`. Delivered only to the Device that sent
 the Command, and kept in the Hand recording for audit; it is absent from
-every player-facing shape, including Replay.
+every player-facing shape, including the table-facing Replay position type.
+A Replay of a Hand still carries its Rejections, as the validated developer
+transcript they are.
 _Avoid_: Calling a Rejection an error or an event.
 
 **Room ID**:
@@ -192,9 +194,12 @@ Rejections. Replaying it never requires any other Hand.
 **Replay**:
 Rebuilding a Hand from its Hand recording by re-running its Commands
 through the engine and validating the generated Events against the
-persisted ones. A pure engine capability. Replay obeys live visibility
-exactly: it re-projects `view`, so a muck stays mucked and a folded Seat's
-cards are shown to no one.
+persisted ones. A pure engine capability, taking no audience, redaction or
+`revealEverything` option: it returns complete `EngineState` per position,
+and the visibility split is made by surface. The table surface obeys live
+visibility exactly by re-projecting `view(state, 'table')`, so a muck stays
+mucked and a folded Seat's cards are shown to no one; the local dev stepper
+renders the complete state directly.
 _Avoid_: Treating Replay as a stored playback or a recording of views.
 
 **Replay position**:
@@ -202,6 +207,17 @@ A point within a replayed Hand, addressed as an Event ordinal — position
 *n* is the state after applying *n* Events, and carries that *n*th Event
 alongside it. Position 0 is the starting state with no Event. A Rejection
 occurs *at* a position without advancing it.
+
+**Incomplete replay**:
+A Replay that stops early with everything it did read agreeing — the
+recoverable prefix of a damaged Hand, never a corrupt one. Two causes: a
+single clearly *torn record*, the final JSONL line a `SIGKILL` cut mid-write,
+which the reading adapter discards; and an *orphaned Command*, where the
+Command log runs past the persisted Events because the outcome was never
+recorded. The table hand picker must not offer an incomplete Hand; the dev
+stepper shows the prefix with a warning.
+_Avoid_: Calling either corruption — a disagreement between complete records
+is the corrupt case, and it is a hard failure.
 
 ## Hand lifecycle
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -14,7 +14,7 @@ export type {
   ReplayPosition,
   ReplayRejection,
   ReplaySources,
-  TornRecord,
+  ReplayTornRecord,
 } from "./replay.js";
 export { createInitialState } from "./room.js";
 export { legalActions } from "./table.js";

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -2,6 +2,20 @@ export { apply } from "./apply.js";
 export { decide } from "./decide.js";
 export { evaluate } from "./evaluate.js";
 export type { HandEvaluation } from "./evaluate.js";
+export { replayHand } from "./replay.js";
+export type {
+  ReplayAuditRecord,
+  ReplayCommandRecord,
+  ReplayFailure,
+  ReplayFlipbook,
+  ReplayHandContext,
+  ReplayInput,
+  ReplayOutcome,
+  ReplayPosition,
+  ReplayRejection,
+  ReplaySources,
+  TornRecord,
+} from "./replay.js";
 export { createInitialState } from "./room.js";
 export { legalActions } from "./table.js";
 export { ENGINE_LOG_VERSION } from "./version.js";

--- a/packages/engine/src/replay.test.ts
+++ b/packages/engine/src/replay.test.ts
@@ -1,0 +1,476 @@
+import { describe, expect, it } from "vitest";
+import { apply } from "./apply.js";
+import { decide } from "./decide.js";
+import { replayHand } from "./replay.js";
+import type {
+  ReplayAuditRecord,
+  ReplayCommandRecord,
+  ReplayHandContext,
+  ReplayInput,
+  ReplaySources,
+} from "./replay.js";
+import type { Command, EngineState, HandEvent, Rejection } from "./types.js";
+import { must } from "./util.js";
+import { ENGINE_LOG_VERSION } from "./version.js";
+
+const sources: ReplaySources = {
+  context: "hand-0001.context.json",
+  commands: "hand-0001.commands.jsonl",
+  events: "hand-0001.events.jsonl",
+};
+
+interface Recording {
+  readonly context: ReplayHandContext;
+  readonly commands: ReplayCommandRecord[];
+  readonly events: ReplayAuditRecord[];
+}
+
+/**
+ * Stands in for a live run and the recorder watching it: plays `commands`
+ * from `state` exactly as the server does, and captures the Hand context,
+ * Command log and Event/`Rejection` audit stream a recording would hold.
+ */
+function record(
+  state: EngineState,
+  commands: readonly Command[],
+): { recording: Recording; state: EngineState } {
+  const recording: Recording = {
+    context: {
+      v: ENGINE_LOG_VERSION,
+      seats: [...state.seats],
+      button: state.button,
+    },
+    commands: [],
+    events: [],
+  };
+  let current = state;
+  for (const command of commands) {
+    recording.commands.push({ ...command, v: ENGINE_LOG_VERSION });
+    const outcome = decide(current, command);
+    for (const generated of Array.isArray(outcome) ? outcome : [outcome]) {
+      recording.events.push({ ...generated, v: ENGINE_LOG_VERSION });
+      if (generated.type !== "Rejection") current = apply(current, generated);
+    }
+  }
+  return { recording, state: current };
+}
+
+function inputFrom(
+  recording: Recording,
+  overrides: Partial<ReplayInput> = {},
+): ReplayInput {
+  return { sources, ...recording, ...overrides };
+}
+
+/** A three-seat hand that runs preflop to a fold-out, button on seat 0. */
+function foldOutHand(): Recording {
+  const start: EngineState = { seats: [0, 1, 2], button: 0, hand: null };
+  return record(start, [
+    { type: "startHand", seatId: 0, seed: "replay-seed" },
+    { type: "fold", seatId: 1 },
+    { type: "fold", seatId: 2 },
+  ]).recording;
+}
+
+describe("replayHand: the flipbook", () => {
+  it("makes position 0 the starting state with no event", () => {
+    const outcome = replayHand(inputFrom(foldOutHand()));
+
+    expect(outcome.status).toBe("complete");
+    if (outcome.status !== "complete") return;
+    const first = outcome.positions[0];
+    expect(first).toEqual({
+      position: 0,
+      event: null,
+      state: { seats: [0, 1, 2], button: 0, hand: null },
+    });
+  });
+
+  it("carries the nth generated event and the complete state after applying it", () => {
+    const recording = foldOutHand();
+    const outcome = replayHand(inputFrom(recording));
+
+    expect(outcome.status).toBe("complete");
+    if (outcome.status !== "complete") return;
+
+    const persistedEvents = recording.events.map(({ v, ...rest }) => {
+      void v;
+      return rest as HandEvent;
+    });
+    expect(outcome.positions).toHaveLength(persistedEvents.length + 1);
+    expect(outcome.positions.map((p) => p.event).slice(1)).toEqual(
+      persistedEvents,
+    );
+    expect(outcome.positions.map((p) => p.position)).toEqual(
+      outcome.positions.map((_, index) => index),
+    );
+
+    // Each position's state is the fold of every event up to and including it.
+    let expected: EngineState = { seats: [0, 1, 2], button: 0, hand: null };
+    for (const [index, event] of persistedEvents.entries()) {
+      expected = apply(expected, event);
+      expect(outcome.positions[index + 1]?.state).toEqual(expected);
+    }
+  });
+
+  it("reaches state the terminal view cannot express — a folded-out hand's board", () => {
+    // Seat 1 folds on the turn, leaving a board no `FoldedOutView` carries.
+    const start: EngineState = { seats: [0, 1], button: 0, hand: null };
+    const { recording } = record(start, [
+      { type: "startHand", seatId: 0, seed: "board-seed" },
+      { type: "call", seatId: 0 },
+      { type: "check", seatId: 1 },
+      { type: "check", seatId: 1 },
+      { type: "check", seatId: 0 },
+      { type: "fold", seatId: 1 },
+    ]);
+    const outcome = replayHand(inputFrom(recording));
+
+    expect(outcome.status).toBe("complete");
+    if (outcome.status !== "complete") return;
+    const boardDealt = outcome.positions.find(
+      (position) => position.event?.type === "BoardDealt",
+    );
+    const board =
+      boardDealt?.state.hand?.status === "betting"
+        ? boardDealt.state.hand.board
+        : [];
+    expect(board).toHaveLength(3);
+  });
+
+  it("is pure — the same input replays to the same flipbook", () => {
+    const recording = foldOutHand();
+    expect(replayHand(inputFrom(recording))).toEqual(
+      replayHand(inputFrom(recording)),
+    );
+  });
+});
+
+describe("replayHand: rejections", () => {
+  it("validates them without advancing the event ordinal or changing state", () => {
+    const start: EngineState = { seats: [0, 1, 2], button: 0, hand: null };
+    const { recording } = record(start, [
+      { type: "startHand", seatId: 0, seed: "replay-seed" },
+      // Seat 2 is not the actor preflop (ring is [1, 2, 0]) — rejected.
+      { type: "fold", seatId: 2 },
+      { type: "fold", seatId: 1 },
+      { type: "fold", seatId: 2 },
+    ]);
+    const rejected = recording.events.filter((e) => e.type === "Rejection");
+    expect(rejected).toHaveLength(1);
+
+    const outcome = replayHand(inputFrom(recording));
+    expect(outcome.status).toBe("complete");
+    if (outcome.status !== "complete") return;
+
+    expect(outcome.rejections).toEqual([
+      {
+        position: 3,
+        record: 3,
+        rejection: {
+          type: "Rejection",
+          reason: "not-your-turn",
+          command: { type: "fold", seatId: 2 },
+        } satisfies Rejection,
+      },
+    ]);
+    // Position 3 is the last event before the rejection, and the events after
+    // it carry on from that unchanged state.
+    expect(outcome.positions[3]?.event?.type).toBe("StreetStarted");
+    expect(outcome.positions[4]?.event).toEqual({
+      type: "ActionTaken",
+      seatId: 1,
+      action: "fold",
+    });
+  });
+});
+
+describe("replayHand: the starting state", () => {
+  it("replays a later hand from its recorded button and leading nextHand", () => {
+    // Hand 1 played out live; hand 2 opens on the rotated button and its
+    // command log begins with the `nextHand` that started it.
+    const first = record({ seats: [0, 1, 2], button: 0, hand: null }, [
+      { type: "startHand", seatId: 0, seed: "hand-1" },
+      { type: "fold", seatId: 1 },
+      { type: "fold", seatId: 2 },
+    ]);
+    expect(first.state.button).toBe(1);
+
+    const second = record(first.state, [
+      { type: "nextHand", seatId: 0, seed: "hand-2" },
+      { type: "fold", seatId: 2 },
+      { type: "fold", seatId: 0 },
+    ]);
+    expect(second.recording.context.button).toBe(1);
+
+    const outcome = replayHand(inputFrom(second.recording));
+    expect(outcome.status).toBe("complete");
+    if (outcome.status !== "complete") return;
+    expect(outcome.positions[0]?.state).toEqual({
+      seats: [0, 1, 2],
+      button: 1,
+      hand: null,
+    });
+    expect(outcome.positions.at(-1)?.state).toEqual(second.state);
+  });
+});
+
+describe("replayHand: context validation", () => {
+  it("fails at the boundary when the button is not a seated player", () => {
+    const recording = foldOutHand();
+    const outcome = replayHand(
+      inputFrom(recording, {
+        context: { ...recording.context, button: 7 },
+      }),
+    );
+
+    expect(outcome).toEqual({
+      status: "failed",
+      failure: {
+        kind: "invalid-context",
+        reason: "button-not-seated",
+        file: sources.context,
+      },
+    });
+  });
+
+  it.each([
+    { label: "too few seats", seats: [0] },
+    { label: "too many seats", seats: [0, 1, 2, 3, 4, 5, 6, 7, 8] },
+  ])("fails when a context has $label", ({ seats }) => {
+    const recording = foldOutHand();
+    const outcome = replayHand(
+      inputFrom(recording, {
+        context: { ...recording.context, seats, button: 0 },
+      }),
+    );
+
+    expect(outcome).toEqual({
+      status: "failed",
+      failure: {
+        kind: "invalid-context",
+        reason: "seat-count-out-of-range",
+        file: sources.context,
+      },
+    });
+  });
+
+  it("fails when the command log does not open by starting a hand", () => {
+    const recording = foldOutHand();
+    const outcome = replayHand(
+      inputFrom(recording, { commands: recording.commands.slice(1) }),
+    );
+
+    expect(outcome).toEqual({
+      status: "failed",
+      failure: {
+        kind: "invalid-command-log",
+        reason: "does-not-start-a-hand",
+        file: sources.commands,
+      },
+    });
+  });
+
+  it("fails when the command log is empty", () => {
+    const outcome = replayHand(inputFrom(foldOutHand(), { commands: [] }));
+
+    expect(outcome).toEqual({
+      status: "failed",
+      failure: {
+        kind: "invalid-command-log",
+        reason: "empty",
+        file: sources.commands,
+      },
+    });
+  });
+});
+
+describe("replayHand: version tags", () => {
+  it("rejects a context that does not carry the running engine log version", () => {
+    const recording = foldOutHand();
+    const outcome = replayHand(
+      inputFrom(recording, { context: { ...recording.context, v: 1 } }),
+    );
+
+    expect(outcome).toEqual({
+      status: "failed",
+      failure: {
+        kind: "unsupported-version",
+        expected: ENGINE_LOG_VERSION,
+        actual: 1,
+        file: sources.context,
+        record: null,
+      },
+    });
+  });
+
+  it("rejects a stale command record, naming its file and ordinal", () => {
+    const recording = foldOutHand();
+    const commands = [...recording.commands];
+    commands[2] = { ...must(commands[2]), v: 2 };
+    const outcome = replayHand(inputFrom(recording, { commands }));
+
+    expect(outcome).toEqual({
+      status: "failed",
+      failure: {
+        kind: "unsupported-version",
+        expected: ENGINE_LOG_VERSION,
+        actual: 2,
+        file: sources.commands,
+        record: 2,
+      },
+    });
+  });
+
+  it("rejects a stale event record, naming its file and ordinal", () => {
+    const recording = foldOutHand();
+    const events = [...recording.events];
+    events[1] = { ...must(events[1]), v: 99 };
+    const outcome = replayHand(inputFrom(recording, { events }));
+
+    expect(outcome).toEqual({
+      status: "failed",
+      failure: {
+        kind: "unsupported-version",
+        expected: ENGINE_LOG_VERSION,
+        actual: 99,
+        file: sources.events,
+        record: 1,
+      },
+    });
+  });
+
+  it("reports the version mismatch ahead of an invalid context", () => {
+    const recording = foldOutHand();
+    const outcome = replayHand(
+      inputFrom(recording, {
+        context: { ...recording.context, v: 1, button: 7 },
+      }),
+    );
+
+    expect(outcome.status === "failed" ? outcome.failure.kind : null).toBe(
+      "unsupported-version",
+    );
+  });
+});
+
+describe("replayHand: generated against persisted", () => {
+  it("hard-fails on the first differing record", () => {
+    const recording = foldOutHand();
+    const events = [...recording.events];
+    events[2] = {
+      type: "StreetStarted",
+      street: "preflop",
+      actor: 99,
+      v: ENGINE_LOG_VERSION,
+    };
+    const outcome = replayHand(inputFrom(recording, { events }));
+
+    expect(outcome.status).toBe("failed");
+    if (outcome.status !== "failed") return;
+    expect(outcome.failure.kind).toBe("record-mismatch");
+    if (outcome.failure.kind !== "record-mismatch") return;
+    expect(outcome.failure.record).toBe(2);
+    expect(outcome.failure.file).toBe(sources.events);
+    expect(outcome.failure.generated).toEqual({
+      type: "StreetStarted",
+      street: "preflop",
+      actor: 1,
+    });
+    expect(outcome.failure.persisted).toEqual({
+      type: "StreetStarted",
+      street: "preflop",
+      actor: 99,
+    });
+  });
+
+  it("hard-fails when the persisted stream runs past the generated one", () => {
+    const recording = foldOutHand();
+    const extra = must(recording.events[0]);
+    const outcome = replayHand(
+      inputFrom(recording, { events: [...recording.events, extra] }),
+    );
+
+    expect(outcome.status).toBe("failed");
+    if (outcome.status !== "failed") return;
+    expect(outcome.failure.kind).toBe("record-mismatch");
+    if (outcome.failure.kind !== "record-mismatch") return;
+    expect(outcome.failure.record).toBe(recording.events.length);
+    expect(outcome.failure.generated).toBeNull();
+    expect(outcome.failure.persisted).toEqual({
+      type: "HandStarted",
+      seed: "replay-seed",
+      button: 0,
+    });
+  });
+});
+
+describe("replayHand: incomplete, not corrupt", () => {
+  it("stops at the last corroborated operation for an orphaned trailing command", () => {
+    const recording = foldOutHand();
+    // The audit stream stops after the first fold's `ActionTaken`; the third
+    // command has no recorded outcome at all.
+    const events = recording.events.slice(0, 4);
+    const outcome = replayHand(inputFrom(recording, { events }));
+
+    expect(outcome.status).toBe("incomplete");
+    if (outcome.status !== "incomplete") return;
+    expect(outcome.orphanedCommand).toBe(2);
+    expect(outcome.tornRecord).toBeNull();
+    // Positions cover the whole corroborated prefix and nothing beyond it.
+    expect(outcome.positions).toHaveLength(events.length + 1);
+    expect(outcome.positions.at(-1)?.event).toEqual({
+      type: "ActionTaken",
+      seatId: 1,
+      action: "fold",
+    });
+  });
+
+  it("discards a partially recorded operation rather than half-applying it", () => {
+    const recording = foldOutHand();
+    // Cut mid-operation: the last fold generated three events, only one of
+    // which was recorded before the process died.
+    const events = recording.events.slice(0, recording.events.length - 2);
+    const outcome = replayHand(inputFrom(recording, { events }));
+
+    expect(outcome.status).toBe("incomplete");
+    if (outcome.status !== "incomplete") return;
+    expect(outcome.orphanedCommand).toBe(2);
+    // The half-recorded operation contributes no position at all.
+    expect(outcome.positions).toHaveLength(5);
+    expect(outcome.positions.at(-1)?.event).toEqual({
+      type: "ActionTaken",
+      seatId: 1,
+      action: "fold",
+    });
+  });
+
+  it("reports a torn final record with its file and line", () => {
+    const recording = foldOutHand();
+    const tornRecord = { file: sources.events, line: 9 };
+    const outcome = replayHand(inputFrom(recording, { tornRecord }));
+
+    expect(outcome.status).toBe("incomplete");
+    if (outcome.status !== "incomplete") return;
+    expect(outcome.tornRecord).toEqual(tornRecord);
+    expect(outcome.orphanedCommand).toBeNull();
+    // The intact prefix the adapter did hand over still replays in full.
+    expect(outcome.positions).toHaveLength(recording.events.length + 1);
+  });
+
+  it("reports both when a torn tail also orphaned the trailing command", () => {
+    const recording = foldOutHand();
+    const tornRecord = { file: sources.events, line: 6 };
+    const outcome = replayHand(
+      inputFrom(recording, {
+        events: recording.events.slice(0, 4),
+        tornRecord,
+      }),
+    );
+
+    expect(outcome.status).toBe("incomplete");
+    if (outcome.status !== "incomplete") return;
+    expect(outcome.tornRecord).toEqual(tornRecord);
+    expect(outcome.orphanedCommand).toBe(2);
+  });
+});

--- a/packages/engine/src/replay.test.ts
+++ b/packages/engine/src/replay.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import { apply } from "./apply.js";
-import { decide } from "./decide.js";
 import { replayHand } from "./replay.js";
 import type {
   ReplayAuditRecord,
@@ -9,6 +8,7 @@ import type {
   ReplayInput,
   ReplaySources,
 } from "./replay.js";
+import { play } from "./test-utils.js";
 import type { Command, EngineState, HandEvent, Rejection } from "./types.js";
 import { must } from "./util.js";
 import { ENGINE_LOG_VERSION } from "./version.js";
@@ -46,11 +46,13 @@ function record(
   let current = state;
   for (const command of commands) {
     recording.commands.push({ ...command, v: ENGINE_LOG_VERSION });
-    const outcome = decide(current, command);
-    for (const generated of Array.isArray(outcome) ? outcome : [outcome]) {
-      recording.events.push({ ...generated, v: ENGINE_LOG_VERSION });
-      if (generated.type !== "Rejection") current = apply(current, generated);
+    const outcome = play(current, command);
+    const generated =
+      "rejection" in outcome ? [outcome.rejection] : outcome.events;
+    for (const item of generated) {
+      recording.events.push({ ...item, v: ENGINE_LOG_VERSION });
     }
+    current = outcome.state;
   }
   return { recording, state: current };
 }
@@ -441,6 +443,32 @@ describe("replayHand: incomplete, not corrupt", () => {
     expect(outcome.positions.at(-1)?.event).toEqual({
       type: "ActionTaken",
       seatId: 1,
+      action: "fold",
+    });
+  });
+
+  it("is corrupt, not incomplete, when a surviving tail record disagrees", () => {
+    const recording = foldOutHand();
+    // The last operation generated three events and only one was recorded —
+    // and that one contradicts the Command log. Less evidence than there are
+    // Commands is incomplete only while nothing disagrees.
+    const events = recording.events.slice(0, 5);
+    events[4] = {
+      type: "ActionTaken",
+      seatId: 0,
+      action: "fold",
+      v: ENGINE_LOG_VERSION,
+    };
+    const outcome = replayHand(inputFrom(recording, { events }));
+
+    expect(outcome.status).toBe("failed");
+    if (outcome.status !== "failed") return;
+    expect(outcome.failure.kind).toBe("record-mismatch");
+    if (outcome.failure.kind !== "record-mismatch") return;
+    expect(outcome.failure.record).toBe(4);
+    expect(outcome.failure.generated).toEqual({
+      type: "ActionTaken",
+      seatId: 2,
       action: "fold",
     });
   });

--- a/packages/engine/src/replay.ts
+++ b/packages/engine/src/replay.ts
@@ -7,11 +7,17 @@ import type {
   Rejection,
   SeatId,
 } from "./types.js";
+import { must } from "./util.js";
 import { ENGINE_LOG_VERSION } from "./version.js";
 
 /**
- * The Hand-start context a recording holds: the participating Seats and the
- * Button the Hand was dealt on. Not a state snapshot — it carries no cards.
+ * The Hand context (CONTEXT.md), narrowed to the two facts Replay bootstraps
+ * from: the participating Seats and the Button the Hand was dealt on. Not a
+ * state snapshot — it carries no cards.
+ *
+ * The recording's own context document also carries the Hand ordinal and
+ * `startedAt`; neither enters the engine. The ordinal addresses a file in a
+ * layout the engine knows nothing about, and `startedAt` is a clock.
  */
 export interface ReplayHandContext {
   readonly v: number;
@@ -39,7 +45,7 @@ export interface ReplaySources {
 }
 
 /** A clearly torn final JSONL record the caller's reader discarded. */
-export interface TornRecord {
+export interface ReplayTornRecord {
   readonly file: string;
   readonly line: number;
 }
@@ -50,7 +56,7 @@ export interface ReplayInput {
   readonly commands: readonly ReplayCommandRecord[];
   /** The persisted Event/`Rejection` stream, as audit evidence. */
   readonly events: readonly ReplayAuditRecord[];
-  readonly tornRecord?: TornRecord | null;
+  readonly tornRecord?: ReplayTornRecord | null;
 }
 
 /**
@@ -117,11 +123,11 @@ export type ReplayOutcome =
   | ({ readonly status: "complete" } & ReplayFlipbook)
   | ({
       readonly status: "incomplete";
-      readonly tornRecord: TornRecord | null;
+      readonly tornRecord: ReplayTornRecord | null;
       /**
-       * The ordinal of the first Command with no complete audit evidence —
-       * where replay stopped. Null when only a torn record made it
-       * incomplete.
+       * The zero-based ordinal, in the Command log, of the first Command with
+       * no complete audit evidence — where replay stopped. Null when only a
+       * torn record made the replay incomplete.
        */
       readonly orphanedCommand: number | null;
     } & ReplayFlipbook)
@@ -169,16 +175,46 @@ export function replayHand(input: ReplayInput): ReplayOutcome {
   };
   const positions: ReplayPosition[] = [{ position: 0, event: null, state }];
   const rejections: ReplayRejection[] = [];
-  let record = 0;
+  let audit = 0;
 
   for (const [ordinal, commandRecord] of input.commands.entries()) {
-    const outcome = decide(state, asCommand(commandRecord, ordinal === 0));
-    const generated = Array.isArray(outcome) ? outcome : [outcome];
+    const command =
+      ordinal === 0
+        ? openingCommand(commandRecord)
+        : bareCommand(commandRecord);
+    const outcome = decide(state, command);
+    const generated = Array.isArray(outcome)
+      ? outcome
+      : [asRecorded(outcome, commandRecord)];
+
+    // Whatever evidence survives is compared before anything is concluded
+    // from its length: a truncated operation is only *incomplete* when the
+    // records that did survive agree. One that contradicts them is corrupt.
+    const corroborated = Math.min(
+      generated.length,
+      input.events.length - audit,
+    );
+    for (let offset = 0; offset < corroborated; offset += 1) {
+      const item = must(generated[offset]);
+      const persisted = withoutVersion(must(input.events[audit + offset]));
+      if (!equal(item, persisted)) {
+        return {
+          status: "failed",
+          failure: {
+            kind: "record-mismatch",
+            record: audit + offset,
+            generated: item,
+            persisted,
+            file: input.sources.events,
+          },
+        };
+      }
+    }
 
     // Only a fully corroborated operation is committed: a half-recorded one
     // leaves the flipbook at the last complete position rather than applying
     // events no audit record backs.
-    if (record + generated.length > input.events.length) {
+    if (corroborated < generated.length) {
       return {
         status: "incomplete",
         positions,
@@ -187,28 +223,12 @@ export function replayHand(input: ReplayInput): ReplayOutcome {
         orphanedCommand: ordinal,
       };
     }
-    for (const [offset, item] of generated.entries()) {
-      const persisted = input.events[record + offset];
-      if (persisted === undefined || !equal(item, withoutVersion(persisted))) {
-        return {
-          status: "failed",
-          failure: {
-            kind: "record-mismatch",
-            record: record + offset,
-            generated: item,
-            persisted:
-              persisted === undefined ? null : withoutVersion(persisted),
-            file: input.sources.events,
-          },
-        };
-      }
-    }
 
     for (const [offset, item] of generated.entries()) {
       if (item.type === "Rejection") {
         rejections.push({
           position: positions.length - 1,
-          record: record + offset,
+          record: audit + offset,
           rejection: item,
         });
         continue;
@@ -216,16 +236,16 @@ export function replayHand(input: ReplayInput): ReplayOutcome {
       state = apply(state, item);
       positions.push({ position: positions.length, event: item, state });
     }
-    record += generated.length;
+    audit += generated.length;
   }
 
-  const trailing = input.events[record];
+  const trailing = input.events[audit];
   if (trailing !== undefined) {
     return {
       status: "failed",
       failure: {
         kind: "record-mismatch",
-        record,
+        record: audit,
         generated: null,
         persisted: withoutVersion(trailing),
         file: input.sources.events,
@@ -249,17 +269,36 @@ export function replayHand(input: ReplayInput): ReplayOutcome {
 /**
  * A Hand's Command log opens with the operation that started it, which for
  * every Hand after the first is a `nextHand`. `decide` only accepts that
- * against a completed Hand, and Replay is scoped to one Hand — so the opening
- * Command is run as the `startHand` it behaved as. Both take the same path
- * through `beginHand`, on the same seed and the same recorded Button, so the
- * generated Events are identical to the ones the live run recorded.
+ * against a *completed* Hand, and Replay is scoped to one Hand starting from
+ * no Hand at all — so the opening Command is run as the `startHand` it
+ * behaved as. Both take the same path through `beginHand`, on the same seed
+ * and the same recorded Button, so the generated Events are identical to the
+ * ones the live run recorded.
  */
-function asCommand(record: ReplayCommandRecord, opensHand: boolean): Command {
-  const { v, ...command } = record;
-  void v;
-  if (opensHand && command.type === "nextHand") {
+function openingCommand(record: ReplayCommandRecord): Command {
+  const command = bareCommand(record);
+  if (command.type === "nextHand") {
     return { type: "startHand", seatId: command.seatId, seed: command.seed };
   }
+  return command;
+}
+
+/**
+ * Restores the Command as *recorded* onto a generated Rejection. `decide`
+ * echoes back whatever Command it was handed, so without this the opening
+ * `nextHand`-as-`startHand` substitution above would leak into the comparison
+ * and report a faithful recording as corrupt.
+ */
+function asRecorded(
+  rejection: Rejection,
+  record: ReplayCommandRecord,
+): Rejection {
+  return { ...rejection, command: bareCommand(record) };
+}
+
+function bareCommand(record: ReplayCommandRecord): Command {
+  const { v, ...command } = record;
+  void v;
   return command;
 }
 

--- a/packages/engine/src/replay.ts
+++ b/packages/engine/src/replay.ts
@@ -1,0 +1,372 @@
+import { apply } from "./apply.js";
+import { decide } from "./decide.js";
+import type {
+  Command,
+  EngineState,
+  HandEvent,
+  Rejection,
+  SeatId,
+} from "./types.js";
+import { ENGINE_LOG_VERSION } from "./version.js";
+
+/**
+ * The Hand-start context a recording holds: the participating Seats and the
+ * Button the Hand was dealt on. Not a state snapshot — it carries no cards.
+ */
+export interface ReplayHandContext {
+  readonly v: number;
+  readonly seats: readonly SeatId[];
+  readonly button: SeatId;
+}
+
+/** One persisted Command line: the bare `Command` plus its version tag. */
+export type ReplayCommandRecord = Command & { readonly v: number };
+
+/** One persisted audit line: a `HandEvent` or `Rejection` plus its version tag. */
+export type ReplayAuditRecord = (HandEvent | Rejection) & {
+  readonly v: number;
+};
+
+/**
+ * Where each stream came from, for diagnostics. Replay never opens these —
+ * the I/O-owning caller reads the files and names them here so a failure can
+ * say which one it is about.
+ */
+export interface ReplaySources {
+  readonly context: string;
+  readonly commands: string;
+  readonly events: string;
+}
+
+/** A clearly torn final JSONL record the caller's reader discarded. */
+export interface TornRecord {
+  readonly file: string;
+  readonly line: number;
+}
+
+export interface ReplayInput {
+  readonly sources: ReplaySources;
+  readonly context: ReplayHandContext;
+  readonly commands: readonly ReplayCommandRecord[];
+  /** The persisted Event/`Rejection` stream, as audit evidence. */
+  readonly events: readonly ReplayAuditRecord[];
+  readonly tornRecord?: TornRecord | null;
+}
+
+/**
+ * One notch of the flipbook: its generated Event and the complete
+ * `EngineState` after applying it. Position 0 is the starting state and has
+ * no Event.
+ *
+ * The state is carried whole, never as a projected view: `FoldedOutView`
+ * has no board, so a fold-out hand's board would be unreachable from a
+ * sequence of views alone.
+ */
+export interface ReplayPosition {
+  readonly position: number;
+  readonly event: HandEvent | null;
+  readonly state: EngineState;
+}
+
+/**
+ * A validated Rejection. It changes no state and creates no position:
+ * `position` is the unchanged position it occurred at, and `record` is its
+ * ordinal in the persisted audit stream.
+ */
+export interface ReplayRejection {
+  readonly position: number;
+  readonly record: number;
+  readonly rejection: Rejection;
+}
+
+export interface ReplayFlipbook {
+  readonly positions: readonly ReplayPosition[];
+  readonly rejections: readonly ReplayRejection[];
+}
+
+export type ReplayFailure =
+  | {
+      readonly kind: "unsupported-version";
+      readonly expected: number;
+      readonly actual: number;
+      readonly file: string;
+      /** The record's ordinal in its file; null for the single-record context. */
+      readonly record: number | null;
+    }
+  | {
+      readonly kind: "invalid-context";
+      readonly reason: "button-not-seated" | "seat-count-out-of-range";
+      readonly file: string;
+    }
+  | {
+      readonly kind: "invalid-command-log";
+      readonly reason: "empty" | "does-not-start-a-hand";
+      readonly file: string;
+    }
+  | {
+      readonly kind: "record-mismatch";
+      /** The first differing record's ordinal in the audit stream. */
+      readonly record: number;
+      /** Null when the persisted stream runs past what the Commands generate. */
+      readonly generated: HandEvent | Rejection | null;
+      readonly persisted: HandEvent | Rejection | null;
+      readonly file: string;
+    };
+
+export type ReplayOutcome =
+  | ({ readonly status: "complete" } & ReplayFlipbook)
+  | ({
+      readonly status: "incomplete";
+      readonly tornRecord: TornRecord | null;
+      /**
+       * The ordinal of the first Command with no complete audit evidence —
+       * where replay stopped. Null when only a torn record made it
+       * incomplete.
+       */
+      readonly orphanedCommand: number | null;
+    } & ReplayFlipbook)
+  | { readonly status: "failed"; readonly failure: ReplayFailure };
+
+/**
+ * Replays one recorded Hand into an addressable flipbook of positions.
+ *
+ * The Command log is the source of truth: Commands are re-run through
+ * `decide`, the Events they generate are folded through `apply`, and the
+ * complete generated Event/`Rejection` sequence is *compared* against the
+ * persisted audit stream. Persisted records are never trusted, repaired or
+ * substituted — a disagreement between complete records is a hard failure.
+ *
+ * Pure by construction: no filesystem, no clock, no ambient randomness. It
+ * takes no audience, redaction or `revealEverything` option — the visibility
+ * split is by surface, and callers project the returned state themselves.
+ */
+export function replayHand(input: ReplayInput): ReplayOutcome {
+  const versionFailure = firstVersionMismatch(input);
+  if (versionFailure !== null) {
+    return { status: "failed", failure: versionFailure };
+  }
+
+  const contextFailure = validateContext(input.context, input.sources.context);
+  if (contextFailure !== null) {
+    return { status: "failed", failure: contextFailure };
+  }
+
+  const commandFailure = validateCommandLog(
+    input.commands,
+    input.sources.commands,
+  );
+  if (commandFailure !== null) {
+    return { status: "failed", failure: commandFailure };
+  }
+
+  // Replay builds its own starting state: `createInitialState` hard-codes the
+  // button to `seats[0]`, and a general "state at an arbitrary Button" export
+  // would weaken that invariant for every live caller.
+  let state: EngineState = {
+    seats: [...input.context.seats],
+    button: input.context.button,
+    hand: null,
+  };
+  const positions: ReplayPosition[] = [{ position: 0, event: null, state }];
+  const rejections: ReplayRejection[] = [];
+  let record = 0;
+
+  for (const [ordinal, commandRecord] of input.commands.entries()) {
+    const outcome = decide(state, asCommand(commandRecord, ordinal === 0));
+    const generated = Array.isArray(outcome) ? outcome : [outcome];
+
+    // Only a fully corroborated operation is committed: a half-recorded one
+    // leaves the flipbook at the last complete position rather than applying
+    // events no audit record backs.
+    if (record + generated.length > input.events.length) {
+      return {
+        status: "incomplete",
+        positions,
+        rejections,
+        tornRecord: input.tornRecord ?? null,
+        orphanedCommand: ordinal,
+      };
+    }
+    for (const [offset, item] of generated.entries()) {
+      const persisted = input.events[record + offset];
+      if (persisted === undefined || !equal(item, withoutVersion(persisted))) {
+        return {
+          status: "failed",
+          failure: {
+            kind: "record-mismatch",
+            record: record + offset,
+            generated: item,
+            persisted:
+              persisted === undefined ? null : withoutVersion(persisted),
+            file: input.sources.events,
+          },
+        };
+      }
+    }
+
+    for (const [offset, item] of generated.entries()) {
+      if (item.type === "Rejection") {
+        rejections.push({
+          position: positions.length - 1,
+          record: record + offset,
+          rejection: item,
+        });
+        continue;
+      }
+      state = apply(state, item);
+      positions.push({ position: positions.length, event: item, state });
+    }
+    record += generated.length;
+  }
+
+  const trailing = input.events[record];
+  if (trailing !== undefined) {
+    return {
+      status: "failed",
+      failure: {
+        kind: "record-mismatch",
+        record,
+        generated: null,
+        persisted: withoutVersion(trailing),
+        file: input.sources.events,
+      },
+    };
+  }
+
+  if (input.tornRecord != null) {
+    return {
+      status: "incomplete",
+      positions,
+      rejections,
+      tornRecord: input.tornRecord,
+      orphanedCommand: null,
+    };
+  }
+
+  return { status: "complete", positions, rejections };
+}
+
+/**
+ * A Hand's Command log opens with the operation that started it, which for
+ * every Hand after the first is a `nextHand`. `decide` only accepts that
+ * against a completed Hand, and Replay is scoped to one Hand — so the opening
+ * Command is run as the `startHand` it behaved as. Both take the same path
+ * through `beginHand`, on the same seed and the same recorded Button, so the
+ * generated Events are identical to the ones the live run recorded.
+ */
+function asCommand(record: ReplayCommandRecord, opensHand: boolean): Command {
+  const { v, ...command } = record;
+  void v;
+  if (opensHand && command.type === "nextHand") {
+    return { type: "startHand", seatId: command.seatId, seed: command.seed };
+  }
+  return command;
+}
+
+function withoutVersion(record: ReplayAuditRecord): HandEvent | Rejection {
+  const { v, ...rest } = record;
+  void v;
+  return rest;
+}
+
+function firstVersionMismatch(input: ReplayInput): ReplayFailure | null {
+  const mismatch = (
+    actual: number,
+    file: string,
+    record: number | null,
+  ): ReplayFailure => ({
+    kind: "unsupported-version",
+    expected: ENGINE_LOG_VERSION,
+    actual,
+    file,
+    record,
+  });
+
+  if (input.context.v !== ENGINE_LOG_VERSION) {
+    return mismatch(input.context.v, input.sources.context, null);
+  }
+  for (const [ordinal, command] of input.commands.entries()) {
+    if (command.v !== ENGINE_LOG_VERSION) {
+      return mismatch(command.v, input.sources.commands, ordinal);
+    }
+  }
+  for (const [ordinal, event] of input.events.entries()) {
+    if (event.v !== ENGINE_LOG_VERSION) {
+      return mismatch(event.v, input.sources.events, ordinal);
+    }
+  }
+  return null;
+}
+
+/**
+ * The same 2-to-8 bound `createInitialState` enforces, plus the Button being
+ * a seated player. Checked here so a context naming a Button that was never
+ * dealt in fails as an invalid context, not somewhere inside
+ * `rotateFromButton`.
+ */
+function validateContext(
+  context: ReplayHandContext,
+  file: string,
+): ReplayFailure | null {
+  if (context.seats.length < 2 || context.seats.length > 8) {
+    return { kind: "invalid-context", reason: "seat-count-out-of-range", file };
+  }
+  if (!context.seats.includes(context.button)) {
+    return { kind: "invalid-context", reason: "button-not-seated", file };
+  }
+  return null;
+}
+
+function validateCommandLog(
+  commands: readonly ReplayCommandRecord[],
+  file: string,
+): ReplayFailure | null {
+  const first = commands[0];
+  if (first === undefined) {
+    return { kind: "invalid-command-log", reason: "empty", file };
+  }
+  if (first.type !== "startHand" && first.type !== "nextHand") {
+    return {
+      kind: "invalid-command-log",
+      reason: "does-not-start-a-hand",
+      file,
+    };
+  }
+  return null;
+}
+
+/**
+ * Structural equality over parsed JSON records. Key order survives a JSONL
+ * round trip, so `JSON.stringify` would usually agree — but "usually" is not
+ * what an audit comparison is for.
+ */
+function equal(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) || Array.isArray(b)) {
+    return (
+      Array.isArray(a) &&
+      Array.isArray(b) &&
+      a.length === b.length &&
+      a.every((item, index) => equal(item, b[index]))
+    );
+  }
+  if (
+    typeof a !== "object" ||
+    typeof b !== "object" ||
+    a === null ||
+    b === null
+  ) {
+    return false;
+  }
+  const left = a as Record<string, unknown>;
+  const right = b as Record<string, unknown>;
+  const keys = Object.keys(left);
+  return (
+    keys.length === Object.keys(right).length &&
+    keys.every(
+      (key) =>
+        Object.prototype.hasOwnProperty.call(right, key) &&
+        equal(left[key], right[key]),
+    )
+  );
+}


### PR DESCRIPTION
Implements #115 — the pure `Replay` capability that turns one Hand's recording into an addressable flipbook. Based on `replay`, as the issue requires.

## What landed

`replayHand` in `packages/engine/src/replay.ts`, exported from the engine. It takes a Hand's context, that Hand's ordered Command records and its persisted Event/`Rejection` records as audit evidence, re-runs the Commands through `decide`, folds generated Events through `apply`, and **compares** the complete generated sequence against the persisted stream. Persisted records are never trusted, repaired or substituted.

It builds its own `{ seats, button, hand: null }` starting state — no new engine export, since `createInitialState` hard-codes the Button to `seats[0]` and a general "state at an arbitrary Button" export would weaken that invariant for every live caller.

Outcomes are a returned union rather than thrown errors, so the §7 CLI can map them straight onto its exit table:

- `complete` — positions plus validated rejections.
- `incomplete` — the recoverable prefix, carrying a torn record (file + line) and/or the zero-based ordinal of the orphaned Command it stopped at. Both can be reported together.
- `failed` — a typed failure: `unsupported-version` (expected, actual, file, record), `invalid-context` (`button-not-seated`, `seat-count-out-of-range`), `invalid-command-log`, or `record-mismatch` naming the first differing record.

Position 0 is the starting state with no Event; position *n* carries the *n*th generated Event and the complete `EngineState` after applying it. Rejections are validated, change no state and do not advance the Event ordinal — they carry the unchanged position they occurred at and their ordinal in the audit stream.

## Two decisions worth review

**The opening Command is run as the `startHand` it behaved as.** A Hand's Command log opens with `nextHand` for every Hand after the first, and `decide` only accepts that against a completed Hand — but Replay is scoped to one Hand starting from no Hand at all. Both take the same `beginHand` path on the same seed and recorded Button, so the generated Events are identical to the ones the live run recorded. Without this, no Hand after the first would replay. A generated `Rejection` has the Command restored as recorded, so the substitution cannot leak into the comparison.

**Two CONTEXT.md glossary entries are corrected.** The Replay entry said the capability "re-projects `view`", which contradicts #115's "the engine returns complete state and no projected view" — the projection is the table *surface's* job (§4). The Rejection entry said Rejections are absent from Replay, where §5 makes them absent from the *table-facing position type* and §7 makes them first-class in the dev stepper. A new **Incomplete replay** entry names the torn-record and orphaned-Command vocabulary.

## Review findings fixed before merge

The spec review caught a real bug in the first commit: the length guard ran ahead of the comparison, so a final operation whose outcome was only partly recorded was called incomplete without checking the records that *did* survive — a tail contradicting the Command log read as recoverable damage rather than corruption. The surviving prefix is now compared first and only a clean-but-short one is downgraded, with a regression test.

## Verification

- 22 replay tests, and the full engine suite green: 23 files, 120 tests — including Phase 1's fast-check secrecy property test, unchanged.
- `npx tsc -b` across the monorepo exits 0; `npm run lint` (eslint + prettier) clean.

Not run: the full monorepo suite — CI is the source of truth for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3VFrqszkqnwkkcqvfddh7
