### PR TITLE
PROTOTYPE (do not merge): player-side D/SB/BB position marker

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clean": "tsc --build tsconfig.json --clean",
     "test": "vitest run",
     "lint": "eslint . && prettier --check .",
+    "proto:position-marker": "npm run dev -w @table-top-poker/player-client -- --open /prototype-position-marker.html",
     "format": "prettier --write ."
   },
   "devDependencies": {

--- a/packages/player-client/prototype-position-marker.html
+++ b/packages/player-client/prototype-position-marker.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <title>PROTOTYPE — player position marker</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script
+      type="module"
+      src="/src/prototype-position-marker/main.tsx"
+    ></script>
+  </body>
+</html>

--- a/packages/player-client/src/prototype-position-marker/MockPlayerScreen.tsx
+++ b/packages/player-client/src/prototype-position-marker/MockPlayerScreen.tsx
@@ -1,0 +1,180 @@
+// PROTOTYPE — throwaway. See prototype-position-marker/README.md.
+import {
+  Card,
+  color,
+  font,
+  fontSize,
+  radius,
+} from "@table-top-poker/ui-shared";
+import type { ReactNode } from "react";
+import { playerTopPillStyle } from "../topPillStyle.js";
+
+/**
+ * A static stand-in for the real player screen: same top pill row, same turn
+ * banner, same hole-card region and action bar, built from the same tokens —
+ * but with no store, no socket and no gestures, so a variant can hang a marker
+ * anywhere in it without touching production components.
+ */
+export interface Slots {
+  /** Rides inside the "Seat 3" pill, at its right end. */
+  readonly inSeatPill?: ReactNode;
+  /** Sits in the top row, to the left of the connection pill. */
+  readonly inTopRow?: ReactNode;
+  /** Replaces the turn banner's tone dot. */
+  readonly asBannerDot?: ReactNode;
+  /** Free-floating over the hole-card region (position it yourself). */
+  readonly overCards?: ReactNode;
+  /** A full-width strip between the banner and the cards. */
+  readonly underBanner?: ReactNode;
+}
+
+const pillStyle = {
+  ...playerTopPillStyle,
+  // Relative so a variant can hang a corner badge off the pill the way the
+  // table hangs one off a seat avatar.
+  position: "relative" as const,
+  gap: "0.5em",
+  background: color.control,
+  border: `1px solid ${color.border}`,
+  color: color.textMuted,
+};
+
+export function MockPlayerScreen({ slots }: { readonly slots: Slots }) {
+  return (
+    <div className="app-shell" data-testid="proto-shell">
+      <header
+        style={{
+          flex: "none",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "16px 18px 0",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: "0.6em" }}>
+          <div style={pillStyle}>Ewan · Seat 3{slots.inSeatPill}</div>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: "0.6em" }}>
+          {slots.inTopRow}
+          <span style={pillStyle}>
+            <span
+              style={{
+                width: "0.5em",
+                height: "0.5em",
+                borderRadius: "50%",
+                background: color.textDim,
+              }}
+            />
+            connected
+          </span>
+          <span style={{ ...pillStyle, padding: "0 10px" }}>⋯</span>
+        </div>
+      </header>
+
+      <main className="hand">
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "0.8em",
+            borderRadius: radius.panel,
+            padding: "0.9em 1.1em",
+            background:
+              "linear-gradient(120deg,rgba(229,68,60,.22),rgba(229,68,60,.08))",
+            border: `1px solid ${color.accentBorder}`,
+          }}
+        >
+          {slots.asBannerDot ?? (
+            <span
+              style={{
+                width: "0.7em",
+                height: "0.7em",
+                borderRadius: "50%",
+                flex: "none",
+                background: color.accentBright,
+              }}
+            />
+          )}
+          <div
+            style={{ display: "flex", flexDirection: "column", gap: "0.1em" }}
+          >
+            <span
+              style={{
+                fontFamily: font.mono,
+                fontSize: fontSize.xs,
+                letterSpacing: "0.22em",
+                textTransform: "uppercase",
+                color: color.textBright,
+              }}
+            >
+              Your turn
+            </span>
+            <span
+              style={{
+                fontSize: fontSize.md,
+                fontWeight: 600,
+                color: color.text,
+              }}
+            >
+              You&apos;re to act — flop
+            </span>
+          </div>
+        </div>
+
+        {slots.underBanner}
+
+        <div
+          style={{
+            position: "relative",
+            flex: 1,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: 0,
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              gap: "calc(var(--hole-card-unit) * 0.5)",
+              fontSize: "var(--hole-card-unit)",
+            }}
+          >
+            <div style={{ transform: "rotate(-4deg)" }}>
+              <Card rank="A" suit="spades" />
+            </div>
+            <div style={{ transform: "rotate(4deg)" }}>
+              <Card rank="K" suit="hearts" />
+            </div>
+          </div>
+          {slots.overCards}
+        </div>
+
+        <div style={{ display: "flex", gap: "10px", flex: "none" }}>
+          {["Fold", "Check", "Raise"].map((label) => (
+            <div
+              key={label}
+              style={{
+                flex: 1,
+                textAlign: "center",
+                padding: "14px 0",
+                borderRadius: radius.control,
+                background:
+                  label === "Raise" ? color.accent : color.controlFill,
+                border: `1px solid ${label === "Raise" ? color.accent : color.border}`,
+                fontFamily: font.mono,
+                fontSize: fontSize.sm,
+                fontWeight: 700,
+                letterSpacing: "0.16em",
+                textTransform: "uppercase",
+                color: label === "Raise" ? "#fff" : color.textMuted,
+              }}
+            >
+              {label}
+            </div>
+          ))}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/packages/player-client/src/prototype-position-marker/PositionMarker.tsx
+++ b/packages/player-client/src/prototype-position-marker/PositionMarker.tsx
@@ -1,0 +1,72 @@
+// PROTOTYPE — throwaway. See prototype-position-marker/README.md.
+import { color, font, shadow } from "@table-top-poker/ui-shared";
+import type { CSSProperties } from "react";
+
+export type Marker = "button" | "small-blind" | "big-blind";
+
+export const markerLabel: Record<Marker, string> = {
+  button: "D",
+  "small-blind": "SB",
+  "big-blind": "BB",
+};
+
+/** The long form, for variants that spell the position out. */
+export const markerWord: Record<Marker, string> = {
+  button: "Dealer",
+  "small-blind": "Small blind",
+  "big-blind": "Big blind",
+};
+
+/** Lifted verbatim from table-client's Seats.tsx so the two can be compared. */
+export const markerBackground: Record<Marker, string> = {
+  button: color.buttonMarker,
+  "small-blind": color.blindSmallMarker,
+  "big-blind": color.blindBigMarker,
+};
+
+/**
+ * The table's seat-pod badge, extracted. Same trick as Seats.tsx: the diameter
+ * sits on the outer element and the font size on an inner one, so the disc
+ * stays circular whatever the label's length.
+ */
+export function PositionMarker({
+  marker,
+  diameter = "1.6em",
+  fontSize = "0.62em",
+  style,
+}: {
+  readonly marker: Marker;
+  readonly diameter?: string;
+  readonly fontSize?: string;
+  readonly style?: CSSProperties;
+}) {
+  return (
+    <span
+      data-testid={`position-marker-${marker}`}
+      style={{
+        width: diameter,
+        height: diameter,
+        borderRadius: "50%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flex: "none",
+        background: markerBackground[marker],
+        color: color.pillInk,
+        boxShadow: shadow.card,
+        ...style,
+      }}
+    >
+      <span
+        style={{
+          fontFamily: font.mono,
+          fontSize,
+          fontWeight: 700,
+          lineHeight: 1,
+        }}
+      >
+        {markerLabel[marker]}
+      </span>
+    </span>
+  );
+}

