### PR TITLE
feat(protocol): shared hand summaries and the hand-listing wire contract

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -219,6 +219,27 @@ stepper shows the prefix with a warning.
 _Avoid_: Calling either corruption — a disagreement between complete records
 is the corrupt case, and it is a hard failure.
 
+**Hand summary**:
+What one completed Hand looks like in a list of them — its ordinal and
+start time, the Button, the Seats dealt in and the Survivors, the public
+Board, the Street reached, the Betting shape and the outcome. Derived once,
+by a pure function over the Hand's Events, so the server and anything
+replaying from disk cannot disagree about it.
+_Avoid_: Calling it a Hand context — that is the document a Hand recording
+opens with, not this projection of a finished Hand.
+
+**Betting shape**:
+How the betting went, as one of five structured descriptors — a walk, a
+preflop raise, checked down, one raise, or a raise war with its raise
+count. It is what makes otherwise identical fold-outs distinguishable in a
+list. Structured, never prose: the wording belongs to whichever client
+renders it.
+
+**Survivor**:
+A Seat that was dealt into a Hand and never folded. One Survivor means the
+Hand folded out; two or more mean it reached Showdown. Distinct from the
+Seats dealt in, which folding never reduces.
+
 ## Hand lifecycle
 
 ```

--- a/packages/player-client/src/actions/rejectionCopy.ts
+++ b/packages/player-client/src/actions/rejectionCopy.ts
@@ -33,5 +33,9 @@ export function rejectionCopy(
       return "Not enough players to start.";
     case "not-permitted":
       return "That's not something you can do.";
+    case "replay-not-supported":
+      // Replay is a table-device surface; a phone never sends the request
+      // this answers, so this exists only to keep the switch exhaustive.
+      return "Hand review isn't available here.";
   }
 }

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -198,6 +198,12 @@ export function useWebSocket(
             active = false;
             optionsRef.current.onEvicted?.();
             break;
+          case "hand-list":
+          case "hand-summary":
+            // Hand review is a table-device surface (#129 §6); the server
+            // never sends these to a seat, and a phone has nothing to do
+            // with one if it ever did.
+            break;
         }
       });
     }

--- a/packages/protocol/src/hand.ts
+++ b/packages/protocol/src/hand.ts
@@ -17,9 +17,19 @@ export interface HandUpdateMessage {
   readonly view: PlayerView | TableView;
 }
 
-/** A server-rejected command, reason-coded, delivered to the sender only. */
+/**
+ * A server-rejected command, reason-coded, delivered to the sender only.
+ *
+ * `replay-not-supported` answers a well-formed replay request this server
+ * cannot serve yet, so a client can tell "not built" from a dropped socket.
+ * It retires when the Replay read path lands.
+ */
 export type ServerRejectionReason =
-  "invalid-command" | "room-not-found" | "not-enough-players" | "not-permitted";
+  | "invalid-command"
+  | "room-not-found"
+  | "not-enough-players"
+  | "not-permitted"
+  | "replay-not-supported";
 
 export interface CommandRejectedMessage {
   readonly type: "command-rejected";

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,4 +1,6 @@
 export * from "@table-top-poker/engine";
 export * from "./command-schema.js";
 export * from "./hand.js";
+export * from "./replay-schema.js";
 export * from "./room.js";
+export * from "./summary.js";

--- a/packages/protocol/src/replay-schema.test.ts
+++ b/packages/protocol/src/replay-schema.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { ReplayRequestSchema } from "./replay-schema.js";
+
+describe("ReplayRequestSchema", () => {
+  it("accepts a bare list-hands request", () => {
+    expect(ReplayRequestSchema.safeParse({ type: "list-hands" }).success).toBe(
+      true,
+    );
+  });
+
+  it("accepts a get-hand request addressing an ordinal", () => {
+    const result = ReplayRequestSchema.safeParse({
+      type: "get-hand",
+      handOrdinal: 4,
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data).toEqual({
+      type: "get-hand",
+      handOrdinal: 4,
+    });
+  });
+
+  it("rejects a get-hand with no ordinal", () => {
+    expect(ReplayRequestSchema.safeParse({ type: "get-hand" }).success).toBe(
+      false,
+    );
+  });
+
+  it.each([0, -1, 1.5, "4", null])(
+    "rejects %p as a hand ordinal",
+    (handOrdinal) => {
+      const result = ReplayRequestSchema.safeParse({
+        type: "get-hand",
+        handOrdinal,
+      });
+      expect(result.success).toBe(false);
+    },
+  );
+
+  it("rejects unknown fields on a request", () => {
+    const result = ReplayRequestSchema.safeParse({
+      type: "list-hands",
+      roomCode: "attacker-chosen",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an unknown request type", () => {
+    expect(ReplayRequestSchema.safeParse({ type: "get-room" }).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects a non-object payload", () => {
+    expect(ReplayRequestSchema.safeParse("list-hands").success).toBe(false);
+    expect(ReplayRequestSchema.safeParse(null).success).toBe(false);
+  });
+});

--- a/packages/protocol/src/replay-schema.ts
+++ b/packages/protocol/src/replay-schema.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+/**
+ * Wire-level shape of a replay request a client sends over the *existing*
+ * room socket — no separate HTTP route, because the socket already carries
+ * room and per-seat identity from connect time (Phase 2 spec #129 §5).
+ *
+ * A deliberate sibling of `ClientCommandSchema` rather than a member of it:
+ * a replay request never reaches `decide`, but it is untrusted JSON crossing
+ * the same boundary, so it is parsed by the same Zod seam before the server
+ * acts on it.
+ *
+ * The room is never client-supplied here — the server reads it off the
+ * authenticated socket, exactly as it does for a command.
+ */
+export const ReplayRequestSchema = z.discriminatedUnion("type", [
+  /** "Send me every hand this session has played." */
+  z.strictObject({ type: z.literal("list-hands") }),
+  /** "Send me hand N", addressed by the 1-based ordinal a summary carries. */
+  z.strictObject({
+    type: z.literal("get-hand"),
+    handOrdinal: z.int().positive(),
+  }),
+]);
+
+export type ReplayRequest = z.infer<typeof ReplayRequestSchema>;
+export type ReplayRequestType = ReplayRequest["type"];

--- a/packages/protocol/src/replay-schema.ts
+++ b/packages/protocol/src/replay-schema.ts
@@ -24,4 +24,3 @@ export const ReplayRequestSchema = z.discriminatedUnion("type", [
 ]);
 
 export type ReplayRequest = z.infer<typeof ReplayRequestSchema>;
-export type ReplayRequestType = ReplayRequest["type"];

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -6,6 +6,7 @@ import type {
 } from "@table-top-poker/engine";
 import { z } from "zod";
 import type { CommandRejectedMessage, HandUpdateMessage } from "./hand.js";
+import type { HandSummary } from "./summary.js";
 
 /**
  * How many seats a room may be created with (issue #74). Two is the
@@ -219,6 +220,28 @@ export interface RoomEndedMessage {
   readonly type: "room-ended";
 }
 
+/**
+ * The session's hands so far, oldest ordinal first — sent when a table
+ * identity connects, and in answer to a `list-hands` request. Deliberately
+ * its own message and not part of `RoomView`, which changes on a different
+ * cadence (seats, presence) and should not grow on every seat change
+ * (Phase 2 spec #129 §5). Replaces the recipient's list wholesale.
+ */
+export interface HandListMessage {
+  readonly type: "hand-list";
+  readonly summaries: readonly HandSummary[];
+}
+
+/**
+ * One hand's summary, pushed the moment that hand completes. Appends to the
+ * list a `hand-list` established, so a table that connected mid-session
+ * never has to re-request the hands it already holds.
+ */
+export interface HandSummaryMessage {
+  readonly type: "hand-summary";
+  readonly summary: HandSummary;
+}
+
 export type ServerMessage =
   | RoomViewMessage
   | PlayerEvictedMessage
@@ -226,4 +249,6 @@ export type ServerMessage =
   | HandUpdateMessage
   | CommandRejectedMessage
   | ViewSnapshotMessage
-  | RoomEndedMessage;
+  | RoomEndedMessage
+  | HandListMessage
+  | HandSummaryMessage;

--- a/packages/protocol/src/summary.test.ts
+++ b/packages/protocol/src/summary.test.ts
@@ -1,0 +1,368 @@
+import type { Card, HandEvent, SeatId } from "@table-top-poker/engine";
+import { describe, expect, it } from "vitest";
+import { summarise, type HandContext } from "./summary.js";
+
+const context: HandContext = {
+  handOrdinal: 3,
+  startedAt: "2026-08-13T19:04:00.000Z",
+};
+
+function card(rank: Card["rank"], suit: Card["suit"]): Card {
+  return { rank, suit };
+}
+
+const FLOP: Card[] = [
+  card("2", "clubs"),
+  card("7", "hearts"),
+  card("K", "spades"),
+];
+const TURN: Card[] = [card("9", "diamonds")];
+const RIVER: Card[] = [card("A", "clubs")];
+
+/** The three events every hand opens with, for a given button and field. */
+function opening(button: SeatId, seats: readonly SeatId[]): HandEvent[] {
+  return [
+    { type: "HandStarted", seed: "seed", button },
+    {
+      type: "HoleCardsDealt",
+      deals: seats.map((seatId) => ({
+        seatId,
+        cards: [card("3", "clubs"), card("4", "clubs")] as [Card, Card],
+      })),
+    },
+    { type: "StreetStarted", street: "preflop", actor: seats[0] ?? 0 },
+  ];
+}
+
+function fold(seatId: SeatId): HandEvent {
+  return { type: "ActionTaken", seatId, action: "fold" };
+}
+
+function check(seatId: SeatId): HandEvent {
+  return { type: "ActionTaken", seatId, action: "check" };
+}
+
+function raise(seatId: SeatId): HandEvent {
+  return { type: "ActionTaken", seatId, action: "raise" };
+}
+
+function call(seatId: SeatId): HandEvent {
+  return { type: "ActionTaken", seatId, action: "call" };
+}
+
+/** The board deal plus the street's opening event, as the engine emits them. */
+function street(
+  name: "flop" | "turn" | "river",
+  cards: Card[],
+  actor: SeatId,
+): HandEvent[] {
+  return [
+    {
+      type: "StreetClosed",
+      street: name === "flop" ? "preflop" : name === "turn" ? "flop" : "turn",
+    },
+    { type: "BoardDealt", street: name, cards },
+    { type: "StreetStarted", street: name, actor },
+  ];
+}
+
+function foldedOut(winner: SeatId): HandEvent[] {
+  return [{ type: "HandFoldedOut", winner }, { type: "HandComplete" }];
+}
+
+function showdown(seats: readonly SeatId[], winners: SeatId[]): HandEvent[] {
+  return [
+    { type: "StreetClosed", street: "river" },
+    {
+      type: "ShowdownReached",
+      results: seats.map((seatId) => ({
+        seatId,
+        rank: winners.includes(seatId) ? 2 : 1,
+        bestHand: [...FLOP, ...TURN, ...RIVER] as [
+          Card,
+          Card,
+          Card,
+          Card,
+          Card,
+        ],
+        description: `seat ${String(seatId)}'s hand`,
+      })),
+      winners,
+    },
+    { type: "HandComplete" },
+  ];
+}
+
+describe("summarise", () => {
+  it("carries the context's ordinal and start time through untouched", () => {
+    const summary = summarise(
+      [...opening(2, [0, 1, 2]), fold(0), fold(1), ...foldedOut(2)],
+      context,
+    );
+    expect(summary.handOrdinal).toBe(3);
+    expect(summary.startedAt).toBe("2026-08-13T19:04:00.000Z");
+  });
+
+  it("reads the button and the dealt-in field off the opening events", () => {
+    const summary = summarise(
+      [...opening(2, [0, 1, 2]), fold(0), fold(1), ...foldedOut(2)],
+      context,
+    );
+    expect(summary.button).toBe(2);
+    expect(summary.seatsDealtIn).toEqual([0, 1, 2]);
+  });
+
+  it("counts everyone who never folded as a survivor", () => {
+    const summary = summarise(
+      [
+        ...opening(0, [0, 1, 2, 3]),
+        fold(1),
+        call(2),
+        call(3),
+        check(0),
+        ...street("flop", FLOP, 2),
+        check(2),
+        check(3),
+        fold(0),
+        ...street("turn", TURN, 2),
+        check(2),
+        fold(3),
+        ...foldedOut(2),
+      ],
+      context,
+    );
+    expect(summary.seatsDealtIn).toEqual([0, 1, 2, 3]);
+    expect(summary.survivors).toEqual([2]);
+  });
+
+  it("collects the public board in deal order and reports the street reached", () => {
+    const summary = summarise(
+      [
+        ...opening(0, [0, 1]),
+        call(0),
+        check(1),
+        ...street("flop", FLOP, 1),
+        check(1),
+        check(0),
+        ...street("turn", TURN, 1),
+        check(1),
+        fold(0),
+        ...foldedOut(1),
+      ],
+      context,
+    );
+    expect(summary.board).toEqual([...FLOP, ...TURN]);
+    expect(summary.streetReached).toBe("turn");
+  });
+
+  it("leaves the board empty on a hand that died preflop", () => {
+    const summary = summarise(
+      [...opening(1, [0, 1]), fold(0), ...foldedOut(1)],
+      context,
+    );
+    expect(summary.board).toEqual([]);
+    expect(summary.streetReached).toBe("preflop");
+  });
+
+  describe("betting shape", () => {
+    it("calls an unraised preflop fold-out a walk", () => {
+      const summary = summarise(
+        [...opening(1, [0, 1, 2]), fold(0), fold(1), ...foldedOut(2)],
+        context,
+      );
+      expect(summary.bettingShape).toEqual({ kind: "walk" });
+    });
+
+    it("calls a single raise that ends it preflop a preflop raise", () => {
+      const summary = summarise(
+        [...opening(1, [0, 1, 2]), raise(0), fold(1), fold(2), ...foldedOut(0)],
+        context,
+      );
+      expect(summary.bettingShape).toEqual({ kind: "preflop-raise" });
+    });
+
+    it("calls a hand with no raise at all checked down", () => {
+      const summary = summarise(
+        [
+          ...opening(0, [0, 1]),
+          call(0),
+          check(1),
+          ...street("flop", FLOP, 1),
+          check(1),
+          check(0),
+          ...street("turn", TURN, 1),
+          check(1),
+          check(0),
+          ...street("river", RIVER, 1),
+          check(1),
+          check(0),
+          ...showdown([0, 1], [1]),
+        ],
+        context,
+      );
+      expect(summary.bettingShape).toEqual({ kind: "checked-down" });
+    });
+
+    it("calls one raise past preflop a one-raise hand", () => {
+      const summary = summarise(
+        [
+          ...opening(0, [0, 1]),
+          call(0),
+          check(1),
+          ...street("flop", FLOP, 1),
+          raise(1),
+          call(0),
+          ...street("turn", TURN, 1),
+          check(1),
+          fold(0),
+          ...foldedOut(1),
+        ],
+        context,
+      );
+      expect(summary.bettingShape).toEqual({ kind: "one-raise" });
+    });
+
+    it("counts the raises in a raise war, wherever they fell", () => {
+      const summary = summarise(
+        [
+          ...opening(0, [0, 1]),
+          raise(0),
+          raise(1),
+          raise(0),
+          call(1),
+          ...street("flop", FLOP, 1),
+          raise(1),
+          fold(0),
+          ...foldedOut(1),
+        ],
+        context,
+      );
+      expect(summary.bettingShape).toEqual({ kind: "raise-war", raises: 4 });
+    });
+
+    it("prefers the raise count over the preflop shorthand once it is a war", () => {
+      const summary = summarise(
+        [
+          ...opening(0, [0, 1, 2]),
+          raise(0),
+          raise(1),
+          fold(2),
+          fold(0),
+          ...foldedOut(1),
+        ],
+        context,
+      );
+      expect(summary.bettingShape).toEqual({ kind: "raise-war", raises: 2 });
+    });
+  });
+
+  describe("outcome", () => {
+    it("names the last player standing on a fold-out", () => {
+      const summary = summarise(
+        [...opening(1, [0, 1, 2]), fold(0), fold(1), ...foldedOut(2)],
+        context,
+      );
+      expect(summary.outcome).toEqual({ kind: "folded-out", winner: 2 });
+    });
+
+    it("carries every showdown reveal and the winners", () => {
+      const summary = summarise(
+        [
+          ...opening(0, [0, 1]),
+          call(0),
+          check(1),
+          ...street("flop", FLOP, 1),
+          check(1),
+          check(0),
+          ...street("turn", TURN, 1),
+          check(1),
+          check(0),
+          ...street("river", RIVER, 1),
+          check(1),
+          check(0),
+          ...showdown([0, 1], [1]),
+        ],
+        context,
+      );
+      expect(summary.outcome).toEqual({
+        kind: "showdown",
+        winners: [1],
+        reveals: [
+          {
+            seatId: 0,
+            bestHand: [...FLOP, ...TURN, ...RIVER],
+            description: "seat 0's hand",
+          },
+          {
+            seatId: 1,
+            bestHand: [...FLOP, ...TURN, ...RIVER],
+            description: "seat 1's hand",
+          },
+        ],
+      });
+      expect(summary.survivors).toEqual([0, 1]);
+    });
+
+    it("carries every winner of a split pot", () => {
+      const summary = summarise(
+        [
+          ...opening(0, [0, 1]),
+          call(0),
+          check(1),
+          ...street("flop", FLOP, 1),
+          check(1),
+          check(0),
+          ...street("turn", TURN, 1),
+          check(1),
+          check(0),
+          ...street("river", RIVER, 1),
+          check(1),
+          check(0),
+          ...showdown([0, 1], [0, 1]),
+        ],
+        context,
+      );
+      expect(summary.outcome).toMatchObject({
+        kind: "showdown",
+        winners: [0, 1],
+      });
+    });
+  });
+
+  describe("incomplete and invalid recordings", () => {
+    it("refuses a hand that never completed", () => {
+      expect(() =>
+        summarise([...opening(1, [0, 1, 2]), fold(0)], context),
+      ).toThrow(/HandComplete/);
+    });
+
+    it("refuses a stream that never started a hand", () => {
+      expect(() => summarise([{ type: "HandComplete" }], context)).toThrow(
+        /HandStarted/,
+      );
+    });
+
+    it("refuses a completed hand with no outcome event", () => {
+      expect(() =>
+        summarise(
+          [...opening(1, [0, 1]), fold(0), { type: "HandComplete" }],
+          context,
+        ),
+      ).toThrow(/outcome/);
+    });
+
+    it("refuses an empty stream", () => {
+      expect(() => summarise([], context)).toThrow();
+    });
+  });
+
+  it("derives nothing from ambient state — the same events summarise identically twice", () => {
+    const events: HandEvent[] = [
+      ...opening(1, [0, 1, 2]),
+      fold(0),
+      fold(1),
+      ...foldedOut(2),
+    ];
+    expect(summarise(events, context)).toEqual(summarise(events, context));
+  });
+});

