### PR TITLE
fix(engine)!: open preflop left of the blinds, with the BB last

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -132,7 +132,10 @@ holds independent of their Seat.
 **Small Blind / Big Blind**:
 The Seats immediately clockwise of the Button (SB = Button+1, BB =
 Button+2), fixing action order and the BB's option to check/raise if
-everyone limps preflop. No chip *amount* is tracked or stored by the engine
+everyone limps preflop. Preflop opens on the first Seat left of the blinds
+(Button+3) and runs to the BB, so the BB's "option" is simply their turn,
+which is the last one — not a second visit. No chip *amount* is tracked or
+stored by the engine
 — players post real physical blinds at the table, outside the program — but
 preflop *legality* still mirrors that post: every Seat except the BB faces
 a bet (must call/fold/raise, may not check) until someone raises or the BB
@@ -212,8 +215,9 @@ occurs *at* a position without advancing it.
    DEALING_HOLE          — hole cards dealt to each seated Player
         │ deal complete
         ▼
-   PREFLOP (a Street)    — button+1 first to act (heads-up: button acts
-        │                  first); BB gets the option if everyone limps
+   PREFLOP (a Street)    — button+3 first to act, running round to the BB
+        │                  last (heads-up: button acts first); the BB's
+        │                  option is that last turn
         ▼
    FLOP (a Street)       — 3 board cards dealt, betting round
         │

--- a/docs/adr/0001-preflop-legality-without-tracked-blind-values.md
+++ b/docs/adr/0001-preflop-legality-without-tracked-blind-values.md
@@ -27,9 +27,9 @@ Preflop, before any real `raise` command, every seat *except* the Big
 Blind faces a bet: `check` is illegal for them (must `fold`/`call`/`raise`),
 mirroring that they haven't yet matched the difference between their own
 post (nothing on this decision, or the Small Blind) and the Big Blind's.
-The Big Blind alone may `check` — on their ordinary first turn, and again
-on the later "option" revisit if the street was limped around — because
-their own post already matches the current bet. Once a real `raise` fires,
+The Big Blind alone may `check` on their turn — which preflop is the last
+one of the lap, so it doubles as their "option" — because their own post
+already matches the current bet. Once a real `raise` fires,
 the ordinary bet/raise/call machinery takes over for every seat, and this
 special case no longer applies for the rest of the street.
 
@@ -44,10 +44,11 @@ feature. Postflop is unaffected: nobody has a standing post there, so
 - `decide`'s legality check now needs to know the acting seat and the
   hand's `ring`/`button`, not just a single `raiseOccurred` boolean —
   `isLegal` and `facingBet` take the seat as a parameter.
-- The Big Blind seat identity (`bigBlindSeat`) is now needed both for
-  street closure (the existing "BB option" flag) and for legality, and had
-  to be generalized to heads-up, where the non-Button seat is the Big
-  Blind rather than `ring[1]`.
+- The Big Blind seat identity (`bigBlindSeat`) is needed for legality, and
+  had to be generalized to heads-up, where the non-Button seat is the Big
+  Blind rather than `ring[1]`. It was also needed for street closure while
+  preflop opened on the Small Blind; issue #210 corrected the order so the
+  lap ends on the Big Blind, and that closure machinery is gone.
 - `CONTEXT.md` and Phase 1 spec #130's "no values posted" wording is
   updated to distinguish "no chip *amount* tracked" from "preflop legality
   ignores that a bet exists" — the former stands, the latter doesn't.

--- a/packages/engine/src/apply.ts
+++ b/packages/engine/src/apply.ts
@@ -57,7 +57,6 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
             ]),
           ),
           toAct: [],
-          bbOptionPending: false,
           raiseOccurred: false,
         },
       };
@@ -76,19 +75,13 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
     case "StreetStarted": {
       const hand = asBetting(state);
       const live = hand.ring.filter((seat) => !seatState(hand, seat).folded);
-      const { toAct, bbOptionPending } = initialToAct(
-        hand.ring,
-        live,
-        hand.button,
-        event.street,
-      );
+      const toAct = initialToAct(hand.ring, live, hand.button, event.street);
       return {
         ...state,
         hand: {
           ...hand,
           street: event.street,
           toAct,
-          bbOptionPending,
           raiseOccurred: false,
         },
       };
@@ -106,25 +99,14 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
       // Ordinary actions always belong to `toAct[0]`; an eviction may fold a
       // live seat later in the queue, so remove the event's seat by identity
       // and leave the current actor at the head of the queue.
-      let toAct = hand.toAct.filter((seat) => seat !== event.seatId);
-      let bbOptionPending = hand.bbOptionPending;
-
-      if (event.action === "raise") {
-        toAct = requeueAfterRaise(hand.ring, players, event.seatId);
-        bbOptionPending = false;
-      } else if (toAct.length === 0 && bbOptionPending) {
-        const bigBlind = bigBlindSeat(hand.ring, hand.button);
-        // The BB may have already folded earlier in this same lap (at their
-        // normal turn) — a folded seat never gets a turn, option or not.
-        if (!must(players.get(bigBlind)).folded) {
-          toAct = [bigBlind];
-        }
-        bbOptionPending = false;
-      }
+      const toAct =
+        event.action === "raise"
+          ? requeueAfterRaise(hand.ring, players, event.seatId)
+          : hand.toAct.filter((seat) => seat !== event.seatId);
 
       return {
         ...state,
-        hand: { ...hand, players, raiseOccurred, toAct, bbOptionPending },
+        hand: { ...hand, players, raiseOccurred, toAct },
       };
     }
 

--- a/packages/engine/src/blinds.test.ts
+++ b/packages/engine/src/blinds.test.ts
@@ -53,7 +53,8 @@ describe("view: blinds during betting", () => {
     let state = createInitialState([0, 1, 2]);
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "fixed" }]);
     const before = bettingView(state);
-    state = playAll(state, [{ type: "fold", seatId: 1 }]);
+    // Preflop opens on the button three-handed, so seat 0 is the folder.
+    state = playAll(state, [{ type: "fold", seatId: 0 }]);
     const after = bettingView(state);
 
     expect(after.smallBlind).toBe(before.smallBlind);
