### PR TITLE
fix(player): let the hole cards fill the phone they land on

### DIFF
--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -298,24 +298,16 @@ function TurnBanner({ banner }: { readonly banner: Banner }) {
 }
 
 /**
- * A caption under a pair is a label — small, spaced, uppercase; a caption
- * under empty slots is a sentence explaining why they're empty, and reads as
- * prose.
+ * Empty slots get a sentence saying why they are empty, so it reads as prose.
+ * A visible pair gets nothing: it was captioned "Your hole cards · flop" once,
+ * which named what the player is plainly looking at and repeated the street
+ * the banner above already gives.
  */
-const captionStyle: Record<"label" | "prose", CSSProperties> = {
-  label: {
-    fontFamily: font.mono,
-    fontSize: fontSize.xs,
-    letterSpacing: "0.2em",
-    textTransform: "uppercase",
-    color: color.textDim,
-  },
-  prose: {
-    fontSize: fontSize.md,
-    lineHeight: 1.5,
-    color: color.textDim,
-    maxWidth: "16em",
-  },
+const absentCaptionStyle: CSSProperties = {
+  fontSize: fontSize.md,
+  lineHeight: 1.5,
+  color: color.textDim,
+  maxWidth: "16em",
 };
 
 /**
@@ -323,6 +315,8 @@ const captionStyle: Record<"label" | "prose", CSSProperties> = {
  * every caption on this screen; the pair owns card presentation and nothing
  * else, which is why the `Absent` copy is decided here (folded reads
  * differently from not-dealt-in) while the empty slots are drawn there.
+ *
+ * Only empty slots are captioned — a pair the player can see explains itself.
  */
 function HoleCardsRegion({
   cards,
@@ -333,7 +327,8 @@ function HoleCardsRegion({
   readonly cards: readonly [CardType, CardType] | null;
   readonly locked?: boolean;
   readonly actions: CardActions;
-  readonly caption: string;
+  /** Why the slots are empty. Absent alongside cards, which need no caption. */
+  readonly caption?: string;
 }) {
   const absent = cards === null;
   return (
@@ -344,13 +339,16 @@ function HoleCardsRegion({
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-        gap: absent ? "1.1em" : "0.9em",
+        // Only ever between the empty slots and the sentence under them: a
+        // visible pair carries its own hint down to its bottom edge and is the
+        // sole child here.
+        gap: "1.1em",
         minHeight: 0,
         textAlign: "center",
       }}
     >
       <HoleCardPair cards={cards} locked={locked} actions={actions} />
-      <span style={captionStyle[absent ? "prose" : "label"]}>{caption}</span>
+      {absent && <span style={absentCaptionStyle}>{caption}</span>}
     </div>
   );
 }
@@ -446,7 +444,6 @@ export function Hand({
             cards={myResult.holeCards}
             locked
             actions={actions}
-            caption="Your hole cards · showdown"
           />
         ) : (
           <HoleCardsRegion
@@ -474,11 +471,7 @@ export function Hand({
     >
       <TurnBanner banner={bannerFor(view, connectionStatus, seatId, seats)} />
       {view.yourHoleCards ? (
-        <HoleCardsRegion
-          cards={view.yourHoleCards}
-          actions={actions}
-          caption={`Your hole cards · ${view.street}`}
-        />
+        <HoleCardsRegion cards={view.yourHoleCards} actions={actions} />
       ) : (
         <HoleCardsRegion
           cards={null}

--- a/packages/player-client/src/app-shell.css
+++ b/packages/player-client/src/app-shell.css
@@ -54,7 +54,22 @@ body {
   display: flex;
   flex-direction: column;
   gap: 14px;
-  padding: 10px 18px 24px;
+  padding: 10px 12px 24px;
+  /* The hole cards size themselves off this box, not off the viewport — the
+   * phone column is capped at 480px, so viewport units would overshoot it on a
+   * desktop tab. */
+  container-type: inline-size;
+  /*
+   * One length drives the whole pair: each card is 3.5 × 5 of it and the gap
+   * between them 0.5, so the pair spans 7.5 units laid out and about 8.02
+   * once the resting tilt is counted. Sizing it off the column rather than
+   * pinning it to a nominal 16px root is what lets the cards grow into the
+   * phone they actually land on: 12.4cqw keeps that 8.02 just inside the
+   * content box at any width, and the dvh term stops a short screen
+   * (landscape, or a raised keyboard) from pushing the pair over the captions
+   * below it.
+   */
+  --hole-card-unit: clamp(2.2rem, min(12.4cqw, 7.6dvh), 4.2rem);
 }
 
 /*

--- a/packages/player-client/src/holecards/HoleCardPair.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.tsx
@@ -42,6 +42,15 @@ const suitWords: Record<Suit, string> = {
   spades: "spades",
 };
 
+/**
+ * The font-size the whole pair is drawn at — every card dimension is an `em`
+ * of it. `--hole-card-unit` is set by `.hand`, which sizes it from the phone
+ * column's own width and the viewport height; the fallback is the fixed size
+ * this used to be, for any surface that renders a pair outside that shell
+ * (tests included).
+ */
+const HOLE_CARD_UNIT = "var(--hole-card-unit, 2.6em)";
+
 function cardWords(card: CardType): string {
   return `${rankWords[card.rank]} of ${suitWords[card.suit]}`;
 }
@@ -82,7 +91,7 @@ function Absent() {
   return (
     <div
       data-testid="no-hole-cards"
-      style={{ display: "flex", gap: "0.9em", fontSize: "2.6em" }}
+      style={{ display: "flex", gap: "0.9em", fontSize: HOLE_CARD_UNIT }}
     >
       {[-5, 5].map((tilt) => (
         <span
@@ -195,12 +204,31 @@ export function HoleCardPair(props: HoleCardPairProps) {
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
-        gap: "0.55em",
+        // The pair claims the whole card region rather than only the height its
+        // cards need, so the spare height on a tall phone is *inside* this
+        // column where it can be placed, instead of padding the region around
+        // a group that stays tight however much screen it is given.
+        flex: 1,
+        minHeight: 0,
+        // The floor under the hint on a screen with nothing spare to give.
+        gap: "1.1em",
       }}
     >
       {/* The positioning parent for the Check stamp, which is painted over the
        * pair rather than laid out beside it. */}
-      <div style={{ position: "relative", display: "flex" }}>
+      <div
+        style={{
+          position: "relative",
+          display: "flex",
+          // Auto margins take the column's free space above and below the
+          // cards, which leaves the hint sitting at the bottom of the pair —
+          // next to `Hand`'s caption and just over the action buttons, where
+          // the two lines of copy read as one block. The cards float centred in
+          // whatever is left. On a short screen there is no free space to take
+          // and this collapses to the stack the phone already had.
+          margin: "auto 0",
+        }}
+      >
         <button
           type="button"
           data-testid="hole-cards"
@@ -250,7 +278,7 @@ export function HoleCardPair(props: HoleCardPairProps) {
               duration: DEAL_IN_MS / 1000,
               ease: [0.2, 0.8, 0.2, 1],
             }}
-            style={{ display: "flex", fontSize: "2.6em" }}
+            style={{ display: "flex", fontSize: HOLE_CARD_UNIT }}
           >
             {/* A layer of its own, so the fold drag and the muck flight can drive
              * `y` and `opacity` from `MotionValue`s while the deal-in above keeps


### PR DESCRIPTION
The hole cards were pinned to a fixed `2.6em`, which made every card 146 × 208px on every device — the same on a 375px iPhone SE as on a 440px 16 Pro Max or a 480px desktop column. The widest surfaces had the most unused screen.

## What changed

**The cards size themselves off the phone column.** One custom property on `.hand` drives the whole pair, sized from the column's own inline size via a container query and capped against the viewport height:

```css
--hole-card-unit: clamp(2.2rem, min(12.4cqw, 7.6dvh), 4.2rem);
```

`12.4cqw` comes from the pair's real extent — 3.5 + 0.5 + 3.5 = 7.5 units laid out, plus the ±3° resting tilt pushing ~0.26 units past each edge, so 8.02 units land just inside the content box at any width. `.hand`'s horizontal padding drops 18px → 12px. Container units rather than viewport ones because the column is capped at 480px, so `vw` would overshoot it in a desktop tab.

| Device | Card width before | After |
|---|---|---|
| iPhone SE (375px) | 146px | 152px |
| iPhone 14 (390px) | 146px | 159px |
| 16 Pro Max (440px) | 146px | 182px |
| desktop column (480px) | 146px | 198px |

**The pair places its own spare height.** It now claims the whole card region (`flex: 1`) and the cards take the free space as auto margins, which floats them centred and leaves the coaching hint at the pair's bottom edge, just above the action buttons. On a tall phone that moves ~86px of dead margin into the layout; on a short one there is nothing spare to take and it collapses to the stack the phone already had.

Spacing the surplus by arithmetic was tried first — a second custom property keyed on excess viewport height — and it spread the space evenly, which pushed the hint and the caption 60px apart on a tall phone. Letting flexbox place it is what actually worked, and it needs no magic baseline.

**The caption under a visible pair is gone.** "Your hole cards · flop" named what the player is plainly looking at and repeated the street the banner above already carries. Empty slots keep their sentence — folded, mucked or not dealt in is not self-evident from two dashed outlines.

## Notes for review

- `Hand` reads `--hole-card-unit` through a CSS variable rather than importing a constant from `holecards/`. That module's `index.ts` deliberately exports two names and a spacing value is not one of them, so the contract lives in `.hand` where the value is worked out.
- A layout with the buttons at the top and the cards at the bottom was tried and rejected in review; it is not in this branch.

## Verification

Full player-client suite (349 tests), `npm run build` and `npm run lint` pass. Checked by hand in Chrome device emulation at iPhone SE and 16 Pro Max.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ypV87XS8jMXM1aivSpMmM