### PR TITLE
Add room-configurable shot clock

### DIFF
--- a/packages/player-client/src/store/roomSlice.ts
+++ b/packages/player-client/src/store/roomSlice.ts
@@ -1,9 +1,15 @@
-import type { RoomView, SeatView } from "@table-top-poker/protocol";
+import {
+  DEFAULT_SHOT_CLOCK,
+  type RoomView,
+  type SeatView,
+  type ShotClockSettings,
+} from "@table-top-poker/protocol";
 import type { StateCreator } from "zustand";
 
 export interface RoomSlice {
   readonly roomCode: string | null;
   readonly seats: readonly SeatView[];
+  readonly shotClockSettings: ShotClockSettings;
   readonly joinError: string | null;
   readonly setRoomView: (view: RoomView) => void;
   readonly setJoinError: (message: string | null) => void;
@@ -13,14 +19,25 @@ export interface RoomSlice {
 export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
   roomCode: null,
   seats: [],
+  shotClockSettings: DEFAULT_SHOT_CLOCK,
   joinError: null,
   setRoomView: (view) => {
-    set({ roomCode: view.code, seats: view.seats, joinError: null });
+    set({
+      roomCode: view.code,
+      seats: view.seats,
+      shotClockSettings: view.shotClockSettings,
+      joinError: null,
+    });
   },
   setJoinError: (message) => {
     set({ joinError: message });
   },
   clearRoom: () => {
-    set({ roomCode: null, seats: [], joinError: null });
+    set({
+      roomCode: null,
+      seats: [],
+      shotClockSettings: DEFAULT_SHOT_CLOCK,
+      joinError: null,
+    });
   },
 });

--- a/packages/player-client/src/store/store.test.ts
+++ b/packages/player-client/src/store/store.test.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_SOUND_SETTINGS } from "@table-top-poker/protocol";
+import {
+  DEFAULT_SHOT_CLOCK,
+  DEFAULT_SOUND_SETTINGS,
+} from "@table-top-poker/protocol";
 import { beforeEach, describe, expect, it } from "vitest";
 import { usePlayerStore } from "./store.js";
 
