### PR TITLE
fix: suggest Hasbulla for seat selection

### DIFF
--- a/packages/player-client/src/SeatPicker.tsx
+++ b/packages/player-client/src/SeatPicker.tsx
@@ -287,7 +287,7 @@ export function SeatPicker({
               required
               aria-required="true"
               maxLength={MAX_DISPLAY_NAME_LENGTH}
-              placeholder="e.g. Avery"
+              placeholder="e.g. Hasbulla"
               onChange={(event) => {
                 setDisplayName(event.target.value);
               }}


### PR DESCRIPTION
## Summary

- Change the seat-selection display-name suggestion from “Avery” to “Hasbulla”.

## Validation

- `npm test --workspace @table-top-poker/player-client` — 366 tests passed.
- `npx prettier --check packages/player-client/src/SeatPicker.tsx` — passed.
