### PR TITLE
Edit the shot clock from House Rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -936,6 +936,15 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/react-test-renderer": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
+      "integrity": "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -3196,6 +3205,12 @@
         "react": "^19.2.8"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "dev": true
+    },
     "node_modules/react-peel": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-peel/-/react-peel-2.1.0.tgz",
@@ -3203,6 +3218,19 @@
       "peerDependencies": {
         "react": "16.8.0 || >=17.x",
         "react-dom": "16.8.0 || >=17.x"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.8.tgz",
+      "integrity": "sha512-GHKPaDRaNYU24PHTLG8Bx8VMY9t+qNfxQbt/Yjp7aMWBkKU6766SR0n6TnYu7P5I1MfEuAMUadqiyDHyI4Yy9Q==",
+      "dev": true,
+      "dependencies": {
+        "react-is": "^19.2.8",
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
       }
     },
     "node_modules/readable-stream": {
@@ -4143,7 +4171,9 @@
       "devDependencies": {
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
+        "@types/react-test-renderer": "^19.1.0",
         "@vitejs/plugin-react": "^6.0.4",
+        "react-test-renderer": "^19.2.8",
         "vite": "^8.1.5"
       }
     },

--- a/packages/player-client/src/store/store.test.ts
+++ b/packages/player-client/src/store/store.test.ts
@@ -50,6 +50,7 @@ describe("usePlayerStore", () => {
     usePlayerStore.getState().setRoomView({
       code: "ABCD",
       pendingSeatCount: null,
+      pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
@@ -74,6 +75,7 @@ describe("usePlayerStore", () => {
     usePlayerStore.getState().setRoomView({
       code: "ABCD",
       pendingSeatCount: null,
+      pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
@@ -108,6 +110,7 @@ describe("usePlayerStore", () => {
     usePlayerStore.getState().setRoomView({
       code: "ABCD",
       pendingSeatCount: null,
+      pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
@@ -141,6 +144,7 @@ describe("usePlayerStore", () => {
     usePlayerStore.getState().setRoomView({
       code: "ABCD",
       pendingSeatCount: null,
+      pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
@@ -178,6 +182,7 @@ describe("usePlayerStore", () => {
     usePlayerStore.getState().setRoomView({
       code: "ABCD",
       pendingSeatCount: null,
+      pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [

--- a/packages/protocol/src/room.test.ts
+++ b/packages/protocol/src/room.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  ChangeShotClockRequestSchema,
   ChangeSeatCountRequestSchema,
   ClaimSeatRequestSchema,
   CreateRoomRequestSchema,
@@ -116,6 +117,27 @@ describe("ShotClockSettingsSchema", () => {
         enabled: true,
         seconds: 90,
         timeout: 0,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("ChangeShotClockRequestSchema", () => {
+  it("uses the same integer duration bounds and strict body shape", () => {
+    expect(
+      ChangeShotClockRequestSchema.parse({ enabled: false, seconds: 90 }),
+    ).toEqual({ enabled: false, seconds: 90 });
+    expect(
+      ChangeShotClockRequestSchema.safeParse({
+        enabled: true,
+        seconds: MIN_SHOT_CLOCK_SECONDS - 1,
+      }).success,
+    ).toBe(false);
+    expect(
+      ChangeShotClockRequestSchema.safeParse({
+        enabled: true,
+        seconds: 90,
+        extra: true,
       }).success,
     ).toBe(false);
   });

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -141,6 +141,13 @@ export const ShotClockSettingsSchema = z.strictObject({
   seconds: z.int().min(MIN_SHOT_CLOCK_SECONDS).max(MAX_SHOT_CLOCK_SECONDS),
 });
 
+/** Body of the table-only deferred shot-clock settings request. */
+export const ChangeShotClockRequestSchema = ShotClockSettingsSchema;
+
+export type ChangeShotClockRequest = z.infer<
+  typeof ChangeShotClockRequestSchema
+>;
+
 /** The sources from which a client or server can answer whether a hand is live. */
 export type HandStateSource = EngineState | PlayerView | TableView | null;
 
@@ -211,6 +218,8 @@ export interface RoomView {
   readonly seats: readonly SeatView[];
   /** A shrink queued until the next deal-in, or null when none is queued. */
   readonly pendingSeatCount: number | null;
+  /** A shot-clock change queued until the next deal-in, or null when none is queued. */
+  readonly pendingShotClock: ShotClockSettings | null;
   /** Room-wide tactile-sound settings (#182), replayed on join/reconnect. */
   readonly soundSettings: SoundSettings;
   /** Room-wide action-clock settings, replayed on join/reconnect. */

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -3,7 +3,9 @@ import {
   DEFAULT_SHOT_CLOCK,
   DEFAULT_SOUND_SETTINGS,
   MAX_SEAT_COUNT,
+  MAX_SHOT_CLOCK_SECONDS,
   MIN_SEAT_COUNT,
+  MIN_SHOT_CLOCK_SECONDS,
   type RoomView,
   type ServerMessage,
 } from "@table-top-poker/protocol";
@@ -163,6 +165,7 @@ describe("rooms HTTP routes", () => {
     expect(joined.json<RoomView>()).toEqual({
       code,
       pendingSeatCount: null,
+      pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: unclaimedSeats(),
@@ -883,6 +886,74 @@ describe("seat-count settings route", () => {
   });
 });
 
+describe("shot-clock settings route", () => {
+  let app: FastifyInstance;
+  let rooms: RoomStore;
+
+  beforeEach(async () => {
+    rooms = new RoomStore();
+    app = await buildApp({ rooms });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it("rejects invalid shot-clock bodies at the HTTP boundary", async () => {
+    const room = rooms.create();
+    const invalidBodies = [
+      undefined,
+      {},
+      { enabled: true, seconds: MIN_SHOT_CLOCK_SECONDS - 1 },
+      { enabled: true, seconds: MAX_SHOT_CLOCK_SECONDS + 1 },
+      { enabled: true, seconds: 5.5 },
+      { enabled: "true", seconds: 90 },
+      { enabled: true, seconds: "90" },
+      { enabled: true, seconds: 90, extra: true },
+    ];
+
+    for (const payload of invalidBodies) {
+      const response = await app.inject({
+        method: "POST",
+        url: `/rooms/${room.code}/shot-clock`,
+        ...(payload === undefined ? {} : { payload }),
+      });
+      expect(response.statusCode).toBe(400);
+      expect(response.json()).toEqual({ error: "invalid-request-body" });
+    }
+  });
+
+  it("queues a setting during a live hand until the next hand", async () => {
+    const room = rooms.create();
+    rooms.claimSeat(room.code, 0, "P0");
+    rooms.claimSeat(room.code, 1, "P1");
+    const started = rooms.dispatch(room.code, "table", "startHand");
+    if (!("steps" in started)) throw new Error("expected start-hand steps");
+
+    const settings = { enabled: true, seconds: 30 };
+    const response = await app.inject({
+      method: "POST",
+      url: `/rooms/${room.code}/shot-clock`,
+      payload: settings,
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual(settings);
+    expect(room.shotClockSettings).toEqual(DEFAULT_SHOT_CLOCK);
+    expect(room.pendingShotClock).toEqual(settings);
+
+    const actor = rooms.currentActor(room.code);
+    if (actor === undefined) throw new Error("expected a current actor");
+    const folded = rooms.dispatch(room.code, actor, "fold");
+    if (!("steps" in folded)) throw new Error("expected fold steps");
+    const next = rooms.dispatch(room.code, "table", "nextHand");
+    if (!("steps" in next)) throw new Error("expected next-hand steps");
+
+    expect(room.shotClockSettings).toEqual(settings);
+    expect(room.pendingShotClock).toBeNull();
+  });
+});
+
 describe("seat-count movement over WebSocket", () => {
   let app: FastifyInstance;
   let rooms: RoomStore;
@@ -1158,6 +1229,7 @@ describe("WebSocket upgrade", () => {
       view: {
         code: room.code,
         pendingSeatCount: null,
+        pendingShotClock: null,
         soundSettings: DEFAULT_SOUND_SETTINGS,
         shotClockSettings: DEFAULT_SHOT_CLOCK,
         seats: unclaimedSeats(),
@@ -2180,6 +2252,103 @@ describe("action clock", () => {
 });
 
 describe("action clock duration selection", () => {
+  it("defers a REST edit until the next hand without touching the live timer", async () => {
+    const rooms = new RoomStore();
+    const scheduled: {
+      readonly timeoutMs: number;
+      readonly callback: () => void;
+      readonly handle: ReturnType<typeof setTimeout>;
+    }[] = [];
+    const cleared: ReturnType<typeof setTimeout>[] = [];
+    const actionClock = new ActionClock(
+      90_000,
+      (callback, timeoutMs) => {
+        const handle = setTimeout(() => undefined, 60_000);
+        handle.unref();
+        scheduled.push({ timeoutMs, callback, handle });
+        return handle;
+      },
+      (handle) => {
+        cleared.push(handle);
+        clearTimeout(handle);
+      },
+    );
+    const app = await buildApp({ rooms, actionClock });
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected a bound TCP address");
+    }
+
+    const room = rooms.create(2);
+    const oldSettings = { enabled: true, seconds: 7 };
+    const newSettings = { enabled: true, seconds: 13 };
+    const initialSettings = rooms.changeShotClockSettings(
+      room.code,
+      oldSettings,
+    );
+    if ("error" in initialSettings) {
+      throw new Error("expected valid initial shot-clock settings");
+    }
+    rooms.claimSeat(room.code, 0, "P0");
+    rooms.claimSeat(room.code, 1, "P1");
+
+    const table = new WebSocket(
+      `ws://127.0.0.1:${String(address.port)}/ws?room=${room.code}&role=table`,
+    );
+    try {
+      await new Promise<void>((resolve, reject) => {
+        table.once("open", resolve);
+        table.once("error", reject);
+      });
+      table.send(JSON.stringify({ type: "startHand" }));
+
+      for (let attempt = 0; attempt < 100; attempt++) {
+        if (scheduled.some((timer) => timer.timeoutMs === 7_000)) break;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      const initialTimer = scheduled.find((timer) => timer.timeoutMs === 7_000);
+      if (initialTimer === undefined) {
+        throw new Error("timed out waiting for the initial action timer");
+      }
+      const scheduledBeforeEdit = scheduled.length;
+      const clearedBeforeEdit = cleared.length;
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/rooms/${room.code}/shot-clock`,
+        payload: newSettings,
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(scheduled).toHaveLength(scheduledBeforeEdit);
+      expect(cleared).toHaveLength(clearedBeforeEdit);
+      expect(room.shotClockSettings).toEqual(oldSettings);
+      expect(room.pendingShotClock).toEqual(newSettings);
+
+      // Firing the timer that was armed before the edit still applies the
+      // old in-flight behavior to the current actor.
+      initialTimer.callback();
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      expect(room.engine?.hand?.status).toBe("complete");
+      expect(room.shotClockSettings).toEqual(oldSettings);
+
+      table.send(JSON.stringify({ type: "nextHand" }));
+      for (let attempt = 0; attempt < 100; attempt++) {
+        if (scheduled.some((timer) => timer.timeoutMs === 13_000)) break;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+
+      expect(scheduled.at(-1)?.timeoutMs).toBe(13_000);
+      expect(room.shotClockSettings).toEqual(newSettings);
+      expect(room.pendingShotClock).toBeNull();
+    } finally {
+      table.close();
+      actionClock.clear(room.code);
+      await app.close();
+    }
+  });
+
   it("schedules each room from its configured seconds", async () => {
     const rooms = new RoomStore();
     const durations: number[] = [];

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -3,6 +3,7 @@ import fastifyWebsocket from "@fastify/websocket";
 import {
   AddBotsRequestSchema,
   ChangeSeatCountRequestSchema,
+  ChangeShotClockRequestSchema,
   ChangeSoundSettingsRequestSchema,
   ClaimSeatRequestSchema,
   LeaveSeatRequestSchema,
@@ -838,6 +839,28 @@ export async function buildApp(
     const result = rooms.changeSoundSettings(room.code, body.data);
     if ("error" in result) {
       return reply.code(404).send({ error: result.error });
+    }
+    broadcastRoomView(room.code);
+    return result;
+  });
+
+  /**
+   * Table-device shot-clock settings: every edit is queued for the next hand,
+   * so this route never re-arms or clears a live hand's action timer. The
+   * resulting pending value is pushed through the room-view broadcast.
+   */
+  app.post<RoomCodeRoute>("/rooms/:code/shot-clock", (request, reply) => {
+    const body = ChangeShotClockRequestSchema.safeParse(request.body);
+    if (!body.success) {
+      return reply.code(400).send({ error: "invalid-request-body" });
+    }
+    const room = findRoomOrReject(rooms, request.params.code, reply);
+    if (!room) return;
+    const result = rooms.changeShotClockSettings(room.code, body.data);
+    if ("error" in result) {
+      return reply
+        .code(result.error === "room-not-found" ? 404 : 400)
+        .send({ error: result.error });
     }
     broadcastRoomView(room.code);
     return result;

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -1063,6 +1063,7 @@ describe("toRoomView", () => {
     expect(view).toEqual({
       code: room.code,
       pendingSeatCount: null,
+      pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
@@ -1120,14 +1121,30 @@ describe("changeSoundSettings", () => {
 });
 
 describe("changeShotClockSettings", () => {
-  it("replaces the room settings atomically", () => {
+  it("queues an edit during a hand and applies it at the next deal-in", () => {
     const store = new RoomStore();
     const room = store.create();
+    store.claimSeat(room.code, 0, "P0");
+    store.claimSeat(room.code, 1, "P1");
+    const started = store.dispatch(room.code, "table", "startHand");
+    if (!("steps" in started)) throw new Error("expected start-hand steps");
     const settings = { enabled: true, seconds: 30 };
 
     expect(store.changeShotClockSettings(room.code, settings)).toEqual(
       settings,
     );
+    expect(room.shotClockSettings).toEqual(DEFAULT_SHOT_CLOCK);
+    expect(toRoomView(room).pendingShotClock).toEqual(settings);
+
+    const actor = store.currentActor(room.code);
+    if (actor === undefined) throw new Error("expected a current actor");
+    const folded = store.dispatch(room.code, actor, "fold");
+    if (!("steps" in folded)) throw new Error("expected fold steps");
+    const next = store.dispatch(room.code, "table", "nextHand");
+    if (!("steps" in next)) throw new Error("expected next-hand steps");
+
+    expect(room.shotClockSettings).toEqual(settings);
+    expect(room.pendingShotClock).toBeNull();
     expect(toRoomView(room).shotClockSettings).toEqual(settings);
   });
 
@@ -1142,6 +1159,7 @@ describe("changeShotClockSettings", () => {
       }),
     ).toEqual({ error: "invalid-shot-clock" });
     expect(room.shotClockSettings).toEqual(DEFAULT_SHOT_CLOCK);
+    expect(room.pendingShotClock).toBeNull();
   });
 
   it("reports an unknown room", () => {

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -68,6 +68,8 @@ export interface Room {
   engine: EngineState | null;
   /** A live-hand shrink waits here until the next deal-in recompute. */
   pendingSeatCount: number | null;
+  /** A shot-clock change waits here until the next deal-in. */
+  pendingShotClock: ShotClockSettings | null;
   /** Room-wide tactile-sound settings (#182), set by the table. */
   soundSettings: SoundSettings;
   /** Room-wide action-clock settings, set by the table. */
@@ -245,6 +247,13 @@ function applyPendingShrink(room: Room): SeatRepack {
   return repack;
 }
 
+/** Applies the latest shot-clock edit only when a new hand is dealt. */
+function applyPendingShotClock(room: Room): void {
+  if (room.pendingShotClock === null) return;
+  room.shotClockSettings = room.pendingShotClock;
+  room.pendingShotClock = null;
+}
+
 function appliedSeatCountChange(
   room: Room,
   moves: readonly SeatMove[] = [],
@@ -376,6 +385,7 @@ export class RoomStore {
       seats: makeSeats(seatCount),
       engine: null,
       pendingSeatCount: null,
+      pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
     };
@@ -614,7 +624,7 @@ export class RoomStore {
   }
 
   /**
-   * Replaces the room's action-clock settings atomically. Applying the shared
+   * Queues a room action-clock edit for the next deal-in. Applying the shared
    * schema here keeps direct callers from constructing invalid room state.
    */
   changeShotClockSettings(
@@ -627,8 +637,11 @@ export class RoomStore {
     if (!parsed.success) {
       return { error: "invalid-shot-clock" };
     }
-    room.shotClockSettings = parsed.data;
-    return room.shotClockSettings;
+    // Keep the active hand's timer untouched. The pending value is drained
+    // after the next successful `startHand`/`nextHand` dispatch, before the
+    // application re-arms the clock for that new hand.
+    room.pendingShotClock = parsed.data;
+    return parsed.data;
   }
 
   /** Whether `seatId` reads as "sitting out" in the room's public view — see `isSittingOut`. */
@@ -727,6 +740,7 @@ export class RoomStore {
 
     if (type === "startHand" || type === "nextHand") {
       updateWaitingForNextHand(room, candidateEngine.seats);
+      applyPendingShotClock(room);
     }
 
     return seatMoves.length > 0 ? { ...result, seatMoves } : result;
@@ -780,6 +794,7 @@ export function toRoomView(room: Room): RoomView {
   return {
     code: room.code,
     pendingSeatCount: room.pendingSeatCount,
+    pendingShotClock: room.pendingShotClock,
     soundSettings: room.soundSettings,
     shotClockSettings: room.shotClockSettings,
     seats: room.seats.map((seat) => {

--- a/packages/table-client/package.json
+++ b/packages/table-client/package.json
@@ -24,7 +24,9 @@
   "devDependencies": {
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@types/react-test-renderer": "^19.1.0",
     "@vitejs/plugin-react": "^6.0.4",
+    "react-test-renderer": "^19.2.8",
     "vite": "^8.1.5"
   }
 }

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -4,12 +4,14 @@ import {
   isHandComplete,
   isHandLive,
   MIN_SEAT_COUNT,
+  type ShotClockSettings,
   type SoundSettings,
 } from "@table-top-poker/protocol";
 import { color, unlockAudio } from "@table-top-poker/ui-shared";
 import { useCallback, useEffect, useState } from "react";
 import {
   changeSeatCount,
+  changeShotClockSettings,
   changeSoundSettings,
   createRoom,
   addBots,
@@ -41,7 +43,9 @@ export function App() {
   const qrCodeDataUrl = useTableStore((state) => state.qrCodeDataUrl);
   const seats = useTableStore((state) => state.seats);
   const pendingSeatCount = useTableStore((state) => state.pendingSeatCount);
+  const pendingShotClock = useTableStore((state) => state.pendingShotClock);
   const soundSettings = useTableStore((state) => state.soundSettings);
+  const shotClockSettings = useTableStore((state) => state.shotClockSettings);
   const testMode = useTableStore((state) => state.testMode);
   const connectionStatus = useTableStore((state) => state.connectionStatus);
   const handView = useTableStore((state) => state.handView);
@@ -146,15 +150,9 @@ export function App() {
   }, [roomCode, testMode]);
 
   const handleChangeSeatCount = useCallback(
-    (seatCount: number) => {
+    async (seatCount: number): Promise<void> => {
       if (roomCode === null) return;
-      changeSeatCount(roomCode, seatCount)
-        .then(() => {
-          setSettingsOpen(false);
-        })
-        .catch((error: unknown) => {
-          console.error(error);
-        });
+      await changeSeatCount(roomCode, seatCount);
     },
     [roomCode],
   );
@@ -167,6 +165,14 @@ export function App() {
       changeSoundSettings(roomCode, next).catch((error: unknown) => {
         console.error(error);
       });
+    },
+    [roomCode],
+  );
+
+  const handleChangeShotClockSettings = useCallback(
+    async (next: ShotClockSettings): Promise<void> => {
+      if (roomCode === null) return;
+      await changeShotClockSettings(roomCode, next);
     },
     [roomCode],
   );
@@ -289,10 +295,13 @@ export function App() {
               <HouseRulesSheet
                 seatCount={seats.length}
                 pendingSeatCount={pendingSeatCount}
+                pendingShotClock={pendingShotClock}
                 seats={seats}
                 handInProgress={isHandLive(handView)}
                 soundSettings={soundSettings}
+                shotClockSettings={shotClockSettings}
                 onApply={handleChangeSeatCount}
+                onApplyShotClock={handleChangeShotClockSettings}
                 onChangeSoundSettings={handleChangeSoundSettings}
                 onClose={() => {
                   setSettingsOpen(false);

--- a/packages/table-client/src/HouseRulesSheet.test.tsx
+++ b/packages/table-client/src/HouseRulesSheet.test.tsx
@@ -1,11 +1,22 @@
 import {
+  DEFAULT_SHOT_CLOCK,
   DEFAULT_SOUND_SETTINGS,
   type SeatView,
 } from "@table-top-poker/protocol";
+/* eslint-disable @typescript-eslint/no-deprecated -- React 19's DOM-free component test renderer is deprecated but remains the available interaction harness here. */
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
-import { HouseRulesSheet } from "./HouseRulesSheet.js";
+import { act, create } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
+import {
+  HouseRulesSheet,
+  type ShotClockSecondsDraft,
+  updateShotClockSecondsDraft,
+} from "./HouseRulesSheet.js";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
 
 const seats: SeatView[] = [
   {
@@ -73,12 +84,77 @@ const noop = () => {
   /* unused */
 };
 
+const shotClockProps = {
+  pendingShotClock: null,
+  shotClockSettings: DEFAULT_SHOT_CLOCK,
+  onApplyShotClock: noop,
+};
+
+function renderSheet(
+  overrides: Partial<React.ComponentProps<typeof HouseRulesSheet>> = {},
+): React.ReactElement {
+  return (
+    <HouseRulesSheet
+      seatCount={4}
+      pendingSeatCount={null}
+      {...shotClockProps}
+      seats={seats.slice(0, 4)}
+      handInProgress
+      soundSettings={DEFAULT_SOUND_SETTINGS}
+      onApply={noop}
+      onChangeSoundSettings={noop}
+      onClose={noop}
+      {...overrides}
+    />
+  );
+}
+
+function deferred(): {
+  readonly promise: Promise<void>;
+  readonly resolve: () => void;
+} {
+  let resolvePromise!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
+}
+
+interface InteractiveTestNode {
+  readonly props: {
+    readonly disabled?: boolean;
+    readonly value?: string;
+    readonly onClick?: () => void;
+    readonly onChange?: (event: {
+      readonly currentTarget: { readonly value: string };
+    }) => void;
+  };
+}
+
+interface TestRenderer {
+  readonly root: {
+    findByProps(props: Record<string, unknown>): InteractiveTestNode;
+  };
+  readonly unmount: () => void;
+}
+
+function findNode(renderer: TestRenderer, testId: string): InteractiveTestNode {
+  return renderer.root.findByProps({ "data-testid": testId });
+}
+
+async function settleReactUpdates(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 describe("HouseRulesSheet", () => {
   it("shows the chosen house-rules surface and a repack preview", () => {
     const html = renderToStaticMarkup(
       <HouseRulesSheet
         seatCount={8}
         pendingSeatCount={4}
+        {...shotClockProps}
         seats={seats}
         handInProgress
         soundSettings={DEFAULT_SOUND_SETTINGS}
@@ -100,6 +176,7 @@ describe("HouseRulesSheet", () => {
       <HouseRulesSheet
         seatCount={8}
         pendingSeatCount={3}
+        {...shotClockProps}
         seats={seats}
         handInProgress
         soundSettings={DEFAULT_SOUND_SETTINGS}
@@ -121,6 +198,7 @@ describe("HouseRulesSheet", () => {
       <HouseRulesSheet
         seatCount={4}
         pendingSeatCount={null}
+        {...shotClockProps}
         seats={seats.slice(0, 4)}
         handInProgress
         soundSettings={DEFAULT_SOUND_SETTINGS}
@@ -138,6 +216,7 @@ describe("HouseRulesSheet", () => {
       <HouseRulesSheet
         seatCount={4}
         pendingSeatCount={null}
+        {...shotClockProps}
         seats={seats.slice(0, 4)}
         handInProgress
         soundSettings={{
@@ -173,6 +252,7 @@ describe("HouseRulesSheet", () => {
       <HouseRulesSheet
         seatCount={4}
         pendingSeatCount={null}
+        {...shotClockProps}
         seats={seats.slice(0, 4)}
         handInProgress
         soundSettings={{
@@ -192,5 +272,134 @@ describe("HouseRulesSheet", () => {
     expect(html).toContain(
       'data-testid="sound-notifications-toggle" disabled=""',
     );
+  });
+
+  it("renders the deferred shot-clock controls", () => {
+    const html = renderToStaticMarkup(
+      <HouseRulesSheet
+        seatCount={4}
+        pendingSeatCount={null}
+        pendingShotClock={{ enabled: true, seconds: 30 }}
+        shotClockSettings={DEFAULT_SHOT_CLOCK}
+        seats={seats.slice(0, 4)}
+        handInProgress
+        soundSettings={DEFAULT_SOUND_SETTINGS}
+        onApply={noop}
+        onApplyShotClock={noop}
+        onChangeSoundSettings={noop}
+        onClose={noop}
+      />,
+    );
+
+    expect(html).toContain('data-testid="shot-clock-settings"');
+    expect(html).toContain('data-testid="shot-clock-toggle"');
+    expect(html).toContain('data-testid="shot-clock-seconds"');
+    expect(html).toContain("Applies from the next hand");
+  });
+
+  it("accepts a valid seconds value typed one digit at a time", () => {
+    let draft: ShotClockSecondsDraft = {
+      input: "90",
+      seconds: 90,
+      valid: true,
+    };
+
+    // Replacing the current value with 45 emits these two input events. The
+    // first value is transient, but must remain visible so the second digit
+    // can complete the valid setting.
+    draft = updateShotClockSecondsDraft(draft, "4");
+    expect(draft).toEqual({ input: "4", seconds: 90, valid: false });
+    draft = updateShotClockSecondsDraft(draft, "45");
+
+    expect(draft).toEqual({ input: "45", seconds: 45, valid: true });
+  });
+
+  it("waits for both settings writes before closing", async () => {
+    const seatWrite = deferred();
+    const shotClockWrite = deferred();
+    const onApply = vi.fn(() => seatWrite.promise);
+    const onApplyShotClock = vi.fn(() => shotClockWrite.promise);
+    const onClose = vi.fn();
+    let renderer!: TestRenderer;
+
+    act(() => {
+      renderer = create(renderSheet({ onApply, onApplyShotClock, onClose }));
+    });
+
+    act(() => {
+      findNode(renderer, "shot-clock-toggle").props.onClick?.();
+    });
+
+    const done = () => findNode(renderer, "settings-done");
+    await act(async () => {
+      done().props.onClick?.();
+      await settleReactUpdates();
+    });
+
+    expect(onApply).toHaveBeenCalledTimes(1);
+    expect(onApplyShotClock).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(done().props.disabled).toBe(true);
+
+    await act(async () => {
+      seatWrite.resolve();
+      await settleReactUpdates();
+    });
+    expect(onClose).not.toHaveBeenCalled();
+
+    await act(async () => {
+      shotClockWrite.resolve();
+      await settleReactUpdates();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    act(() => {
+      renderer.unmount();
+    });
+  });
+
+  it("blocks submission while seconds is visibly invalid", async () => {
+    const onApply = vi.fn(() => Promise.resolve());
+    const onApplyShotClock = vi.fn(() => Promise.resolve());
+    const onClose = vi.fn();
+    let renderer!: TestRenderer;
+
+    act(() => {
+      renderer = create(renderSheet({ onApply, onApplyShotClock, onClose }));
+    });
+
+    const input = () => findNode(renderer, "shot-clock-seconds");
+    act(() => {
+      input().props.onChange?.({ currentTarget: { value: "4" } });
+    });
+
+    expect(input().props.value).toBe("4");
+    expect(findNode(renderer, "shot-clock-validation")).toBeDefined();
+    expect(findNode(renderer, "settings-done").props.disabled).toBe(true);
+
+    await act(async () => {
+      findNode(renderer, "settings-done").props.onClick?.();
+      await settleReactUpdates();
+    });
+    expect(onApply).not.toHaveBeenCalled();
+    expect(onApplyShotClock).not.toHaveBeenCalled();
+
+    act(() => {
+      input().props.onChange?.({ currentTarget: { value: "45" } });
+    });
+    expect(input().props.value).toBe("45");
+    expect(findNode(renderer, "settings-done").props.disabled).toBe(false);
+
+    await act(async () => {
+      findNode(renderer, "settings-done").props.onClick?.();
+      await settleReactUpdates();
+    });
+    expect(onApplyShotClock).toHaveBeenCalledWith({
+      enabled: false,
+      seconds: 45,
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    act(() => {
+      renderer.unmount();
+    });
   });
 });

--- a/packages/table-client/src/HouseRulesSheet.tsx
+++ b/packages/table-client/src/HouseRulesSheet.tsx
@@ -1,8 +1,11 @@
 import {
   MAX_SEAT_COUNT,
+  MAX_SHOT_CLOCK_SECONDS,
   MIN_SEAT_COUNT,
+  MIN_SHOT_CLOCK_SECONDS,
   type SeatView,
   type SeatMove,
+  type ShotClockSettings,
   type SoundSettings,
 } from "@table-top-poker/protocol";
 import {
@@ -20,10 +23,15 @@ import { seatLabel } from "./seatLabel.js";
 export interface HouseRulesSheetProps {
   readonly seatCount: number;
   readonly pendingSeatCount: number | null;
+  readonly pendingShotClock: ShotClockSettings | null;
   readonly seats: readonly SeatView[];
   readonly handInProgress: boolean;
   readonly soundSettings: SoundSettings;
-  readonly onApply: (seatCount: number) => void;
+  readonly shotClockSettings: ShotClockSettings;
+  readonly onApply: (seatCount: number) => void | Promise<void>;
+  readonly onApplyShotClock: (
+    settings: ShotClockSettings,
+  ) => void | Promise<void>;
   readonly onChangeSoundSettings: (next: SoundSettings) => void;
   readonly onClose: () => void;
 }
@@ -64,6 +72,33 @@ const stepperButtonStyle: CSSProperties = {
   color: color.textBright,
   cursor: "pointer",
 };
+
+export interface ShotClockSecondsDraft {
+  readonly input: string;
+  readonly seconds: number;
+  readonly valid: boolean;
+}
+
+/**
+ * Keeps transient keystrokes visible while committing only valid settings.
+ * For example, replacing 90 with 45 naturally produces "4" before "45";
+ * "4" is retained in the input but does not overwrite the last valid value.
+ */
+export function updateShotClockSecondsDraft(
+  draft: ShotClockSecondsDraft,
+  input: string,
+): ShotClockSecondsDraft {
+  const seconds = Number(input);
+  if (
+    /^\d+$/.test(input) &&
+    Number.isInteger(seconds) &&
+    seconds >= MIN_SHOT_CLOCK_SECONDS &&
+    seconds <= MAX_SHOT_CLOCK_SECONDS
+  ) {
+    return { input, seconds, valid: true };
+  }
+  return { ...draft, input, valid: false };
+}
 
 /**
  * A single on/off switch. `nested` renders the smaller, indented variant used
@@ -152,10 +187,13 @@ function Toggle({
 export function HouseRulesSheet({
   seatCount,
   pendingSeatCount,
+  pendingShotClock,
   seats,
   handInProgress,
   soundSettings,
+  shotClockSettings,
   onApply,
+  onApplyShotClock,
   onChangeSoundSettings,
   onClose,
 }: HouseRulesSheetProps) {
@@ -165,6 +203,51 @@ export function HouseRulesSheet({
   const atFloor = draft <= floor;
   const moves = previewMoves(seats, draft);
   const shrinkIsQueued = handInProgress && draft < seatCount;
+  const [shotClockDraft, setShotClockDraft] = useState(
+    pendingShotClock ?? shotClockSettings,
+  );
+  const [shotClockSecondsDraft, setShotClockSecondsDraft] = useState(() =>
+    updateShotClockSecondsDraft(
+      {
+        input: "",
+        seconds: (pendingShotClock ?? shotClockSettings).seconds,
+        valid: true,
+      },
+      String((pendingShotClock ?? shotClockSettings).seconds),
+    ),
+  );
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const shotClockChanged =
+    shotClockDraft.enabled !==
+      (pendingShotClock ?? shotClockSettings).enabled ||
+    shotClockDraft.seconds !== (pendingShotClock ?? shotClockSettings).seconds;
+  const shotClockIsQueued = pendingShotClock !== null || shotClockChanged;
+
+  async function applyHouseRules(): Promise<void> {
+    if (saving || !shotClockSecondsDraft.valid) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const writes: Promise<void>[] = [
+        Promise.resolve().then(() => onApply(draft)),
+      ];
+      if (shotClockChanged) {
+        writes.push(
+          Promise.resolve().then(() => onApplyShotClock(shotClockDraft)),
+        );
+      }
+      const results = await Promise.allSettled(writes);
+      if (results.some((result) => result.status === "rejected")) {
+        throw new Error("house-rules-save-failed");
+      }
+      onClose();
+    } catch {
+      setSaveError("Could not save house rules. Try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
 
   return (
     <div
@@ -221,6 +304,7 @@ export function HouseRulesSheet({
             type="button"
             aria-label="Close table settings"
             data-testid="close-settings-button"
+            disabled={saving}
             onClick={onClose}
             style={{
               width: 42,
@@ -284,14 +368,14 @@ export function HouseRulesSheet({
                 type="button"
                 data-testid="seat-count-decrement"
                 aria-label="Decrease seat count"
-                disabled={atFloor}
+                disabled={atFloor || saving}
                 onClick={() => {
                   setDraft((count) => Math.max(floor, count - 1));
                 }}
                 style={{
                   ...stepperButtonStyle,
-                  opacity: atFloor ? 0.32 : 1,
-                  cursor: atFloor ? "not-allowed" : "pointer",
+                  opacity: atFloor || saving ? 0.32 : 1,
+                  cursor: atFloor || saving ? "not-allowed" : "pointer",
                 }}
               >
                 −
@@ -313,7 +397,7 @@ export function HouseRulesSheet({
                 type="button"
                 data-testid="seat-count-increment"
                 aria-label="Increase seat count"
-                disabled={draft >= MAX_SEAT_COUNT}
+                disabled={draft >= MAX_SEAT_COUNT || saving}
                 onClick={() => {
                   setDraft((count) => Math.min(MAX_SEAT_COUNT, count + 1));
                 }}
@@ -372,6 +456,7 @@ export function HouseRulesSheet({
             <Toggle
               label="Sound"
               checked={soundSettings.sounds}
+              disabled={saving}
               testId="sound-master-toggle"
               onChange={(sounds) => {
                 onChangeSoundSettings({ ...soundSettings, sounds });
@@ -381,7 +466,7 @@ export function HouseRulesSheet({
               label="Cards"
               nested
               checked={soundSettings.cards}
-              disabled={!soundSettings.sounds}
+              disabled={saving || !soundSettings.sounds}
               testId="sound-cards-toggle"
               onChange={(cards) => {
                 onChangeSoundSettings({ ...soundSettings, cards });
@@ -391,7 +476,7 @@ export function HouseRulesSheet({
               label="Actions"
               nested
               checked={soundSettings.actions}
-              disabled={!soundSettings.sounds}
+              disabled={saving || !soundSettings.sounds}
               testId="sound-actions-toggle"
               onChange={(actions) => {
                 onChangeSoundSettings({ ...soundSettings, actions });
@@ -401,12 +486,105 @@ export function HouseRulesSheet({
               label="Notifications"
               nested
               checked={soundSettings.notifications}
-              disabled={!soundSettings.sounds}
+              disabled={saving || !soundSettings.sounds}
               testId="sound-notifications-toggle"
               onChange={(notifications) => {
                 onChangeSoundSettings({ ...soundSettings, notifications });
               }}
             />
+          </div>
+
+          <div
+            data-testid="shot-clock-settings"
+            style={{
+              paddingTop: 20,
+              display: "flex",
+              flexDirection: "column",
+              gap: 16,
+              borderTop: `1px solid ${color.mutedSurface}`,
+              marginTop: 20,
+            }}
+          >
+            <Toggle
+              label="Shot clock"
+              checked={shotClockDraft.enabled}
+              disabled={saving}
+              testId="shot-clock-toggle"
+              onChange={(enabled) => {
+                setShotClockDraft((current) => ({ ...current, enabled }));
+              }}
+            />
+            <label
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 20,
+                paddingLeft: 22,
+                color: color.textDim,
+                fontSize: fontSize.md,
+              }}
+            >
+              <span>Seconds per turn</span>
+              <input
+                type="number"
+                min={MIN_SHOT_CLOCK_SECONDS}
+                max={MAX_SHOT_CLOCK_SECONDS}
+                step={1}
+                value={shotClockSecondsDraft.input}
+                data-testid="shot-clock-seconds"
+                aria-label="Shot clock seconds"
+                disabled={saving}
+                onChange={(event) => {
+                  const next = updateShotClockSecondsDraft(
+                    shotClockSecondsDraft,
+                    event.currentTarget.value,
+                  );
+                  setShotClockSecondsDraft(next);
+                  setShotClockDraft((current) => ({
+                    ...current,
+                    seconds: next.seconds,
+                  }));
+                }}
+                style={{
+                  width: 92,
+                  padding: "9px 10px",
+                  borderRadius: 10,
+                  border: `1px solid ${color.border}`,
+                  background: color.controlFill,
+                  color: color.textBright,
+                  fontFamily: font.mono,
+                  fontSize: fontSize.md,
+                  textAlign: "right",
+                }}
+              />
+            </label>
+            {!shotClockSecondsDraft.valid ? (
+              <span
+                data-testid="shot-clock-validation"
+                role="alert"
+                style={{
+                  color: color.accentBright,
+                  fontSize: fontSize.caption,
+                  paddingLeft: 22,
+                }}
+              >
+                Enter a whole number from {String(MIN_SHOT_CLOCK_SECONDS)} to{" "}
+                {String(MAX_SHOT_CLOCK_SECONDS)} seconds.
+              </span>
+            ) : null}
+            {shotClockIsQueued ? (
+              <span
+                style={{
+                  ...kickerStyle,
+                  fontSize: "10.5px",
+                  color: color.textFaint,
+                  paddingLeft: 22,
+                }}
+              >
+                Applies from the next hand
+              </span>
+            ) : null}
           </div>
 
           <div
@@ -418,6 +596,17 @@ export function HouseRulesSheet({
               gap: 16,
             }}
           >
+            {saveError !== null ? (
+              <span
+                role="alert"
+                style={{
+                  color: color.accentBright,
+                  fontSize: fontSize.caption,
+                }}
+              >
+                {saveError}
+              </span>
+            ) : null}
             <span
               style={{
                 ...kickerStyle,
@@ -427,15 +616,17 @@ export function HouseRulesSheet({
             >
               {shrinkIsQueued
                 ? "Applies from the next hand"
-                : "Applies immediately"}
+                : "Seat count: Applies immediately"}
             </span>
             <PillButton
               data-testid="settings-done"
+              aria-busy={saving}
+              disabled={saving || !shotClockSecondsDraft.valid}
               onClick={() => {
-                onApply(draft);
+                void applyHouseRules();
               }}
             >
-              Done
+              {saving ? "Saving…" : "Done"}
             </PillButton>
           </div>
         </div>

--- a/packages/table-client/src/api/rooms.test.ts
+++ b/packages/table-client/src/api/rooms.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   addBots,
   changeSeatCount,
+  changeShotClockSettings,
   createRoom,
   endSession,
   fetchConfig,
@@ -152,5 +153,37 @@ describe("changeSeatCount", () => {
     await expect(changeSeatCount("ABCD", 1)).rejects.toThrow(
       "failed to change seat count: 400",
     );
+  });
+});
+
+describe("changeShotClockSettings", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts the requested settings to the deferred table route", async () => {
+    const body = { enabled: true, seconds: 30 };
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify(body), { status: 200 }),
+    );
+
+    await expect(changeShotClockSettings("ABCD", body)).resolves.toEqual(body);
+    expect(fetch).toHaveBeenCalledWith("/rooms/ABCD/shot-clock", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  });
+
+  it("throws when the server rejects a setting", async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 400 }));
+
+    await expect(
+      changeShotClockSettings("ABCD", { enabled: true, seconds: 4 }),
+    ).rejects.toThrow("failed to change shot-clock settings: 400");
   });
 });

--- a/packages/table-client/src/api/rooms.ts
+++ b/packages/table-client/src/api/rooms.ts
@@ -1,6 +1,7 @@
 import type {
   RoomView,
   SeatCountChange,
+  ShotClockSettings,
   SoundSettings,
 } from "@table-top-poker/protocol";
 
@@ -118,4 +119,22 @@ export async function changeSoundSettings(
     );
   }
   return (await response.json()) as SoundSettings;
+}
+
+/** The table device's deferred room-wide action-clock settings. */
+export async function changeShotClockSettings(
+  code: string,
+  settings: ShotClockSettings,
+): Promise<ShotClockSettings> {
+  const response = await fetch(`/rooms/${code}/shot-clock`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(settings),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `failed to change shot-clock settings: ${String(response.status)}`,
+    );
+  }
+  return (await response.json()) as ShotClockSettings;
 }

--- a/packages/table-client/src/store/roomSlice.ts
+++ b/packages/table-client/src/store/roomSlice.ts
@@ -14,6 +14,7 @@ export interface RoomSlice {
   readonly qrCodeDataUrl: string | null;
   readonly seats: readonly SeatView[];
   readonly pendingSeatCount: number | null;
+  readonly pendingShotClock: ShotClockSettings | null;
   readonly soundSettings: SoundSettings;
   readonly shotClockSettings: ShotClockSettings;
   readonly setRoomCreated: (room: {
@@ -31,16 +32,24 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
   qrCodeDataUrl: null,
   seats: [],
   pendingSeatCount: null,
+  pendingShotClock: null,
   soundSettings: DEFAULT_SOUND_SETTINGS,
   shotClockSettings: DEFAULT_SHOT_CLOCK,
   setRoomCreated: ({ code, joinUrl, qrCodeDataUrl }) => {
-    set({ roomCode: code, joinUrl, qrCodeDataUrl, pendingSeatCount: null });
+    set({
+      roomCode: code,
+      joinUrl,
+      qrCodeDataUrl,
+      pendingSeatCount: null,
+      pendingShotClock: null,
+    });
   },
   setRoomView: (view) => {
     set({
       roomCode: view.code,
       seats: view.seats,
       pendingSeatCount: view.pendingSeatCount,
+      pendingShotClock: view.pendingShotClock,
       soundSettings: view.soundSettings,
       shotClockSettings: view.shotClockSettings,
     });
@@ -52,6 +61,7 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
       qrCodeDataUrl: null,
       seats: [],
       pendingSeatCount: null,
+      pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
     });

--- a/packages/table-client/src/store/store.test.ts
+++ b/packages/table-client/src/store/store.test.ts
@@ -44,6 +44,7 @@ describe("useTableStore", () => {
     useTableStore.getState().setRoomView({
       code: "ABCD",
       pendingSeatCount: null,
+      pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
@@ -72,6 +73,7 @@ describe("useTableStore", () => {
     useTableStore.getState().setRoomView({
       code: "ABCD",
       pendingSeatCount: 4,
+      pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [
@@ -100,6 +102,7 @@ describe("useTableStore", () => {
     useTableStore.getState().setRoomView({
       code: "ABCD",
       pendingSeatCount: null,
+      pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
       seats: [


### PR DESCRIPTION
## Summary

- add a validated room shot-clock update endpoint and expose queued settings in room views
- defer enable, disable, and seconds changes until the next successfully started hand without disturbing the live hand timer
- add House Rules controls with editable seconds, queued-state messaging, validation, save progress, and error handling
- cover protocol, server deferral and timer behavior, API/store integration, and component interactions

Closes #222

## Validation

- npm test — 94 files, 885 tests passed
- npm run build
- npm run lint
- git diff --check

## Review

The implementation completed three independent GPT-5.6 Sol high review rounds. Findings from the first two rounds were resolved; the final round reported no actionable issues.