### PR TITLE
feat(player): show the dealer and blind position in the turn banner

### DIFF
--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -342,4 +342,135 @@ describe("Hand", () => {
       expect(html).not.toContain("data-presentation");
     });
   });
+
+  describe("position marker (issue #207)", () => {
+    const bettingView: PlayerView = {
+      phase: "betting",
+      button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 6,
+      street: "flop",
+      board: [],
+      toAct: [3],
+      seats: [
+        { seatId: 0, folded: false },
+        { seatId: 1, folded: false },
+        { seatId: 2, folded: false },
+        { seatId: 3, folded: false },
+      ],
+      yourSeatId: 0,
+      yourHoleCards: null,
+      legalActions: [],
+    };
+
+    it.each([
+      [0, "button"],
+      [1, "small-blind"],
+      [2, "big-blind"],
+    ])(
+      "gives seat %i's banner the %s disc in place of the tone dot",
+      (seatId, marker) => {
+        const html = renderToStaticMarkup(
+          <Hand
+            view={{ ...bettingView, yourSeatId: seatId }}
+            seatId={seatId}
+          />,
+        );
+
+        expect(html).toContain(`data-marker="${marker}"`);
+        expect(html).not.toContain('data-testid="turn-banner-dot"');
+      },
+    );
+
+    it("leaves the tone dot alone for a seat holding no position", () => {
+      const html = renderToStaticMarkup(
+        <Hand view={{ ...bettingView, yourSeatId: 3 }} seatId={3} />,
+      );
+
+      expect(html).toContain('data-testid="turn-banner-dot"');
+      expect(html).not.toContain('data-testid="position-badge"');
+    });
+
+    // Between hands the button is a forecast of the next deal — the most
+    // useful moment to see it — and the completed phases still say where you
+    // sat, exactly as the table pod beside you does.
+    const otherPhases: readonly (readonly [string, PlayerView])[] = [
+      ["no-hand", { phase: "no-hand", button: 0 }],
+      [
+        "showdown",
+        {
+          phase: "showdown",
+          button: 0,
+          smallBlind: 1,
+          bigBlind: 2,
+          dealtSeatCount: 3,
+          board: [],
+          results: [],
+          winners: [1],
+        },
+      ],
+      [
+        "folded-out",
+        {
+          phase: "folded-out",
+          button: 0,
+          smallBlind: 1,
+          bigBlind: 2,
+          dealtSeatCount: 3,
+          winner: 1,
+        },
+      ],
+    ];
+
+    it.each(otherPhases)(
+      "carries the marker through the %s phase too",
+      (_phase, view) => {
+        const html = renderToStaticMarkup(<Hand view={view} seatId={0} />);
+        expect(html).toContain('data-marker="button"');
+      },
+    );
+
+    it("shows the heads-up button its disc and the other seat nothing", () => {
+      // The table's suppression, applied to the phone on purpose (decision 2):
+      // the engine reports smallBlind === button, and neither device marks the
+      // heads-up big blind.
+      const headsUp: PlayerView = {
+        ...bettingView,
+        button: 0,
+        smallBlind: 0,
+        bigBlind: 1,
+        dealtSeatCount: 2,
+      };
+
+      expect(
+        renderToStaticMarkup(
+          <Hand view={{ ...headsUp, yourSeatId: 0 }} seatId={0} />,
+        ),
+      ).toContain('data-marker="button"');
+      expect(
+        renderToStaticMarkup(
+          <Hand view={{ ...headsUp, yourSeatId: 1 }} seatId={1} />,
+        ),
+      ).not.toContain('data-testid="position-badge"');
+    });
+
+    it("dims the disc while the banner is reporting a dropped connection", () => {
+      const html = renderToStaticMarkup(
+        <Hand view={bettingView} seatId={0} connectionStatus="disconnected" />,
+      );
+
+      expect(html).toMatch(/data-testid="turn-banner"[^>]*data-tone="offline"/);
+      expect(html).toContain('data-marker="button"');
+      expect(html).toContain("opacity:0.55");
+    });
+
+    it("keeps the disc at full strength while connected", () => {
+      const html = renderToStaticMarkup(
+        <Hand view={bettingView} seatId={0} connectionStatus="connected" />,
+      );
+
+      expect(html).toContain("opacity:1");
+    });
+  });
 });

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -7,13 +7,16 @@ import {
   color,
   font,
   fontSize,
+  positionMarkerFor,
   radius,
   shadow,
+  type PositionMarker,
 } from "@table-top-poker/ui-shared";
 import { motion } from "motion/react";
 import type { CSSProperties } from "react";
 import type { ActionIntent } from "./actions/useActionIntent.js";
 import { HoleCardPair, type CardActions } from "./holecards/index.js";
