### PR TITLE
feat(server): drive bot seats through hands

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -27,6 +27,12 @@ import { existsSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import type { WebSocket } from "ws";
 import { ActionClock } from "./action-clock.js";
+import {
+  chooseBotAction,
+  shouldSitIn,
+  shouldSitOut,
+  type BotRng,
+} from "./bot-policy.js";
 import { joinUrl, roomQrCodeDataUrl } from "./qr.js";
 import {
   type ClaimSeatError,
@@ -66,6 +72,14 @@ export interface BuildAppOptions {
   readonly handLogDir?: string;
   /** Enables test-only server features such as bot players. */
   readonly testMode?: boolean;
+  /** Randomness for bot actions, delays, and between-hand sit rolls. */
+  readonly botRng?: BotRng;
+  /**
+   * Bot action delay in milliseconds. A scalar is useful for deterministic
+   * tests; a two-item range is sampled for each scheduled action in the
+   * form `[minimum, maximum)`.
+   */
+  readonly botActionDelayMs?: number | readonly [number, number];
   /** Overridable for tests only; production runs `ActionClock`'s 90s default. */
   readonly actionClockMs?: number;
   /** How often the server pings every open socket (Phase 1 spec #130 §7). */
@@ -110,6 +124,45 @@ interface WsRoute {
 
 type SocketIdentity = SeatId | "table" | "lobby";
 type ActionClockPolicy = "reschedule" | "preserve";
+type BotActionDelay = number | readonly [number, number];
+
+const DEFAULT_BOT_ACTION_DELAY_MS: readonly [number, number] = [250, 750];
+
+function assertBotActionDelay(delay: BotActionDelay): void {
+  if (typeof delay === "number") {
+    if (!Number.isFinite(delay) || delay < 0) {
+      throw new RangeError(
+        `bot action delay must be a finite non-negative number, got ${String(delay)}`,
+      );
+    }
+    return;
+  }
+
+  const [minimum, maximum] = delay;
+  if (
+    !Number.isFinite(minimum) ||
+    !Number.isFinite(maximum) ||
+    minimum < 0 ||
+    maximum < minimum
+  ) {
+    throw new RangeError(
+      `bot action delay range must contain finite non-negative values in ascending order, got [${String(minimum)}, ${String(maximum)}]`,
+    );
+  }
+}
+
+function unitRandom(rng: BotRng): number {
+  const value = rng();
+  if (Number.isNaN(value)) return 0;
+  return Math.min(Math.max(value, 0), 1 - Number.EPSILON / 2);
+}
+
+function sampleBotActionDelay(delay: BotActionDelay, rng: BotRng): number {
+  if (typeof delay === "number") return delay;
+  const [minimum, maximum] = delay;
+  if (minimum === maximum) return minimum;
+  return minimum + unitRandom(rng) * (maximum - minimum);
+}
 
 /**
  * Narrows a socket's identity to a seat. Only a seat may be handed
@@ -210,6 +263,10 @@ export async function buildApp(
   const rooms = options.rooms ?? new RoomStore();
   const handLogs = new Map<string, HandLog>();
   const testMode = options.testMode ?? false;
+  const botRng = options.botRng ?? Math.random;
+  const botActionDelay: BotActionDelay =
+    options.botActionDelayMs ?? DEFAULT_BOT_ACTION_DELAY_MS;
+  assertBotActionDelay(botActionDelay);
   const pingIntervalMs = options.pingIntervalMs ?? 10_000;
   const missedPongLimit = options.missedPongLimit ?? 2;
   const graceWindowMs = options.graceWindowMs ?? 60_000;
@@ -221,6 +278,8 @@ export async function buildApp(
   const evictedSockets = new WeakSet<WebSocket>();
   /** One timer per room, armed the moment its table-role socket closes. */
   const tableGraceTimers = new Map<string, NodeJS.Timeout>();
+  /** At most one pending bot action per room; replaced when the actor moves. */
+  const botActionTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const app = Fastify();
 
   function send(socket: WebSocket, message: ServerMessage): void {
@@ -346,6 +405,7 @@ export async function buildApp(
       tableGraceTimers.delete(code);
     }
     actionClock.clear(code);
+    clearBotActionTimer(code);
     handLogs.delete(code);
     rooms.end(code);
   }
@@ -396,6 +456,7 @@ export async function buildApp(
   app.addHook("onClose", (_instance, done) => {
     clearInterval(pingTimer);
     for (const timer of tableGraceTimers.values()) clearTimeout(timer);
+    for (const code of botActionTimers.keys()) clearBotActionTimer(code);
     done();
   });
 
@@ -426,6 +487,86 @@ export async function buildApp(
         });
       }
     }
+  }
+
+  function clearBotActionTimer(code: string): void {
+    const timer = botActionTimers.get(code);
+    if (timer === undefined) return;
+    clearTimeout(timer);
+    botActionTimers.delete(code);
+  }
+
+  /**
+   * Rolls the between-hand cadence for every bot. This runs when the prior
+   * hand reaches HandComplete, before the table can issue nextHand, so the
+   * next deal-in sees the resulting voluntary seat states. A bot never
+   * releases its claim; only the sitting-out bit changes.
+   */
+  function rollBotSitStates(code: string): boolean {
+    if (!testMode) return false;
+    const room = rooms.get(code);
+    if (!room) return false;
+
+    let changed = false;
+    for (const seat of room.seats) {
+      if (!seat.claimed || seat.bot !== true) continue;
+      if (seat.sittingOut) {
+        if (shouldSitIn(botRng)) {
+          rooms.setSittingOut(code, seat.id, false);
+          changed = true;
+        }
+      } else if (shouldSitOut(botRng)) {
+        rooms.setSittingOut(code, seat.id, true);
+        changed = true;
+      }
+    }
+    return changed;
+  }
+
+  /**
+   * Arms the one pending bot action for a room, replacing any stale timer
+   * left behind by a real action, eviction, or another room-store mutation.
+   */
+  function scheduleBotAction(code: string): void {
+    clearBotActionTimer(code);
+    if (!testMode) return;
+
+    const room = rooms.get(code);
+    const actor = rooms.currentActor(code);
+    if (room === undefined || actor === undefined) return;
+    const seat = room.seats[actor];
+    if (!seat?.claimed || seat.bot !== true) return;
+
+    const timer = setTimeout(
+      () => {
+        botActionTimers.delete(code);
+
+        // Everything below is deliberately read again at fire time. A timer
+        // may outlive an intervening human action, eviction, hand completion,
+        // or room teardown.
+        const currentRoom = rooms.get(code);
+        if (!currentRoom || rooms.currentActor(code) !== actor) return;
+        const currentSeat = currentRoom.seats[actor];
+        if (!currentSeat?.claimed || currentSeat.bot !== true) return;
+        const engine = currentRoom.engine;
+        if (engine?.hand?.status !== "betting") return;
+
+        const actorView = view(engine, actor);
+        if (
+          actorView.phase !== "betting" ||
+          actorView.legalActions.length === 0
+        ) {
+          return;
+        }
+
+        const action = chooseBotAction(actorView.legalActions, botRng);
+        const result = rooms.dispatch(code, actor, action);
+        if (!("steps" in result)) return;
+        publishDispatch(code, result);
+      },
+      sampleBotActionDelay(botActionDelay, botRng),
+    );
+    botActionTimers.set(code, timer);
   }
 
   /**
@@ -471,11 +612,18 @@ export async function buildApp(
     for (const step of result.steps) {
       fanOutHandUpdate(code, step);
     }
+    if (
+      testMode &&
+      result.steps.some((step) => step.event.type === "HandComplete")
+    ) {
+      if (rollBotSitStates(code)) broadcastRoomView(code);
+    }
     if (options.actionClock === "preserve") {
       if (rooms.currentActor(code) === undefined) actionClock.clear(code);
     } else {
       rescheduleActionClock(code);
     }
+    scheduleBotAction(code);
   }
 
   // `index: false` — the explicit "/" route below owns index resolution

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -31,6 +31,7 @@ import {
   chooseBotAction,
   shouldSitIn,
   shouldSitOut,
+  unitRandom,
   type BotRng,
 } from "./bot-policy.js";
 import { joinUrl, roomQrCodeDataUrl } from "./qr.js";
@@ -149,12 +150,6 @@ function assertBotActionDelay(delay: BotActionDelay): void {
       `bot action delay range must contain finite non-negative values in ascending order, got [${String(minimum)}, ${String(maximum)}]`,
     );
   }
-}
-
-function unitRandom(rng: BotRng): number {
-  const value = rng();
-  if (Number.isNaN(value)) return 0;
-  return Math.min(Math.max(value, 0), 1 - Number.EPSILON / 2);
 }
 
 function sampleBotActionDelay(delay: BotActionDelay, rng: BotRng): number {
@@ -518,6 +513,9 @@ export async function buildApp(
     // Returning bots are considered first so a table can recover from a
     // previous roll that left only one eligible seat.
     for (const seat of sittingOutBots) {
+      // Guard before the roll so a disconnected bot never consumes an RNG
+      // draw it cannot act on, matching the recovery and sit-out loops below.
+      if (seat.disconnected) continue;
       if (shouldSitIn(botRng)) {
         rooms.setSittingOut(code, seat.id, false);
         changed = true;
@@ -547,8 +545,11 @@ export async function buildApp(
     // Active bots may opt out only while the table would still have two
     // connected, claimed, non-sitting-out seats for the next deal-in.
     for (const seat of activeBots) {
-      if (!shouldSitOut(botRng)) continue;
+      // Guard before the roll so the draw is only consumed when the seat can
+      // actually sit out; drawing first would let the two-seat floor shift
+      // every later action-selection draw for a deterministic RNG.
       if (seat.disconnected || seat.sittingOut || eligibleCount <= 2) continue;
+      if (!shouldSitOut(botRng)) continue;
       rooms.setSittingOut(code, seat.id, true);
       eligibleCount--;
       changed = true;
@@ -594,7 +595,16 @@ export async function buildApp(
 
         const action = chooseBotAction(actorView.legalActions, botRng);
         const result = rooms.dispatch(code, actor, action);
-        if (!("steps" in result)) return;
+        if (!("steps" in result)) {
+          // `action` came straight from the engine's `legalActions`, so a
+          // rejection is not expected. If it somehow happens, re-arm the
+          // clock and the bot so the seat still faces a deadline and the bot
+          // retries rather than stalling — an eviction path may have left the
+          // clock preserved (unarmed) while this actor remains on it.
+          rescheduleActionClock(code);
+          scheduleBotAction(code);
+          return;
+        }
         publishDispatch(code, result);
       },
       sampleBotActionDelay(botActionDelay, botRng),

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -508,17 +508,50 @@ export async function buildApp(
     if (!room) return false;
 
     let changed = false;
-    for (const seat of room.seats) {
-      if (!seat.claimed || seat.bot !== true) continue;
-      if (seat.sittingOut) {
-        if (shouldSitIn(botRng)) {
-          rooms.setSittingOut(code, seat.id, false);
-          changed = true;
-        }
-      } else if (shouldSitOut(botRng)) {
-        rooms.setSittingOut(code, seat.id, true);
+    const bots = room.seats.filter((seat) => seat.claimed && seat.bot === true);
+    // Remember which bots were already sitting out. A bot that returns for
+    // this boundary should remain in for the next deal rather than being
+    // immediately asked to sit out again in the same roll.
+    const sittingOutBots = bots.filter((seat) => seat.sittingOut);
+    const activeBots = bots.filter((seat) => !seat.sittingOut);
+
+    // Returning bots are considered first so a table can recover from a
+    // previous roll that left only one eligible seat.
+    for (const seat of sittingOutBots) {
+      if (shouldSitIn(botRng)) {
+        rooms.setSittingOut(code, seat.id, false);
         changed = true;
       }
+    }
+
+    const dealInEligible = () =>
+      room.seats.filter(
+        (seat) => seat.claimed && !seat.disconnected && !seat.sittingOut,
+      ).length;
+    let eligibleCount = dealInEligible();
+
+    // A failed sit-in roll must not permanently strand a room that still has
+    // two connected claimed seats available. This is a recovery override, not
+    // a normal cadence decision, and is only used until two seats can deal in.
+    if (eligibleCount < 2) {
+      for (const seat of sittingOutBots) {
+        if (eligibleCount >= 2) break;
+        if (seat.sittingOut && !seat.disconnected) {
+          rooms.setSittingOut(code, seat.id, false);
+          eligibleCount++;
+          changed = true;
+        }
+      }
+    }
+
+    // Active bots may opt out only while the table would still have two
+    // connected, claimed, non-sitting-out seats for the next deal-in.
+    for (const seat of activeBots) {
+      if (!shouldSitOut(botRng)) continue;
+      if (seat.disconnected || seat.sittingOut || eligibleCount <= 2) continue;
+      rooms.setSittingOut(code, seat.id, true);
+      eligibleCount--;
+      changed = true;
     }
     return changed;
   }

--- a/packages/server/src/bot-driver.test.ts
+++ b/packages/server/src/bot-driver.test.ts
@@ -57,12 +57,14 @@ async function waitFor(
 async function waitForMessage(
   running: RunningApp,
   predicate: (message: ServerMessage) => boolean,
+  startAt = 0,
 ): Promise<void> {
-  if (running.messages.some(predicate)) return;
+  if (running.messages.slice(startAt).some(predicate)) return;
   await new Promise<void>((resolve) => {
     const onMessage = (data: Buffer) => {
       const message = JSON.parse(data.toString()) as ServerMessage;
-      if (!predicate(message)) return;
+      const messageIndex = running.messages.length - 1;
+      if (messageIndex < startAt || !predicate(message)) return;
       running.socket.off("message", onMessage);
       resolve();
     };
@@ -126,50 +128,126 @@ describe("bot driver", () => {
     );
   });
 
-  it("rolls bot sit-out/in state at the completed-hand boundary", async () => {
-    const rooms = new RoomStore();
-    const room = rooms.create(3);
-    rooms.addBots(room, 3);
-    let rngCalls = 0;
-    const botRng = () => {
-      const value =
-        rngCalls < 12
-          ? 0.5
-          : rngCalls < 15
-            ? ([0, 0.5, 0.5][rngCalls - 12] ?? 0.5)
-            : rngCalls < 23
-              ? 0.5
-              : ([0, 0.5, 0.5][rngCalls - 23] ?? 0.5);
-      rngCalls++;
-      return value;
-    };
-
+  it("keeps a two-seat floor, reports cadence over WS, and deals a waiting bot next hand", async () => {
     app = await buildApp({
-      rooms,
       testMode: true,
-      botRng,
-      botActionDelayMs: 1,
+      botRng: () => 0,
+      botActionDelayMs: 50,
       pingIntervalMs: 100_000,
     });
-    const running = await openTable(app, room.code);
+    const created = await app.inject({
+      method: "POST",
+      url: "/rooms",
+      payload: { seatCount: 4 },
+    });
+    const code = created.json<{ readonly code: string }>().code;
+    const added = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/bots`,
+      payload: { count: 3 },
+    });
+    expect(added.json()).toEqual({ joined: 3 });
+
+    const running = await openTable(app, code);
     socket = running.socket;
-
     socket.send(JSON.stringify({ type: "startHand" }));
-    await waitFor(() => room.engine?.hand?.status === "complete");
-    expect(room.seats[0]).toMatchObject({
-      claimed: true,
-      bot: true,
-      sittingOut: true,
-    });
 
+    await waitForMessage(
+      running,
+      (message) =>
+        message.type === "hand-update" && message.event.type === "HandComplete",
+    );
+    await waitForMessage(
+      running,
+      (message) =>
+        message.type === "room-view" &&
+        message.view.seats.some(
+          (seat) => seat.sittingOutReason === "voluntary",
+        ),
+    );
+    const firstCadenceView = [...running.messages]
+      .reverse()
+      .find((message) => message.type === "room-view");
+    if (firstCadenceView?.type !== "room-view") {
+      throw new Error("expected a cadence room view");
+    }
+    expect(
+      firstCadenceView.view.seats.filter(
+        (seat) => seat.claimed && !seat.sittingOut,
+      ),
+    ).toHaveLength(2);
+    expect(
+      firstCadenceView.view.seats.some(
+        (seat) => seat.sittingOutReason === "voluntary",
+      ),
+    ).toBe(true);
+
+    const firstNextHandMessage = running.messages.length;
     socket.send(JSON.stringify({ type: "nextHand" }));
-    await waitFor(() => rngCalls >= 26 && room.seats[0]?.sittingOut === false);
-    expect(room.engine?.seats).toEqual([1, 2]);
-    expect(room.seats[0]).toMatchObject({
-      claimed: true,
-      bot: true,
-      sittingOut: false,
+    await waitForMessage(
+      running,
+      (message) =>
+        message.type === "hand-update" && message.event.type === "HandStarted",
+      firstNextHandMessage,
+    );
+
+    // This claim happens after deal-in, so its room view must explain that it
+    // is waiting for the next hand rather than calling it voluntary sit-out.
+    const claimedMidHand = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/bots`,
+      payload: { count: 1 },
     });
+    expect(claimedMidHand.json()).toEqual({ joined: 1 });
+    await waitForMessage(
+      running,
+      (message) =>
+        message.type === "room-view" &&
+        message.view.seats.some(
+          (seat) => seat.sittingOutReason === "waiting-for-next-hand",
+        ),
+    );
+
+    const secondCadenceMessage = running.messages.length;
+    await waitForMessage(
+      running,
+      (message) =>
+        message.type === "hand-update" && message.event.type === "HandComplete",
+      firstNextHandMessage,
+    );
+    await waitForMessage(
+      running,
+      (message) =>
+        message.type === "room-view" &&
+        message.view.seats.some(
+          (seat) => seat.sittingOutReason === "waiting-for-next-hand",
+        ),
+      secondCadenceMessage,
+    );
+    const secondNextHandMessage = running.messages.length;
+    socket.send(JSON.stringify({ type: "nextHand" }));
+    await waitForMessage(
+      running,
+      (message) =>
+        message.type === "hand-update" && message.event.type === "HandStarted",
+      secondNextHandMessage,
+    );
+    await waitForMessage(
+      running,
+      (message) => message.type === "room-view",
+      secondNextHandMessage,
+    );
+    const nextDealView = [...running.messages]
+      .slice(secondNextHandMessage)
+      .find((message) => message.type === "room-view");
+    if (nextDealView?.type !== "room-view") {
+      throw new Error("expected room view after next hand");
+    }
+    expect(
+      nextDealView.view.seats.some(
+        (seat) => seat.sittingOutReason === "waiting-for-next-hand",
+      ),
+    ).toBe(false);
   });
 
   it("is inert when test mode is disabled", async () => {

--- a/packages/server/src/bot-driver.test.ts
+++ b/packages/server/src/bot-driver.test.ts
@@ -1,0 +1,206 @@
+import type { ServerMessage } from "@table-top-poker/protocol";
+import type { FastifyInstance } from "fastify";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import WebSocket from "ws";
+import { buildApp } from "./app.js";
+import { RoomStore } from "./rooms.js";
+
+interface RunningApp {
+  readonly app: FastifyInstance;
+  readonly socket: WebSocket;
+  readonly messages: ServerMessage[];
+}
+
+async function openTable(
+  app: FastifyInstance,
+  code: string,
+): Promise<RunningApp> {
+  await app.listen({ port: 0, host: "127.0.0.1" });
+  const address = app.server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("expected a bound TCP address");
+  }
+
+  const socket = new WebSocket(
+    `ws://127.0.0.1:${String(address.port)}/ws?room=${code}&role=table`,
+  );
+  const messages: ServerMessage[] = [];
+  socket.on("message", (data: Buffer) => {
+    messages.push(JSON.parse(data.toString()) as ServerMessage);
+  });
+  await new Promise<void>((resolve, reject) => {
+    socket.once("open", resolve);
+    socket.once("error", reject);
+  });
+  return { app, socket, messages };
+}
+
+async function closeTable(socket: WebSocket): Promise<void> {
+  if (socket.readyState === WebSocket.CLOSED) return;
+  await new Promise<void>((resolve) => {
+    socket.once("close", resolve);
+    socket.close();
+  });
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message = "timed out waiting for bot driver",
+): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+async function waitForMessage(
+  running: RunningApp,
+  predicate: (message: ServerMessage) => boolean,
+): Promise<void> {
+  if (running.messages.some(predicate)) return;
+  await new Promise<void>((resolve) => {
+    const onMessage = (data: Buffer) => {
+      const message = JSON.parse(data.toString()) as ServerMessage;
+      if (!predicate(message)) return;
+      running.socket.off("message", onMessage);
+      resolve();
+    };
+    running.socket.on("message", onMessage);
+  });
+}
+
+describe("bot driver", () => {
+  let app: FastifyInstance | undefined;
+  let socket: WebSocket | undefined;
+
+  afterEach(async () => {
+    if (socket) await closeTable(socket);
+    if (app) await app.close();
+    vi.useRealTimers();
+    socket = undefined;
+    app = undefined;
+  });
+
+  it("chains legal actions for an all-bot hand started by the table", async () => {
+    vi.useFakeTimers();
+    const rooms = new RoomStore();
+    const room = rooms.create(3);
+    const added = rooms.addBots(room, 3);
+    expect(added.seats).toHaveLength(3);
+
+    app = await buildApp({
+      rooms,
+      testMode: true,
+      botRng: () => 0.5,
+      botActionDelayMs: 1,
+      pingIntervalMs: 100_000,
+    });
+    const running = await openTable(app, room.code);
+    socket = running.socket;
+
+    socket.send(JSON.stringify({ type: "startHand" }));
+    for (let attempt = 0; attempt < 30; attempt++) {
+      if (room.engine?.hand?.status === "complete") break;
+      await vi.advanceTimersByTimeAsync(1);
+    }
+    await waitForMessage(
+      running,
+      (message) =>
+        message.type === "hand-update" && message.event.type === "HandComplete",
+    );
+
+    const actions = running.messages.filter(
+      (message) =>
+        message.type === "hand-update" && message.event.type === "ActionTaken",
+    );
+    expect(actions.length).toBeGreaterThan(1);
+    expect(running.messages).not.toContainEqual(
+      expect.objectContaining({ type: "command-rejected" }),
+    );
+    expect(running.messages).toContainEqual(
+      expect.objectContaining({
+        type: "hand-update",
+        event: { type: "HandComplete" },
+      }),
+    );
+  });
+
+  it("rolls bot sit-out/in state at the completed-hand boundary", async () => {
+    const rooms = new RoomStore();
+    const room = rooms.create(3);
+    rooms.addBots(room, 3);
+    let rngCalls = 0;
+    const botRng = () => {
+      const value =
+        rngCalls < 12
+          ? 0.5
+          : rngCalls < 15
+            ? ([0, 0.5, 0.5][rngCalls - 12] ?? 0.5)
+            : rngCalls < 23
+              ? 0.5
+              : ([0, 0.5, 0.5][rngCalls - 23] ?? 0.5);
+      rngCalls++;
+      return value;
+    };
+
+    app = await buildApp({
+      rooms,
+      testMode: true,
+      botRng,
+      botActionDelayMs: 1,
+      pingIntervalMs: 100_000,
+    });
+    const running = await openTable(app, room.code);
+    socket = running.socket;
+
+    socket.send(JSON.stringify({ type: "startHand" }));
+    await waitFor(() => room.engine?.hand?.status === "complete");
+    expect(room.seats[0]).toMatchObject({
+      claimed: true,
+      bot: true,
+      sittingOut: true,
+    });
+
+    socket.send(JSON.stringify({ type: "nextHand" }));
+    await waitFor(() => rngCalls >= 26 && room.seats[0]?.sittingOut === false);
+    expect(room.engine?.seats).toEqual([1, 2]);
+    expect(room.seats[0]).toMatchObject({
+      claimed: true,
+      bot: true,
+      sittingOut: false,
+    });
+  });
+
+  it("is inert when test mode is disabled", async () => {
+    const rooms = new RoomStore();
+    const room = rooms.create(2);
+    rooms.addBots(room, 2);
+    let rngCalls = 0;
+
+    app = await buildApp({
+      rooms,
+      botRng: () => {
+        rngCalls++;
+        return 0.5;
+      },
+      botActionDelayMs: 1,
+      pingIntervalMs: 100_000,
+    });
+    const running = await openTable(app, room.code);
+    socket = running.socket;
+
+    socket.send(JSON.stringify({ type: "startHand" }));
+    await waitFor(() => room.engine?.hand?.status === "betting");
+    await new Promise((resolve) => setTimeout(resolve, 25));
+
+    expect(rngCalls).toBe(0);
+    expect(room.engine?.hand?.status).toBe("betting");
+    expect(running.messages).not.toContainEqual(
+      expect.objectContaining({
+        type: "hand-update",
+        event: { type: "ActionTaken" },
+      }),
+    );
+  });
+});

--- a/packages/server/src/bot-policy.ts
+++ b/packages/server/src/bot-policy.ts
@@ -29,7 +29,7 @@ export const DEFAULT_SIT_IN_PROBABILITY = 0.35;
 /** The greatest representable JavaScript number below 1. */
 const MAX_UNIT_RANDOM = 1 - Number.EPSILON / 2;
 
-function unitRandom(rng: BotRng): number {
+export function unitRandom(rng: BotRng): number {
   const value = rng();
 
   // Math.random() is in [0, 1). Clamp invalid injected values to the nearest


### PR DESCRIPTION
## Summary

- add a test-mode bot driver that schedules legal bot actions through `RoomStore.dispatch`
- chain consecutive bot turns with fire-time state validation while leaving the action clock as a backstop
- apply between-hand sit-out/sit-in cadence while preserving at least two deal-in-eligible seats
- cover all-bot play, cadence state transitions, next-hand progression, and production-mode inertness through app-level HTTP/WebSocket tests

## Why

Bot seats could be added and choose actions, but no server-side orchestration drove them through live hands or managed their between-hand cadence. This completes that app-layer driver without moving orchestration into the engine.

## Validation

- all 175 server tests
- targeted bot-driver test file repeated 5 times
- TypeScript build
- ESLint
- Prettier
- `git diff --check`

Closes #216