--- a/packages/player-client/src/prototype-position-marker/Prototype.tsx
+++ b/packages/player-client/src/prototype-position-marker/Prototype.tsx
@@ -1,0 +1,174 @@
+// PROTOTYPE — throwaway. See prototype-position-marker/README.md.
+import { color, font, fontSize, radius } from "@table-top-poker/ui-shared";
+import { useEffect, useState } from "react";
+import { MockPlayerScreen } from "./MockPlayerScreen.js";
+import type { Marker } from "./PositionMarker.js";
+import { variants } from "./variants.js";
+
+/** The seat the prototype pretends you are sitting in. */
+type Position = "button" | "small-blind" | "big-blind" | "none";
+
+/**
+ * The same suppression rule table-client's `Seats.markerFor` applies, copied
+ * here so the player screen can be judged against the display the table
+ * already gives: no blinds between hands, and heads-up shows only the button.
+ */
+function markerFor(
+  position: Position,
+  phase: "betting" | "no-hand",
+  headsUp: boolean,
+): Marker | null {
+  if (position === "none") return null;
+  if (phase === "no-hand" || headsUp) {
+    return position === "button" ? "button" : null;
+  }
+  return position;
+}
+
+function readParam(name: string, fallback: string): string {
+  if (typeof window === "undefined") return fallback;
+  return new URLSearchParams(window.location.search).get(name) ?? fallback;
+}
+
+const barButton = (active: boolean) => ({
+  padding: "7px 12px",
+  borderRadius: radius.pill,
+  border: `1px solid ${active ? color.accent : color.border}`,
+  background: active ? color.accentWash : "transparent",
+  color: active ? color.text : color.textDim,
+  fontFamily: font.mono,
+  fontSize: fontSize.xs,
+  letterSpacing: "0.12em",
+  textTransform: "uppercase" as const,
+  cursor: "pointer",
+  whiteSpace: "nowrap" as const,
+});
+
+export function Prototype() {
+  const [variantId, setVariantId] = useState(() =>
+    readParam("variant", variants[0].id),
+  );
+  const [position, setPosition] = useState<Position>(
+    () => readParam("position", "button") as Position,
+  );
+  const [phase, setPhase] = useState<"betting" | "no-hand">("betting");
+  const [headsUp, setHeadsUp] = useState(false);
+
+  const variant = variants.find((v) => v.id === variantId) ?? variants[0];
+  const marker = markerFor(position, phase, headsUp);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    params.set("variant", variant.id);
+    params.set("position", position);
+    window.history.replaceState(null, "", `?${params.toString()}`);
+  }, [variant.id, position]);
+
+  return (
+    <div
+      style={{
+        // #root (app-shell.css) already owns the viewport box and centres its
+        // child; this just fills it.
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        background: color.background,
+        color: color.text,
+        fontFamily: font.body,
+      }}
+    >
+      <div
+        style={{
+          flex: 1,
+          minHeight: 0,
+          display: "flex",
+          justifyContent: "center",
+          padding: "18px 0 0",
+        }}
+      >
+        <div style={{ width: "100%", maxWidth: 480, height: "68dvh" }}>
+          <MockPlayerScreen
+            slots={marker ? variant.slots(marker) : {}}
+            key={`${variant.id}-${String(marker)}`}
+          />
+        </div>
+      </div>
+
+      <div
+        style={{
+          flex: "none",
+          borderTop: `1px solid ${color.border}`,
+          background: color.surfaceGradient,
+          padding: "12px 16px 18px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+        }}
+      >
+        <div style={{ display: "flex", gap: 8, overflowX: "auto" }}>
+          {variants.map((v) => (
+            <button
+              key={v.id}
+              onClick={() => {
+                setVariantId(v.id);
+              }}
+              style={barButton(v.id === variant.id)}
+            >
+              {v.name}
+            </button>
+          ))}
+        </div>
+
+        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+          {(["button", "small-blind", "big-blind", "none"] as const).map(
+            (p) => (
+              <button
+                key={p}
+                onClick={() => {
+                  setPosition(p);
+                }}
+                style={barButton(p === position)}
+              >
+                {p === "button" ? "dealer" : p}
+              </button>
+            ),
+          )}
+          <button
+            onClick={() => {
+              setPhase(phase === "betting" ? "no-hand" : "betting");
+            }}
+            style={barButton(phase === "no-hand")}
+          >
+            phase: {phase}
+          </button>
+          <button
+            onClick={() => {
+              setHeadsUp(!headsUp);
+            }}
+            style={barButton(headsUp)}
+          >
+            heads-up: {headsUp ? "on" : "off"}
+          </button>
+        </div>
+
+        <div
+          style={{
+            fontFamily: font.mono,
+            fontSize: fontSize.xs,
+            lineHeight: 1.7,
+            color: color.textDim,
+          }}
+        >
+          <div>
+            state → variant={variant.id} position={position} phase={phase}{" "}
+            headsUp={String(headsUp)} ⇒ marker={String(marker)}
+          </div>
+          <div style={{ color: color.textMuted, marginTop: 6 }}>
+            {variant.note}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/player-client/src/prototype-position-marker/README.md
+++ b/packages/player-client/src/prototype-position-marker/README.md
@@ -1,0 +1,60 @@
+# PROTOTYPE — player-side position marker
+
+**Throwaway.** Delete this whole directory (plus
+`packages/player-client/prototype-position-marker.html` and the
+`proto:position-marker` script in the root `package.json`) once the question
+below is answered.
+
+## The question
+
+Where and how should the player's phone show that *they* are on the dealer
+button, the small blind or the big blind — in a style consistent with the
+markers the table already shows on its seat pods?
+
+## Run it
+
+```
+npm run proto:position-marker
+```
+
+Opens Vite on `/prototype-position-marker.html`. Switch variants from the bar
+along the bottom; the URL carries `?variant=…&position=…` so a particular view
+can be shared or reloaded.
+
+## What's real and what isn't
+
+- **Real:** the badge itself (`PositionMarker.tsx` is lifted verbatim from
+  `table-client/src/Seats.tsx` — same diameter/font-size split, same
+  `color.buttonMarker` / `blindSmallMarker` / `blindBigMarker`, same
+  `shadow.card`), the design tokens, `playerTopPillStyle`, the real `Card`.
+- **Real, and worth knowing:** `PlayerView` already carries `button`,
+  `smallBlind`, `bigBlind` and `dealtSeatCount` on every non-`no-hand` phase
+  (`engine/src/view.ts`), so **no protocol or server change is needed** — this
+  is purely a rendering decision.
+- **Fake:** the screen around it (`MockPlayerScreen.tsx`) — a static stand-in
+  for `StatusBar` + `Hand` + `ActionBar`, with no store, socket or gestures.
+
+## Suppression rules carried over from the table
+
+`Prototype.tsx` copies `Seats.markerFor`, so the two suppressions the table
+already makes (issue #160, decision 4) can be checked here too:
+
+- `phase: no-hand` → only the button shows.
+- heads-up (`dealtSeatCount === 2`) → only the button shows, no SB/BB.
+
+Toggle both from the bottom bar. The open question they raise for the player
+screen: on the table those rules stop *two markers landing on one seat*. On the
+player screen you only ever see your own, so heads-up suppression means a
+player who is the small blind is shown nothing at all. Consistency with the
+table may not be the right call here.
+
+## Variants
+
+| id | idea |
+| --- | --- |
+| `seat-pill-corner` | badge hung off the corner of the "Seat 3" pill — the table's exact move |
+| `seat-pill-inline` | same disc, riding inside the pill |
+| `top-row-chip` | its own pill in the top row: disc + the word |
+| `banner-dot` | takes over the turn banner's status dot |
+| `under-banner-strip` | a dedicated strip with the word and what it implies |
+| `over-cards` | a physical-looking chip beside the hole cards |

--- a/packages/player-client/src/prototype-position-marker/main.tsx
+++ b/packages/player-client/src/prototype-position-marker/main.tsx
@@ -1,0 +1,16 @@
+// PROTOTYPE — throwaway. See prototype-position-marker/README.md.
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { Prototype } from "./Prototype.js";
+import "../app-shell.css";
+
+const rootEl = document.getElementById("root");
+if (!rootEl) {
+  throw new Error("#root element not found");
+}
+
+ReactDOM.createRoot(rootEl).render(
+  <React.StrictMode>
+    <Prototype />
+  </React.StrictMode>,
+);

--- a/packages/player-client/src/prototype-position-marker/variants.tsx
+++ b/packages/player-client/src/prototype-position-marker/variants.tsx
@@ -1,0 +1,154 @@
+// PROTOTYPE — throwaway. See prototype-position-marker/README.md.
+import { color, font, fontSize, radius } from "@table-top-poker/ui-shared";
+import type { Slots } from "./MockPlayerScreen.js";
+import {
+  markerBackground,
+  markerWord,
+  PositionMarker,
+  type Marker,
+} from "./PositionMarker.js";
+import { playerTopPillStyle } from "../topPillStyle.js";
+
+export interface Variant {
+  readonly id: string;
+  readonly name: string;
+  /** What this variant is arguing for, in one line. */
+  readonly note: string;
+  readonly slots: (marker: Marker) => Slots;
+}
+
+/** Non-empty by type, so the first entry can be the default without a `!`. */
+export const variants: readonly [Variant, ...Variant[]] = [
+  {
+    id: "seat-pill-corner",
+    name: "Seat pill, corner badge",
+    note: "The table's exact move: the badge hangs off the corner of the thing that identifies you. Reads as 'this seat is the dealer' with no extra chrome, but it's small and it breaks the top row's clean pill silhouette.",
+    slots: (marker) => ({
+      inSeatPill: (
+        <PositionMarker
+          marker={marker}
+          diameter="1.9em"
+          fontSize="0.72em"
+          style={{ position: "absolute", top: "-0.55em", right: "-0.6em" }}
+        />
+      ),
+    }),
+  },
+  {
+    id: "seat-pill-inline",
+    name: "Seat pill, inline disc",
+    note: "Same disc, but riding inside the pill instead of off its corner. Nothing overlaps, the row keeps its shape — at the cost of looking like part of the seat label rather than a marker that moves each hand.",
+    slots: (marker) => ({
+      inSeatPill: (
+        <PositionMarker marker={marker} diameter="1.7em" fontSize="0.66em" />
+      ),
+    }),
+  },
+  {
+    id: "top-row-chip",
+    name: "Top row, labelled chip",
+    note: "Its own pill next to the connection badge: disc plus the word. Unambiguous for anyone who doesn't already read D/SB/BB — but it's a third pill competing for a narrow row, and the word is redundant once you know the code.",
+    slots: (marker) => ({
+      inTopRow: (
+        <span
+          style={{
+            ...playerTopPillStyle,
+            gap: "0.55em",
+            paddingLeft: 5,
+            background: color.control,
+            border: `1px solid ${color.border}`,
+            color: color.textMuted,
+          }}
+        >
+          <PositionMarker marker={marker} diameter="1.9em" fontSize="0.72em" />
+          {markerWord[marker]}
+        </span>
+      ),
+    }),
+  },
+  {
+    id: "banner-dot",
+    name: "Banner, in place of the tone dot",
+    note: "The marker takes over the slot the banner's status dot already occupies, so position lands where the player is looking for the state of the hand. Costs the tone dot, and the marker inherits the banner's turn-glow it has nothing to do with.",
+    slots: (marker) => ({
+      asBannerDot: (
+        <PositionMarker marker={marker} diameter="2.1em" fontSize="0.8em" />
+      ),
+    }),
+  },
+  {
+    id: "under-banner-strip",
+    name: "Strip under the banner",
+    note: "A dedicated row: disc, word, and room to say what it implies ('you act last'). Most legible and the most room to grow — but it spends vertical space the hole cards want on something that changes once a hand.",
+    slots: (marker) => ({
+      underBanner: (
+        <div
+          style={{
+            flex: "none",
+            display: "flex",
+            alignItems: "center",
+            gap: "0.7em",
+            padding: "0.55em 0.9em",
+            borderRadius: radius.control,
+            background: color.mutedSurface,
+            border: `1px solid ${color.border}`,
+          }}
+        >
+          <PositionMarker marker={marker} diameter="2em" fontSize="0.76em" />
+          <span
+            style={{
+              fontFamily: font.mono,
+              fontSize: fontSize.xs,
+              letterSpacing: "0.2em",
+              textTransform: "uppercase",
+              color: color.textMuted,
+            }}
+          >
+            {markerWord[marker]}
+          </span>
+          <span
+            style={{
+              marginLeft: "auto",
+              fontSize: fontSize.sm,
+              color: color.textFaint,
+            }}
+          >
+            {marker === "button"
+              ? "You act last"
+              : marker === "small-blind"
+                ? "Posted ½ blind"
+                : "Posted the blind"}
+          </span>
+        </div>
+      ),
+    }),
+  },
+  {
+    id: "over-cards",
+    name: "Chip beside the cards",
+    note: "A physical dealer button sitting next to your cards, at table scale — the closest thing to how it works on felt, and impossible to miss. Also the loudest, and it crowds the card region on a small phone.",
+    slots: (marker) => ({
+      overCards: (
+        <div
+          style={{
+            position: "absolute",
+            top: "8%",
+            right: "4%",
+            fontSize: "1.6rem",
+          }}
+        >
+          <PositionMarker
+            marker={marker}
+            diameter="2.2em"
+            fontSize="0.8em"
+            style={{
+              border: `2px solid rgba(255,255,255,.55)`,
+              outline: `1px solid ${markerBackground[marker]}`,
+              outlineOffset: 2,
+            }}
+          />
+        </div>
+      ),
+    }),
+  },
+];


### PR DESCRIPTION
**Throwaway prototype — not for merge.** Opened as a pointer to the branch, per the prototype skill.

## The question

Where and how should the player's phone show that *they* are on the dealer button, small blind or big blind, in a style consistent with the markers the table already draws on its seat pods?

## Run it

```
npm run proto:position-marker
```

Six variants, switchable from the bar along the bottom; the URL carries `?variant=…&position=…`. The bottom bar also toggles `phase` and heads-up so the table's two marker-suppression rules can be checked, and prints the derived state on every switch.

| id | idea |
| --- | --- |
| `seat-pill-corner` | badge hung off the corner of the "Seat 3" pill — the table's exact move |
| `seat-pill-inline` | same disc, riding inside the pill |
| `top-row-chip` | its own pill in the top row: disc + the word |
| `banner-dot` | takes over the turn banner's status dot |
| `under-banner-strip` | a dedicated strip with the word and what it implies |
| `over-cards` | a physical-looking chip beside the hole cards |

## Findings so far

- **No protocol or server work is needed.** `PlayerView` already carries `button`, `smallBlind`, `bigBlind` and `dealtSeatCount` on every non-`no-hand` phase (`engine/src/view.ts`). This is purely a rendering decision.
- **Consistency is cheap.** The badge is lifted verbatim from `table-client/src/Seats.tsx` — same diameter/font-size split, same `color.buttonMarker`/`blindSmallMarker`/`blindBigMarker`, same `shadow.card` — so table and player show the same object.
- **One rule may not carry over.** The table suppresses SB/BB heads-up (#160, decision 4) to stop two markers landing on one seat. On the player screen you only ever see your own, so that rule would show a heads-up small blind nothing at all. Worth deciding explicitly.

## Scope

Additive only: one Vite entry, one `src/prototype-position-marker/` directory, one root script. No production component is touched, and `vite build` still emits only `index.html`, so the release is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UvUynydEB7FTmUauTDhV6