@@ -69,8 +70,8 @@ describe("view: blinds on a completed hand", () => {
     const betting = bettingView(state);
 
     state = playAll(state, [
+      { type: "fold", seatId: 0 },
       { type: "fold", seatId: 1 },
-      { type: "fold", seatId: 2 },
     ]);
 
     // `HandComplete` has rotated the engine button on to the next seat, but
@@ -90,10 +91,10 @@ describe("view: blinds on a completed hand", () => {
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "sd" }]);
     const betting = bettingView(state);
 
+    // Preflop runs button, SB, BB; every later street runs SB, BB, button.
     state = playAll(state, [
-      { type: "call", seatId: 1 },
-      { type: "check", seatId: 2 },
       { type: "call", seatId: 0 },
+      { type: "call", seatId: 1 },
       { type: "check", seatId: 2 },
       { type: "check", seatId: 1 },
       { type: "check", seatId: 2 },

--- a/packages/engine/src/command-seat-id.test.ts
+++ b/packages/engine/src/command-seat-id.test.ts
@@ -18,9 +18,9 @@ describe("Command seat identity", () => {
     let state = initial;
     for (const event of started) state = apply(state, event);
 
-    const action = decide(state, { type: "fold", seatId: 1 });
+    const action = decide(state, { type: "fold", seatId: 0 });
     expect(action).toEqual([
-      { type: "ActionTaken", seatId: 1, action: "fold" },
+      { type: "ActionTaken", seatId: 0, action: "fold" },
     ]);
   });
 });

--- a/packages/engine/src/complete-hand-state.test.ts
+++ b/packages/engine/src/complete-hand-state.test.ts
@@ -6,15 +6,16 @@ describe("CompleteHandState carries how the hand ended", () => {
   it("tags a fold-out completion with reason 'folded-out' and the winner", () => {
     let state = createInitialState([0, 1, 2]);
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "foldout" }]);
+    // Preflop runs button, SB, BB — the BB is left holding the pot.
     state = playAll(state, [
+      { type: "fold", seatId: 0 },
       { type: "fold", seatId: 1 },
-      { type: "fold", seatId: 2 },
     ]);
 
     if (state.hand?.status !== "complete") throw new Error("expected complete");
     expect(state.hand.reason).toBe("folded-out");
     if (state.hand.reason === "folded-out") {
-      expect(state.hand.winner).toBe(0);
+      expect(state.hand.winner).toBe(2);
     }
   });
 