@@ -48,6 +51,7 @@ describe("usePlayerStore", () => {
       code: "ABCD",
       pendingSeatCount: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
+      shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
         {
           id: 0,
@@ -71,6 +75,7 @@ describe("usePlayerStore", () => {
       code: "ABCD",
       pendingSeatCount: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
+      shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
         {
           id: 0,
@@ -104,6 +109,7 @@ describe("usePlayerStore", () => {
       code: "ABCD",
       pendingSeatCount: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
+      shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
         {
           id: 0,
@@ -136,6 +142,7 @@ describe("usePlayerStore", () => {
       code: "ABCD",
       pendingSeatCount: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
+      shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
         {
           id: 0,
@@ -172,6 +179,7 @@ describe("usePlayerStore", () => {
       code: "ABCD",
       pendingSeatCount: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
+      shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
         {
           id: 0,

--- a/packages/protocol/src/room.test.ts
+++ b/packages/protocol/src/room.test.ts
@@ -3,10 +3,14 @@ import {
   ChangeSeatCountRequestSchema,
   ClaimSeatRequestSchema,
   CreateRoomRequestSchema,
+  DEFAULT_SHOT_CLOCK,
   DEFAULT_SEAT_COUNT,
   MAX_DISPLAY_NAME_LENGTH,
   MAX_SEAT_COUNT,
+  MAX_SHOT_CLOCK_SECONDS,
+  MIN_SHOT_CLOCK_SECONDS,
   MIN_SEAT_COUNT,
+  ShotClockSettingsSchema,
 } from "./room.js";
 
 describe("ClaimSeatRequestSchema", () => {
@@ -70,6 +74,50 @@ describe("CreateRoomRequestSchema", () => {
         false,
       );
     }
+  });
+});
+
+describe("ShotClockSettingsSchema", () => {
+  it("defaults a room to a disabled 90-second clock", () => {
+    expect(DEFAULT_SHOT_CLOCK).toEqual({ enabled: false, seconds: 90 });
+  });
+
+  it("accepts an enabled clock at the inclusive duration bounds", () => {
+    expect(
+      ShotClockSettingsSchema.parse({
+        enabled: true,
+        seconds: MIN_SHOT_CLOCK_SECONDS,
+      }),
+    ).toEqual({ enabled: true, seconds: MIN_SHOT_CLOCK_SECONDS });
+    expect(
+      ShotClockSettingsSchema.parse({
+        enabled: false,
+        seconds: MAX_SHOT_CLOCK_SECONDS,
+      }),
+    ).toEqual({ enabled: false, seconds: MAX_SHOT_CLOCK_SECONDS });
+  });
+
+  it("requires a distinct boolean enabled flag and integer seconds", () => {
+    for (const enabled of [0, 1, "true", null]) {
+      expect(
+        ShotClockSettingsSchema.safeParse({ enabled, seconds: 90 }).success,
+      ).toBe(false);
+    }
+    for (const seconds of [0, 4, 601, 5.5, "90", null]) {
+      expect(
+        ShotClockSettingsSchema.safeParse({ enabled: true, seconds }).success,
+      ).toBe(false);
+    }
+  });
+
+  it("rejects extra fields", () => {
+    expect(
+      ShotClockSettingsSchema.safeParse({
+        enabled: true,
+        seconds: 90,
+        timeout: 0,
+      }).success,
+    ).toBe(false);
   });
 });
 

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -119,6 +119,28 @@ export type ChangeSoundSettingsRequest = z.infer<
 export type SoundSettingsChangeError =
   "room-not-found" | "invalid-request-body";
 
+/** Inclusive bounds for a room's player action timer. */
+export const MIN_SHOT_CLOCK_SECONDS = 5;
+export const MAX_SHOT_CLOCK_SECONDS = 600;
+
+/** A room-owned player action timer configuration. */
+export interface ShotClockSettings {
+  readonly enabled: boolean;
+  readonly seconds: number;
+}
+
+/** A fresh room has an unbounded action clock, with 90 seconds ready to enable. */
+export const DEFAULT_SHOT_CLOCK: ShotClockSettings = {
+  enabled: false,
+  seconds: 90,
+};
+
+/** The single trust-boundary definition for shot-clock settings. */
+export const ShotClockSettingsSchema = z.strictObject({
+  enabled: z.boolean(),
+  seconds: z.int().min(MIN_SHOT_CLOCK_SECONDS).max(MAX_SHOT_CLOCK_SECONDS),
+});
+
 /** The sources from which a client or server can answer whether a hand is live. */
 export type HandStateSource = EngineState | PlayerView | TableView | null;
 
@@ -191,6 +213,8 @@ export interface RoomView {
   readonly pendingSeatCount: number | null;
   /** Room-wide tactile-sound settings (#182), replayed on join/reconnect. */
   readonly soundSettings: SoundSettings;
+  /** Room-wide action-clock settings, replayed on join/reconnect. */
+  readonly shotClockSettings: ShotClockSettings;
 }
 
 /** Pushed over the room's WebSocket whenever seat state changes. */

--- a/packages/server/src/action-clock.test.ts
+++ b/packages/server/src/action-clock.test.ts
@@ -13,6 +13,16 @@ describe("ActionClock", () => {
     expect(setTimeoutFn).toHaveBeenCalledWith(expect.any(Function), 90_000);
   });
 
+  it("accepts a room-specific duration when scheduling", () => {
+    const setTimeoutFn = vi.fn(setTimeout);
+    const clearTimeoutFn = vi.fn(clearTimeout);
+    const clock = new ActionClock(90_000, setTimeoutFn, clearTimeoutFn);
+
+    clock.schedule("ROOM", 5_000, vi.fn());
+
+    expect(setTimeoutFn).toHaveBeenCalledWith(expect.any(Function), 5_000);
+  });
+
   it("clears a room's prior timer when scheduling a new one", () => {
     const handles: unknown[] = [];
     const setTimeoutFn = vi.fn((fn: () => void, ms: number) => {

--- a/packages/server/src/action-clock.ts
+++ b/packages/server/src/action-clock.ts
@@ -25,9 +25,27 @@ export class ActionClock {
   }
 
   /** Replaces any timer already running for `key` with a fresh one. */
-  schedule(key: string, onTimeout: () => void): void {
+  schedule(key: string, onTimeout: () => void): void;
+  /** Replaces any timer with a fresh timer at a room-specific duration. */
+  schedule(key: string, timeoutMs: number, onTimeout: () => void): void;
+  schedule(
+    key: string,
+    timeoutMsOrCallback: number | (() => void),
+    maybeCallback?: () => void,
+  ): void {
     this.clear(key);
-    this.#timers.set(key, this.#setTimeoutFn(onTimeout, this.#timeoutMs));
+    const timeoutMs =
+      typeof timeoutMsOrCallback === "number"
+        ? timeoutMsOrCallback
+        : this.#timeoutMs;
+    const onTimeout =
+      typeof timeoutMsOrCallback === "function"
+        ? timeoutMsOrCallback
+        : maybeCallback;
+    if (onTimeout === undefined) {
+      throw new TypeError("action clock timeout callback is required");
+    }
+    this.#timers.set(key, this.#setTimeoutFn(onTimeout, timeoutMs));
   }
 
   clear(key: string): void {

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SEAT_COUNT,
+  DEFAULT_SHOT_CLOCK,
   DEFAULT_SOUND_SETTINGS,
   MAX_SEAT_COUNT,
   MIN_SEAT_COUNT,
@@ -19,6 +20,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import WebSocket from "ws";
+import { ActionClock } from "./action-clock.js";
 import { buildApp } from "./app.js";
 import { RoomStore, toRoomView } from "./rooms.js";
 
@@ -162,6 +164,7 @@ describe("rooms HTTP routes", () => {
       code,
       pendingSeatCount: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
+      shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: unclaimedSeats(),
     });
   });
@@ -1156,6 +1159,7 @@ describe("WebSocket upgrade", () => {
         code: room.code,
         pendingSeatCount: null,
         soundSettings: DEFAULT_SOUND_SETTINGS,
+        shotClockSettings: DEFAULT_SHOT_CLOCK,
         seats: unclaimedSeats(),
       },
     });
@@ -1946,6 +1950,14 @@ describe("action clock", () => {
     await new Promise((resolve) => setTimeout(resolve, ms));
   }
 
+  function enableShotClock(room: ReturnType<RoomStore["create"]>): void {
+    const result = rooms.changeShotClockSettings(room.code, {
+      enabled: true,
+      seconds: 5,
+    });
+    if ("error" in result) throw new Error("expected shot-clock settings");
+  }
+
   async function claimAndConnect(
     code: string,
     seatId: number,
@@ -1968,6 +1980,7 @@ describe("action clock", () => {
 
   it("auto-folds the current actor via a synthesized fold once the clock elapses", async () => {
     const room = rooms.create();
+    enableShotClock(room);
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
     await claimAndConnect(room.code, 0);
@@ -1993,8 +2006,53 @@ describe("action clock", () => {
     ]);
   });
 
+  it("does not arm a timer for a fresh room with the clock disabled", async () => {
+    const room = rooms.create();
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    await claimAndConnect(room.code, 0);
+    await claimAndConnect(room.code, 1);
+    await claimAndConnect(room.code, 2);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle(ACTION_CLOCK_MS + 60);
+
+    expect(actionsSeen(table.messages)).toHaveLength(0);
+    expect(rooms.currentActor(room.code)).toBeDefined();
+  });
+
+  it("checks on expiry when checking is free", async () => {
+    const room = rooms.create(2);
+    enableShotClock(room);
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const seat0 = await claimAndConnect(room.code, 0);
+    const seat1 = await claimAndConnect(room.code, 1);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    seat0.socket.send(JSON.stringify({ type: "call" }));
+    await settle();
+    seat1.socket.send(JSON.stringify({ type: "check" }));
+    await settle();
+    const seatOneChecksBeforeExpiry = actionsSeen(table.messages).filter(
+      (event) => event.action === "check" && event.seatId === 1,
+    ).length;
+
+    // The flop's first actor has a free check; expiry should preserve it.
+    await settle(ACTION_CLOCK_MS + 60);
+
+    const seatOneChecksAfterExpiry = actionsSeen(table.messages).filter(
+      (event) => event.action === "check" && event.seatId === 1,
+    ).length;
+    expect(seatOneChecksAfterExpiry).toBe(seatOneChecksBeforeExpiry + 1);
+  });
+
   it("does not reset the current actor's clock for a different seat's eviction", async () => {
     const room = rooms.create();
+    enableShotClock(room);
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
     for (const seatId of [0, 1, 2])
@@ -2021,6 +2079,7 @@ describe("action clock", () => {
 
   it("does not auto-fold a seat that acts before the clock elapses", async () => {
     const room = rooms.create();
+    enableShotClock(room);
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
     const seat0 = await claimAndConnect(room.code, 0);
@@ -2047,6 +2106,7 @@ describe("action clock", () => {
 
   it("resets the clock onto the new actor after a real action, rather than firing against the old one", async () => {
     const room = rooms.create();
+    enableShotClock(room);
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
     const seat0 = await claimAndConnect(room.code, 0);
@@ -2076,6 +2136,7 @@ describe("action clock", () => {
 
   it("resets the clock onto the new street's first actor after a street transition", async () => {
     const room = rooms.create();
+    enableShotClock(room);
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
     const seat0 = await claimAndConnect(room.code, 0);
@@ -2095,7 +2156,8 @@ describe("action clock", () => {
     // The BB acts last, so its check is the option and closes the street.
     seat2.socket.send(JSON.stringify({ type: "check" }));
     await settle();
-    // Preflop closes; the flop's first actor (seat 1, SB) now idles out.
+    // Preflop closes; the flop's first actor (seat 1, SB) now idles out. A
+    // free check is preserved when the shot clock expires.
     await settle(ACTION_CLOCK_MS + 60);
 
     const streetsStarted = table.messages
@@ -2104,16 +2166,91 @@ describe("action clock", () => {
       .filter((e) => e.type === "StreetStarted");
     expect(streetsStarted.some((e) => e.street === "flop")).toBe(true);
 
-    const folds = actionsSeen(table.messages).filter(
-      (e) => e.action === "fold",
+    const checks = actionsSeen(table.messages).filter(
+      (e) => e.action === "check",
     );
-    expect(folds).toEqual([
+    expect(checks).toContainEqual(
       expect.objectContaining({
         type: "ActionTaken",
         seatId: 1,
-        action: "fold",
+        action: "check",
       }),
-    ]);
+    );
+  });
+});
+
+describe("action clock duration selection", () => {
+  it("schedules each room from its configured seconds", async () => {
+    const rooms = new RoomStore();
+    const durations: number[] = [];
+    const actionClock = new ActionClock(
+      90_000,
+      (callback, milliseconds) => {
+        durations.push(milliseconds);
+        const timer = setTimeout(callback, 60_000);
+        timer.unref();
+        return timer;
+      },
+      clearTimeout,
+    );
+    const app = await buildApp({
+      rooms,
+      actionClock,
+      // This must not mask the per-room duration when an injected clock is
+      // used; it remains here to guard that test-only override explicitly.
+      actionClockMs: 1,
+    });
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected a bound TCP address");
+    }
+
+    const first = rooms.create();
+    const second = rooms.create();
+    const firstSettings = rooms.changeShotClockSettings(first.code, {
+      enabled: true,
+      seconds: 7,
+    });
+    const secondSettings = rooms.changeShotClockSettings(second.code, {
+      enabled: true,
+      seconds: 13,
+    });
+    if ("error" in firstSettings || "error" in secondSettings) {
+      throw new Error("expected valid shot-clock settings");
+    }
+    for (const room of [first, second]) {
+      rooms.claimSeat(room.code, 0, "P0");
+      rooms.claimSeat(room.code, 1, "P1");
+    }
+
+    const sockets = [first, second].map(
+      (room) =>
+        new WebSocket(
+          `ws://127.0.0.1:${String(address.port)}/ws?room=${room.code}&role=table`,
+        ),
+    );
+    try {
+      await Promise.all(
+        sockets.map(
+          (socket) =>
+            new Promise<void>((resolve, reject) => {
+              socket.once("open", resolve);
+              socket.once("error", reject);
+            }),
+        ),
+      );
+      for (const socket of sockets) {
+        socket.send(JSON.stringify({ type: "startHand" }));
+      }
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(durations).toEqual(expect.arrayContaining([7_000, 13_000]));
+      expect(durations).not.toContain(1);
+    } finally {
+      for (const socket of sockets) socket.close();
+      await app.close();
+    }
   });
 });
 
@@ -2169,6 +2306,14 @@ describe("presence and reconnection", () => {
 
   async function settle(ms = 20): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  function enableShotClock(room: ReturnType<RoomStore["create"]>): void {
+    const result = rooms.changeShotClockSettings(room.code, {
+      enabled: true,
+      seconds: 5,
+    });
+    if ("error" in result) throw new Error("expected shot-clock settings");
   }
 
   function seatDisconnected(
@@ -2267,6 +2412,7 @@ describe("presence and reconnection", () => {
 
   it("lands a reconnecting seat in a folded seat after it folded while away", async () => {
     const room = rooms.create();
+    enableShotClock(room);
     const table = connect(`room=${room.code}&role=table`);
     await opened(table.socket);
     const claim0 = rooms.claimSeat(room.code, 0, "P0");

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -81,8 +81,10 @@ export interface BuildAppOptions {
    * form `[minimum, maximum)`.
    */
   readonly botActionDelayMs?: number | readonly [number, number];
-  /** Overridable for tests only; production runs `ActionClock`'s 90s default. */
+  /** Overridable for tests only; production uses each room's configured seconds. */
   readonly actionClockMs?: number;
+  /** Injectable action clock for deterministic server tests. */
+  readonly actionClock?: ActionClock;
   /** How often the server pings every open socket (Phase 1 spec #130 §7). */
   readonly pingIntervalMs?: number;
   /** Missed pongs before a seat's badge flips to "disconnected". */
@@ -267,7 +269,8 @@ export async function buildApp(
   const graceWindowMs = options.graceWindowMs ?? 60_000;
   const roomSockets = new Map<string, Set<WebSocket>>();
   const socketIdentity = new Map<WebSocket, SocketIdentity>();
-  const actionClock = new ActionClock(options.actionClockMs);
+  const actionClock =
+    options.actionClock ?? new ActionClock(options.actionClockMs);
   const socketRoomCode = new Map<WebSocket, string>();
   const pingMissed = new Map<WebSocket, number>();
   const evictedSockets = new WeakSet<WebSocket>();
@@ -620,18 +623,51 @@ export async function buildApp(
    * Phase 1 spec #130 §7.
    */
   function rescheduleActionClock(code: string): void {
+    const room = rooms.get(code);
     const actor = rooms.currentActor(code);
-    if (actor === undefined) {
+    if (room === undefined || actor === undefined) {
       actionClock.clear(code);
       return;
     }
-    actionClock.schedule(code, () => {
-      const result = rooms.dispatch(code, actor, "fold");
+
+    const { enabled, seconds } = room.shotClockSettings;
+    if (!enabled) {
+      actionClock.clear(code);
+      return;
+    }
+
+    // `actionClockMs` is only a convenience override for the default clock
+    // used by the existing timer tests. An injected clock is authoritative so
+    // tests can observe each room's configured duration directly.
+    const timeoutMs =
+      options.actionClock === undefined && options.actionClockMs !== undefined
+        ? options.actionClockMs
+        : seconds * 1000;
+    actionClock.schedule(code, timeoutMs, () => {
+      const currentRoom = rooms.get(code);
+      if (!currentRoom || rooms.currentActor(code) !== actor) {
+        rescheduleActionClock(code);
+        return;
+      }
+
+      // A timeout should preserve a free check. Read legal actions at fire
+      // time because the scheduled callback may outlive another room-store
+      // mutation even after its timer has been replaced.
+      const actorView =
+        currentRoom.engine === null
+          ? undefined
+          : view(currentRoom.engine, actor);
+      const action =
+        actorView?.phase === "betting" &&
+        actorView.legalActions.includes("check")
+          ? "check"
+          : "fold";
+      const result = rooms.dispatch(code, actor, action);
       // `actor` was read as the live current actor at schedule time, and
       // any real action in between would have rescheduled (and thus
-      // replaced) this very timer — so `dispatch` rejecting the
-      // synthesized fold isn't expected to happen. If it somehow does, the
-      // clock still re-arms below.
+      // replaced) this very timer — so `dispatch` rejecting the synthesized
+      // action isn't expected to happen. If it somehow does, the clock still
+      // re-arms below.
       if ("steps" in result) {
         publishDispatch(code, result);
         return;

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SEAT_COUNT,
+  DEFAULT_SHOT_CLOCK,
   DEFAULT_SOUND_SETTINGS,
   MAX_DISPLAY_NAME_LENGTH,
   MAX_SEAT_COUNT,
@@ -25,6 +26,14 @@ describe("RoomStore", () => {
       expect(seat.token).toBeNull();
       expect(seat.sittingOut).toBe(false);
     }
+  });
+
+  it("creates a room with the shot clock disabled by default", () => {
+    const store = new RoomStore();
+    const room = store.create();
+
+    expect(room.shotClockSettings).toEqual(DEFAULT_SHOT_CLOCK);
+    expect(toRoomView(room).shotClockSettings).toEqual(DEFAULT_SHOT_CLOCK);
   });
 
   it("creates a room with the seat count the creator chose", () => {
@@ -1055,6 +1064,7 @@ describe("toRoomView", () => {
       code: room.code,
       pendingSeatCount: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
+      shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
         {
           id: 0,
@@ -1106,5 +1116,42 @@ describe("changeSoundSettings", () => {
     expect(store.changeSoundSettings("ZZZZ", DEFAULT_SOUND_SETTINGS)).toEqual({
       error: "room-not-found",
     });
+  });
+});
+
+describe("changeShotClockSettings", () => {
+  it("replaces the room settings atomically", () => {
+    const store = new RoomStore();
+    const room = store.create();
+    const settings = { enabled: true, seconds: 30 };
+
+    expect(store.changeShotClockSettings(room.code, settings)).toEqual(
+      settings,
+    );
+    expect(toRoomView(room).shotClockSettings).toEqual(settings);
+  });
+
+  it("rejects an invalid duration without changing the room", () => {
+    const store = new RoomStore();
+    const room = store.create();
+
+    expect(
+      store.changeShotClockSettings(room.code, {
+        enabled: true,
+        seconds: 4,
+      }),
+    ).toEqual({ error: "invalid-shot-clock" });
+    expect(room.shotClockSettings).toEqual(DEFAULT_SHOT_CLOCK);
+  });
+
+  it("reports an unknown room", () => {
+    const store = new RoomStore();
+
+    expect(
+      store.changeShotClockSettings("ZZZZ", {
+        enabled: true,
+        seconds: 30,
+      }),
+    ).toEqual({ error: "room-not-found" });
   });
 });

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -3,11 +3,13 @@ import {
   apply,
   createInitialState,
   DEFAULT_SEAT_COUNT,
+  DEFAULT_SHOT_CLOCK,
   DEFAULT_SOUND_SETTINGS,
   decide,
   MAX_SEAT_COUNT,
   MAX_DISPLAY_NAME_LENGTH,
   MIN_SEAT_COUNT,
+  ShotClockSettingsSchema,
   SeatCountSchema,
   type ClientCommandType,
   type Command,
@@ -22,6 +24,7 @@ import {
   type SeatCountChange,
   type SeatCountChangeError,
   type SeatMove,
+  type ShotClockSettings,
   type SittingOutReason,
   type SoundSettings,
 } from "@table-top-poker/protocol";
@@ -67,6 +70,8 @@ export interface Room {
   pendingSeatCount: number | null;
   /** Room-wide tactile-sound settings (#182), set by the table. */
   soundSettings: SoundSettings;
+  /** Room-wide action-clock settings, set by the table. */
+  shotClockSettings: ShotClockSettings;
 }
 
 export type ClaimSeatError =
@@ -372,6 +377,7 @@ export class RoomStore {
       engine: null,
       pendingSeatCount: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
+      shotClockSettings: DEFAULT_SHOT_CLOCK,
     };
     this.#rooms.set(code, room);
     return room;
@@ -607,6 +613,24 @@ export class RoomStore {
     return room.soundSettings;
   }
 
+  /**
+   * Replaces the room's action-clock settings atomically. Applying the shared
+   * schema here keeps direct callers from constructing invalid room state.
+   */
+  changeShotClockSettings(
+    code: string,
+    settings: ShotClockSettings,
+  ): ShotClockSettings | { error: "room-not-found" | "invalid-shot-clock" } {
+    const room = this.#rooms.get(code);
+    if (!room) return { error: "room-not-found" };
+    const parsed = ShotClockSettingsSchema.safeParse(settings);
+    if (!parsed.success) {
+      return { error: "invalid-shot-clock" };
+    }
+    room.shotClockSettings = parsed.data;
+    return room.shotClockSettings;
+  }
+
   /** Whether `seatId` reads as "sitting out" in the room's public view — see `isSittingOut`. */
   isSittingOut(code: string, seatId: SeatId): boolean {
     const room = this.#rooms.get(code);
@@ -757,6 +781,7 @@ export function toRoomView(room: Room): RoomView {
     code: room.code,
     pendingSeatCount: room.pendingSeatCount,
     soundSettings: room.soundSettings,
+    shotClockSettings: room.shotClockSettings,
     seats: room.seats.map((seat) => {
       const reason = sittingOutReason(room, seat.id);
       return {

--- a/packages/table-client/src/store/roomSlice.ts
+++ b/packages/table-client/src/store/roomSlice.ts
@@ -1,7 +1,9 @@
 import {
+  DEFAULT_SHOT_CLOCK,
   DEFAULT_SOUND_SETTINGS,
   type RoomView,
   type SeatView,
+  type ShotClockSettings,
   type SoundSettings,
 } from "@table-top-poker/protocol";
 import type { StateCreator } from "zustand";
@@ -13,6 +15,7 @@ export interface RoomSlice {
   readonly seats: readonly SeatView[];
   readonly pendingSeatCount: number | null;
   readonly soundSettings: SoundSettings;
+  readonly shotClockSettings: ShotClockSettings;
   readonly setRoomCreated: (room: {
     code: string;
     joinUrl: string;
@@ -29,6 +32,7 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
   seats: [],
   pendingSeatCount: null,
   soundSettings: DEFAULT_SOUND_SETTINGS,
+  shotClockSettings: DEFAULT_SHOT_CLOCK,
   setRoomCreated: ({ code, joinUrl, qrCodeDataUrl }) => {
     set({ roomCode: code, joinUrl, qrCodeDataUrl, pendingSeatCount: null });
   },
@@ -38,6 +42,7 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
       seats: view.seats,
       pendingSeatCount: view.pendingSeatCount,
       soundSettings: view.soundSettings,
+      shotClockSettings: view.shotClockSettings,
     });
   },
   clearRoom: () => {
@@ -48,6 +53,7 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
       seats: [],
       pendingSeatCount: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
+      shotClockSettings: DEFAULT_SHOT_CLOCK,
     });
   },
 });

--- a/packages/table-client/src/store/store.test.ts
+++ b/packages/table-client/src/store/store.test.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_SOUND_SETTINGS } from "@table-top-poker/protocol";
+import {
+  DEFAULT_SHOT_CLOCK,
+  DEFAULT_SOUND_SETTINGS,
+} from "@table-top-poker/protocol";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useTableStore } from "./store.js";
 
@@ -42,6 +45,7 @@ describe("useTableStore", () => {
       code: "ABCD",
       pendingSeatCount: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
+      shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
         {
           id: 0,
@@ -69,6 +73,7 @@ describe("useTableStore", () => {
       code: "ABCD",
       pendingSeatCount: 4,
       soundSettings: DEFAULT_SOUND_SETTINGS,
+      shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
         {
           id: 0,
@@ -96,6 +101,7 @@ describe("useTableStore", () => {
       code: "ABCD",
       pendingSeatCount: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
+      shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
         {
           id: 0,


### PR DESCRIPTION
## Summary

- add protocol-level `ShotClockSettings` with a disabled-by-default 90-second configuration surfaced through `RoomView`
- arm each room's action timer only when enabled and use its configured duration
- automatically check on expiry when checking is free, otherwise fold
- validate settings and propagate them through server and client room state
- add targeted protocol, server, and client coverage for defaults, validation, timer arming, configured durations, and check-vs-fold expiry

## Why

The action clock was hardcoded to 90 seconds and always armed. Rooms now own an explicit shot-clock configuration, allowing unbounded turns by default and predictable timeout behavior when enabled.

## Validation

- 194 targeted tests passed
- TypeScript build passed
- ESLint passed
- Prettier check passed
- `git diff --check` passed
- three review rounds completed; final GPT-5.6-Sol high review was clean

Closes #221