### PR TITLE
feat(server): add test-mode config discovery

### DIFF
--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -216,6 +216,32 @@ describe("rooms HTTP routes", () => {
   });
 });
 
+describe("GET /config", () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("reports test mode off by default", async () => {
+    app = await buildApp();
+
+    const response = await app.inject({ method: "GET", url: "/config" });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ testMode: false });
+  });
+
+  it("reports test mode when enabled in the app options", async () => {
+    app = await buildApp({ testMode: true });
+
+    const response = await app.inject({ method: "GET", url: "/config" });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ testMode: true });
+  });
+});
+
 describe("POST /rooms/:code/sound", () => {
   let app: FastifyInstance;
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -63,6 +63,8 @@ export interface BuildAppOptions {
   readonly rooms?: RoomStore;
   /** Root directory for append-as-you-go per-game hand logs. */
   readonly handLogDir?: string;
+  /** Enables test-only server features such as bot players. */
+  readonly testMode?: boolean;
   /** Overridable for tests only; production runs `ActionClock`'s 90s default. */
   readonly actionClockMs?: number;
   /** How often the server pings every open socket (Phase 1 spec #130 §7). */
@@ -206,6 +208,7 @@ export async function buildApp(
 ): Promise<FastifyInstance> {
   const rooms = options.rooms ?? new RoomStore();
   const handLogs = new Map<string, HandLog>();
+  const testMode = options.testMode ?? false;
   const pingIntervalMs = options.pingIntervalMs ?? 10_000;
   const missedPongLimit = options.missedPongLimit ?? 2;
   const graceWindowMs = options.graceWindowMs ?? 60_000;
@@ -491,6 +494,8 @@ export async function buildApp(
       .header("cache-control", "no-store")
       .send(readIndexOr(publicTableIndexPath));
   });
+
+  app.get("/config", () => ({ testMode }));
 
   app.post("/rooms", async (request, reply) => {
     // The table client picks a seat count (issue #74); this is the trust

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -2,7 +2,11 @@ import { buildApp } from "./app.js";
 
 async function main(): Promise<void> {
   const handLogDir = process.env.HAND_LOG_DIR;
-  const app = await buildApp(handLogDir === undefined ? {} : { handLogDir });
+  const testMode = process.env.POKER_TEST_MODE !== undefined;
+  const app = await buildApp({
+    ...(handLogDir === undefined ? {} : { handLogDir }),
+    testMode,
+  });
   const port = Number(process.env.PORT ?? 3000);
   const host = process.env.HOST ?? "127.0.0.1";
   await app.listen({ port, host });

--- a/packages/table-client/src/api/rooms.test.ts
+++ b/packages/table-client/src/api/rooms.test.ts
@@ -1,5 +1,35 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { changeSeatCount, createRoom, endSession } from "./rooms.js";
+import {
+  changeSeatCount,
+  createRoom,
+  endSession,
+  fetchConfig,
+} from "./rooms.js";
+
+describe("fetchConfig", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("gets the server config and returns the test-mode flag", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ testMode: true }), { status: 200 }),
+    );
+
+    await expect(fetchConfig()).resolves.toEqual({ testMode: true });
+    expect(fetch).toHaveBeenCalledWith("/config", { method: "GET" });
+  });
+
+  it("throws when the server rejects the request", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 503 }));
+
+    await expect(fetchConfig()).rejects.toThrow("failed to fetch config: 503");
+  });
+});
 
 describe("createRoom", () => {
   beforeEach(() => {

--- a/packages/table-client/src/api/rooms.ts
+++ b/packages/table-client/src/api/rooms.ts
@@ -10,6 +10,19 @@ export interface CreatedRoom {
   readonly qrCodeDataUrl: string;
 }
 
+export interface ServerConfig {
+  readonly testMode: boolean;
+}
+
+/** Reads server-global capabilities once when the table client boots. */
+export async function fetchConfig(): Promise<ServerConfig> {
+  const response = await fetch("/config", { method: "GET" });
+  if (!response.ok) {
+    throw new Error(`failed to fetch config: ${String(response.status)}`);
+  }
+  return (await response.json()) as ServerConfig;
+}
+
 /**
  * Confirms a room is still live before the table re-attaches on refresh
  * (#175). The WebSocket handshake 404s for a dead room, but a browser socket

--- a/packages/table-client/src/main.tsx
+++ b/packages/table-client/src/main.tsx
@@ -1,12 +1,25 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App.js";
+import { fetchConfig } from "./api/rooms.js";
 import "./app-shell.css";
+import { useTableStore } from "./store/store.js";
 
 const rootEl = document.getElementById("root");
 if (!rootEl) {
   throw new Error("#root element not found");
 }
+
+// Discover server-global capabilities once per page load. The store defaults
+// to the safe/off state if the endpoint is unavailable, so a transient fetch
+// failure never exposes test-only UI by accident.
+void fetchConfig()
+  .then(({ testMode }) => {
+    useTableStore.getState().setTestMode(testMode);
+  })
+  .catch((error: unknown) => {
+    console.error(error);
+  });
 
 ReactDOM.createRoot(rootEl).render(
   <React.StrictMode>

--- a/packages/table-client/src/store/configSlice.ts
+++ b/packages/table-client/src/store/configSlice.ts
@@ -1,0 +1,13 @@
+import type { StateCreator } from "zustand";
+
+export interface ConfigSlice {
+  readonly testMode: boolean;
+  readonly setTestMode: (testMode: boolean) => void;
+}
+
+export const createConfigSlice: StateCreator<ConfigSlice> = (set) => ({
+  testMode: false,
+  setTestMode: (testMode) => {
+    set({ testMode });
+  },
+});

--- a/packages/table-client/src/store/store.test.ts
+++ b/packages/table-client/src/store/store.test.ts
@@ -11,6 +11,13 @@ describe("useTableStore", () => {
     const state = useTableStore.getState();
     expect(state.connectionStatus).toBe("disconnected");
     expect(state.roomCode).toBeNull();
+    expect(state.testMode).toBe(false);
+  });
+
+  it("updates the test-mode config independently of the room state", () => {
+    useTableStore.getState().setTestMode(true);
+    expect(useTableStore.getState().testMode).toBe(true);
+    expect(useTableStore.getState().roomCode).toBeNull();
   });
 
   it("updates the connection slice independently of the room slice", () => {

--- a/packages/table-client/src/store/store.ts
+++ b/packages/table-client/src/store/store.ts
@@ -3,13 +3,15 @@ import {
   type ConnectionSlice,
   createConnectionSlice,
 } from "./connectionSlice.js";
+import { createConfigSlice, type ConfigSlice } from "./configSlice.js";
 import { createHandSlice, type HandSlice } from "./handSlice.js";
 import { createRoomSlice, type RoomSlice } from "./roomSlice.js";
 
-export type TableStore = ConnectionSlice & RoomSlice & HandSlice;
+export type TableStore = ConnectionSlice & ConfigSlice & RoomSlice & HandSlice;
 
 export const useTableStore = create<TableStore>()((...args) => ({
   ...createConnectionSlice(...args),
+  ...createConfigSlice(...args),
   ...createRoomSlice(...args),
   ...createHandSlice(...args),
 }));

--- a/packages/table-client/src/vite-config.test.ts
+++ b/packages/table-client/src/vite-config.test.ts
@@ -9,8 +9,11 @@ describe("table-client Vite dev proxy", () => {
       fileURLToPath(new URL("../vite.config.ts", import.meta.url)),
     );
 
-    expect(loaded?.config.server?.proxy).toMatchObject({
-      "/config": "http://localhost:3000",
-    });
+    const proxy = loaded?.config.server?.proxy;
+    expect(proxy).toBeDefined();
+    if (proxy === undefined) return;
+
+    expect(proxy["/rooms"]).toBeDefined();
+    expect(proxy["/config"]).toBe(proxy["/rooms"]);
   });
 });

--- a/packages/table-client/src/vite-config.test.ts
+++ b/packages/table-client/src/vite-config.test.ts
@@ -1,0 +1,16 @@
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { loadConfigFromFile } from "vite";
+
+describe("table-client Vite dev proxy", () => {
+  it("forwards server config discovery to the backend", async () => {
+    const loaded = await loadConfigFromFile(
+      { command: "serve", mode: "test" },
+      fileURLToPath(new URL("../vite.config.ts", import.meta.url)),
+    );
+
+    expect(loaded?.config.server?.proxy).toMatchObject({
+      "/config": "http://localhost:3000",
+    });
+  });
+});

--- a/packages/table-client/vite.config.ts
+++ b/packages/table-client/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig(({ command, mode }) => {
           target: backendWebSocketOrigin,
           ws: true,
         },
+        "/config": backendOrigin,
         "/rooms": backendOrigin,
       },
     },


### PR DESCRIPTION
## Summary

- read POKER_TEST_MODE once during server startup and pass it into buildApp
- expose the server-wide flag through GET /config
- fetch config when the table client loads and retain testMode in shared Zustand state
- proxy /config to the backend in Vite development, including custom BACKEND_ORIGIN setups
- cover enabled and disabled server responses, client fetching and state, and development proxy wiring

## Why

This adds the reusable test-mode discovery layer required by the upcoming bot-development tickets while leaving production behavior disabled by default.

## Validation

- server test suite: 152 passed
- table-client test suite: 113 passed
- TypeScript builds passed
- Vite production build passed
- ESLint and Prettier passed
- git diff --check passed

Closes #213