--- a/packages/engine/src/decide.ts
+++ b/packages/engine/src/decide.ts
@@ -79,7 +79,7 @@ function beginHand(state: EngineState, seed: string): HandEvent[] {
   events.push(holeCardsDealt);
   scratch = apply(scratch, holeCardsDealt);
 
-  const { toAct } = initialToAct(ring, ring, button, "preflop");
+  const toAct = initialToAct(ring, ring, button, "preflop");
   const streetStarted: HandEvent = {
     type: "StreetStarted",
     street: "preflop",
@@ -223,7 +223,7 @@ function decideActionEvents(
   events.push(boardDealt);
   scratch = apply(scratch, boardDealt);
 
-  const { toAct: nextToAct } = initialToAct(
+  const nextToAct = initialToAct(
     handAfterAction.ring,
     live,
     hand.button,

--- a/packages/engine/src/fold-out.test.ts
+++ b/packages/engine/src/fold-out.test.ts
@@ -9,11 +9,12 @@ describe("fold-out early exit", () => {
     let state = createInitialState([0, 1, 2]);
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "foldout" }]);
 
-    // Preflop: 1 folds, 2 (BB) folds — only seat 0 remains live, mid-street.
-    state = playAll(state, [{ type: "fold", seatId: 1 }]);
+    // Preflop: 0 (button, first to act) folds, then 1 (SB) folds — only seat
+    // 2 remains live, mid-street with the BB never having acted.
+    state = playAll(state, [{ type: "fold", seatId: 0 }]);
     expect(state.hand?.status).toBe("betting");
 
-    const result = decide(state, { type: "fold", seatId: 2 });
+    const result = decide(state, { type: "fold", seatId: 1 });
     if (!Array.isArray(result)) throw new Error("expected events");
 
     expect(result.some((e) => e.type === "StreetClosed")).toBe(false);
@@ -21,7 +22,7 @@ describe("fold-out early exit", () => {
     const foldedOut = result.find((e) => e.type === "HandFoldedOut");
     expect(foldedOut).toBeDefined();
     if (foldedOut?.type === "HandFoldedOut") {
-      expect(foldedOut.winner).toBe(0);
+      expect(foldedOut.winner).toBe(2);
     }
     expect(result.at(-1)?.type).toBe("HandComplete");
 

--- a/packages/engine/src/lifecycle.test.ts
+++ b/packages/engine/src/lifecycle.test.ts
@@ -10,13 +10,14 @@ describe("a full hand, 3 seats, start to showdown", () => {
     let state = createInitialState([0, 1, 2]);
     expect(state.button).toBe(0);
 
-    // ring (button 0) = [1, 2, 0]; preflop order = [1, 2, 0], BB = seat 2.
+    // ring (button 0) = [1, 2, 0]; preflop order = [0, 1, 2], BB = seat 2.
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "seed-1" }]);
     expect(state.hand?.status).toBe("betting");
 
-    // Preflop: 1 calls the BB (not free to check — only the BB itself is),
-    // 2 (BB) raises, 0 calls, 1 calls (closes back to raiser).
+    // Preflop: 0 and 1 call the BB (not free to check — only the BB itself
+    // is), 2 (BB) raises, 0 calls, 1 calls (closes back to raiser).
     state = playAll(state, [
+      { type: "call", seatId: 0 },
       { type: "call", seatId: 1 },
       { type: "raise", seatId: 2 },
       { type: "call", seatId: 0 },

--- a/packages/engine/src/next-hand.test.ts
+++ b/packages/engine/src/next-hand.test.ts
@@ -8,10 +8,10 @@ describe("nextHand", () => {
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "hand-1" }]);
     expect(state.button).toBe(0);
 
-    // Fold everyone but seat 0 out to reach HAND_COMPLETE quickly.
+    // Fold everyone but seat 2 out to reach HAND_COMPLETE quickly.
     state = playAll(state, [
+      { type: "fold", seatId: 0 },
       { type: "fold", seatId: 1 },
-      { type: "fold", seatId: 2 },
     ]);
     expect(state.hand?.status).toBe("complete");
     expect(state.button).toBe(1);

--- a/packages/engine/src/preflop-order.test.ts
+++ b/packages/engine/src/preflop-order.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { initialToAct, rotateFromButton } from "./table.js";
+import type { SeatId } from "./types.js";
+
+/**
+ * Preflop opens on the first seat left of the blinds and ends on the big
+ * blind (Robert's Rules of Poker, "Button and Blind Use") — the button-
+ * relative ring rotated to start at button+3. Heads-up is the exception:
+ * the small blind is on the button and acts first preflop.
+ *
+ * Table-driven across the full supported field (MAX_SEAT_COUNT is 8), with
+ * the button on seat 1 so the expected orders read as plain seat numbers.
+ */
+const BUTTON: SeatId = 1;
+
+const cases: { n: number; expected: SeatId[]; note: string }[] = [
+  { n: 2, expected: [1, 2], note: "BTN/SB, BB" },
+  { n: 3, expected: [1, 2, 3], note: "BTN, SB, BB" },
+  { n: 4, expected: [4, 1, 2, 3], note: "UTG, BTN, SB, BB" },
+  { n: 5, expected: [4, 5, 1, 2, 3], note: "UTG, UTG+1, BTN, SB, BB" },
+  { n: 6, expected: [4, 5, 6, 1, 2, 3], note: "UTG..UTG+2, BTN, SB, BB" },
+  { n: 7, expected: [4, 5, 6, 7, 1, 2, 3], note: "UTG..LJ, BTN, SB, BB" },
+  { n: 8, expected: [4, 5, 6, 7, 8, 1, 2, 3], note: "UTG..HJ, BTN, SB, BB" },
+];
+
+describe("initialToAct: preflop order", () => {
+  for (const { n, expected, note } of cases) {
+    it(`opens left of the blinds and ends on the BB ${String(n)}-handed (${note})`, () => {
+      const seats: SeatId[] = Array.from({ length: n }, (_, i) => i + 1);
+      const ring = rotateFromButton(seats, BUTTON);
+
+      expect(initialToAct(ring, ring, BUTTON, "preflop")).toEqual(expected);
+    });
+  }
+});
+
+describe("initialToAct: postflop order", () => {
+  for (const { n } of cases) {
+    it(`runs small blind to button ${String(n)}-handed`, () => {
+      const seats: SeatId[] = Array.from({ length: n }, (_, i) => i + 1);
+      const ring = rotateFromButton(seats, BUTTON);
+
+      expect(initialToAct(ring, ring, BUTTON, "flop")).toEqual(ring);
+    });
+  }
+});
+
+describe("initialToAct: folded seats", () => {
+  it("drops folded seats from the preflop lap, keeping the rotation", () => {
+    const ring = rotateFromButton([1, 2, 3, 4, 5], BUTTON);
+    // Seat 4 (UTG) and seat 2 (SB) are out; the rest keep their order.
+    expect(initialToAct(ring, [1, 3, 5], BUTTON, "preflop")).toEqual([5, 1, 3]);
+  });
+
+  it("keeps heads-up order off the ring, not the live seats", () => {
+    // A 3-seat ring with only 2 live seats is unreachable today, but must
+    // not read as heads-up: blind positions are decided off `ring.length`,
+    // and the action order has to agree with them.
+    const ring = rotateFromButton([1, 2, 3], BUTTON);
+    expect(initialToAct(ring, [1, 3], BUTTON, "preflop")).toEqual([1, 3]);
+  });
+});

--- a/packages/engine/src/rejections.test.ts
+++ b/packages/engine/src/rejections.test.ts
@@ -21,8 +21,8 @@ describe("rejections", () => {
   it("not-your-turn: acting out of turn", () => {
     let state = createInitialState([0, 1, 2]);
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "s" }]);
-    // Preflop first actor is seat 1, not seat 0.
-    const outcome = play(state, { type: "check", seatId: 0 });
+    // Preflop first actor is seat 0 (the button, three-handed), not seat 1.
+    const outcome = play(state, { type: "check", seatId: 1 });
     if (!("rejection" in outcome)) throw new Error("expected a rejection");
     expect(outcome.rejection.reason).toBe("not-your-turn");
   });
@@ -31,21 +31,22 @@ describe("rejections", () => {
     let state = createInitialState([0, 1, 2]);
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "s" }]);
     state = playAll(state, [
-      { type: "call", seatId: 1 },
-      { type: "raise", seatId: 2 },
+      { type: "call", seatId: 0 },
+      { type: "raise", seatId: 1 },
     ]);
-    const outcome = play(state, { type: "check", seatId: 0 });
+    const outcome = play(state, { type: "check", seatId: 2 });
     if (!("rejection" in outcome)) throw new Error("expected a rejection");
     expect(outcome.rejection.reason).toBe("action-not-legal");
   });
 
   it("action-not-legal: checking preflop when you're not the big blind", () => {
-    // Seat 1 (SB) faces the BB's post and must call/fold/raise, not check.
+    // Seat 0 (the button, first to act) faces the BB's post and must
+    // call/fold/raise, not check.
     const state = createInitialState([0, 1, 2]);
     const started = playAll(state, [
       { type: "startHand", seatId: 0, seed: "s" },
     ]);
-    const outcome = play(started, { type: "check", seatId: 1 });
+    const outcome = play(started, { type: "check", seatId: 0 });
     if (!("rejection" in outcome)) throw new Error("expected a rejection");
     expect(outcome.rejection.reason).toBe("action-not-legal");
   });
@@ -54,7 +55,10 @@ describe("rejections", () => {
     // The BB has nothing to call on an unraised preflop — only check/raise.
     let state = createInitialState([0, 1, 2]);
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "s" }]);
-    state = playAll(state, [{ type: "call", seatId: 1 }]);
+    state = playAll(state, [
+      { type: "call", seatId: 0 },
+      { type: "call", seatId: 1 },
+    ]);
     const outcome = play(state, { type: "call", seatId: 2 });
     if (!("rejection" in outcome)) throw new Error("expected a rejection");
     expect(outcome.rejection.reason).toBe("action-not-legal");

--- a/packages/engine/src/showdown.test.ts
+++ b/packages/engine/src/showdown.test.ts
@@ -79,6 +79,7 @@ describe("ShowdownReached omits folded seats", () => {
     const state = createInitialState([0, 1, 2]);
     const events = playAndCollect(state, [
       { type: "startHand", seatId: 0, seed: "seed-1" },
+      { type: "call", seatId: 0 },
       { type: "call", seatId: 1 },
       { type: "raise", seatId: 2 },
       { type: "call", seatId: 0 },

--- a/packages/engine/src/street-closure.test.ts
+++ b/packages/engine/src/street-closure.test.ts
@@ -1,15 +1,24 @@
 import { describe, expect, it } from "vitest";
 import { createInitialState } from "./room.js";
-import { playAll } from "./test-utils.js";
+import { bigBlindSeat, smallBlindSeat } from "./table.js";
+import { play, playAll } from "./test-utils.js";
+import type { EngineState, SeatId } from "./types.js";
 
 function street(state: ReturnType<typeof createInitialState>) {
   if (state.hand?.status !== "betting") throw new Error("expected betting");
   return state.hand;
 }
 
+function actor(state: EngineState): SeatId {
+  const [next] = street(state).toAct;
+  if (next === undefined) throw new Error("expected an actor");
+  return next;
+}
+
 describe("street closure — limped-around preflop", () => {
-  it("closes only once the BB has had its option, with nobody raising", () => {
-    // 3 seats; button 0, small blind 1, big blind 2.
+  it("closes after one lap ending on the BB, with nobody raising", () => {
+    // 3 seats; button 0, small blind 1, big blind 2. Preflop opens on the
+    // first seat left of the blinds, which three-handed is the button.
     const BUTTON = 0;
     const SB = 1;
     const BB = 2;
@@ -18,29 +27,93 @@ describe("street closure — limped-around preflop", () => {
     state = playAll(state, [
       { type: "startHand", seatId: BUTTON, seed: "limp" },
     ]);
+    expect(street(state).toAct).toEqual([BUTTON, SB, BB]);
 
-    // SB calls the BB's post (only the BB may check an unraised preflop) —
-    // BB hasn't acted yet even though it's technically their normal turn
-    // next — confirm the street is still open after the SB.
-    state = playAll(state, [{ type: "call", seatId: SB }]);
-    expect(street(state).street).toBe("preflop");
-    expect(street(state).toAct[0]).toBe(BB);
-
-    // BB checks its first (normal) turn — button hasn't acted yet, so the
-    // street must still be open, and BB gets a second "option" visit later.
-    state = playAll(state, [{ type: "check", seatId: BB }]);
-    expect(street(state).street).toBe("preflop");
-    expect(street(state).toAct[0]).toBe(BUTTON);
-
-    // Button calls — completes the first lap. Nobody raised, so the BB's
-    // option is still outstanding: the street must NOT close here.
+    // Only the BB may check an unraised preflop; everyone else calls.
     state = playAll(state, [{ type: "call", seatId: BUTTON }]);
+    expect(street(state).street).toBe("preflop");
+    expect(street(state).toAct).toEqual([SB, BB]);
+
+    state = playAll(state, [{ type: "call", seatId: SB }]);
     expect(street(state).street).toBe("preflop");
     expect(street(state).toAct).toEqual([BB]);
 
-    // BB's option: checking now finally closes preflop.
+    // The BB's option is simply their turn, and it is the last one — no
+    // second visit, and checking it closes preflop.
     state = playAll(state, [{ type: "check", seatId: BB }]);
     expect(street(state).street).toBe("flop");
+  });
+
+  it("rejects the small blind trying to open preflop", () => {
+    // The reported production bug: preflop opened on the small blind.
+    const BUTTON = 0;
+    const SB = 1;
+    const BB = 2;
+
+    let state = createInitialState([BUTTON, SB, BB]);
+    state = playAll(state, [
+      { type: "startHand", seatId: BUTTON, seed: "sb-out-of-turn" },
+    ]);
+
+    const outcome = play(state, { type: "call", seatId: SB });
+    if (!("rejection" in outcome)) {
+      throw new Error("expected the small blind's open to be rejected");
+    }
+    expect(outcome.rejection.reason).toBe("not-your-turn");
+  });
+
+  it("gives a folding BB no phantom extra turn", () => {
+    const BUTTON = 0;
+    const SB = 1;
+    const BB = 2;
+
+    let state = createInitialState([BUTTON, SB, BB]);
+    state = playAll(state, [
+      { type: "startHand", seatId: BUTTON, seed: "bb-folds" },
+      { type: "call", seatId: BUTTON },
+      { type: "call", seatId: SB },
+    ]);
+    expect(street(state).toAct).toEqual([BB]);
+
+    // Folding the option closes preflop exactly as checking it would; the
+    // BB must not be re-queued behind their own fold.
+    state = playAll(state, [{ type: "fold", seatId: BB }]);
+    expect(street(state).street).toBe("flop");
+    expect(street(state).toAct).toEqual([SB, BUTTON]);
+  });
+
+  it("takes exactly one action per live seat, BB last, at every field size", () => {
+    for (let n = 2; n <= 8; n++) {
+      const seats: SeatId[] = Array.from({ length: n }, (_, i) => i);
+      let state = createInitialState(seats);
+      state = playAll(state, [
+        { type: "startHand", seatId: 0, seed: `limp-${String(n)}` },
+      ]);
+      const ring = street(state).ring;
+      const bigBlind = bigBlindSeat(ring, 0);
+      const smallBlind = smallBlindSeat(ring, 0);
+
+      // Preflop never opens on either blind with 3+ seats; heads-up the
+      // small blind is on the button and opens by rule.
+      expect(actor(state)).not.toBe(bigBlind);
+      if (n > 2) expect(actor(state)).not.toBe(smallBlind);
+
+      const acted: SeatId[] = [];
+      while (street(state).street === "preflop") {
+        const seatId = actor(state);
+        acted.push(seatId);
+        state = playAll(state, [
+          seatId === bigBlind
+            ? { type: "check", seatId }
+            : { type: "call", seatId },
+        ]);
+      }
+
+      expect(acted).toHaveLength(n);
+      expect(new Set(acted).size).toBe(n);
+      expect(acted[n - 1]).toBe(bigBlind);
+      expect(street(state).street).toBe("flop");
+    }
   });
 });
 
@@ -55,19 +128,19 @@ describe("street closure — raised and called", () => {
       { type: "startHand", seatId: BUTTON, seed: "raised" },
     ]);
 
-    // SB calls, BB raises — action must return to BB to close, skipping the
-    // BB-option mechanic entirely since a real raise already happened.
+    // Button calls, SB raises mid-lap — the requeue runs in ring order from
+    // the raiser, so the BB (who had not yet acted) still gets their turn.
     state = playAll(state, [
-      { type: "call", seatId: SB },
-      { type: "raise", seatId: BB },
+      { type: "call", seatId: BUTTON },
+      { type: "raise", seatId: SB },
     ]);
-    expect(street(state).toAct).toEqual([BUTTON, SB]);
+    expect(street(state).toAct).toEqual([BB, BUTTON]);
+
+    state = playAll(state, [{ type: "call", seatId: BB }]);
+    expect(street(state).street).toBe("preflop");
+    expect(street(state).toAct).toEqual([BUTTON]);
 
     state = playAll(state, [{ type: "call", seatId: BUTTON }]);
-    expect(street(state).street).toBe("preflop");
-    expect(street(state).toAct).toEqual([SB]);
-
-    state = playAll(state, [{ type: "call", seatId: SB }]);
     expect(street(state).street).toBe("flop");
   });
 
@@ -82,22 +155,23 @@ describe("street closure — raised and called", () => {
     ]);
 
     state = playAll(state, [
-      { type: "call", seatId: SB },
+      { type: "call", seatId: BUTTON },
+      { type: "raise", seatId: SB },
       { type: "raise", seatId: BB },
-      { type: "raise", seatId: BUTTON },
     ]);
-    // Button re-raised: only SB and BB owe a response now, in that order.
-    expect(street(state).toAct).toEqual([SB, BB]);
+    // BB re-raised: only the button and SB owe a response now, in that order.
+    expect(street(state).toAct).toEqual([BUTTON, SB]);
 
     state = playAll(state, [
+      { type: "call", seatId: BUTTON },
       { type: "call", seatId: SB },
-      { type: "call", seatId: BB },
     ]);
     expect(street(state).street).toBe("flop");
   });
 
   it("requeues correctly when the raiser is the BB and an earlier seat already folded", () => {
-    // 4 seats; button 0, small blind 1, big blind 2, UTG 3.
+    // 4 seats; button 0, small blind 1, big blind 2, UTG 3 — so preflop
+    // runs UTG, button, SB, BB.
     const BUTTON = 0;
     const SB = 1;
     const BB = 2;
@@ -107,15 +181,16 @@ describe("street closure — raised and called", () => {
     state = playAll(state, [
       { type: "startHand", seatId: BUTTON, seed: "bb-raise" },
     ]);
+    expect(street(state).toAct).toEqual([UTG, BUTTON, SB, BB]);
 
     state = playAll(state, [
+      { type: "call", seatId: UTG },
+      { type: "call", seatId: BUTTON },
       { type: "fold", seatId: SB },
       { type: "raise", seatId: BB },
     ]);
-    // SB already folded, so only UTG and the button owe a response — the
-    // BB-option flag is also moot now, since a real raise already happened.
+    // SB already folded, so only UTG and the button owe a response.
     expect(street(state).toAct).toEqual([UTG, BUTTON]);
-    expect(street(state).bbOptionPending).toBe(false);
 
     state = playAll(state, [
       { type: "call", seatId: UTG },

--- a/packages/engine/src/table.test.ts
+++ b/packages/engine/src/table.test.ts
@@ -13,6 +13,7 @@ describe("legalActions", () => {
       throw new Error("expected betting");
     }
     // ring (button 0) = [1, 2, 0]; seat 1 (SB) faces the BB's post.
+    // Preflop order is [0, 1, 2], but legality is positional, not turn-based.
     expect(legalActions(started.hand, 1)).toEqual(["fold", "call", "raise"]);
   });
 
@@ -24,11 +25,11 @@ describe("legalActions", () => {
     if (started.hand?.status !== "betting") {
       throw new Error("expected betting");
     }
-    // BB is seat 2 here — its own post already matches, so it may check.
+    // BB is seat 2 here — its own post already matches, so it may check on
+    // its turn, which is the last one of the preflop lap.
     const afterLap = playAll(started, [
-      { type: "call", seatId: 1 },
-      { type: "check", seatId: 2 },
       { type: "call", seatId: 0 },
+      { type: "call", seatId: 1 },
     ]);
     if (afterLap.hand?.status !== "betting") {
       throw new Error("expected betting");

--- a/packages/engine/src/table.ts
+++ b/packages/engine/src/table.ts
@@ -34,32 +34,35 @@ export function liveSeats(hand: BettingHandState): SeatId[] {
 }
 
 /**
- * The action order and whether the big blind's one-time preflop "option" is
- * still pending, for the start of a street.
+ * The action order for the start of a street: the live seats, in the order
+ * they owe a decision.
  *
- * Ordinary streets (and heads-up preflop, where the two-seat order already
- * ends at the big blind) close as soon as every live seat has acted once
- * with no raise: closure falls straight out of `toAct` draining to empty.
- * Preflop with 3+ live players is the one case that doesn't reduce to a
- * single lap — the big blind sits mid-order (`ring[1]`), not last, so it
- * needs an explicit flag: once the first lap (SB, BB, ..., button) drains
- * with no raise, the big blind gets one final visit before the street can
- * close (`bbOptionPending`, consumed in `apply`'s `ActionTaken` handling).
+ * Postflop runs the ring as-is, small blind through button. Preflop with
+ * 3+ seats starts "with the first player to the left of the blinds"
+ * (Robert's Rules of Poker, "Button and Blind Use") — the ring rotated two
+ * seats, `UTG, ..., BTN, SB, BB`. Heads-up the small blind is on the
+ * button and acts first, so the order is `BTN/SB, BB`.
+ *
+ * The big blind is last in every case, so their one-time "option" needs no
+ * special machinery: every street closes the same way, when `toAct` drains.
+ * Heads-up is decided off `ring.length`, matching `smallBlindSeat` and
+ * `bigBlindSeat` — a short-handed lap must never read as heads-up and
+ * disagree with the blind positions it was dealt with.
  */
 export function initialToAct(
   ring: readonly SeatId[],
   live: readonly SeatId[],
   button: SeatId,
   street: Street,
-): { toAct: SeatId[]; bbOptionPending: boolean } {
-  const isHeadsUp = live.length === 2;
+): SeatId[] {
+  if (street !== "preflop") return ring.filter((seat) => live.includes(seat));
 
-  const toAct =
-    street === "preflop" && isHeadsUp
-      ? [button, ...live.filter((seat) => seat !== button)]
-      : ring.filter((seat) => live.includes(seat));
+  const order =
+    ring.length === 2
+      ? [button, ...ring.filter((seat) => seat !== button)]
+      : [...ring.slice(2), ...ring.slice(0, 2)];
 
-  return { toAct, bbOptionPending: street === "preflop" && !isHeadsUp };
+  return order.filter((seat) => live.includes(seat));
 }
 
 /**

--- a/packages/engine/src/table.ts
+++ b/packages/engine/src/table.ts
@@ -45,9 +45,9 @@ export function liveSeats(hand: BettingHandState): SeatId[] {
  *
  * The big blind is last in every case, so their one-time "option" needs no
  * special machinery: every street closes the same way, when `toAct` drains.
- * Heads-up is decided off `ring.length`, matching `smallBlindSeat` and
- * `bigBlindSeat` — a short-handed lap must never read as heads-up and
- * disagree with the blind positions it was dealt with.
+ * Heads-up is decided off the ring, via the same `isHeadsUp` the blind
+ * seats use — a short-handed lap must never read as heads-up and disagree
+ * with the blind positions it was dealt with.
  */
 export function initialToAct(
   ring: readonly SeatId[],
@@ -57,12 +57,28 @@ export function initialToAct(
 ): SeatId[] {
   if (street !== "preflop") return ring.filter((seat) => live.includes(seat));
 
-  const order =
-    ring.length === 2
-      ? [button, ...ring.filter((seat) => seat !== button)]
-      : [...ring.slice(2), ...ring.slice(0, 2)];
+  const order = isHeadsUp(ring)
+    ? [button, ...ring.filter((seat) => seat !== button)]
+    : [...ring.slice(BLIND_COUNT), ...ring.slice(0, BLIND_COUNT)];
 
   return order.filter((seat) => live.includes(seat));
+}
+
+/**
+ * The two blind seats at the head of the ring, `[SB, BB]` — the rotation
+ * preflop action skips past, and the reason `initialToAct` opens at
+ * `ring[2]`.
+ */
+const BLIND_COUNT = 2;
+
+/**
+ * Whether this hand is heads-up, off the seats it was dealt to rather than
+ * the seats still live. Every position rule that reads differently heads-up
+ * — both blind seats and the preflop order — asks this one question, so
+ * they cannot disagree with each other partway through a hand.
+ */
+function isHeadsUp(ring: readonly SeatId[]): boolean {
+  return ring.length === BLIND_COUNT;
 }
 
 /**
@@ -74,7 +90,7 @@ export function smallBlindSeat(
   ring: readonly SeatId[],
   button: SeatId,
 ): SeatId {
-  if (ring.length === 2) return button;
+  if (isHeadsUp(ring)) return button;
   return must(ring[0], "the small blind needs at least 2 seated players");
 }
 
@@ -84,7 +100,7 @@ export function smallBlindSeat(
  * non-button seat is the big blind instead.
  */
 export function bigBlindSeat(ring: readonly SeatId[], button: SeatId): SeatId {
-  if (ring.length === 2) {
+  if (isHeadsUp(ring)) {
     return must(
       ring.find((seat) => seat !== button),
       "heads-up needs a non-button seat",
@@ -101,7 +117,8 @@ export function bigBlindSeat(ring: readonly SeatId[], button: SeatId): SeatId {
  * seat faces a bet once someone has actually raised; preflop, before that,
  * every seat except the big blind also faces a bet — the big blind's own
  * post already matches it, which is exactly why the big blind alone may
- * check on an unraised preflop (their normal turn, or their later option).
+ * check on an unraised preflop. Preflop that turn is the last of the lap,
+ * so it is also the big blind's "option".
  */
 export function facingBet(
   hand: Pick<BettingHandState, "street" | "ring" | "button" | "raiseOccurred">,

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -84,11 +84,6 @@ export interface BettingHandState {
   readonly players: ReadonlyMap<SeatId, SeatHandState>;
   /** Seats still owed a decision this street, in order; `toAct[0]` is the current actor. */
   readonly toAct: readonly SeatId[];
-  /**
-   * Preflop only, 3+ live players: true until the big blind has had its
-   * one-time "option" turn after a no-raise lap all the way to the button.
-   */
-  readonly bbOptionPending: boolean;
   readonly raiseOccurred: boolean;
 }
 

--- a/packages/engine/src/version.test.ts
+++ b/packages/engine/src/version.test.ts
@@ -7,7 +7,7 @@ describe("ENGINE_LOG_VERSION", () => {
     expect(ENGINE_LOG_VERSION).toBeGreaterThan(0);
   });
 
-  it("uses the next version for the seat-addressed command schema", () => {
-    expect(ENGINE_LOG_VERSION).toBe(3);
+  it("uses the next version for the corrected preflop action order", () => {
+    expect(ENGINE_LOG_VERSION).toBe(4);
   });
 });

--- a/packages/engine/src/version.ts
+++ b/packages/engine/src/version.ts
@@ -1,6 +1,6 @@
 /**
- * Schema version tag for persisted command/event log records — bumped
- * whenever a change to `HandEvent`/`Command` shapes or the shuffle would
+ * Compatibility version tag for persisted command/event log records — bumped
+ * whenever command or event shapes, the shuffle, or engine behaviour would
  * break bit-identical replay. See Phase 1 spec #130 §5.
  */
-export const ENGINE_LOG_VERSION = 3;
+export const ENGINE_LOG_VERSION = 4;

--- a/packages/engine/src/view.test.ts
+++ b/packages/engine/src/view.test.ts
@@ -29,13 +29,12 @@ function headsUpToRiver(seed: string): EngineState {
 function onTheFlopThreeWay(): EngineState {
   let state = createInitialState([0, 1, 2]);
   state = playAll(state, [{ type: "startHand", seatId: 0, seed: "mid" }]);
-  // ring (button 0) = [1, 2, 0], BB = seat 2. Only the BB can check preflop
-  // absent a raise; everyone else calls. No raise, so the BB also gets its
-  // one-time option turn after the lap closes back around.
+  // ring (button 0) = [1, 2, 0], so preflop runs [0, 1, 2] with BB = seat 2.
+  // Only the BB can check preflop absent a raise; everyone else calls. The
+  // BB acts last, so its check closes the street — no extra option turn.
   state = playAll(state, [
-    { type: "call", seatId: 1 },
-    { type: "check", seatId: 2 },
     { type: "call", seatId: 0 },
+    { type: "call", seatId: 1 },
     { type: "check", seatId: 2 },
   ]);
   if (state.hand?.status !== "betting" || state.hand.street !== "flop") {
@@ -152,6 +151,7 @@ describe("view: post-showdown", () => {
     let state = createInitialState([0, 1, 2]);
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "seed-1" }]);
     state = playAll(state, [
+      { type: "call", seatId: 0 },
       { type: "call", seatId: 1 },
       { type: "raise", seatId: 2 },
       { type: "call", seatId: 0 },

--- a/packages/harness/fixtures/hand-1.commands.jsonl
+++ b/packages/harness/fixtures/hand-1.commands.jsonl
@@ -1,4 +1,5 @@
 {"type":"startHand","seatId":0,"seed":"harness-fixture-1"}
+{"type":"call","seatId":0}
 {"type":"call","seatId":1}
 {"type":"raise","seatId":2}
 {"type":"call","seatId":0}

--- a/packages/harness/fixtures/hand-1.expected.jsonl
+++ b/packages/harness/fixtures/hand-1.expected.jsonl
@@ -1,6 +1,7 @@
 {"type":"HandStarted","seed":"harness-fixture-1","button":0}
 {"type":"HoleCardsDealt","deals":[{"seatId":1,"cards":[{"rank":"7","suit":"clubs"},{"rank":"5","suit":"spades"}]},{"seatId":2,"cards":[{"rank":"9","suit":"spades"},{"rank":"2","suit":"clubs"}]},{"seatId":0,"cards":[{"rank":"J","suit":"clubs"},{"rank":"7","suit":"hearts"}]}]}
-{"type":"StreetStarted","street":"preflop","actor":1}
+{"type":"StreetStarted","street":"preflop","actor":0}
+{"type":"ActionTaken","seatId":0,"action":"call"}
 {"type":"ActionTaken","seatId":1,"action":"call"}
 {"type":"ActionTaken","seatId":2,"action":"raise"}
 {"type":"ActionTaken","seatId":0,"action":"call"}

--- a/packages/harness/src/fixtures.test.ts
+++ b/packages/harness/src/fixtures.test.ts
@@ -43,10 +43,8 @@ describe("hand-1 fixture", () => {
 
 describe("hand-1 fixture: replay through the engine", () => {
   it("folds the recorded event log into a state carrying the hand's blinds", async () => {
-    // The fixture was recorded before `smallBlind`/`bigBlind` existed on the
-    // completed hand. `HandEvent` shapes are unchanged (ENGINE_LOG_VERSION is
-    // still 3), so the untouched log still replays — and the blinds resolve
-    // from the ring the replay rebuilds, not from anything in the log.
+    // The fixture events do not carry `smallBlind`/`bigBlind`; those values
+    // resolve from the ring the replay rebuilds, not from anything in the log.
     const recorded = await readFile(`${fixturesDir}hand-1.expected.jsonl`, {
       encoding: "utf8",
     });
@@ -58,7 +56,7 @@ describe("hand-1 fixture: replay through the engine", () => {
     let state = createInitialState([0, 1, 2]);
     for (const event of events) state = apply(state, event);
 
-    expect(ENGINE_LOG_VERSION).toBe(3);
+    expect(ENGINE_LOG_VERSION).toBe(4);
     if (state.hand?.status !== "complete") throw new Error("expected complete");
     // Button on seat 0, so ring order is [1, 2, 0]: seat 1 posts the small
     // blind and seat 2 the big blind, three-handed.

--- a/packages/harness/src/harness.test.ts
+++ b/packages/harness/src/harness.test.ts
@@ -25,7 +25,7 @@ describe("runHarness", () => {
   it("folds each event into state and writes one JSON line per event", async () => {
     const commands = [
       { type: "startHand", seatId: 0, seed: "seed-1" },
-      { type: "call", seatId: 1 },
+      { type: "call", seatId: 0 },
     ];
     const input = Readable.from(
       commands.map((command) => JSON.stringify(command) + "\n"),
@@ -88,8 +88,8 @@ describe("runHarness", () => {
   it("is deterministic: replaying the same command stream twice produces byte-identical output", async () => {
     const commandLines = [
       JSON.stringify({ type: "startHand", seatId: 0, seed: "seed-1" }),
-      JSON.stringify({ type: "call", seatId: 1 }),
-      JSON.stringify({ type: "raise", seatId: 2 }),
+      JSON.stringify({ type: "call", seatId: 0 }),
+      JSON.stringify({ type: "raise", seatId: 1 }),
     ];
 
     async function run(): Promise<string> {
@@ -178,7 +178,7 @@ describe("runHarness", () => {
       const log = new HandLog(logDir, "game-1", [0, 1, 2]);
       const commandLines = [
         JSON.stringify({ type: "startHand", seatId: 0, seed: "seed-1" }),
-        JSON.stringify({ type: "call", seatId: 1 }),
+        JSON.stringify({ type: "call", seatId: 0 }),
       ];
       const input = Readable.from(commandLines.map((line) => line + "\n"));
       const { writable, lines } = collectingWritable();
@@ -218,7 +218,9 @@ describe("runHarness", () => {
       const input = Readable.from(
         [
           { type: "startHand", seatId: 0, seed: "seed-1" },
-          { type: "check", seatId: 1 },
+          // Seat 0 opens preflop three-handed and faces the BB's post, so
+          // checking is illegal rather than merely out of turn.
+          { type: "check", seatId: 0 },
         ].map((command) => JSON.stringify(command) + "\n"),
       );
       const { writable } = collectingWritable();

--- a/packages/harness/src/replay.test.ts
+++ b/packages/harness/src/replay.test.ts
@@ -57,8 +57,8 @@ describe("replay guarantee", () => {
     const commands = [
       { type: "startHand", seatId: 0, seed: "replay-seed" },
       { type: "evict", seatId: 2 },
-      { type: "call", seatId: 1 },
       { type: "call", seatId: 0 },
+      { type: "call", seatId: 1 },
     ];
     const original = collectingWritable();
     await runHarness({

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -1342,10 +1342,12 @@ describe("hand command dispatch over WebSocket", () => {
     table.socket.send(JSON.stringify({ type: "startHand" }));
     await settle();
 
-    // button = seat 0, ring = [1, 2, 0], BB = seat 2 (see rooms.ts/room.ts).
-    // Preflop: SB calls, BB raises — forcing seat 0 and seat 1 to act again
-    // (street closure waits for every live player since the raise, not just
-    // one lap), both call, street closes.
+    // button = seat 0, ring = [1, 2, 0], BB = seat 2 (see rooms.ts/room.ts),
+    // so preflop runs [0, 1, 2]. Button and SB call, BB raises — forcing
+    // seat 0 and seat 1 to act again (street closure waits for every live
+    // player since the raise, not just one lap), both call, street closes.
+    seat0.socket.send(JSON.stringify({ type: "call" }));
+    await settle();
     seat1.socket.send(JSON.stringify({ type: "call" }));
     await settle();
     seat2.socket.send(JSON.stringify({ type: "raise" }));
@@ -1571,15 +1573,15 @@ describe("hand command dispatch over WebSocket", () => {
     table.socket.send(JSON.stringify({ type: "startHand" }));
     await settle();
 
-    // Preflop's first actor is seat 1 (SB), not seat 0.
-    seat0.socket.send(JSON.stringify({ type: "check" }));
+    // Preflop's first actor is seat 0 (the button, three-handed), not seat 1.
+    seat1.socket.send(JSON.stringify({ type: "check" }));
     await settle();
 
-    expect(seat0.messages).toContainEqual({
+    expect(seat1.messages).toContainEqual({
       type: "command-rejected",
       reason: "not-your-turn",
     });
-    expect(seat1.messages).not.toContainEqual(
+    expect(seat0.messages).not.toContainEqual(
       expect.objectContaining({ type: "command-rejected" }),
     );
     expect(table.messages).not.toContainEqual(
@@ -1599,15 +1601,15 @@ describe("hand command dispatch over WebSocket", () => {
     table.socket.send(JSON.stringify({ type: "startHand" }));
     await settle();
 
-    // Seat 1 (SB) faces the BB's post and can't check.
-    seat1.socket.send(JSON.stringify({ type: "check" }));
+    // Seat 0 (the button, first to act) faces the BB's post and can't check.
+    seat0.socket.send(JSON.stringify({ type: "check" }));
     await settle();
 
-    expect(seat1.messages).toContainEqual({
+    expect(seat0.messages).toContainEqual({
       type: "command-rejected",
       reason: "action-not-legal",
     });
-    expect(seat0.messages).not.toContainEqual(
+    expect(seat1.messages).not.toContainEqual(
       expect.objectContaining({ type: "command-rejected" }),
     );
     expect(seat2.messages).not.toContainEqual(
@@ -1843,7 +1845,7 @@ describe("action clock", () => {
     table.socket.send(JSON.stringify({ type: "startHand" }));
     await settle();
 
-    // Preflop's first actor is seat 1 (SB) — takes no action at all.
+    // Preflop's first actor is seat 0 (the button) — takes no action at all.
     await settle(ACTION_CLOCK_MS + 60);
 
     const folds = actionsSeen(table.messages).filter(
@@ -1852,7 +1854,7 @@ describe("action clock", () => {
     expect(folds).toEqual([
       expect.objectContaining({
         type: "ActionTaken",
-        seatId: 1,
+        seatId: 0,
         action: "fold",
       }),
     ]);
@@ -1896,7 +1898,7 @@ describe("action clock", () => {
     table.socket.send(JSON.stringify({ type: "startHand" }));
     await settle();
 
-    seat1.socket.send(JSON.stringify({ type: "call" }));
+    seat0.socket.send(JSON.stringify({ type: "call" }));
     await settle(ACTION_CLOCK_MS - 50);
 
     const folds = actionsSeen(table.messages).filter(
@@ -1914,17 +1916,17 @@ describe("action clock", () => {
     const room = rooms.create();
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
-    await claimAndConnect(room.code, 0);
-    const seat1 = await claimAndConnect(room.code, 1);
+    const seat0 = await claimAndConnect(room.code, 0);
+    await claimAndConnect(room.code, 1);
     await claimAndConnect(room.code, 2);
     await settle();
 
     table.socket.send(JSON.stringify({ type: "startHand" }));
     await settle();
 
-    // Seat 1 (SB) acts immediately; seat 2 (BB) then sits idle and should
-    // be the one auto-folded, not seat 1.
-    seat1.socket.send(JSON.stringify({ type: "call" }));
+    // Seat 0 (the button, first to act) acts immediately; seat 1 (SB) then
+    // sits idle and should be the one auto-folded, not seat 0.
+    seat0.socket.send(JSON.stringify({ type: "call" }));
     await settle(ACTION_CLOCK_MS + 60);
 
     const folds = actionsSeen(table.messages).filter(
@@ -1933,7 +1935,7 @@ describe("action clock", () => {
     expect(folds).toEqual([
       expect.objectContaining({
         type: "ActionTaken",
-        seatId: 2,
+        seatId: 1,
         action: "fold",
       }),
     ]);
@@ -1951,17 +1953,13 @@ describe("action clock", () => {
     table.socket.send(JSON.stringify({ type: "startHand" }));
     await settle();
 
-    // Preflop, no raise: every seat (button included) still owes a decision.
-    seat1.socket.send(JSON.stringify({ type: "call" }));
-    await settle();
-    seat2.socket.send(JSON.stringify({ type: "check" }));
-    await settle();
-    // The button never posted a blind, so it must call the BB's amount
-    // rather than check.
+    // Preflop, no raise: one lap of [0, 1, 2]. The button and SB never
+    // matched the BB's post, so they must call rather than check.
     seat0.socket.send(JSON.stringify({ type: "call" }));
     await settle();
-    // No raise occurred, so the BB gets its one-time option before the
-    // street actually closes.
+    seat1.socket.send(JSON.stringify({ type: "call" }));
+    await settle();
+    // The BB acts last, so its check is the option and closes the street.
     seat2.socket.send(JSON.stringify({ type: "check" }));
     await settle();
     // Preflop closes; the flop's first actor (seat 1, SB) now idles out.


### PR DESCRIPTION
Closes #210.

Preflop action order was wrong for every field size from 3 to 8 players: the round opened on the **small blind** instead of the first seat left of the blinds, and the big blind got **two turns** on an unraised preflop. Heads-up was the only correct case. Confirmed in production against 61 recorded hands from the 4-handed session in room `YDYC` — 61/61 preflops opened on the SB, and 27 of the 29 unraised preflops gave the BB a second turn.

## The fix

`initialToAct` (`packages/engine/src/table.ts`) fell through to the postflop branch for 3+ players, so preflop inherited the postflop ring order `SB…BTN`. It now rotates the ring to start at button+3 — `UTG…BTN, SB, BB`, per Robert's Rules of Poker, "Button and Blind Use".

With the big blind genuinely last, its "option" is simply its turn, so `bbOptionPending` is deleted outright: the flag, the `BettingHandState` field, the re-queue branch in `apply.ts` (including the folded-BB guard, now unreachable rather than load-bearing), and the assertion in `street-closure.test.ts`. Preflop closes by `toAct` draining, exactly as every other street already did.

`initialToAct` also switches its heads-up test from `live.length === 2` to the ring, so it can no longer disagree with `smallBlindSeat`/`bigBlindSeat`. The second commit pulls that shared question out into one `isHeadsUp(ring)` rather than three hand-rolled `ring.length === 2` checks.

## ⚠️ `hand-1.expected.jsonl` was regenerated — not hand-edited

`packages/harness/fixtures/hand-1.commands.jsonl` was a 3-handed hand whose preflop opened on seat 1 (the SB) — the bug, committed as a golden fixture. `fixtures.test.ts` asserts it byte-for-byte and also replays it through the engine, so both tests failed after the fix.

The commands file is re-recorded in the corrected order (preflop opens on the button, seat 0; the raise and all postflop streets kept as they were), and **`hand-1.expected.jsonl` was regenerated by piping it through the fixed engine**. That diff is machine-produced and can't be reviewed line by line, so for the record: the only substantive changes are the `StreetStarted` actor (1 → 0) and one extra `ActionTaken`. The deck, board cards, hole cards and showdown results are byte-identical, since the deck is seed-derived and unaffected by action order.

## Test coverage

Both levels the issue asked for:

- **New `packages/engine/src/preflop-order.test.ts`** — table-driven over `initialToAct` for n = 2..8, matching the issue's expected column seat-for-seat. Plus the postflop order and folded-seat cases, which guard the rotation and the `ring.length` heads-up predicate directly.
- **`street-closure.test.ts`, end-to-end through `decide`/`apply`** — an unraised preflop closing in exactly n actions with the BB last (at every field size); **the small blind's open being rejected `not-your-turn`**, which is the property that actually failed in production; a BB folding its final turn getting no phantom extra turn; and a mid-lap raise re-queueing from the new opener.

Twelve existing test files across engine, harness and server scripted the old preflop order and are re-ordered to match — that was the bug's other footprint.

## Also in here

`CONTEXT.md` and `docs/adr/0001-…` described the buggy order in prose (`PREFLOP — button+1 first to act`; the BB checking "on their normal turn, and again on the later option revisit"). Both corrected. One judgement call worth a look: I edited ADR-0001's **Decision** text rather than leaving it and noting the correction only in Consequences. My reasoning is that an accepted ADR shouldn't describe behaviour that no longer exists, and the Consequences section records why it changed — happy to revert to the original wording if you'd rather keep the decision text immutable.

No hand logs from room `YDYC` are committed. They're recordings of the buggy engine — they replay through `apply` without complaint before and after the fix, so they'd assert nothing — and they carry real players' hole cards.

## Verification

Full suite 856/856, `npm run build` and `npm run lint` clean locally. (The one prettier warning, `assets/graphics/last-nights-game-statistics.json`, is untracked and pre-existing — untouched by this branch.)

**Not deployed.** Per the triage note, the Pi is still running the buggy engine; a restart drops in-memory rooms and hands, so that's a by-hand step for a moment when no game is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145CqSaZPWL2mSSV4acdRhB