--- a/packages/protocol/src/summary.test.ts
+++ b/packages/protocol/src/summary.test.ts
@@ -1,8 +1,8 @@
 import type { Card, HandEvent, SeatId } from "@table-top-poker/engine";
 import { describe, expect, it } from "vitest";
-import { summarise, type HandContext } from "./summary.js";
+import { summarise, type HandSummaryContext } from "./summary.js";
 
-const context: HandContext = {
+const context: HandSummaryContext = {
   handOrdinal: 3,
   startedAt: "2026-08-13T19:04:00.000Z",
 };

--- a/packages/protocol/src/summary.ts
+++ b/packages/protocol/src/summary.ts
@@ -1,0 +1,167 @@
+import type { Card, HandEvent, SeatId, Street } from "@table-top-poker/engine";
+
+/**
+ * How the betting went, as a descriptor rather than a sentence (Phase 2
+ * spec #129 §5). The felt's wording — *walk — folded round*, *raise war — 4
+ * raises* — lives in `table-client` with the rest of its copy; putting it
+ * here would force the dev stepper (§7) to parse English back into a number
+ * `summarise` already had.
+ */
+export type BettingShape =
+  | { readonly kind: "walk" }
+  | { readonly kind: "preflop-raise" }
+  | { readonly kind: "checked-down" }
+  | { readonly kind: "one-raise" }
+  | { readonly kind: "raise-war"; readonly raises: number };
+
+/**
+ * One seat's showdown hand as the whole room saw it. Reveals only ever come
+ * from a `ShowdownReached` event, which the engine emits solely for seats
+ * that reached showdown live — so nothing here widens the visibility
+ * boundary (Phase 1 spec #130 §4).
+ */
+export interface ShowdownReveal {
+  readonly seatId: SeatId;
+  readonly bestHand: readonly [Card, Card, Card, Card, Card];
+  readonly description: string;
+}
+
+export type HandOutcome =
+  | { readonly kind: "folded-out"; readonly winner: SeatId }
+  | {
+      readonly kind: "showdown";
+      readonly winners: readonly SeatId[];
+      readonly reveals: readonly ShowdownReveal[];
+    };
+
+/**
+ * The two facts about a hand that its own Events cannot answer: where it sits
+ * in the session, and when it began. Everything else in a `HandSummary` is
+ * derived, which is what keeps `summarise` free of a clock and of ambient
+ * state.
+ */
+export interface HandContext {
+  /** 1-based, matching the recording's `hand-NNNN` partition. */
+  readonly handOrdinal: number;
+  /** ISO 8601 — the picker's start-time clock reads this (§6). */
+  readonly startedAt: string;
+}
+
+/** One row of the table device's hand picker, derived once and shared (§5). */
+export interface HandSummary {
+  readonly handOrdinal: number;
+  readonly startedAt: string;
+  readonly button: SeatId;
+  /** Every seat the hand was dealt to, in deal order — folds never remove one. */
+  readonly seatsDealtIn: readonly SeatId[];
+  /** The seats that never folded; one on a fold-out, two or more at showdown. */
+  readonly survivors: readonly SeatId[];
+  readonly board: readonly Card[];
+  readonly streetReached: Street;
+  readonly bettingShape: BettingShape;
+  readonly outcome: HandOutcome;
+}
+
+/** Raised when a recording is not a complete, valid hand — never for a well-formed one. */
+export class IncompleteHandError extends Error {}
+
+function bettingShapeOf(
+  raises: number,
+  streetReached: Street,
+  outcome: HandOutcome,
+): BettingShape {
+  // A raise count of two or more is the more informative reading even when
+  // the war was settled preflop, so it wins over the preflop shorthand.
+  if (raises >= 2) return { kind: "raise-war", raises };
+  const diedPreflop =
+    outcome.kind === "folded-out" && streetReached === "preflop";
+  if (raises === 1)
+    return diedPreflop ? { kind: "preflop-raise" } : { kind: "one-raise" };
+  return diedPreflop ? { kind: "walk" } : { kind: "checked-down" };
+}
+
+/**
+ * Derives a hand's picker summary from the Events it produced.
+ *
+ * Pure: no I/O, no clock, no ambient state. The server calls it with the
+ * Events it just broadcast; anything replaying from disk calls it with the
+ * Events it just validated. Sharing one derivation is the point — two
+ * independent ones would drift, and the picker would disagree with the scrub
+ * it opens (Phase 2 spec #129 §5).
+ *
+ * Throws `IncompleteHandError` unless `events` is a complete hand: it must
+ * open with `HandStarted`, close with `HandComplete`, and carry an outcome.
+ * Callers holding a partial recording are expected to keep it out of the
+ * listing rather than summarise it (§4).
+ */
+export function summarise(
+  events: readonly HandEvent[],
+  context: HandContext,
+): HandSummary {
+  const started = events.find((event) => event.type === "HandStarted");
+  if (started === undefined) {
+    throw new IncompleteHandError("hand recording has no HandStarted event");
+  }
+  if (!events.some((event) => event.type === "HandComplete")) {
+    throw new IncompleteHandError("hand recording has no HandComplete event");
+  }
+
+  const seatsDealtIn: SeatId[] = [];
+  const folded = new Set<SeatId>();
+  const board: Card[] = [];
+  let streetReached: Street = "preflop";
+  let raises = 0;
+  let outcome: HandOutcome | undefined;
+
+  for (const event of events) {
+    switch (event.type) {
+      case "HoleCardsDealt":
+        for (const deal of event.deals) seatsDealtIn.push(deal.seatId);
+        break;
+      case "StreetStarted":
+        streetReached = event.street;
+        break;
+      case "ActionTaken":
+        if (event.action === "fold") folded.add(event.seatId);
+        if (event.action === "raise") raises += 1;
+        break;
+      case "BoardDealt":
+        board.push(...event.cards);
+        break;
+      case "HandFoldedOut":
+        outcome = { kind: "folded-out", winner: event.winner };
+        break;
+      case "ShowdownReached":
+        outcome = {
+          kind: "showdown",
+          winners: [...event.winners],
+          reveals: event.results.map(({ seatId, bestHand, description }) => ({
+            seatId,
+            bestHand: [...bestHand] as [Card, Card, Card, Card, Card],
+            description,
+          })),
+        };
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (outcome === undefined) {
+    throw new IncompleteHandError(
+      "hand recording completed with no outcome event",
+    );
+  }
+
+  return {
+    handOrdinal: context.handOrdinal,
+    startedAt: context.startedAt,
+    button: started.button,
+    seatsDealtIn,
+    survivors: seatsDealtIn.filter((seatId) => !folded.has(seatId)),
+    board,
+    streetReached,
+    bettingShape: bettingShapeOf(raises, streetReached, outcome),
+    outcome,
+  };
+}

--- a/packages/protocol/src/summary.ts
+++ b/packages/protocol/src/summary.ts
@@ -39,8 +39,14 @@ export type HandOutcome =
  * in the session, and when it began. Everything else in a `HandSummary` is
  * derived, which is what keeps `summarise` free of a clock and of ambient
  * state.
+ *
+ * Deliberately *not* named `HandContext`: that term is taken, and means the
+ * four-field document a Hand recording opens with (`CONTEXT.md`). This is a
+ * strict subset — the Seats and Button it also carries are derivable from the
+ * Events, so asking a caller for them would invite two answers to one
+ * question.
  */
-export interface HandContext {
+export interface HandSummaryContext {
   /** 1-based, matching the recording's `hand-NNNN` partition. */
   readonly handOrdinal: number;
   /** ISO 8601 — the picker's start-time clock reads this (§6). */
@@ -65,13 +71,25 @@ export interface HandSummary {
 /** Raised when a recording is not a complete, valid hand — never for a well-formed one. */
 export class IncompleteHandError extends Error {}
 
+/**
+ * The five shapes partition every hand, and the spec fixes the union without
+ * fixing the predicates. Two boundary calls are made here deliberately:
+ *
+ * 1. **Two or more raises reads as a war wherever it happened**, so a preflop
+ *    3-bet that ends preflop is `raise-war`, not `preflop-raise`. The count is
+ *    the more informative fact, and `preflop-raise` — "preflop raise took it"
+ *    — describes *one* raise winning uncontested.
+ * 2. **`checked-down` is the residual**, so it also covers an unraised hand
+ *    that saw a flop and then folded out. `walk` is reserved for the hand that
+ *    died preflop, which is the distinction the picker needs (a walk is a
+ *    visibly short row). The felt's copy for `checked-down` should therefore
+ *    not promise a showdown — that is a `table-client` wording decision.
+ */
 function bettingShapeOf(
   raises: number,
   streetReached: Street,
   outcome: HandOutcome,
 ): BettingShape {
-  // A raise count of two or more is the more informative reading even when
-  // the war was settled preflop, so it wins over the preflop shorthand.
   if (raises >= 2) return { kind: "raise-war", raises };
   const diedPreflop =
     outcome.kind === "folded-out" && streetReached === "preflop";
@@ -96,7 +114,7 @@ function bettingShapeOf(
  */
 export function summarise(
   events: readonly HandEvent[],
-  context: HandContext,
+  context: HandSummaryContext,
 ): HandSummary {
   const started = events.find((event) => event.type === "HandStarted");
   if (started === undefined) {

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -2590,6 +2590,34 @@ describe("hand summaries over WebSocket", () => {
     });
   });
 
+  it("answers a well-formed get-hand rather than dropping it", async () => {
+    const { table } = await seatedRoom();
+    table.socket.send(JSON.stringify({ type: "get-hand", handOrdinal: 1 }));
+    await settle();
+
+    expect(table.messages).toContainEqual({
+      type: "command-rejected",
+      reason: "replay-not-supported",
+    });
+  });
+
+  it("summarises nothing for a hand still in progress", async () => {
+    const { code, table, seats } = await seatedRoom();
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    await foldToTheEnd(code, seats);
+
+    table.socket.send(JSON.stringify({ type: "nextHand" }));
+    await settle();
+
+    // The second hand is live, so the listing still holds only the first —
+    // an ordinal is spent at the deal, but a row is earned at completion.
+    expect(rooms.get(code)?.engine?.hand?.status).toBe("betting");
+    expect(
+      summariesIn(table.messages).map((m) => m.summary.handOrdinal),
+    ).toEqual([1]);
+  });
+
   it("keeps the hand listing out of RoomView", async () => {
     const { code, table, seats } = await seatedRoom();
     table.socket.send(JSON.stringify({ type: "startHand" }));

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -1027,8 +1027,11 @@ describe("WebSocket upgrade", () => {
       socket.on("error", reject);
     });
     await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(messages).toHaveLength(1);
-    expect(messages[0]).toEqual({
+    // A table also gets its (empty) hand listing on connect; this test is
+    // about the room views, so count only those.
+    const roomViews = () => messages.filter((m) => m.type === "room-view");
+    expect(roomViews()).toHaveLength(1);
+    expect(roomViews()[0]).toEqual({
       type: "room-view",
       view: {
         code: room.code,
@@ -1045,9 +1048,8 @@ describe("WebSocket upgrade", () => {
     });
     await new Promise((resolve) => setTimeout(resolve, 20));
 
-    expect(messages).toHaveLength(2);
-    expect(messages[1]?.type).toBe("room-view");
-    expect((messages[1] as { view: RoomView }).view.seats[0]).toEqual({
+    expect(roomViews()).toHaveLength(2);
+    expect((roomViews()[1] as { view: RoomView }).view.seats[0]).toEqual({
       id: 0,
       claimed: true,
       displayName: "Avery",
@@ -2375,6 +2377,258 @@ describe("presence and reconnection", () => {
     expect(rooms.get(room.code)).toBeDefined();
     expect(reconnectedTable.messages).not.toContainEqual({
       type: "room-ended",
+    });
+  });
+});
+
+describe("hand summaries over WebSocket", () => {
+  let app: FastifyInstance;
+  let rooms: RoomStore;
+  let port: number;
+
+  beforeEach(async () => {
+    rooms = new RoomStore();
+    app = await buildApp({ rooms, recordings: testRecordings() });
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected a bound TCP address");
+    }
+    port = address.port;
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  function connect(query: string): {
+    socket: WebSocket;
+    messages: ServerMessage[];
+  } {
+    const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/ws?${query}`);
+    const messages: ServerMessage[] = [];
+    socket.on("message", (data: Buffer) => {
+      messages.push(JSON.parse(data.toString()) as ServerMessage);
+    });
+    return { socket, messages };
+  }
+
+  async function opened(socket: WebSocket): Promise<void> {
+    if (socket.readyState === WebSocket.OPEN) return;
+    await new Promise<void>((resolve, reject) => {
+      socket.on("open", resolve);
+      socket.on("error", reject);
+    });
+  }
+
+  async function settle(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+
+  async function claimAndConnect(
+    code: string,
+    seatId: number,
+  ): Promise<{ socket: WebSocket; messages: ServerMessage[] }> {
+    const claim = rooms.claimSeat(code, seatId, `P${String(seatId)}`);
+    if (!("seat" in claim)) throw new Error("expected a claimed seat");
+    const conn = connect(
+      `room=${code}&seat=${String(seatId)}&token=${claim.seat.token ?? ""}`,
+    );
+    await opened(conn.socket);
+    return conn;
+  }
+
+  /** A three-seat room with the table and every seat connected. */
+  async function seatedRoom(): Promise<{
+    code: string;
+    table: { socket: WebSocket; messages: ServerMessage[] };
+    seats: Record<number, { socket: WebSocket; messages: ServerMessage[] }>;
+  }> {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const seats = {
+      0: await claimAndConnect(room.code, 0),
+      1: await claimAndConnect(room.code, 1),
+      2: await claimAndConnect(room.code, 2),
+    };
+    await settle();
+    return { code: room.code, table, seats };
+  }
+
+  /** Folds whoever is on the clock until the hand is over. */
+  async function foldToTheEnd(
+    code: string,
+    seats: Record<number, { socket: WebSocket }>,
+  ): Promise<void> {
+    for (let i = 0; i < 8; i++) {
+      if (rooms.get(code)?.engine?.hand?.status === "complete") return;
+      const actor = rooms.currentActor(code);
+      if (actor === undefined) throw new Error("expected a current actor");
+      seats[actor]?.socket.send(JSON.stringify({ type: "fold" }));
+      await settle();
+    }
+    throw new Error("hand did not complete");
+  }
+
+  function summariesIn(messages: ServerMessage[]) {
+    return messages.filter((m) => m.type === "hand-summary");
+  }
+
+  it("pushes one summary to the table the moment a hand completes", async () => {
+    const { code, table, seats } = await seatedRoom();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    expect(summariesIn(table.messages)).toHaveLength(0);
+
+    await foldToTheEnd(code, seats);
+
+    const summaries = summariesIn(table.messages);
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]?.summary).toMatchObject({
+      handOrdinal: 1,
+      bettingShape: { kind: "walk" },
+      streetReached: "preflop",
+      board: [],
+    });
+    // Deal order is button-relative, so assert the field, not its rotation.
+    expect([...(summaries[0]?.summary.seatsDealtIn ?? [])].sort()).toEqual([
+      0, 1, 2,
+    ]);
+    expect(summaries[0]?.summary.survivors).toHaveLength(1);
+    expect(summaries[0]?.summary.outcome.kind).toBe("folded-out");
+    expect(Date.parse(summaries[0]?.summary.startedAt ?? "")).not.toBeNaN();
+  });
+
+  it("never pushes a summary to a player's socket", async () => {
+    const { code, table, seats } = await seatedRoom();
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    await foldToTheEnd(code, seats);
+
+    for (const seat of Object.values(seats)) {
+      expect(summariesIn(seat.messages)).toHaveLength(0);
+      expect(seat.messages.some((m) => m.type === "hand-list")).toBe(false);
+    }
+  });
+
+  it("numbers hands 1-based across the room's life", async () => {
+    const { code, table, seats } = await seatedRoom();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    await foldToTheEnd(code, seats);
+    table.socket.send(JSON.stringify({ type: "nextHand" }));
+    await settle();
+    await foldToTheEnd(code, seats);
+
+    expect(
+      summariesIn(table.messages).map((m) => m.summary.handOrdinal),
+    ).toEqual([1, 2]);
+  });
+
+  it("gives a table that connects mid-session the whole accumulated list", async () => {
+    const { code, table, seats } = await seatedRoom();
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    await foldToTheEnd(code, seats);
+    table.socket.send(JSON.stringify({ type: "nextHand" }));
+    await settle();
+    await foldToTheEnd(code, seats);
+
+    // The kiosk reloads; Phase 1's catch-up snapshot carries no summaries.
+    table.socket.close();
+    await settle();
+    const reloaded = connect(`room=${code}&role=table`);
+    await opened(reloaded.socket);
+    await settle();
+
+    const list = reloaded.messages.find((m) => m.type === "hand-list");
+    expect(list?.summaries.map((s) => s.handOrdinal)).toEqual([1, 2]);
+  });
+
+  it("answers a list-hands request with the accumulated list", async () => {
+    const { code, table, seats } = await seatedRoom();
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    await foldToTheEnd(code, seats);
+
+    table.messages.length = 0;
+    table.socket.send(JSON.stringify({ type: "list-hands" }));
+    await settle();
+
+    const list = table.messages.find((m) => m.type === "hand-list");
+    expect(list?.summaries).toHaveLength(1);
+    expect(table.messages.some((m) => m.type === "command-rejected")).toBe(
+      false,
+    );
+  });
+
+  it("refuses a list-hands request from a player's socket", async () => {
+    const { seats } = await seatedRoom();
+    const seat = seats[0];
+    if (seat === undefined) throw new Error("expected a connected seat");
+    seat.socket.send(JSON.stringify({ type: "list-hands" }));
+    await settle();
+
+    expect(seat.messages).toContainEqual({
+      type: "command-rejected",
+      reason: "not-permitted",
+    });
+    expect(seat.messages.some((m) => m.type === "hand-list")).toBe(false);
+  });
+
+  it("rejects a malformed replay request at the same boundary as a command", async () => {
+    const { table } = await seatedRoom();
+    table.socket.send(JSON.stringify({ type: "get-hand", handOrdinal: 0 }));
+    await settle();
+
+    expect(table.messages).toContainEqual({
+      type: "command-rejected",
+      reason: "invalid-command",
+    });
+  });
+
+  it("keeps the hand listing out of RoomView", async () => {
+    const { code, table, seats } = await seatedRoom();
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    await foldToTheEnd(code, seats);
+
+    const view = table.messages.findLast((m) => m.type === "room-view")?.view;
+    expect(JSON.stringify(view)).not.toContain("handOrdinal");
+  });
+
+  it("starts a fresh table's listing empty rather than silent", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    await settle();
+
+    expect(table.messages).toContainEqual({
+      type: "hand-list",
+      summaries: [],
+    });
+  });
+
+  it("discards the listing when the room ends", async () => {
+    const { code, table, seats } = await seatedRoom();
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    await foldToTheEnd(code, seats);
+
+    await app.inject({ method: "POST", url: `/rooms/${code}/end` });
+    await settle();
+
+    const revived = rooms.create();
+    const freshTable = connect(`room=${revived.code}&role=table`);
+    await opened(freshTable.socket);
+    await settle();
+
+    expect(freshTable.messages).toContainEqual({
+      type: "hand-list",
+      summaries: [],
     });
   });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -260,11 +260,23 @@ export async function buildApp(
    * already broadcast, so `summarise` can be handed the whole hand the
    * moment it completes. `startedAt` is stamped here rather than inside
    * `summarise`, which stays free of a clock.
+   *
+   * `handOrdinal` is stamped at `HandStarted` and counts hands *started*, not
+   * hands completed — that is what `HandLog` numbers its `hand-NNNN`
+   * partitions by, and a summary's ordinal is the address `get-hand` will
+   * resolve against a recording. Counting completions instead would silently
+   * desynchronise the two the first time a hand was abandoned mid-deal.
    */
   const handsInProgress = new Map<
     string,
-    { readonly startedAt: string; readonly events: HandEvent[] }
+    {
+      readonly handOrdinal: number;
+      readonly startedAt: string;
+      readonly events: HandEvent[];
+    }
   >();
+  /** Hands *started* per room, so an abandoned hand still consumes its ordinal. */
+  const handsStarted = new Map<string, number>();
   const pingIntervalMs = options.pingIntervalMs ?? 10_000;
   const missedPongLimit = options.missedPongLimit ?? 2;
   const graceWindowMs = options.graceWindowMs ?? 60_000;
@@ -424,6 +436,7 @@ export async function buildApp(
     actionClock.clear(code);
     handSummaries.delete(code);
     handsInProgress.delete(code);
+    handsStarted.delete(code);
     closeRecording(code);
     rooms.end(code);
   }
@@ -461,7 +474,10 @@ export async function buildApp(
   ): void {
     for (const step of steps) {
       if (step.event.type === "HandStarted") {
+        const handOrdinal = (handsStarted.get(code) ?? 0) + 1;
+        handsStarted.set(code, handOrdinal);
         handsInProgress.set(code, {
+          handOrdinal,
           startedAt: new Date().toISOString(),
           events: [],
         });
@@ -472,13 +488,22 @@ export async function buildApp(
       if (step.event.type !== "HandComplete") continue;
 
       handsInProgress.delete(code);
+      let summary: HandSummary;
+      try {
+        summary = summarise(inProgress.events, {
+          handOrdinal: inProgress.handOrdinal,
+          startedAt: inProgress.startedAt,
+        });
+      } catch {
+        // Only complete, valid hands enter the listing (§4). Unreachable by
+        // construction — this ran because the room broadcast `HandComplete`
+        // — but `publishDispatch` is also called from the action clock's
+        // timer, where a throw would surface as an unhandled rejection long
+        // after the events had gone out. Losing one picker row is the
+        // cheaper failure.
+        continue;
+      }
       const summaries = handSummaries.get(code) ?? [];
-      const summary = summarise(inProgress.events, {
-        // 1-based across the Room's life, matching the recording's
-        // `hand-NNNN` partition.
-        handOrdinal: summaries.length + 1,
-        startedAt: inProgress.startedAt,
-      });
       summaries.push(summary);
       handSummaries.set(code, summaries);
       sendToTables(code, { type: "hand-summary", summary });
@@ -1013,10 +1038,14 @@ export async function buildApp(
             }
             if (replay.data.type === "list-hands") {
               sendHandList(socket, code);
+            } else {
+              // `get-hand` is served by the Replay capability, which lands
+              // with the recording read path; the request shape is validated
+              // here so that ticket adds a response, not a boundary. Answer
+              // rather than drop it, so a client can tell an unbuilt feature
+              // from a dead socket.
+              sendRejection(socket, "replay-not-supported");
             }
-            // `get-hand` is served by the Replay capability, which lands with
-            // the recording read path; the request shape is validated here so
-            // that ticket adds a response, not a boundary.
             return;
           }
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -7,9 +7,12 @@ import {
   LeaveSeatRequestSchema,
   ClientCommandSchema,
   CreateRoomRequestSchema,
+  ReplayRequestSchema,
+  summarise,
   view,
   type CommandRejectedMessage,
   type HandEvent,
+  type HandSummary,
   isHandComplete,
   type SeatId,
   type SeatCountChangeError,
@@ -245,6 +248,23 @@ export async function buildApp(
   const now = options.now ?? (() => new Date());
   /** One open recording per live room, keyed by join code like every other map here. */
   const roomRecordings = new Map<string, RoomRecording>();
+  /**
+   * Every completed hand of a room, oldest first, held for the Room's life —
+   * no disk read is involved (Phase 2 spec #129 §5). A server restart
+   * destroys the Room outright, so there is no session whose listing would
+   * need rebuilding.
+   */
+  const handSummaries = new Map<string, HandSummary[]>();
+  /**
+   * The hand currently being dealt, accumulating the Events the room has
+   * already broadcast, so `summarise` can be handed the whole hand the
+   * moment it completes. `startedAt` is stamped here rather than inside
+   * `summarise`, which stays free of a clock.
+   */
+  const handsInProgress = new Map<
+    string,
+    { readonly startedAt: string; readonly events: HandEvent[] }
+  >();
   const pingIntervalMs = options.pingIntervalMs ?? 10_000;
   const missedPongLimit = options.missedPongLimit ?? 2;
   const graceWindowMs = options.graceWindowMs ?? 60_000;
@@ -402,8 +422,67 @@ export async function buildApp(
       tableGraceTimers.delete(code);
     }
     actionClock.clear(code);
+    handSummaries.delete(code);
+    handsInProgress.delete(code);
     closeRecording(code);
     rooms.end(code);
+  }
+
+  /**
+   * The hand listing is a table-device surface (Phase 2 spec #129 §6), so
+   * summaries go only to table identities — a player's socket never receives
+   * one, and never asks for one.
+   */
+  function sendToTables(code: string, message: ServerMessage): void {
+    const sockets = roomSockets.get(code);
+    if (!sockets) return;
+    for (const socket of sockets) {
+      if (socketIdentity.get(socket) === "table") send(socket, message);
+    }
+  }
+
+  function sendHandList(socket: WebSocket, code: string): void {
+    send(socket, {
+      type: "hand-list",
+      summaries: handSummaries.get(code) ?? [],
+    });
+  }
+
+  /**
+   * Feeds the Events the room just broadcast into the hand being recorded,
+   * and summarises that hand the moment it completes — the same moment
+   * "Review hands" becomes reachable (§6). Only a hand seen whole, from its
+   * `HandStarted` to its `HandComplete`, is ever summarised, so a listing
+   * can't be built from a partial recording (§4).
+   */
+  function accumulateHandSummary(
+    code: string,
+    steps: readonly DispatchStep[],
+  ): void {
+    for (const step of steps) {
+      if (step.event.type === "HandStarted") {
+        handsInProgress.set(code, {
+          startedAt: new Date().toISOString(),
+          events: [],
+        });
+      }
+      const inProgress = handsInProgress.get(code);
+      if (inProgress === undefined) continue;
+      inProgress.events.push(step.event);
+      if (step.event.type !== "HandComplete") continue;
+
+      handsInProgress.delete(code);
+      const summaries = handSummaries.get(code) ?? [];
+      const summary = summarise(inProgress.events, {
+        // 1-based across the Room's life, matching the recording's
+        // `hand-NNNN` partition.
+        handOrdinal: summaries.length + 1,
+        startedAt: inProgress.startedAt,
+      });
+      summaries.push(summary);
+      handSummaries.set(code, summaries);
+      sendToTables(code, { type: "hand-summary", summary });
+    }
   }
 
   /**
@@ -541,6 +620,9 @@ export async function buildApp(
     for (const step of result.steps) {
       fanOutHandUpdate(code, step);
     }
+    // After the fan-out: the summary describes a hand the room has already
+    // seen, so no table learns of a completed hand before its last Event.
+    accumulateHandSummary(code, result.steps);
     if (options.actionClock === "preserve") {
       if (rooms.currentActor(code) === undefined) actionClock.clear(code);
     } else {
@@ -874,6 +956,11 @@ export async function buildApp(
         const room = rooms.get(code);
         if (room) {
           broadcastRoomView(code);
+          // Incremental pushes alone would leave a reloaded table with an
+          // empty picker for hands it had already seen — Phase 1's catch-up
+          // is one view snapshot, which carries no summaries (§5). Sent even
+          // when empty, so the picker has a definite starting state.
+          if (identity === "table") sendHandList(socket, code);
           // One fresh snapshot on connect, never event replay (§7, §9).
           if (room.engine !== null) {
             if (identity === "table") {
@@ -912,7 +999,24 @@ export async function buildApp(
 
           const parseResult = ClientCommandSchema.safeParse(parsed);
           if (!parseResult.success) {
-            sendRejection(socket, "invalid-command");
+            // A replay request rides this same socket and this same Zod
+            // boundary, in its own schema, even though it never reaches
+            // `decide` (§5).
+            const replay = ReplayRequestSchema.safeParse(parsed);
+            if (!replay.success) {
+              sendRejection(socket, "invalid-command");
+              return;
+            }
+            if (socketIdentity.get(socket) !== "table") {
+              sendRejection(socket, "not-permitted");
+              return;
+            }
+            if (replay.data.type === "list-hands") {
+              sendHandList(socket, code);
+            }
+            // `get-hand` is served by the Replay capability, which lands with
+            // the recording read path; the request shape is validated here so
+            // that ticket adds a response, not a boundary.
             return;
           }
 


### PR DESCRIPTION
Implements #116 (Phase 2 spec #129 §5). Based on `replay`, per the ticket's build-branch note.

## What landed

**`summarise(events, context)` — `packages/protocol/src/summary.ts`**
A pure derivation of a hand's picker summary from the Events it produced: no I/O, no clock, no ambient state. The server calls it with the Events it just broadcast; anything replaying from disk will call it with the Events it just validated, so the picker can never drift from the scrub it opens.

`HandContext` carries only the two facts a hand's own Events cannot answer — `handOrdinal` and `startedAt`. Everything else (`button`, `seatsDealtIn`, `survivors`, `board`, `streetReached`, `bettingShape`, `outcome`) is derived. `summarise` throws `IncompleteHandError` on a recording that isn't a complete, valid hand, so a partial one cannot reach the listing.

**`bettingShape`** is the structured discriminated union the spec specifies — no prose crosses the wire. A raise count of two or more reads as `raise-war` even when the war was settled preflop, since the count is the more informative fact.

**`ReplayRequestSchema` — `packages/protocol/src/replay-schema.ts`**
A sibling discriminated union next to `ClientCommandSchema` (`list-hands` / `get-hand`), validated at the same Zod boundary in the socket's message handler even though it never reaches `decide`. `get-hand`'s response belongs to the ticket that lands the recording read path; the boundary is here so that ticket adds a response, not a boundary.

**Server — `packages/server/src/app.ts`**
Accumulates the current hand's Events, and on `HandComplete` summarises it and pushes `hand-summary` to the table. The accumulated list is held in memory for the Room's life (no disk read) and discarded with the Room. A table identity gets the whole list as `hand-list` on connect — including when empty — so a kiosk reloaded mid-session never comes back to an empty picker.

Both messages are their own types on `ServerMessage`; `RoomView` is untouched.

## Verification

- Full suite: 90 files, 823 tests, all passing
- `npx tsc -b` clean; `npm run lint` (eslint + prettier) clean

## Note on file contention

The ticket warns that #114, #116, #118 and #121 all edit `app.ts` around `logDispatch` / `publishDispatch` / hand completion. This branch adds a call to `accumulateHandSummary` immediately after the `fanOutHandUpdate` loop in `publishDispatch`, and a second parse arm in the socket's `message` handler — expect to reconcile those two spots when the siblings land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJDHcvEAKdKUkhrJiwZRNL