### PR TITLE
feat: add test-mode bot seats

### DIFF
--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -45,6 +45,13 @@ export const ClaimSeatRequestSchema = z.strictObject({
 
 export type ClaimSeatRequest = z.infer<typeof ClaimSeatRequestSchema>;
 
+/** Body of the test-mode table action that fills free seats with bots. */
+export const AddBotsRequestSchema = z.strictObject({
+  count: z.int().nonnegative(),
+});
+
+export type AddBotsRequest = z.infer<typeof AddBotsRequestSchema>;
+
 /** Body of a player releasing their own seat (ADR-0005) — the seat's token. */
 export const LeaveSeatRequestSchema = z.strictObject({
   token: z.string().min(1),
@@ -150,6 +157,8 @@ export interface SeatView {
   readonly claimed: boolean;
   /** The required display name for newer claims; absent on pre-name seats. */
   readonly displayName?: string | null;
+  /** Present only for test-mode bot seats. */
+  readonly bot?: boolean;
   readonly sittingOut: boolean;
   /** Why a claimed seat is absent from the current/next deal-in. */
   readonly sittingOutReason: SittingOutReason | null;

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -637,6 +637,113 @@ describe("seat claim/evict routes", () => {
   });
 });
 
+describe("test-mode bot route", () => {
+  let app: FastifyInstance;
+  let rooms: RoomStore;
+  let port: number;
+
+  beforeEach(async () => {
+    rooms = new RoomStore();
+    app = await buildApp({ rooms, testMode: true });
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected a bound TCP address");
+    }
+    port = address.port;
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  async function createRoom(seatCount = 4): Promise<string> {
+    const created = await app.inject({
+      method: "POST",
+      url: "/rooms",
+      payload: { seatCount },
+    });
+    return created.json<RoomCreatedBody>().code;
+  }
+
+  it("claims free seats, clamps to capacity, and reports the actual count", async () => {
+    const code = await createRoom(4);
+    const response = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/bots`,
+      payload: { count: 10 },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ joined: 4 });
+    const room = rooms.get(code);
+    if (!room) throw new Error("expected the room to remain live");
+    expect(room.seats).toHaveLength(4);
+    expect(toRoomView(room).seats).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 0,
+          displayName: "Bot 1",
+          claimed: true,
+          bot: true,
+        }),
+      ]),
+    );
+    expect(toRoomView(room).seats.every((seat) => seat.claimed)).toBe(true);
+  });
+
+  it("is not registered when test mode is off", async () => {
+    await app.close();
+    app = await buildApp({ rooms });
+    const code = rooms.create(4).code;
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/bots`,
+      payload: { count: 1 },
+    });
+
+    expect(response.statusCode).toBe(404);
+  });
+
+  it("broadcasts bot markers to an open room socket", async () => {
+    const code = await createRoom(4);
+    const socket = new WebSocket(
+      `ws://127.0.0.1:${String(port)}/ws?room=${code}&role=table`,
+    );
+    const messages: ServerMessage[] = [];
+    socket.on("message", (data: Buffer) => {
+      messages.push(JSON.parse(data.toString()) as ServerMessage);
+    });
+    await new Promise<void>((resolve, reject) => {
+      socket.once("open", resolve);
+      socket.once("error", reject);
+    });
+
+    await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/bots`,
+      payload: { count: 1 },
+    });
+    for (let attempt = 0; attempt < 100; attempt++) {
+      const latest = messages.findLast(
+        (message) => message.type === "room-view",
+      );
+      if (
+        latest?.type === "room-view" &&
+        latest.view.seats.some((seat) => seat.bot === true)
+      ) {
+        expect(latest.view.seats[0]).toMatchObject({ bot: true });
+        socket.close();
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    socket.close();
+    throw new Error("timed out waiting for bot room view");
+  });
+});
+
 describe("seat-count settings route", () => {
   let app: FastifyInstance;
   let rooms: RoomStore;

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -1,6 +1,7 @@
 import fastifyStatic from "@fastify/static";
 import fastifyWebsocket from "@fastify/websocket";
 import {
+  AddBotsRequestSchema,
   ChangeSeatCountRequestSchema,
   ChangeSoundSettingsRequestSchema,
   ClaimSeatRequestSchema,
@@ -512,6 +513,30 @@ export async function buildApp(
     const qrCodeDataUrl = await roomQrCodeDataUrl(url);
     return { code: room.code, joinUrl: url, qrCodeDataUrl };
   });
+
+  /**
+   * Test-mode table action: fill existing free seats with virtual players.
+   * Keeping this route out of the Fastify registration entirely when the gate
+   * is off makes the production surface a plain 404.
+   */
+  if (testMode) {
+    app.post<RoomCodeRoute>("/rooms/:code/bots", (request, reply) => {
+      const body = AddBotsRequestSchema.safeParse(request.body);
+      if (!body.success) {
+        return reply.code(400).send({ error: "invalid-request-body" });
+      }
+
+      const room = findRoomOrReject(rooms, request.params.code, reply);
+      if (!room) return;
+      const result = rooms.addBots(room.code, body.data.count);
+      if ("error" in result) {
+        return reply.code(404).send({ error: result.error });
+      }
+
+      broadcastRoomView(room.code);
+      return { joined: result.seats.length };
+    });
+  }
 
   app.post<RoomCodeRoute>("/rooms/:code/join", (request, reply) => {
     const room = findRoomOrReject(rooms, request.params.code, reply);

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -528,12 +528,11 @@ export async function buildApp(
 
       const room = findRoomOrReject(rooms, request.params.code, reply);
       if (!room) return;
-      const result = rooms.addBots(room.code, body.data.count);
-      if ("error" in result) {
-        return reply.code(404).send({ error: result.error });
-      }
+      const result = rooms.addBots(room, body.data.count);
 
-      broadcastRoomView(room.code);
+      if (result.seats.length > 0) {
+        broadcastRoomView(room.code);
+      }
       return { joined: result.seats.length };
     });
   }

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -131,9 +131,8 @@ describe("RoomStore", () => {
       const room = store.create(4);
       store.claimSeat(room.code, 0, "Bot 1");
 
-      const result = store.addBots(room.code, 4);
+      const result = store.addBots(room, 4);
 
-      if ("error" in result) throw new Error("expected bots to be added");
       expect(result.seats).toHaveLength(3);
       expect(result.seats.map((seat) => seat.displayName)).toEqual([
         "Bot 2",
@@ -255,8 +254,7 @@ describe("RoomStore", () => {
     it("clears a bot flag when its seat is evicted", () => {
       const store = new RoomStore();
       const room = store.create();
-      const added = store.addBots(room.code, 1);
-      if ("error" in added) throw new Error("expected a bot claim");
+      const added = store.addBots(room, 1);
 
       store.evictSeat(room.code, added.seats[0]?.id ?? 0);
 
@@ -829,8 +827,7 @@ describe("RoomStore", () => {
         if (actor === undefined) throw new Error("expected a current actor");
 
         store.evictSeat(room.code, actor);
-        const added = store.addBots(room.code, 1);
-        if ("error" in added) throw new Error("expected a bot claim");
+        const added = store.addBots(room, 1);
         const bot = added.seats[0];
         if (bot === undefined) throw new Error("expected a bot seat");
 

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -126,6 +126,24 @@ describe("RoomStore", () => {
       });
     });
 
+    it("claims unique bot names on free seats and marks them in the room view", () => {
+      const store = new RoomStore();
+      const room = store.create(4);
+      store.claimSeat(room.code, 0, "Bot 1");
+
+      const result = store.addBots(room.code, 4);
+
+      if ("error" in result) throw new Error("expected bots to be added");
+      expect(result.seats).toHaveLength(3);
+      expect(result.seats.map((seat) => seat.displayName)).toEqual([
+        "Bot 2",
+        "Bot 3",
+        "Bot 4",
+      ]);
+      expect(result.seats.every((seat) => seat.bot === true)).toBe(true);
+      expect(toRoomView(room).seats.filter((seat) => seat.bot)).toHaveLength(3);
+    });
+
     it("rejects a blank or over-long display name without claiming the seat", () => {
       const store = new RoomStore();
       const room = store.create();
@@ -232,6 +250,18 @@ describe("RoomStore", () => {
         claimed: true,
         sittingOut: false,
       });
+    });
+
+    it("clears a bot flag when its seat is evicted", () => {
+      const store = new RoomStore();
+      const room = store.create();
+      const added = store.addBots(room.code, 1);
+      if ("error" in added) throw new Error("expected a bot claim");
+
+      store.evictSeat(room.code, added.seats[0]?.id ?? 0);
+
+      expect(room.seats[0]).not.toHaveProperty("bot");
+      expect(toRoomView(room).seats[0]).not.toHaveProperty("bot");
     });
 
     it("carries names through a repack and clears them on eviction", () => {

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -821,6 +821,53 @@ describe("RoomStore", () => {
         expect(room.engine.hand.players.get(actor)?.folded).toBe(true);
       });
 
+      it("keeps a bot reclaimed into an evicted live seat out until the next hand", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 3);
+        store.dispatch(room.code, "table", "startHand");
+        const actor = store.currentActor(room.code);
+        if (actor === undefined) throw new Error("expected a current actor");
+
+        store.evictSeat(room.code, actor);
+        const added = store.addBots(room.code, 1);
+        if ("error" in added) throw new Error("expected a bot claim");
+        const bot = added.seats[0];
+        if (bot === undefined) throw new Error("expected a bot seat");
+
+        expect(bot.id).toBe(actor);
+        expect(bot.waitingForNextHand).toBe(true);
+        expect(toRoomView(room).seats[actor]).toMatchObject({
+          claimed: true,
+          bot: true,
+          sittingOut: true,
+          sittingOutReason: "waiting-for-next-hand",
+        });
+        if (room.engine?.hand?.status !== "betting") {
+          throw new Error("expected the hand to continue");
+        }
+        expect(room.engine.hand.players.get(actor)?.folded).toBe(true);
+
+        completeHand(store, room);
+        const next = store.dispatch(room.code, "table", "nextHand");
+        if (!("steps" in next)) throw new Error("expected next-hand steps");
+        const holeCardsDealt = next.steps.find(
+          (step) => step.event.type === "HoleCardsDealt",
+        )?.event;
+        if (holeCardsDealt?.type !== "HoleCardsDealt") {
+          throw new Error("expected HoleCardsDealt");
+        }
+
+        expect(holeCardsDealt.deals.map((deal) => deal.seatId)).toContain(
+          actor,
+        );
+        expect(bot).not.toHaveProperty("waitingForNextHand");
+        expect(toRoomView(room).seats[actor]).toMatchObject({
+          sittingOut: false,
+          sittingOutReason: null,
+          bot: true,
+        });
+      });
+
       it("auto-folds a later in-hand seat without moving the current actor", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 3);

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -39,6 +39,8 @@ export interface Seat {
   claimed: boolean;
   /** Required for new claims; absent only for rooms created before names existed. */
   displayName?: string;
+  /** Present only for a test-mode bot claim. */
+  bot?: boolean;
   token: string | null;
   /**
    * Voluntary opt-out only (ADR-0002) — set solely by the `sitOut`/`sitIn`
@@ -165,6 +167,7 @@ function repackSeats(room: Room, seatCount: number): SeatRepack {
       ...(seat.displayName === undefined
         ? {}
         : { displayName: seat.displayName }),
+      ...(seat.bot === true ? { bot: true } : {}),
       token: seat.token,
       sittingOut: seat.sittingOut,
       disconnected: seat.disconnected,
@@ -264,6 +267,7 @@ function claimedSeatFloor(room: Room): number {
 function freeSeat(seat: Seat): void {
   seat.claimed = false;
   delete seat.displayName;
+  delete seat.bot;
   seat.token = null;
   seat.sittingOut = false;
   seat.disconnected = false;
@@ -409,10 +413,50 @@ export class RoomStore {
 
     seat.claimed = true;
     seat.displayName = trimmedName;
+    delete seat.bot;
     seat.token = this.#generateToken();
     seat.sittingOut = false;
     seat.disconnected = false;
     return { seat };
+  }
+
+  /**
+   * Claims currently-free seats as test-mode bots through the same claim path
+   * as a real player. The caller owns the test-mode gate; this store method
+   * only handles the aggregate mutation and returns the seats that joined.
+   */
+  addBots(
+    code: string,
+    count: number,
+  ): { seats: readonly Seat[] } | { error: "room-not-found" } {
+    const room = this.#rooms.get(code);
+    if (!room) return { error: "room-not-found" };
+    if (!Number.isFinite(count) || count <= 0) return { seats: [] };
+
+    const joined: Seat[] = [];
+    const freeSeats = room.seats.filter((seat) => !seat.claimed);
+    for (const seat of freeSeats.slice(0, count)) {
+      const claim = this.claimSeat(code, seat.id, this.#nextBotName(room));
+      if ("error" in claim) continue;
+      claim.seat.bot = true;
+      joined.push(claim.seat);
+    }
+    return { seats: joined };
+  }
+
+  #nextBotName(room: Room): string {
+    const claimedNames = new Set(
+      room.seats
+        .filter((seat) => seat.claimed)
+        .flatMap((seat) =>
+          seat.displayName === undefined
+            ? []
+            : [seat.displayName.toLowerCase()],
+        ),
+    );
+    let number = 1;
+    while (claimedNames.has(`bot ${String(number)}`)) number++;
+    return `Bot ${String(number)}`;
   }
 
   /**
@@ -700,6 +744,7 @@ export function toRoomView(room: Room): RoomView {
         ...(seat.displayName === undefined
           ? {}
           : { displayName: seat.displayName }),
+        ...(seat.bot === true ? { bot: true } : {}),
         sittingOut: reason !== null,
         sittingOutReason: reason,
         disconnected: seat.disconnected,

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -447,18 +447,13 @@ export class RoomStore {
    * as a real player. The caller owns the test-mode gate; this store method
    * only handles the aggregate mutation and returns the seats that joined.
    */
-  addBots(
-    code: string,
-    count: number,
-  ): { seats: readonly Seat[] } | { error: "room-not-found" } {
-    const room = this.#rooms.get(code);
-    if (!room) return { error: "room-not-found" };
+  addBots(room: Room, count: number): { seats: readonly Seat[] } {
     if (!Number.isFinite(count) || count <= 0) return { seats: [] };
 
     const joined: Seat[] = [];
     const freeSeats = room.seats.filter((seat) => !seat.claimed);
     for (const seat of freeSeats.slice(0, count)) {
-      const claim = this.claimSeat(code, seat.id, this.#nextBotName(room));
+      const claim = this.claimSeat(room.code, seat.id, this.#nextBotName(room));
       if ("error" in claim) continue;
       claim.seat.bot = true;
       joined.push(claim.seat);

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -41,6 +41,8 @@ export interface Seat {
   displayName?: string;
   /** Present only for a test-mode bot claim. */
   bot?: boolean;
+  /** Explicit claim/deal lifecycle state; avoids treating a reused seat id as identity. */
+  waitingForNextHand?: boolean;
   token: string | null;
   /**
    * Voluntary opt-out only (ADR-0002) — set solely by the `sitOut`/`sitIn`
@@ -168,6 +170,7 @@ function repackSeats(room: Room, seatCount: number): SeatRepack {
         ? {}
         : { displayName: seat.displayName }),
       ...(seat.bot === true ? { bot: true } : {}),
+      ...(seat.waitingForNextHand === true ? { waitingForNextHand: true } : {}),
       token: seat.token,
       sittingOut: seat.sittingOut,
       disconnected: seat.disconnected,
@@ -256,6 +259,23 @@ function eligibleSeats(room: Room): SeatId[] {
     .map((seat) => seat.id);
 }
 
+/**
+ * Records which claimed seats belong to the newly dealt hand. This explicit
+ * marker is deliberately separate from numeric seat membership: an evicted
+ * seat can be reclaimed before the old hand is complete, and the new claim
+ * must still wait even though its id remains in the old engine ring.
+ */
+function updateWaitingForNextHand(room: Room, dealIn: readonly SeatId[]): void {
+  const dealt = new Set(dealIn);
+  for (const seat of room.seats) {
+    if (!seat.claimed || dealt.has(seat.id)) {
+      delete seat.waitingForNextHand;
+    } else {
+      seat.waitingForNextHand = true;
+    }
+  }
+}
+
 function claimedSeatFloor(room: Room): number {
   return Math.max(
     MIN_SEAT_COUNT,
@@ -268,6 +288,7 @@ function freeSeat(seat: Seat): void {
   seat.claimed = false;
   delete seat.displayName;
   delete seat.bot;
+  delete seat.waitingForNextHand;
   seat.token = null;
   seat.sittingOut = false;
   seat.disconnected = false;
@@ -275,21 +296,17 @@ function freeSeat(seat: Seat): void {
 
 /**
  * Derives the public lifecycle reason for a seat omitted from the current
- * deal-in: a voluntary opt-out, or a claim made after the live hand's ring
- * was fixed (issue #13). Shared by `toRoomView` and single-seat lookups.
+ * deal-in: a voluntary opt-out, or a claim that missed the current deal-in
+ * (issue #13). The waiting marker is explicit because a reclaimed seat may
+ * reuse an id still present in the old engine ring. Shared by `toRoomView`
+ * and single-seat lookups.
  */
 function sittingOutReason(room: Room, seatId: SeatId): SittingOutReason | null {
   const seat = room.seats[seatId];
   if (!seat) return null;
   if (seat.sittingOut) return "voluntary";
 
-  const ring = room.engine?.seats;
-  if (
-    seat.claimed &&
-    !seat.disconnected &&
-    ring !== undefined &&
-    !ring.includes(seatId)
-  ) {
+  if (seat.claimed && !seat.disconnected && seat.waitingForNextHand === true) {
     return "waiting-for-next-hand";
   }
   return null;
@@ -414,6 +431,11 @@ export class RoomStore {
     seat.claimed = true;
     seat.displayName = trimmedName;
     delete seat.bot;
+    if (room.engine === null) {
+      delete seat.waitingForNextHand;
+    } else {
+      seat.waitingForNextHand = true;
+    }
     seat.token = this.#generateToken();
     seat.sittingOut = false;
     seat.disconnected = false;
@@ -683,6 +705,10 @@ export class RoomStore {
     const command = this.#buildCommand(identity, type);
     const result = this.#runEngineCommand(room, candidateEngine, command);
     if (!("steps" in result)) return result;
+
+    if (type === "startHand" || type === "nextHand") {
+      updateWaitingForNextHand(room, candidateEngine.seats);
+    }
 
     return seatMoves.length > 0 ? { ...result, seatMoves } : result;
   }

--- a/packages/table-client/src/App.interaction.test.tsx
+++ b/packages/table-client/src/App.interaction.test.tsx
@@ -1,0 +1,95 @@
+import type { SeatView } from "@table-top-poker/protocol";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "./App.js";
+import type { TableControlsProps } from "./TableControls.js";
+import type { TableStore } from "./store/store.js";
+
+const addBotsMock = vi.hoisted(() => vi.fn());
+const store = vi.hoisted((): { overrides: Partial<TableStore> } => ({
+  overrides: {},
+}));
+const addBotClick = vi.hoisted((): { current: (() => void) | undefined } => ({
+  current: undefined,
+}));
+
+vi.mock("./api/rooms.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./api/rooms.js")>();
+  return { ...actual, addBots: addBotsMock };
+});
+
+vi.mock("./store/store.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./store/store.js")>();
+  const initial = actual.useTableStore.getInitialState();
+  const useTableStore = (selector: (state: TableStore) => unknown) =>
+    selector({ ...initial, ...store.overrides });
+  return {
+    ...actual,
+    useTableStore: Object.assign(useTableStore, actual.useTableStore),
+  };
+});
+
+/** Captures the button's onClick prop so the node test can exercise it. */
+vi.mock("./TableControls.js", () => ({
+  TableControls: (props: TableControlsProps) => {
+    addBotClick.current =
+      props.testMode === true && props.onAddBot !== undefined
+        ? props.onAddBot
+        : undefined;
+    return props.testMode === true && props.onAddBot !== undefined
+      ? React.createElement(
+          "button",
+          { "data-testid": "add-bot-button", onClick: props.onAddBot },
+          "Add bot",
+        )
+      : null;
+  },
+}));
+
+function seat(id: number): SeatView {
+  return {
+    id,
+    claimed: true,
+    sittingOut: false,
+    sittingOutReason: null,
+    disconnected: false,
+  };
+}
+
+function enterRoom(testMode: boolean): void {
+  store.overrides = {
+    roomCode: "ABCD",
+    joinUrl: "http://localhost:3000/join/ABCD",
+    qrCodeDataUrl: "data:image/png;base64,xyz",
+    seats: [seat(0), seat(1)],
+    connectionStatus: "connected",
+    handView: null,
+    testMode,
+  };
+}
+
+describe("App Add bot interaction", () => {
+  beforeEach(() => {
+    addBotsMock.mockReset();
+    addBotsMock.mockResolvedValue({ joined: 1 });
+    addBotClick.current = undefined;
+  });
+
+  it("clicks Add bot to call the endpoint, with no callable control when off", async () => {
+    enterRoom(true);
+    const html = renderToStaticMarkup(<App />);
+    expect(html).toContain('data-testid="add-bot-button"');
+
+    const clickAddBot = addBotClick.current;
+    if (clickAddBot === undefined) throw new Error("expected Add bot control");
+    clickAddBot();
+    await Promise.resolve();
+    expect(addBotsMock).toHaveBeenCalledWith("ABCD", 1);
+
+    enterRoom(false);
+    const offHtml = renderToStaticMarkup(<App />);
+    expect(offHtml).not.toContain('data-testid="add-bot-button"');
+    expect(addBotClick.current).toBeUndefined();
+  });
+});

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -99,7 +99,11 @@ const showdownHand: TableView = {
 };
 
 /** Puts the table in a room, with the seats claimed and hand state given. */
-function enterRoom(claimedSeats: number, handView: TableView | null) {
+function enterRoom(
+  claimedSeats: number,
+  handView: TableView | null,
+  testMode = false,
+) {
   store.overrides = {
     roomCode: "ABCD",
     joinUrl: "http://localhost:3000/join/ABCD",
@@ -107,6 +111,7 @@ function enterRoom(claimedSeats: number, handView: TableView | null) {
     seats: [0, 1].map((id) => seat(id, id < claimedSeats)),
     connectionStatus: "connected",
     handView,
+    testMode,
   };
 }
 
@@ -248,5 +253,17 @@ describe("App", () => {
     expect(html).not.toContain('data-testid="join-panel"');
     expect(html).toContain('data-testid="join-code-toggle"');
     expect(html).toContain('data-testid="connection-status"');
+  });
+
+  it("shows the test-mode Add bot control only when configured", () => {
+    enterRoom(2, null);
+    expect(renderToStaticMarkup(<App />)).not.toContain(
+      'data-testid="add-bot-button"',
+    );
+
+    enterRoom(2, null, true);
+    expect(renderToStaticMarkup(<App />)).toContain(
+      'data-testid="add-bot-button"',
+    );
   });
 });

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -12,6 +12,7 @@ import {
   changeSeatCount,
   changeSoundSettings,
   createRoom,
+  addBots,
   endSession,
   evictSeat,
   fetchRoom,
@@ -41,6 +42,7 @@ export function App() {
   const seats = useTableStore((state) => state.seats);
   const pendingSeatCount = useTableStore((state) => state.pendingSeatCount);
   const soundSettings = useTableStore((state) => state.soundSettings);
+  const testMode = useTableStore((state) => state.testMode);
   const connectionStatus = useTableStore((state) => state.connectionStatus);
   const handView = useTableStore((state) => state.handView);
   const setRoomCreated = useTableStore((state) => state.setRoomCreated);
@@ -135,6 +137,13 @@ export function App() {
         console.error(error);
       });
   }, [roomCode, clearRoom, clearHand]);
+
+  const handleAddBot = useCallback(() => {
+    if (roomCode === null || !testMode) return;
+    addBots(roomCode, 1).catch((error: unknown) => {
+      console.error(error);
+    });
+  }, [roomCode, testMode]);
 
   const handleChangeSeatCount = useCallback(
     (seatCount: number) => {
@@ -263,6 +272,8 @@ export function App() {
                       onStartHand={handleStartHand}
                       onNextHand={handleNextHand}
                       onEndSession={handleEndSession}
+                      testMode={testMode}
+                      onAddBot={handleAddBot}
                     />
                   )
                 }
@@ -297,6 +308,8 @@ export function App() {
                 onStartHand={handleStartHand}
                 onNextHand={handleNextHand}
                 onEndSession={handleEndSession}
+                testMode={testMode}
+                onAddBot={handleAddBot}
                 onViewShowdown={() => {
                   setShowdownCollapsed(false);
                 }}

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -58,6 +58,23 @@ describe("Seats", () => {
     expect(html).toContain("Avery");
   });
 
+  it("shows a visible bot marker only on bot seats", () => {
+    const first = seats[0];
+    const second = seats[1];
+    if (first === undefined || second === undefined) {
+      throw new Error("expected two seats");
+    }
+    const html = renderToStaticMarkup(
+      <Seats seats={[{ ...first, bot: true }, second]} view={null} />,
+    );
+
+    expect(html).toMatch(/data-testid="seat-pod-0"[^>]*data-bot="true"/);
+    expect(html).toContain('data-testid="seat-pod-0-bot-marker"');
+    expect(html).toContain("🤖");
+    expect(html).toMatch(/data-testid="seat-pod-1"[^>]*data-bot="false"/);
+    expect(html).not.toContain('data-testid="seat-pod-1-bot-marker"');
+  });
+
   it("shows every seat as open or sitting-out before any hand exists", () => {
     const html = renderToStaticMarkup(<Seats seats={seats} view={null} />);
     expect(html).toMatch(/data-testid="seat-pod-0"[^>]*data-status="in-hand"/);

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -213,6 +213,31 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
                 </span>
               </span>
             )}
+            {seat.bot === true && (
+              <span
+                aria-label="Bot"
+                data-testid={`seat-pod-${String(seat.id)}-bot-marker`}
+                title="Bot"
+                style={{
+                  position: "absolute",
+                  bottom: "-0.4em",
+                  left: "-0.4em",
+                  width: MARKER_DIAMETER,
+                  height: MARKER_DIAMETER,
+                  borderRadius: "50%",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  background: color.controlFill,
+                  color: color.textBright,
+                  boxShadow: shadow.card,
+                  fontSize: "0.8em",
+                  lineHeight: 1,
+                }}
+              >
+                🤖
+              </span>
+            )}
           </div>
         );
 
@@ -323,6 +348,7 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
             data-turn={visual.isActor}
             data-winner={visual.isWinner}
             data-disconnected={seat.disconnected}
+            data-bot={seat.bot === true}
             onClick={
               seat.claimed && onSeatClick
                 ? () => {

--- a/packages/table-client/src/TableControls.test.tsx
+++ b/packages/table-client/src/TableControls.test.tsx
@@ -144,4 +144,34 @@ describe("TableControls", () => {
     expect(html).toContain(`background:${color.controlFill}`);
     expect(html).toContain("Waiting for at least two players");
   });
+
+  it("shows Add bot only when test mode is enabled", () => {
+    const off = renderToStaticMarkup(
+      <TableControls
+        canStartHand={false}
+        handComplete={false}
+        canDealNextHand={false}
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+        onAddBot={noop}
+      />,
+    );
+    const on = renderToStaticMarkup(
+      <TableControls
+        canStartHand={false}
+        handComplete={false}
+        canDealNextHand={false}
+        testMode
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+        onAddBot={noop}
+      />,
+    );
+
+    expect(off).not.toContain('data-testid="add-bot-button"');
+    expect(on).toContain('data-testid="add-bot-button"');
+    expect(on).toContain("Add bot");
+  });
 });

--- a/packages/table-client/src/TableControls.tsx
+++ b/packages/table-client/src/TableControls.tsx
@@ -55,6 +55,9 @@ export interface TableControlsProps {
   readonly onStartHand: () => void;
   readonly onNextHand: () => void;
   readonly onEndSession: () => void;
+  /** Test-mode-only control for filling free seats with virtual players. */
+  readonly testMode?: boolean;
+  readonly onAddBot?: () => void;
   /**
    * At showdown the reveal overlay owns "Next hand", so the rail offers "View
    * showdown" in that slot instead — reopening the overlay the operator
@@ -97,6 +100,8 @@ export function TableControls({
   onStartHand,
   onNextHand,
   onEndSession,
+  testMode = false,
+  onAddBot,
   atShowdown = false,
   onViewShowdown,
   placement = "rail",
@@ -152,6 +157,16 @@ export function TableControls({
           style={actionButtonStyle}
         >
           Review hands
+        </PillButton>
+      )}
+      {testMode && onAddBot && (
+        <PillButton
+          tone="outline"
+          data-testid="add-bot-button"
+          onClick={onAddBot}
+          style={actionButtonStyle}
+        >
+          Add bot
         </PillButton>
       )}
       <PillButton

--- a/packages/table-client/src/api/rooms.test.ts
+++ b/packages/table-client/src/api/rooms.test.ts
@@ -1,10 +1,35 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  addBots,
   changeSeatCount,
   createRoom,
   endSession,
   fetchConfig,
 } from "./rooms.js";
+
+describe("addBots", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts the requested bot count to the test-mode route", async () => {
+    const body = { joined: 2 };
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify(body), { status: 200 }),
+    );
+
+    await expect(addBots("ABCD", 3)).resolves.toEqual(body);
+    expect(fetch).toHaveBeenCalledWith("/rooms/ABCD/bots", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ count: 3 }),
+    });
+  });
+});
 
 describe("fetchConfig", () => {
   beforeEach(() => {

--- a/packages/table-client/src/api/rooms.ts
+++ b/packages/table-client/src/api/rooms.ts
@@ -14,6 +14,10 @@ export interface ServerConfig {
   readonly testMode: boolean;
 }
 
+export interface BotsAdded {
+  readonly joined: number;
+}
+
 /** Reads server-global capabilities once when the table client boots. */
 export async function fetchConfig(): Promise<ServerConfig> {
   const response = await fetch("/config", { method: "GET" });
@@ -57,6 +61,19 @@ export async function endSession(code: string): Promise<void> {
   if (!response.ok) {
     throw new Error(`failed to end session: ${String(response.status)}`);
   }
+}
+
+/** The test-mode table action that fills currently-free seats with bots. */
+export async function addBots(code: string, count: number): Promise<BotsAdded> {
+  const response = await fetch(`/rooms/${code}/bots`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ count }),
+  });
+  if (!response.ok) {
+    throw new Error(`failed to add bots: ${String(response.status)}`);
+  }
+  return (await response.json()) as BotsAdded;
 }
 
 /** The table device's manual evict action (ADR-0003) — no automatic trigger. */


### PR DESCRIPTION
## Summary

- add a test-mode-only endpoint for filling free room seats with uniquely named bots
- publish bot seat metadata through the room protocol and render bot markers plus an Add bot control on the table
- track post-deal seat claims independently so reclaimed seats wait for the next hand instead of inheriting an evicted player live-hand identity
- cover endpoint gating, clamping, broadcasts, lifecycle transitions, client rendering, and endpoint wiring

## Why

This gives table devices a safe test-mode control for adding seated bot placeholders without changing house-rule seat capacity. Bots use the existing claim, eviction, and room teardown paths.

Closes #215.

## Validation

- npm test — 92 files, 846 tests
- npm run lint
- npm run build
- git diff --check
- independent Sol/high review completed with no remaining actionable findings