### PR TITLE
feat(server): add pure bot policy

### DIFF
--- a/packages/server/src/bot-policy.test.ts
+++ b/packages/server/src/bot-policy.test.ts
@@ -1,0 +1,116 @@
+import fc from "fast-check";
+import { describe, expect, it } from "vitest";
+import {
+  chooseBotAction,
+  DEFAULT_SIT_IN_PROBABILITY,
+  DEFAULT_SIT_OUT_PROBABILITY,
+  shouldSitIn,
+  shouldSitOut,
+} from "./bot-policy.js";
+import type { ActionType } from "@table-top-poker/protocol";
+
+const actionTypes: ActionType[] = ["fold", "check", "call", "raise"];
+
+const legalActionsArb = fc.subarray(actionTypes, { minLength: 1 });
+
+describe("chooseBotAction", () => {
+  it("returns an entry from the supplied legal actions", () => {
+    for (const legalActions of [
+      ["fold", "check", "raise"],
+      ["fold", "call", "raise"],
+      ["fold"],
+    ] as const) {
+      expect(legalActions).toContain(chooseBotAction(legalActions, () => 0.5));
+    }
+  });
+
+  it("is deterministic under an injected RNG", () => {
+    const legalActions = ["fold", "check", "raise"] as const;
+    expect(chooseBotAction(legalActions, () => 0.2)).toBe(
+      chooseBotAction(legalActions, () => 0.2),
+    );
+  });
+
+  it("keeps a free check overwhelmingly more likely than folding", () => {
+    const legalActions = ["fold", "check", "raise"] as const;
+    let folds = 0;
+    let checks = 0;
+    for (let i = 0; i < 10_000; i++) {
+      const action = chooseBotAction(legalActions, () => (i + 0.5) / 10_000);
+      if (action === "fold") folds++;
+      if (action === "check") checks++;
+    }
+
+    expect(folds).toBeGreaterThan(0);
+    expect(checks).toBeGreaterThan(folds * 5);
+  });
+
+  it("leaves every supplied action reachable", () => {
+    const legalActions = ["fold", "check", "raise"] as const;
+    const reached = new Set<ActionType>();
+    for (let i = 0; i < 10_000; i++) {
+      reached.add(chooseBotAction(legalActions, () => (i + 0.5) / 10_000));
+    }
+    expect(reached).toEqual(new Set(legalActions));
+  });
+
+  it("rejects an empty legal-action list", () => {
+    expect(() => chooseBotAction([], () => 0)).toThrow(RangeError);
+  });
+
+  it("always returns a legal action for every nonempty legal-action set", () => {
+    fc.assert(
+      fc.property(
+        legalActionsArb,
+        fc.double({ min: 0, max: 1, noNaN: true }),
+        (legalActions, randomValue) => {
+          const action = chooseBotAction(legalActions, () => randomValue);
+          expect(legalActions).toContain(action);
+        },
+      ),
+    );
+  });
+});
+
+describe("sit-out/in rolls", () => {
+  it("honours configured probability boundaries", () => {
+    expect(shouldSitOut(() => 0, 0)).toBe(false);
+    expect(shouldSitOut(() => 0, 1)).toBe(true);
+    expect(shouldSitIn(() => 0, 0)).toBe(false);
+    expect(shouldSitIn(() => 0, 1)).toBe(true);
+  });
+
+  it("uses sane nontrivial defaults", () => {
+    expect(DEFAULT_SIT_OUT_PROBABILITY).toBeGreaterThan(0);
+    expect(DEFAULT_SIT_OUT_PROBABILITY).toBeLessThan(1);
+    expect(DEFAULT_SIT_IN_PROBABILITY).toBeGreaterThan(0);
+    expect(DEFAULT_SIT_IN_PROBABILITY).toBeLessThan(1);
+  });
+
+  it("is deterministic under an injected RNG", () => {
+    expect(shouldSitOut(() => 0.09)).toBe(shouldSitOut(() => 0.09));
+    expect(shouldSitIn(() => 0.34)).toBe(shouldSitIn(() => 0.34));
+  });
+
+  it("satisfies the configured probability decision for every roll", () => {
+    fc.assert(
+      fc.property(
+        fc.double({ min: 0, max: 1 - Number.EPSILON, noNaN: true }),
+        fc.float({ min: 0, max: 1, noNaN: true }),
+        (randomValue, probability) => {
+          expect(shouldSitOut(() => randomValue, probability)).toBe(
+            randomValue < probability,
+          );
+          expect(shouldSitIn(() => randomValue, probability)).toBe(
+            randomValue < probability,
+          );
+        },
+      ),
+    );
+  });
+
+  it("rejects probabilities outside the unit interval", () => {
+    expect(() => shouldSitOut(() => 0, -0.01)).toThrow(RangeError);
+    expect(() => shouldSitIn(() => 0, 1.01)).toThrow(RangeError);
+  });
+});

