### PR TITLE
fix(table): let the home-screen table run edge to edge on iPad

### DIFF
--- a/packages/player-client/index.html
+++ b/packages/player-client/index.html
@@ -6,6 +6,19 @@
       name="viewport"
       content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
+    <!--
+      Same home-screen story as table-client: a phone added to the home screen
+      launches standalone, and `black-translucent` lets the shell run under the
+      status bar with its safe-area padding keeping the content clear.
+    -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="black-translucent"
+    />
+    <meta name="apple-mobile-web-app-title" content="Poker" />
+    <meta name="theme-color" content="#050403" />
     <title>Table Top Poker — Player</title>
   </head>
   <body>

--- a/packages/table-client/index.html
+++ b/packages/table-client/index.html
@@ -6,6 +6,20 @@
       name="viewport"
       content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
+    <!--
+      The table is meant to be installed to the iPad home screen: iPad Safari
+      always keeps its tab and address bar, a home-screen launch does not.
+      `black-translucent` lets the felt run under the status bar; the shell's
+      safe-area padding keeps the header clear of it.
+    -->
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="black-translucent"
+    />
+    <meta name="apple-mobile-web-app-title" content="Poker Table" />
+    <meta name="theme-color" content="#0b0a09" />
     <title>Table Top Poker — Table</title>
   </head>
   <body>

--- a/packages/table-client/src/app-shell.css
+++ b/packages/table-client/src/app-shell.css
@@ -4,9 +4,17 @@
 
 html,
 body {
+  height: 100%;
   margin: 0;
   padding: 0;
   touch-action: manipulation;
+  overscroll-behavior: none;
+  /*
+   * The shell insets itself by the safe areas, so on a home-screen install
+   * the status-bar strip shows the page background rather than the shell.
+   * Without this it is the browser default white.
+   */
+  background: #0b0a09;
 }
 
 #root {


### PR DESCRIPTION
The table shell pads itself by the safe-area insets, but `html`/`body` in table-client had no background — so on an iPad home-screen launch the status-bar strip rendered the browser default white, reading as a white gradient above the felt.

- paint `#0b0a09` on `html, body` (player-client already does this), plus `height: 100%` and `overscroll-behavior: none` to match
- declare the web-app metas on `packages/table-client/index.html` so a home-screen launch is standalone with a translucent dark status bar, and the icon is titled "Poker Table"

No fix for plain iPad Safari — it always keeps its tab and address bar; installing to the home screen is the only way to lose the chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ypV87XS8jMXM1aivSpMmM