+import { PositionBadge } from "./PositionBadge.js";
 import type { ConnectionStatus } from "./store/connectionSlice.js";
 
 export interface HandProps {
@@ -231,7 +234,20 @@ function bannerFor(
   };
 }
 
-function TurnBanner({ banner }: { readonly banner: Banner }) {
+/**
+ * The banner's leading slot carries one of two things. It is the marker
+ * whenever this player holds a position, and the tone dot otherwise — the
+ * marker is the rarer and more specific of the two, and on the hands it
+ * appears the banner's own background and kicker still carry the tone
+ * (issue #207, decision 1).
+ */
+function TurnBanner({
+  banner,
+  marker,
+}: {
+  readonly banner: Banner;
+  readonly marker: PositionMarker | null;
+}) {
   const tone = bannerToneStyle[banner.tone];
   return (
     <motion.div
@@ -257,15 +273,20 @@ function TurnBanner({ banner }: { readonly banner: Banner }) {
         border: `1px solid ${tone.border}`,
       }}
     >
-      <span
-        style={{
-          width: "0.7em",
-          height: "0.7em",
-          borderRadius: "50%",
-          flex: "none",
-          background: tone.dot,
-        }}
-      />
+      {marker ? (
+        <PositionBadge marker={marker} dimmed={banner.tone === "offline"} />
+      ) : (
+        <span
+          data-testid="turn-banner-dot"
+          style={{
+            width: "0.7em",
+            height: "0.7em",
+            borderRadius: "50%",
+            flex: "none",
+            background: tone.dot,
+          }}
+        />
+      )}
       <div
         style={{
           display: "flex",
@@ -386,7 +407,10 @@ export function Hand({
           gap: "1em",
         }}
       >
-        <TurnBanner banner={bannerFor(view, connectionStatus, seatId, seats)} />
+        <TurnBanner
+          banner={bannerFor(view, connectionStatus, seatId, seats)}
+          marker={positionMarkerFor(seatId, view)}
+        />
         <HoleCardsRegion
           cards={null}
           actions={actions}
@@ -410,7 +434,10 @@ export function Hand({
           gap: "1em",
         }}
       >
-        <TurnBanner banner={bannerFor(view, connectionStatus, seatId, seats)} />
+        <TurnBanner
+          banner={bannerFor(view, connectionStatus, seatId, seats)}
+          marker={positionMarkerFor(seatId, view)}
+        />
         <HoleCardsRegion
           cards={null}
           actions={actions}
@@ -438,7 +465,10 @@ export function Hand({
           gap: "1em",
         }}
       >
-        <TurnBanner banner={bannerFor(view, connectionStatus, seatId, seats)} />
+        <TurnBanner
+          banner={bannerFor(view, connectionStatus, seatId, seats)}
+          marker={positionMarkerFor(seatId, view)}
+        />
         {myResult ? (
           <HoleCardsRegion
             cards={myResult.holeCards}
@@ -469,7 +499,10 @@ export function Hand({
         gap: "1em",
       }}
     >
-      <TurnBanner banner={bannerFor(view, connectionStatus, seatId, seats)} />
+      <TurnBanner
+        banner={bannerFor(view, connectionStatus, seatId, seats)}
+        marker={positionMarkerFor(seatId, view)}
+      />
       {view.yourHoleCards ? (
         <HoleCardsRegion cards={view.yourHoleCards} actions={actions} />
       ) : (

--- a/packages/player-client/src/PositionBadge.test.tsx
+++ b/packages/player-client/src/PositionBadge.test.tsx
@@ -1,0 +1,47 @@
+import { positionMarkerColor } from "@table-top-poker/ui-shared";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { PositionBadge } from "./PositionBadge.js";
+
+describe("PositionBadge", () => {
+  it.each([
+    ["button", "D"],
+    ["small-blind", "SB"],
+    ["big-blind", "BB"],
+  ] as const)("prints the table's own label for %s", (marker, label) => {
+    const html = renderToStaticMarkup(<PositionBadge marker={marker} />);
+    expect(html).toContain(`data-marker="${marker}"`);
+    expect(html).toContain(`>${label}</span>`);
+  });
+
+  it("takes its colour from the shared token, not a local copy", () => {
+    const html = renderToStaticMarkup(<PositionBadge marker="small-blind" />);
+    expect(html).toContain(positionMarkerColor["small-blind"]);
+  });
+
+  it("says what the letter means rather than leaving a screen reader to spell it", () => {
+    const html = renderToStaticMarkup(<PositionBadge marker="button" />);
+    expect(html).toContain('aria-label="You are on the dealer button"');
+    // The visible label is decoration once the disc is labelled.
+    expect(html).toContain('aria-hidden="true"');
+  });
+
+  it("keeps the disc round: diameter and label size sit on separate elements", () => {
+    const html = renderToStaticMarkup(<PositionBadge marker="big-blind" />);
+    const outer = /width:2\.1em;height:2\.1em/.exec(html);
+    expect(outer).not.toBeNull();
+    // A font-size on that same element would shrink the true diameter to
+    // 2.1 x 0.8em — the bug #160 hit on the table.
+    expect(html).toMatch(/width:2\.1em;height:2\.1em(?![^>]*font-size)/);
+  });
+
+  it("dims when the banner is no longer reporting live state", () => {
+    const live = renderToStaticMarkup(<PositionBadge marker="button" />);
+    const offline = renderToStaticMarkup(
+      <PositionBadge marker="button" dimmed />,
+    );
+    expect(live).toContain("opacity:1");
+    expect(offline).toContain("opacity:0.55");
+  });
+});

--- a/packages/player-client/src/PositionBadge.tsx
+++ b/packages/player-client/src/PositionBadge.tsx
@@ -1,0 +1,77 @@
+import {
+  color,
+  font,
+  positionMarkerColor,
+  positionMarkerLabel,
+  shadow,
+  type PositionMarker,
+} from "@table-top-poker/ui-shared";
+
+export interface PositionBadgeProps {
+  readonly marker: PositionMarker;
+  /**
+   * Muted to match a banner that is no longer reporting live state. Nothing
+   * else on this screen dims when the socket drops, but this disc is the
+   * brightest thing on it: at full strength it would out-shout the very
+   * banner telling the player their actions won't send (issue #207,
+   * decision 5).
+   */
+  readonly dimmed?: boolean;
+}
+
+/**
+ * The dealer/blind disc, drawn the way the table draws it on a seat pod:
+ * the same three labels and colours (from `ui-shared`, so the two can't
+ * drift), the same `shadow.card` lift, and the same split of diameter and
+ * font size across two elements — `width: 2.1em` and `fontSize: 0.8em` on one
+ * element would make the true diameter `2.1 x 0.8em` and shrink the disc to a
+ * third of its intended size.
+ *
+ * Sized to stand as tall as the banner's kicker-and-text block beside it.
+ */
+const DIAMETER = "2.1em";
+const LABEL_FONT_SIZE = "0.8em";
+
+const spokenPosition: Record<PositionMarker, string> = {
+  button: "You are on the dealer button",
+  "small-blind": "You are the small blind",
+  "big-blind": "You are the big blind",
+};
+
+export function PositionBadge({ marker, dimmed = false }: PositionBadgeProps) {
+  return (
+    <span
+      role="img"
+      aria-label={spokenPosition[marker]}
+      data-testid="position-badge"
+      data-marker={marker}
+      style={{
+        width: DIAMETER,
+        height: DIAMETER,
+        borderRadius: "50%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flex: "none",
+        background: positionMarkerColor[marker],
+        color: color.pillInk,
+        boxShadow: shadow.card,
+        opacity: dimmed ? 0.55 : 1,
+      }}
+    >
+      {/* "D" read aloud is a letter, not a position — `aria-label` above says
+          what it means, so the label itself is decoration to a screen reader. */}
+      <span
+        aria-hidden="true"
+        style={{
+          fontFamily: font.mono,
+          fontSize: LABEL_FONT_SIZE,
+          fontWeight: 700,
+          lineHeight: 1,
+        }}
+      >
+        {positionMarkerLabel[marker]}
+      </span>
+    </span>
+  );
+}

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -1,5 +1,13 @@
 import type { SeatView, TableView } from "@table-top-poker/protocol";
-import { color, font, shadow } from "@table-top-poker/ui-shared";
+import {
+  color,
+  font,
+  positionMarkerColor,
+  positionMarkerFor,
+  positionMarkerLabel,
+  shadow,
+  type PositionMarker,
+} from "@table-top-poker/ui-shared";
 import { AnimatePresence, motion } from "motion/react";
 import { posFor } from "./table/posFor.js";
 
@@ -13,9 +21,6 @@ export interface SeatsProps {
 type SeatStatus =
   "open" | "sitting-out" | "disconnected" | "folded" | "in-hand";
 
-/** Which positional marker a seat carries, if any. Never more than one. */
-type SeatMarker = "button" | "small-blind" | "big-blind";
-
 /**
  * One diameter and one font size for all three markers, resolved against the
  * pod rather than against the marker's own text. The two are set on separate
@@ -26,56 +31,13 @@ type SeatMarker = "button" | "small-blind" | "big-blind";
 const MARKER_DIAMETER = "1.6em";
 const MARKER_FONT_SIZE = "0.62em";
 
-const markerLabel: Record<SeatMarker, string> = {
-  button: "D",
-  "small-blind": "SB",
-  "big-blind": "BB",
-};
-
-const markerBackground: Record<SeatMarker, string> = {
-  button: color.buttonMarker,
-  "small-blind": color.blindSmallMarker,
-  "big-blind": color.blindBigMarker,
-};
-
 interface SeatVisual {
   readonly status: SeatStatus;
-  readonly marker: SeatMarker | null;
+  readonly marker: PositionMarker | null;
   readonly isActor: boolean;
   readonly isWinner: boolean;
   readonly avatarBackground: string;
   readonly avatarColor: string;
-}
-
-/**
- * Which marker this seat carries. All three come off the same view, so the
- * trio always moves on one tick and no seat ever carries two.
- *
- * Two suppressions, both deliberate:
- *
- * - Between hands (`no-hand`) only the button shows. The engine reports no
- *   blinds without a hand, and the button it does report is already a
- *   forecast of the next deal.
- * - **Heads-up (`dealtSeatCount === 2`) only the button shows — no `SB` on
- *   the button seat, and no `BB` on the other seat either.** The engine
- *   honestly reports `smallBlind === button` heads-up (the button does post
- *   the small blind), which would put two markers on one seat. Rather than
- *   stack or combine them, a heads-up hand reverts to exactly the display
- *   that existed before blind markers were added. This is a decision
- *   (issue #160, decision 4), not an oversight.
- */
-function markerFor(seatId: number, view: TableView | null): SeatMarker | null {
-  if (view === null) return null;
-  // Heads-up is a property of the deal, not of who is still live: folds never
-  // change it, so this reads the same in every phase of the hand.
-  const headsUp = view.phase !== "no-hand" && view.dealtSeatCount === 2;
-  if (view.phase === "no-hand" || headsUp) {
-    return seatId === view.button ? "button" : null;
-  }
-  if (seatId === view.button) return "button";
-  if (seatId === view.smallBlind) return "small-blind";
-  if (seatId === view.bigBlind) return "big-blind";
-  return null;
 }
 
 /**
@@ -146,7 +108,7 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
 
   return {
     status,
-    marker: markerFor(seat.id, view),
+    marker: positionMarkerFor(seat.id, view),
     isActor: view?.phase === "betting" && view.toAct[0] === seat.id,
     isWinner,
     avatarBackground,
@@ -234,7 +196,7 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "center",
-                  background: markerBackground[visual.marker],
+                  background: positionMarkerColor[visual.marker],
                   color: color.pillInk,
                   boxShadow: shadow.card,
                 }}
@@ -247,7 +209,7 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
                     lineHeight: 1,
                   }}
                 >
-                  {markerLabel[visual.marker]}
+                  {positionMarkerLabel[visual.marker]}
                 </span>
               </span>
             )}

--- a/packages/ui-shared/src/index.ts
+++ b/packages/ui-shared/src/index.ts
@@ -14,6 +14,12 @@ export type {
 } from "./PillButton.js";
 export { Panel } from "./Panel.js";
 export type { PanelProps } from "./Panel.js";
+export {
+  positionMarkerColor,
+  positionMarkerFor,
+  positionMarkerLabel,
+} from "./positionMarker.js";
+export type { PositionMarker } from "./positionMarker.js";
 export { color, font, fontSize, radius, shadow } from "./theme.js";
 export {
   applyRoomSoundSettings,

--- a/packages/ui-shared/src/positionMarker.test.ts
+++ b/packages/ui-shared/src/positionMarker.test.ts
@@ -1,0 +1,105 @@
+import type { PlayerView, TableView } from "@table-top-poker/protocol";
+import { describe, expect, it } from "vitest";
+import { positionMarkerFor } from "./positionMarker.js";
+
+const positions = {
+  button: 0,
+  smallBlind: 1,
+  bigBlind: 2,
+  dealtSeatCount: 6,
+} as const;
+
+const bettingTable: TableView = {
+  phase: "betting",
+  ...positions,
+  street: "flop",
+  board: [],
+  toAct: [3],
+  seats: [
+    { seatId: 0, folded: false },
+    { seatId: 1, folded: false },
+    { seatId: 2, folded: false },
+  ],
+};
+
+const bettingPlayer: PlayerView = {
+  ...bettingTable,
+  yourSeatId: 1,
+  yourHoleCards: null,
+  legalActions: [],
+};
+
+describe("positionMarkerFor", () => {
+  it("names each of the three positions", () => {
+    expect(positionMarkerFor(0, bettingTable)).toBe("button");
+    expect(positionMarkerFor(1, bettingTable)).toBe("small-blind");
+    expect(positionMarkerFor(2, bettingTable)).toBe("big-blind");
+  });
+
+  it("gives a seat holding no position nothing", () => {
+    expect(positionMarkerFor(3, bettingTable)).toBeNull();
+  });
+
+  it("reads a player view and a table view the same way", () => {
+    // The whole reason this rule left table-client: both devices must answer
+    // identically for the same seat.
+    for (const seatId of [0, 1, 2, 3]) {
+      expect(positionMarkerFor(seatId, bettingPlayer)).toBe(
+        positionMarkerFor(seatId, bettingTable),
+      );
+    }
+  });
+
+  it("has nothing to say about a seat with no view at all", () => {
+    expect(positionMarkerFor(0, null)).toBeNull();
+  });
+
+  it("shows only the button between hands, where the engine reports no blinds", () => {
+    const view: TableView = { phase: "no-hand", button: 1 };
+    expect(positionMarkerFor(1, view)).toBe("button");
+    expect(positionMarkerFor(2, view)).toBeNull();
+  });
+
+  describe("heads-up (issue #160, decision 4)", () => {
+    // The engine honestly reports smallBlind === button heads-up. Rather than
+    // put two markers on one seat, the whole trio reverts to button-only.
+    const headsUp = {
+      button: 0,
+      smallBlind: 0,
+      bigBlind: 1,
+      dealtSeatCount: 2,
+    } as const;
+
+    const cases: readonly (readonly [string, TableView])[] = [
+      ["betting", { ...bettingTable, ...headsUp, toAct: [0], seats: [] }],
+      [
+        "showdown",
+        {
+          phase: "showdown",
+          ...headsUp,
+          board: [],
+          results: [],
+          winners: [0],
+        },
+      ],
+      ["folded-out", { phase: "folded-out", ...headsUp, winner: 0 }],
+    ];
+
+    it.each(cases)("marks the button and nothing else (%s)", (_phase, view) => {
+      expect(positionMarkerFor(0, view)).toBe("button");
+      // Not "small-blind", though the button genuinely posts it heads-up…
+      expect(positionMarkerFor(1, view)).toBeNull();
+      // …and the other seat gets no BB either, on the phone as on the table
+      // (issue #207, decision 2).
+    });
+
+    it("still marks the blinds once a third seat is dealt in", () => {
+      const threeHanded: TableView = {
+        ...bettingTable,
+        ...headsUp,
+        dealtSeatCount: 3,
+      };
+      expect(positionMarkerFor(1, threeHanded)).toBe("big-blind");
+    });
+  });
+});

--- a/packages/ui-shared/src/positionMarker.ts
+++ b/packages/ui-shared/src/positionMarker.ts
@@ -1,0 +1,63 @@
+import type { PlayerView, SeatId, TableView } from "@table-top-poker/protocol";
+import { color } from "./theme.js";
+
+/**
+ * Which positional marker a seat carries, if any. Never more than one.
+ *
+ * Both devices show the same three markers, so the rule that picks one lives
+ * here rather than in either client: the table draws it on every seat pod, the
+ * player screen draws it for the one seat that is theirs, and neither can drift
+ * from the other's answer for the same seat.
+ */
+export type PositionMarker = "button" | "small-blind" | "big-blind";
+
+export const positionMarkerLabel: Record<PositionMarker, string> = {
+  button: "D",
+  "small-blind": "SB",
+  "big-blind": "BB",
+};
+
+export const positionMarkerColor: Record<PositionMarker, string> = {
+  button: color.buttonMarker,
+  "small-blind": color.blindSmallMarker,
+  "big-blind": color.blindBigMarker,
+};
+
+/**
+ * Which marker this seat carries. All three come off the same view, so the
+ * trio always moves on one tick and no seat ever carries two.
+ *
+ * Two suppressions, both deliberate:
+ *
+ * - Between hands (`no-hand`) only the button shows. The engine reports no
+ *   blinds without a hand, and the button it does report is already a
+ *   forecast of the next deal.
+ * - **Heads-up (`dealtSeatCount === 2`) only the button shows — no `SB` on
+ *   the button seat, and no `BB` on the other seat either.** The engine
+ *   honestly reports `smallBlind === button` heads-up (the button does post
+ *   the small blind), which would put two markers on one seat. Rather than
+ *   stack or combine them, a heads-up hand reverts to exactly the display
+ *   that existed before blind markers were added. This is a decision
+ *   (issue #160, decision 4), not an oversight.
+ *
+ * The second suppression is a table-shaped rule applied to both devices on
+ * purpose (issue #207, decision 2): a player screen shows one seat, so it has
+ * no collision to resolve and could name the heads-up big blind — but then the
+ * phone would mark a seat the table beside it deliberately leaves bare.
+ */
+export function positionMarkerFor(
+  seatId: SeatId,
+  view: PlayerView | TableView | null,
+): PositionMarker | null {
+  if (view === null) return null;
+  // Heads-up is a property of the deal, not of who is still live: folds never
+  // change it, so this reads the same in every phase of the hand.
+  const headsUp = view.phase !== "no-hand" && view.dealtSeatCount === 2;
+  if (view.phase === "no-hand" || headsUp) {
+    return seatId === view.button ? "button" : null;
+  }
+  if (seatId === view.button) return "button";
+  if (seatId === view.smallBlind) return "small-blind";
+  if (seatId === view.bigBlind) return "big-blind";
+  return null;
+}


### PR DESCRIPTION
Closes #207. Prototyped first in #206 (branch `proto/player-position-marker`); six placements were built and this one — the marker in place of the turn banner's tone dot — was chosen.

## What changes

The player's phone now says which position the player holds. The marker takes the slot the banner's tone dot occupies, **only when this player holds a position**; otherwise the banner renders exactly as before, so the change is additive.

| | |
| --- | --- |
| Phases | All four — betting, showdown, folded-out, no-hand. Between hands only `D` can appear (the engine reports no blinds without a hand) and that `D` is a forecast of the next deal. |
| Heads-up | Button only, on both devices. The engine reports `smallBlind === button`; #160 decision 4 settled this for the table and the phone now follows it, so the two never disagree about a seat. |
| Offline | The disc dims to 0.55. The banner's offline tone is muted; at full strength a white disc would be the loudest thing on a screen saying "actions won't send". |
| Accessibility | `aria-label="You are on the dealer button"` etc., with the letter itself `aria-hidden` — "D" read aloud is a letter, not a position. |

## The refactor, and why it's in this PR

`markerFor` was private to `table-client/src/Seats.tsx`. It moves to `ui-shared` as `positionMarkerFor(seatId, view)` over `PlayerView | TableView`, taking the label and colour maps with it. "The phone agrees with the table" is a promise that can silently break; shared, it holds by construction. Alone the extraction would be a refactor with no reason to exist, which is why it sits alongside the feature — reviewing them together is what shows the table is genuinely unchanged.

**Table behaviour is unchanged**: `Seats.test.tsx` passes untouched, including its heads-up and no-hand marker cases.

## Known trade, accepted deliberately

The dot's slot now means two things depending on the hand, so a player holding a position loses the tone-coloured dot that told them at a glance whether they won. The banner's background, border and kicker still carry the tone.

## Checks

- `tsc --build` clean
- 516 tests pass across `ui-shared`, `table-client` and `player-client` (25 new: 9 on the shared rule, 7 on the badge, 9 on the banner integration)
- `npm run lint` (eslint + prettier) clean
- `vite build` clean for both clients

No protocol or server work: `PlayerView` already carried `button`, `smallBlind`, `bigBlind` and `dealtSeatCount`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017UvUynydEB7FTmUauTDhV6