### PR TITLE
Add live shot-clock countdown driven by turnEndsAt

### DIFF
--- a/packages/engine/src/view.test.ts
+++ b/packages/engine/src/view.test.ts
@@ -82,6 +82,28 @@ describe("view: legalActions", () => {
   });
 });
 
+describe("view: action-clock deadline", () => {
+  it("carries the server deadline through player and table betting views", () => {
+    const state = onTheFlopThreeWay();
+    const turnEndsAt = 1_750_000_000_000;
+
+    const player = view(state, 0, turnEndsAt);
+    const table = view(state, "table", turnEndsAt);
+    if (player.phase !== "betting" || table.phase !== "betting") {
+      throw new Error("expected betting views");
+    }
+    expect(player.turnEndsAt).toBe(turnEndsAt);
+    expect(table.turnEndsAt).toBe(turnEndsAt);
+  });
+
+  it("defaults the deadline to null when the clock is disabled", () => {
+    const state = onTheFlopThreeWay();
+    const table = view(state, "table");
+    if (table.phase !== "betting") throw new Error("expected betting view");
+    expect(table.turnEndsAt).toBeNull();
+  });
+});
+
 describe("view: other seats' hole cards mid-hand", () => {
   it("a seat does not see another live seat's hole cards", () => {
     const state = onTheFlopThreeWay();

--- a/packages/engine/src/view.ts
+++ b/packages/engine/src/view.ts
@@ -39,6 +39,8 @@ interface ShowdownView extends HandPositions {
 
 export interface PlayerViewBetting extends HandPositions {
   readonly phase: "betting";
+  /** Absolute server deadline for the current actor, or null when disabled. */
+  readonly turnEndsAt: number | null;
   readonly street: Street;
   readonly board: readonly Card[];
   readonly toAct: readonly SeatId[];
@@ -51,6 +53,8 @@ export interface PlayerViewBetting extends HandPositions {
 
 export interface TableViewBetting extends HandPositions {
   readonly phase: "betting";
+  /** Absolute server deadline for the current actor, or null when disabled. */
+  readonly turnEndsAt: number | null;
   readonly street: Street;
   readonly board: readonly Card[];
   readonly toAct: readonly SeatId[];
@@ -68,11 +72,20 @@ export type TableView =
  * `"table"` sentinel. Both are derived from the same authoritative state so
  * the table is never privileged over a player — see Phase 1 spec #130 §4.
  */
-export function view(state: EngineState, seatId: SeatId): PlayerView;
-export function view(state: EngineState, seatId: "table"): TableView;
+export function view(
+  state: EngineState,
+  seatId: SeatId,
+  turnEndsAt?: number | null,
+): PlayerView;
+export function view(
+  state: EngineState,
+  seatId: "table",
+  turnEndsAt?: number | null,
+): TableView;
 export function view(
   state: EngineState,
   seatId: SeatId | "table",
+  turnEndsAt: number | null = null,
 ): PlayerView | TableView {
   if (seatId !== "table" && !state.seats.includes(seatId)) {
     throw new Error(`unknown seat ${String(seatId)}`);
@@ -115,6 +128,7 @@ export function view(
 
   const tableView: TableViewBetting = {
     phase: "betting",
+    turnEndsAt,
     button: hand.button,
     smallBlind: smallBlindSeat(hand.ring, hand.button),
     bigBlind: bigBlindSeat(hand.ring, hand.button),

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -30,6 +30,7 @@ export function App() {
   const seatId = usePlayerStore((state) => state.seatId);
   const displayName = usePlayerStore((state) => state.displayName);
   const connectionStatus = usePlayerStore((state) => state.connectionStatus);
+  const shotClockSettings = usePlayerStore((state) => state.shotClockSettings);
   const handView = usePlayerStore((state) => state.handView);
   const setRoomView = usePlayerStore((state) => state.setRoomView);
   const setJoinError = usePlayerStore((state) => state.setJoinError);
@@ -252,6 +253,7 @@ export function App() {
             seatId={seatId}
             seats={seats}
             connectionStatus={connectionStatus}
+            shotClockSeconds={shotClockSettings.seconds}
             intent={intent}
           />
         )}

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -14,6 +14,7 @@ describe("Hand", () => {
   it("uses the named seat in waiting copy", () => {
     const view: PlayerView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -60,6 +61,7 @@ describe("Hand", () => {
   it("deals own hole cards in face-down, and never shows the shared board mid-hand", () => {
     const view: PlayerView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -94,6 +96,7 @@ describe("Hand", () => {
   it("hides hole cards once folded, without a placeholder leak", () => {
     const view: PlayerView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -119,6 +122,7 @@ describe("Hand", () => {
   it("shows the empty state, not the folded copy, when sitting out of the current hand", () => {
     const view: PlayerView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -142,6 +146,7 @@ describe("Hand", () => {
   it("shows the turn banner announcing it's your turn when you have a legal action", () => {
     const view: PlayerView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -163,9 +168,57 @@ describe("Hand", () => {
     expect(html).toContain("Your turn");
   });
 
+  it("renders the actor's ring from the server deadline", () => {
+    const turnEndsAt = Date.now() + 30_000;
+    const view: PlayerView = {
+      phase: "betting",
+      turnEndsAt,
+      button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
+      street: "turn",
+      board: [],
+      toAct: [0],
+      seats: [{ seatId: 0, folded: false }],
+      yourSeatId: 0,
+      yourHoleCards: null,
+      legalActions: ["fold", "check"],
+    };
+    const html = renderToStaticMarkup(<Hand view={view} seatId={0} />);
+
+    expect(html).toContain('data-testid="turn-banner-shot-clock"');
+    expect(html).toContain("30");
+  });
+
+  it("does not mirror the table countdown on another player's phone", () => {
+    const view: PlayerView = {
+      phase: "betting",
+      turnEndsAt: Date.now() + 30_000,
+      button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
+      street: "turn",
+      board: [],
+      toAct: [1],
+      seats: [
+        { seatId: 0, folded: false },
+        { seatId: 1, folded: false },
+      ],
+      yourSeatId: 0,
+      yourHoleCards: null,
+      legalActions: [],
+    };
+    const html = renderToStaticMarkup(<Hand view={view} seatId={0} />);
+
+    expect(html).not.toContain('data-testid="turn-banner-shot-clock"');
+  });
+
   it("shows a connection-aware banner instead of the turn state while reconnecting", () => {
     const view: PlayerView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -346,6 +399,7 @@ describe("Hand", () => {
   describe("position marker (issue #207)", () => {
     const bettingView: PlayerView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 2,

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -10,6 +10,7 @@ import {
   positionMarkerFor,
   radius,
   shadow,
+  ShotClock,
   type PositionMarker,
 } from "@table-top-poker/ui-shared";
 import { motion } from "motion/react";
@@ -24,6 +25,8 @@ export interface HandProps {
   readonly seatId: number;
   readonly seats?: readonly SeatView[];
   readonly connectionStatus?: ConnectionStatus;
+  /** Current room setting, used only to scale the countdown colour ramp. */
+  readonly shotClockSeconds?: number;
   /**
    * The action intent `App` already owns. `Hand` narrows it to the card
    * module's own port — the module never sees `ActionIntent`, so growing the
@@ -244,9 +247,13 @@ function bannerFor(
 function TurnBanner({
   banner,
   marker,
+  turnEndsAt,
+  shotClockSeconds,
 }: {
   readonly banner: Banner;
   readonly marker: PositionMarker | null;
+  readonly turnEndsAt: number | null;
+  readonly shotClockSeconds: number;
 }) {
   const tone = bannerToneStyle[banner.tone];
   return (
@@ -314,6 +321,14 @@ function TurnBanner({
           {banner.text}
         </span>
       </div>
+      {banner.tone === "turn" && turnEndsAt !== null ? (
+        <ShotClock
+          turnEndsAt={turnEndsAt}
+          durationSeconds={shotClockSeconds}
+          variant="ring"
+          testId="turn-banner-shot-clock"
+        />
+      ) : null}
     </motion.div>
   );
 }
@@ -390,6 +405,7 @@ export function Hand({
   seatId,
   seats = [],
   connectionStatus = "connected",
+  shotClockSeconds = 90,
   intent,
 }: HandProps) {
   const actions = cardActionsFrom(intent);
@@ -410,6 +426,8 @@ export function Hand({
         <TurnBanner
           banner={bannerFor(view, connectionStatus, seatId, seats)}
           marker={positionMarkerFor(seatId, view)}
+          turnEndsAt={null}
+          shotClockSeconds={shotClockSeconds}
         />
         <HoleCardsRegion
           cards={null}
@@ -437,6 +455,8 @@ export function Hand({
         <TurnBanner
           banner={bannerFor(view, connectionStatus, seatId, seats)}
           marker={positionMarkerFor(seatId, view)}
+          turnEndsAt={null}
+          shotClockSeconds={shotClockSeconds}
         />
         <HoleCardsRegion
           cards={null}
@@ -468,6 +488,8 @@ export function Hand({
         <TurnBanner
           banner={bannerFor(view, connectionStatus, seatId, seats)}
           marker={positionMarkerFor(seatId, view)}
+          turnEndsAt={null}
+          shotClockSeconds={shotClockSeconds}
         />
         {myResult ? (
           <HoleCardsRegion
@@ -502,6 +524,8 @@ export function Hand({
       <TurnBanner
         banner={bannerFor(view, connectionStatus, seatId, seats)}
         marker={positionMarkerFor(seatId, view)}
+        turnEndsAt={view.legalActions.length > 0 ? view.turnEndsAt : null}
+        shotClockSeconds={shotClockSeconds}
       />
       {view.yourHoleCards ? (
         <HoleCardsRegion cards={view.yourHoleCards} actions={actions} />

--- a/packages/player-client/src/actions/legalActionsFromView.test.ts
+++ b/packages/player-client/src/actions/legalActionsFromView.test.ts
@@ -15,6 +15,7 @@ describe("legalActionsFromView", () => {
   it("mirrors the view's legalActions during betting", () => {
     const view: PlayerView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 2,

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -2092,6 +2092,71 @@ describe("action clock", () => {
 
     expect(actionsSeen(table.messages)).toHaveLength(0);
     expect(rooms.currentActor(room.code)).toBeDefined();
+    const liveViews = table.messages
+      .filter(
+        (message): message is Extract<ServerMessage, { type: "hand-update" }> =>
+          message.type === "hand-update" && message.view.phase === "betting",
+      )
+      .map((message) => message.view);
+    expect(liveViews.length).toBeGreaterThan(0);
+    expect(
+      liveViews.every(
+        (view) => view.phase === "betting" && view.turnEndsAt === null,
+      ),
+    ).toBe(true);
+  });
+
+  it("publishes one absolute deadline and resumes it in a reconnect snapshot", async () => {
+    const room = rooms.create(2);
+    enableShotClock(room);
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const seat0 = await claimAndConnect(room.code, 0);
+    await claimAndConnect(room.code, 1);
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    const deadline = room.turnEndsAt;
+    expect(deadline).toEqual(expect.any(Number));
+    if (deadline === null) throw new Error("expected a shot-clock deadline");
+    expect(deadline).toBeGreaterThan(Date.now());
+
+    const liveViews = table.messages
+      .filter(
+        (message): message is Extract<ServerMessage, { type: "hand-update" }> =>
+          message.type === "hand-update" && message.view.phase === "betting",
+      )
+      .map((message) => message.view);
+    expect(liveViews.length).toBeGreaterThan(0);
+    expect(
+      liveViews.every(
+        (view) => view.phase === "betting" && view.turnEndsAt === deadline,
+      ),
+    ).toBe(true);
+
+    const claim = rooms.get(room.code)?.seats[0];
+    if (!claim?.token) throw new Error("expected seat token");
+    seat0.socket.close();
+    await settle();
+    const reconnected = connect(
+      `room=${room.code}&seat=0&token=${claim.token}`,
+    );
+    await opened(reconnected.socket);
+    await settle();
+
+    const snapshot = reconnected.messages.find(
+      (message) => message.type === "view-snapshot",
+    );
+    if (snapshot?.type !== "view-snapshot") {
+      throw new Error("expected a view-snapshot");
+    }
+    if (snapshot.view.phase !== "betting") {
+      throw new Error("expected a betting view snapshot");
+    }
+    expect(snapshot.view.turnEndsAt).toBe(deadline);
+    expect(snapshot.view.turnEndsAt).toBeGreaterThan(Date.now());
   });
 
   it("checks on expiry when checking is free", async () => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -86,6 +86,8 @@ export interface BuildAppOptions {
   readonly actionClockMs?: number;
   /** Injectable action clock for deterministic server tests. */
   readonly actionClock?: ActionClock;
+  /** Injectable wall clock for deterministic deadline assertions. */
+  readonly now?: () => number;
   /** How often the server pings every open socket (Phase 1 spec #130 §7). */
   readonly pingIntervalMs?: number;
   /** Missed pongs before a seat's badge flips to "disconnected". */
@@ -316,12 +318,12 @@ export async function buildApp(
       if (identity === "table") {
         send(socket, {
           type: "view-snapshot",
-          view: view(room.engine, "table"),
+          view: view(room.engine, "table", room.turnEndsAt),
         });
       } else if (isSeat(identity) && room.engine.seats.includes(identity)) {
         send(socket, {
           type: "view-snapshot",
-          view: view(room.engine, identity),
+          view: view(room.engine, identity, room.turnEndsAt),
         });
       }
     }
@@ -476,13 +478,13 @@ export async function buildApp(
         send(socket, {
           type: "hand-update",
           event: redactEventFor(step.event, "table"),
-          view: view(step.state, "table"),
+          view: view(step.state, "table", rooms.get(code)?.turnEndsAt),
         });
       } else if (isSeat(identity) && step.state.seats.includes(identity)) {
         send(socket, {
           type: "hand-update",
           event: redactEventFor(step.event, identity),
-          view: view(step.state, identity),
+          view: view(step.state, identity, rooms.get(code)?.turnEndsAt),
         });
       }
     }
@@ -628,12 +630,14 @@ export async function buildApp(
     const actor = rooms.currentActor(code);
     if (room === undefined || actor === undefined) {
       actionClock.clear(code);
+      if (room !== undefined) room.turnEndsAt = null;
       return;
     }
 
     const { enabled, seconds } = room.shotClockSettings;
     if (!enabled) {
       actionClock.clear(code);
+      room.turnEndsAt = null;
       return;
     }
 
@@ -644,6 +648,7 @@ export async function buildApp(
       options.actionClock === undefined && options.actionClockMs !== undefined
         ? options.actionClockMs
         : seconds * 1000;
+    room.turnEndsAt = (options.now ?? Date.now)() + timeoutMs;
     actionClock.schedule(code, timeoutMs, () => {
       const currentRoom = rooms.get(code);
       if (!currentRoom || rooms.currentActor(code) !== actor) {
@@ -689,6 +694,18 @@ export async function buildApp(
       applySeatMoves(code, result.seatMoves);
     }
     logDispatch(code, result);
+    if (options.actionClock === "preserve") {
+      if (rooms.currentActor(code) === undefined) {
+        actionClock.clear(code);
+        const room = rooms.get(code);
+        if (room !== undefined) room.turnEndsAt = null;
+      }
+    } else {
+      // Arm before the first hand-update is sent: every live view, including
+      // the HandStarted view, carries the deadline that governs the resulting
+      // actor. A reconnect snapshot reads the same room field.
+      rescheduleActionClock(code);
+    }
     for (const step of result.steps) {
       fanOutHandUpdate(code, step);
     }
@@ -697,11 +714,6 @@ export async function buildApp(
       result.steps.some((step) => step.event.type === "HandComplete")
     ) {
       if (rollBotSitStates(code)) broadcastRoomView(code);
-    }
-    if (options.actionClock === "preserve") {
-      if (rooms.currentActor(code) === undefined) actionClock.clear(code);
-    } else {
-      rescheduleActionClock(code);
     }
     scheduleBotAction(code);
   }
@@ -1065,7 +1077,7 @@ export async function buildApp(
             if (identity === "table") {
               send(socket, {
                 type: "view-snapshot",
-                view: view(room.engine, "table"),
+                view: view(room.engine, "table", room.turnEndsAt),
               });
             } else if (
               isSeat(identity) &&
@@ -1073,7 +1085,7 @@ export async function buildApp(
             ) {
               send(socket, {
                 type: "view-snapshot",
-                view: view(room.engine, identity),
+                view: view(room.engine, identity, room.turnEndsAt),
               });
             }
           }

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -68,6 +68,8 @@ export interface Room {
   engine: EngineState | null;
   /** A live-hand shrink waits here until the next deal-in recompute. */
   pendingSeatCount: number | null;
+  /** Absolute deadline for the current actor, or null when no clock is armed. */
+  turnEndsAt: number | null;
   /** A shot-clock change waits here until the next deal-in. */
   pendingShotClock: ShotClockSettings | null;
   /** Room-wide tactile-sound settings (#182), set by the table. */
@@ -385,6 +387,7 @@ export class RoomStore {
       seats: makeSeats(seatCount),
       engine: null,
       pendingSeatCount: null,
+      turnEndsAt: null,
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -40,6 +40,7 @@ function seat(id: number, claimed: boolean): SeatView {
 
 const liveHand: TableView = {
   phase: "betting",
+  turnEndsAt: null,
   button: 0,
   smallBlind: 1,
   bigBlind: 2,

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -232,6 +232,7 @@ export function App() {
             <Seats
               seats={seats}
               view={handView}
+              shotClockSeconds={shotClockSettings.seconds}
               onSeatClick={handleSeatClick}
             />
             {menuSeatId !== null && (

--- a/packages/table-client/src/Board.test.tsx
+++ b/packages/table-client/src/Board.test.tsx
@@ -14,6 +14,7 @@ describe("Board", () => {
   it("renders the community cards for a live betting street", () => {
     const view: TableView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 2,

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -128,6 +128,7 @@ describe("Seats", () => {
   it("shows a claimed seat absent from a live hand as sitting out", () => {
     const view: TableView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -164,6 +165,7 @@ describe("Seats", () => {
   it("does not describe a disconnected seat as sitting out", () => {
     const view: TableView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -212,6 +214,7 @@ describe("Seats", () => {
   it("marks status, button and the current actor during betting", () => {
     const view: TableView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -240,9 +243,25 @@ describe("Seats", () => {
     expect(html).toMatch(/data-testid="seat-pod-3"[^>]*data-status="open"/);
   });
 
+  it("renders the active seat's number countdown below its position marker", () => {
+    const html = renderToStaticMarkup(
+      <Seats
+        seats={seats}
+        view={{ ...threeHanded, turnEndsAt: Date.now() + 30_000 }}
+      />,
+    );
+
+    expect(html).toContain('data-testid="seat-shot-clock"');
+    expect(html).toContain(">30</span>");
+    expect((html.match(/data-testid="seat-shot-clock"/g) ?? []).length).toBe(1);
+    expect(styleOf(html, "seat-shot-clock")).toContain("bottom:-0.5em");
+    expect(styleOf(html, "seat-pod-0-small-blind")).toContain("top:-0.4em");
+  });
+
   it("marks a folded seat", () => {
     const view: TableView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -456,6 +475,7 @@ describe("Seats", () => {
   it("keeps the top-row action callout separate from the placard and upright", () => {
     const view: TableView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 3,
@@ -490,6 +510,7 @@ describe("Seats", () => {
   it("keeps a bottom-row action callout unrotated", () => {
     const view: TableView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -558,6 +579,7 @@ describe("Seats", () => {
   it("keeps a folded top-row seat dimmed behind its flipped placard", () => {
     const view: TableView = {
       phase: "betting",
+      turnEndsAt: null,
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -621,10 +643,11 @@ function styleOf(html: string, testid: string): string | null {
   return match?.[1] ?? null;
 }
 
-const threeHanded: TableView = {
+const threeHanded: Extract<TableView, { phase: "betting" }> = {
   // Seats 3, 0 and 1 are in the hand with the button on 3, so ring order
   // (3 -> 0 -> 1) runs the opposite way to seat-number order.
   phase: "betting",
+  turnEndsAt: null,
   button: 3,
   smallBlind: 0,
   bigBlind: 1,
@@ -640,6 +663,7 @@ const threeHanded: TableView = {
 };
 
 const headsUpPositions = {
+  turnEndsAt: null,
   button: 0,
   smallBlind: 0,
   bigBlind: 1,

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -5,6 +5,7 @@ import {
   positionMarkerColor,
   positionMarkerFor,
   positionMarkerLabel,
+  ShotClock,
   shadow,
   type PositionMarker,
 } from "@table-top-poker/ui-shared";
@@ -14,6 +15,8 @@ import { posFor } from "./table/posFor.js";
 export interface SeatsProps {
   readonly seats: readonly SeatView[];
   readonly view: TableView | null;
+  /** Current room setting, used only to scale the countdown colour ramp. */
+  readonly shotClockSeconds?: number;
   /** Called with a claimed seat's id when its pod is clicked — table-only, see ADR-0003. */
   readonly onSeatClick?: (seatId: number) => void;
 }
@@ -122,7 +125,12 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
  * is the only place `seats` and the in-progress `view` are merged into a
  * single per-seat picture — `Board` only ever renders the centre content.
  */
-export function Seats({ seats, view, onSeatClick }: SeatsProps) {
+export function Seats({
+  seats,
+  view,
+  shotClockSeconds = 90,
+  onSeatClick,
+}: SeatsProps) {
   return (
     <div data-testid="seats" style={{ position: "absolute", inset: 0 }}>
       {seats.map((seat) => {
@@ -146,6 +154,15 @@ export function Seats({ seats, view, onSeatClick }: SeatsProps) {
 
         const avatarBlock = (
           <div key="avatar" style={{ position: "relative" }}>
+            {visual.isActor && view?.phase === "betting" ? (
+              <ShotClock
+                turnEndsAt={view.turnEndsAt}
+                durationSeconds={shotClockSeconds}
+                variant="number"
+                testId="seat-shot-clock"
+                numberPosition="bottom-right"
+              />
+            ) : null}
             <div
               data-testid={`seat-pod-${String(seat.id)}-avatar`}
               style={{

--- a/packages/ui-shared/src/ShotClock.tsx
+++ b/packages/ui-shared/src/ShotClock.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from "react";
+import { color, font, fontSize, radius } from "./theme.js";
+
+export type ShotClockVariant = "ring" | "number";
+
+export interface ShotClockProps {
+  /** Absolute server deadline in epoch milliseconds. */
+  readonly turnEndsAt: number | null;
+  /** Configured duration, used only to scale the colour ramp. */
+  readonly durationSeconds: number;
+  readonly variant: ShotClockVariant;
+  readonly testId: string;
+  /** Position for the avatar number badge; ring layout ignores this. */
+  readonly numberPosition?: "top-right" | "bottom-right";
+}
+
+/** Green while ample time remains, through amber, to red at the deadline. */
+export function shotClockColor(fraction: number): string {
+  const remaining = Math.max(0, Math.min(1, fraction));
+  const hue =
+    remaining > 0.4
+      ? 45 + ((remaining - 0.4) / 0.6) * (130 - 45)
+      : (remaining / 0.4) * 45;
+  const saturation = remaining > 0.4 ? 70 : 85;
+  const lightness = remaining > 0.15 ? 52 : 58;
+  return `hsl(${String(hue)} ${String(saturation)}% ${String(lightness)}%)`;
+}
+
+function useNow(): number {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    let frame = 0;
+    const tick = () => {
+      setNow(Date.now());
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  }, []);
+
+  return now;
+}
+
+/**
+ * A render-only countdown. The server owns expiry and remains the only side
+ * that can synthesize an action; this component never sends commands.
+ */
+export function ShotClock({
+  turnEndsAt,
+  durationSeconds,
+  variant,
+  testId,
+  numberPosition = "top-right",
+}: ShotClockProps) {
+  const now = useNow();
+  if (turnEndsAt === null) return null;
+
+  const durationMs = Math.max(1, durationSeconds * 1000);
+  const remainingMs = Math.max(0, turnEndsAt - now);
+  const fraction = Math.max(0, Math.min(1, remainingMs / durationMs));
+  const tint = shotClockColor(fraction);
+  const seconds = Math.ceil(remainingMs / 1000);
+
+  if (variant === "number") {
+    const numberAnchorStyle =
+      numberPosition === "bottom-right"
+        ? { bottom: "-0.5em", right: "-0.5em" }
+        : { top: "-0.5em", right: "-0.5em" };
+    return (
+      <span
+        data-testid={testId}
+        style={{
+          position: "absolute",
+          ...numberAnchorStyle,
+          minWidth: "1.6em",
+          padding: "0 0.3em",
+          textAlign: "center",
+          borderRadius: radius.pill,
+          background: color.pillInk,
+          color: tint,
+          border: `1px solid ${tint}`,
+          fontFamily: font.display,
+          fontWeight: 800,
+          fontSize: "0.7em",
+          fontVariantNumeric: "tabular-nums",
+          pointerEvents: "none",
+        }}
+      >
+        {seconds}
+      </span>
+    );
+  }
+
+  const radiusValue = 46;
+  const circumference = 2 * Math.PI * radiusValue;
+  return (
+    <div
+      data-testid={testId}
+      style={{
+        marginLeft: "auto",
+        position: "relative",
+        width: "2.6em",
+        height: "2.6em",
+        flex: "none",
+      }}
+    >
+      <svg viewBox="0 0 100 100" style={{ width: "100%", height: "100%" }}>
+        <circle
+          cx="50"
+          cy="50"
+          r={radiusValue}
+          fill="none"
+          stroke={color.textFaint}
+          strokeWidth={7}
+        />
+        <circle
+          cx="50"
+          cy="50"
+          r={radiusValue}
+          fill="none"
+          stroke={tint}
+          strokeWidth={7}
+          strokeLinecap="round"
+          transform="rotate(-90 50 50)"
+          strokeDasharray={circumference}
+          strokeDashoffset={circumference * (1 - fraction)}
+        />
+      </svg>
+      <span
+        style={{
+          position: "absolute",
+          inset: 0,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: tint,
+          fontFamily: font.mono,
+          fontSize: fontSize.sm,
+          fontWeight: 700,
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {seconds}
+      </span>
+    </div>
+  );
+}

--- a/packages/ui-shared/src/index.ts
+++ b/packages/ui-shared/src/index.ts
@@ -21,6 +21,8 @@ export {
 } from "./positionMarker.js";
 export type { PositionMarker } from "./positionMarker.js";
 export { color, font, fontSize, radius, shadow } from "./theme.js";
+export { ShotClock, shotClockColor } from "./ShotClock.js";
+export type { ShotClockProps, ShotClockVariant } from "./ShotClock.js";
 export {
   applyRoomSoundSettings,
   onHandUpdate,

--- a/packages/ui-shared/src/positionMarker.test.ts
+++ b/packages/ui-shared/src/positionMarker.test.ts
@@ -11,6 +11,7 @@ const positions = {
 
 const bettingTable: TableView = {
   phase: "betting",
+  turnEndsAt: null,
   ...positions,
   street: "flop",
   board: [],

--- a/packages/ui-shared/src/sound/engine.test.ts
+++ b/packages/ui-shared/src/sound/engine.test.ts
@@ -79,6 +79,7 @@ const actionTaken = (
 /** A player betting view whose turn state is `myTurn`. */
 const bettingView = (myTurn: boolean): PlayerView => ({
   phase: "betting",
+  turnEndsAt: null,
   street: "preflop",
   board: [],
   toAct: myTurn ? [0] : [1],
@@ -105,6 +106,7 @@ const tableHoleCardsDealt = (): HandEvent => ({
 /** A table betting view for a hand dealt to `dealtSeatCount` seats. */
 const tableBettingView = (dealtSeatCount: number): TableView => ({
   phase: "betting",
+  turnEndsAt: null,
   street: "preflop",
   board: [],
   toAct: [0],


### PR DESCRIPTION
## Summary

- add server-authoritative `turnEndsAt` deadlines to player and table betting views
- preserve deadlines across live hand updates and reconnect snapshots
- render the selected table number badge and player ring countdown without client-side expiry actions
- cover disabled clocks, deadline propagation, reconnect resume, actor-only visibility, and countdown layout

Closes #223

## Validation

- `npm run build`
- full test suite: 94 files, 891 tests
- ESLint
- Prettier
- `git diff --check`

## Review

Two independent review rounds were completed. The first identified build-time test narrowing and badge-overlap issues; both were fixed. The second found no actionable issues.