--- a/packages/server/src/bot-policy.test.ts
+++ b/packages/server/src/bot-policy.test.ts
@@ -2,6 +2,7 @@ import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import {
   chooseBotAction,
+  DEFAULT_BOT_ACTION_WEIGHTS,
   DEFAULT_SIT_IN_PROBABILITY,
   DEFAULT_SIT_OUT_PROBABILITY,
   shouldSitIn,
@@ -10,6 +11,7 @@ import {
 import type { ActionType } from "@table-top-poker/protocol";
 
 const actionTypes: ActionType[] = ["fold", "check", "call", "raise"];
+const greatestRollBelowOne = 0.9999999999999999;
 
 const legalActionsArb = fc.subarray(actionTypes, { minLength: 1 });
 
@@ -29,6 +31,29 @@ describe("chooseBotAction", () => {
     expect(chooseBotAction(legalActions, () => 0.2)).toBe(
       chooseBotAction(legalActions, () => 0.2),
     );
+  });
+
+  it("keeps a facing bet alive while reaching call, fold, and raise", () => {
+    const legalActions = ["fold", "call", "raise"] as const;
+    const reached = new Set<ActionType>();
+    let folds = 0;
+    let calls = 0;
+    for (let i = 0; i < 10_000; i++) {
+      const action = chooseBotAction(legalActions, () => (i + 0.5) / 10_000);
+      reached.add(action);
+      if (action === "fold") folds++;
+      if (action === "call") calls++;
+    }
+
+    expect(reached).toEqual(new Set(legalActions));
+    expect(calls).toBeGreaterThan(folds * 5);
+  });
+
+  it("keeps every action weight positive and immutable at runtime", () => {
+    for (const action of actionTypes) {
+      expect(DEFAULT_BOT_ACTION_WEIGHTS[action]).toBeGreaterThan(0);
+    }
+    expect(Object.isFrozen(DEFAULT_BOT_ACTION_WEIGHTS)).toBe(true);
   });
 
   it("keeps a free check overwhelmingly more likely than folding", () => {
@@ -95,7 +120,7 @@ describe("sit-out/in rolls", () => {
   it("satisfies the configured probability decision for every roll", () => {
     fc.assert(
       fc.property(
-        fc.double({ min: 0, max: 1 - Number.EPSILON, noNaN: true }),
+        fc.double({ min: 0, max: greatestRollBelowOne, noNaN: true }),
         fc.float({ min: 0, max: 1, noNaN: true }),
         (randomValue, probability) => {
           expect(shouldSitOut(() => randomValue, probability)).toBe(
@@ -107,6 +132,17 @@ describe("sit-out/in rolls", () => {
         },
       ),
     );
+  });
+
+  it("preserves the greatest valid roll and uses strict less-than semantics", () => {
+    expect(shouldSitOut(() => greatestRollBelowOne, greatestRollBelowOne)).toBe(
+      false,
+    );
+    expect(shouldSitIn(() => greatestRollBelowOne, greatestRollBelowOne)).toBe(
+      false,
+    );
+    expect(shouldSitOut(() => greatestRollBelowOne, 1)).toBe(true);
+    expect(shouldSitIn(() => greatestRollBelowOne, 1)).toBe(true);
   });
 
   it("rejects probabilities outside the unit interval", () => {

--- a/packages/server/src/bot-policy.ts
+++ b/packages/server/src/bot-policy.ts
@@ -1,0 +1,100 @@
+import type { ActionType } from "@table-top-poker/protocol";
+
+/** A source of values in the usual half-open random range [0, 1). */
+export type BotRng = () => number;
+
+/**
+ * Action weights used by the default policy.  The weights are relative rather
+ * than percentages because the policy receives a different set of legal
+ * actions depending on whether the actor is facing a bet.
+ *
+ * A free check (or a call) is deliberately much more likely than folding or
+ * raising, while fold and raise retain positive weights so every legal action
+ * remains reachable.
+ */
+export const DEFAULT_BOT_ACTION_WEIGHTS: Readonly<Record<ActionType, number>> =
+  {
+    fold: 1,
+    check: 12,
+    call: 12,
+    raise: 2,
+  };
+
+/** Default chance for a bot to skip the next hand between hands. */
+export const DEFAULT_SIT_OUT_PROBABILITY = 0.1;
+
+/** Default chance for a sitting-out bot to return for the next hand. */
+export const DEFAULT_SIT_IN_PROBABILITY = 0.35;
+
+function unitRandom(rng: BotRng): number {
+  const value = rng();
+
+  // Math.random() is in [0, 1), but clamping makes injected test sources at
+  // the boundaries harmless and keeps the selector's final fallback useful.
+  if (Number.isNaN(value)) return 0;
+  return Math.min(Math.max(value, 0), 1 - Number.EPSILON);
+}
+
+function assertProbability(probability: number): void {
+  if (!Number.isFinite(probability) || probability < 0 || probability > 1) {
+    throw new RangeError(
+      `probability must be a finite number between 0 and 1, got ${String(probability)}`,
+    );
+  }
+}
+
+/**
+ * Chooses a currently legal action without consulting or mutating engine
+ * state.  The caller supplies the engine's legal-action list; this function
+ * only weights those entries and never derives a replacement list.
+ */
+export function chooseBotAction(
+  legalActions: readonly ActionType[],
+  rng: BotRng = Math.random,
+): ActionType {
+  if (legalActions.length === 0) {
+    throw new RangeError("chooseBotAction needs at least one legal action");
+  }
+
+  const weights = legalActions.map(
+    (action) => DEFAULT_BOT_ACTION_WEIGHTS[action],
+  );
+  const total = weights.reduce((sum, weight) => sum + weight, 0);
+  const target = unitRandom(rng) * total;
+
+  let cumulative = 0;
+  for (let index = 0; index < legalActions.length; index++) {
+    cumulative += weights[index] ?? 0;
+    if (target < cumulative) {
+      const action = legalActions[index];
+      if (action !== undefined) return action;
+    }
+  }
+
+  // unitRandom() makes this unreachable for the normal action weights, but
+  // retaining the final supplied entry protects the member-of-input contract
+  // if the weighting table is changed later.
+  const fallback = legalActions[legalActions.length - 1];
+  if (fallback === undefined) {
+    throw new Error("chooseBotAction lost its supplied legal action");
+  }
+  return fallback;
+}
+
+/** Returns whether a bot should sit out the next hand. */
+export function shouldSitOut(
+  rng: BotRng = Math.random,
+  probability: number = DEFAULT_SIT_OUT_PROBABILITY,
+): boolean {
+  assertProbability(probability);
+  return unitRandom(rng) < probability;
+}
+
+/** Returns whether a sitting-out bot should sit back in for the next hand. */
+export function shouldSitIn(
+  rng: BotRng = Math.random,
+  probability: number = DEFAULT_SIT_IN_PROBABILITY,
+): boolean {
+  assertProbability(probability);
+  return unitRandom(rng) < probability;
+}

--- a/packages/server/src/bot-policy.ts
+++ b/packages/server/src/bot-policy.ts
@@ -60,29 +60,27 @@ export function chooseBotAction(
     throw new RangeError("chooseBotAction needs at least one legal action");
   }
 
-  const weights = legalActions.map(
-    (action) => DEFAULT_BOT_ACTION_WEIGHTS[action],
+  const total = legalActions.reduce(
+    (sum, action) => sum + DEFAULT_BOT_ACTION_WEIGHTS[action],
+    0,
   );
-  const total = weights.reduce((sum, weight) => sum + weight, 0);
   const target = unitRandom(rng) * total;
 
   let cumulative = 0;
-  for (let index = 0; index < legalActions.length; index++) {
-    cumulative += weights[index] ?? 0;
-    if (target < cumulative) {
-      const action = legalActions[index];
-      if (action !== undefined) return action;
-    }
+  for (const action of legalActions) {
+    cumulative += DEFAULT_BOT_ACTION_WEIGHTS[action];
+    if (target < cumulative) return action;
   }
 
-  // unitRandom() makes this unreachable for the normal action weights, but
-  // retaining the final supplied entry protects the member-of-input contract
-  // if the weighting table is changed later.
-  const fallback = legalActions[legalActions.length - 1];
-  if (fallback === undefined) {
-    throw new Error("chooseBotAction lost its supplied legal action");
-  }
-  return fallback;
+  // unitRandom() keeps target < total, so the loop always returns above; this
+  // throw exists only to satisfy the return type.
+  throw new Error("chooseBotAction lost its supplied legal action");
+}
+
+/** Rolls the RNG and reports whether it falls below the given probability. */
+function rollBelow(rng: BotRng, probability: number): boolean {
+  assertProbability(probability);
+  return unitRandom(rng) < probability;
 }
 
 /** Returns whether a bot should sit out the next hand. */
@@ -90,8 +88,7 @@ export function shouldSitOut(
   rng: BotRng = Math.random,
   probability: number = DEFAULT_SIT_OUT_PROBABILITY,
 ): boolean {
-  assertProbability(probability);
-  return unitRandom(rng) < probability;
+  return rollBelow(rng, probability);
 }
 
 /** Returns whether a sitting-out bot should sit back in for the next hand. */
@@ -99,6 +96,5 @@ export function shouldSitIn(
   rng: BotRng = Math.random,
   probability: number = DEFAULT_SIT_IN_PROBABILITY,
 ): boolean {
-  assertProbability(probability);
-  return unitRandom(rng) < probability;
+  return rollBelow(rng, probability);
 }

--- a/packages/server/src/bot-policy.ts
+++ b/packages/server/src/bot-policy.ts
@@ -13,12 +13,12 @@ export type BotRng = () => number;
  * remains reachable.
  */
 export const DEFAULT_BOT_ACTION_WEIGHTS: Readonly<Record<ActionType, number>> =
-  {
+  Object.freeze({
     fold: 1,
     check: 12,
     call: 12,
     raise: 2,
-  };
+  });
 
 /** Default chance for a bot to skip the next hand between hands. */
 export const DEFAULT_SIT_OUT_PROBABILITY = 0.1;
@@ -26,13 +26,17 @@ export const DEFAULT_SIT_OUT_PROBABILITY = 0.1;
 /** Default chance for a sitting-out bot to return for the next hand. */
 export const DEFAULT_SIT_IN_PROBABILITY = 0.35;
 
+/** The greatest representable JavaScript number below 1. */
+const MAX_UNIT_RANDOM = 1 - Number.EPSILON / 2;
+
 function unitRandom(rng: BotRng): number {
   const value = rng();
 
-  // Math.random() is in [0, 1), but clamping makes injected test sources at
-  // the boundaries harmless and keeps the selector's final fallback useful.
+  // Math.random() is in [0, 1). Clamp invalid injected values to the nearest
+  // boundary, but do not round a valid value in that range: MAX_UNIT_RANDOM
+  // is itself a valid value and must remain unchanged.
   if (Number.isNaN(value)) return 0;
-  return Math.min(Math.max(value, 0), 1 - Number.EPSILON);
+  return Math.min(Math.max(value, 0), MAX_UNIT_RANDOM);
 }
 
 function assertProbability(probability: number): void {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,1 +1,10 @@
 export { buildApp } from "./app.js";
+export {
+  chooseBotAction,
+  DEFAULT_BOT_ACTION_WEIGHTS,
+  DEFAULT_SIT_IN_PROBABILITY,
+  DEFAULT_SIT_OUT_PROBABILITY,
+  shouldSitIn,
+  shouldSitOut,
+} from "./bot-policy.js";
+export type { BotRng } from "./bot-policy.js";


### PR DESCRIPTION
## Summary

- add a pure, injected-RNG bot policy for choosing only from engine-supplied legal actions
- weight check/call toward keeping hands alive while leaving fold and raise reachable
- add configurable sit-out and sit-in probability rolls with sane defaults
- cover legality, determinism, probability boundaries, runtime immutability, and both engine action sets with unit and fast-check property tests

## Why

Bot randomness needs a deterministic, independently testable policy layer without I/O or engine mutation. This gives the server a reusable API while keeping the engine's legal actions as the sole source of truth.

## Impact

Bot callers can now select actions and between-hand seating decisions through a pure exported policy API. Existing server behavior is unchanged until callers adopt it.

## Validation

- server bot-policy tests: 14/14
- full TypeScript build
- ESLint
- Prettier
- public declaration/runtime probes
- `git diff --check`

Closes #214
