### PR TITLE
fix(player): stop iPhone pinch-zoom and viewport panning

### DIFF
--- a/packages/player-client/index.html
+++ b/packages/player-client/index.html
@@ -2,9 +2,16 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!--
+      `maximum-scale`/`user-scalable` are honoured by in-app WebViews and older
+      WebKit builds; iOS Safari has ignored them since iOS 10, so the real
+      pinch lock for iPhone lives in `lockViewport`. Suppressing zoom is
+      deliberate here: this is a fixed, single-screen game controller with no
+      scrollable content to reach, and the table view is the readable surface.
+    -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, viewport-fit=cover"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
     />
     <!--
       Same home-screen story as table-client: a phone added to the home screen

--- a/packages/player-client/src/app-shell.css
+++ b/packages/player-client/src/app-shell.css
@@ -14,6 +14,18 @@ body {
 }
 
 /*
+ * `overflow: hidden` alone does not stop iOS Safari dragging the document
+ * around — it still rubber-bands and pans the visual viewport, which is the
+ * "accidental scrolling" iPhone players see and Android players do not. Taking
+ * the body out of flow and pinning it to the viewport leaves nothing to pan.
+ */
+body {
+  position: fixed;
+  inset: 0;
+  width: 100%;
+}
+
+/*
  * player-client is a phone experience even when opened in a wide desktop
  * tab (no phone in hand for testing/demoing) — #root centres a
  * phone-width column instead of letting the shell stretch full-bleed.

--- a/packages/player-client/src/lockViewport.test.ts
+++ b/packages/player-client/src/lockViewport.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Listener } from "./lockViewport.js";
+import { lockViewport } from "./lockViewport.js";
+
+/**
+ * Stands in for `document`: records what was bound and lets a test fire an
+ * event at whatever is listening for it.
+ */
+function fakeTarget() {
+  const listeners = new Map<string, { handler: Listener; options?: unknown }>();
+  return {
+    addEventListener(
+      name: string,
+      handler: Listener,
+      options?: { passive?: boolean },
+    ) {
+      listeners.set(name, { handler, options });
+    },
+    removeEventListener(name: string) {
+      listeners.delete(name);
+    },
+    bound: () => [...listeners.keys()].sort(),
+    optionsFor: (name: string) => listeners.get(name)?.options,
+    fire(name: string, touches?: { length: number }) {
+      const preventDefault = vi.fn();
+      listeners
+        .get(name)
+        ?.handler(
+          touches === undefined
+            ? { preventDefault }
+            : { touches, preventDefault },
+        );
+      return preventDefault;
+    },
+  };
+}
+
+describe("lockViewport", () => {
+  it("cancels the WebKit pinch gestures that ignore the viewport meta", () => {
+    const target = fakeTarget();
+    lockViewport(target);
+
+    for (const name of ["gesturestart", "gesturechange", "gestureend"]) {
+      expect(target.fire(name)).toHaveBeenCalled();
+    }
+  });
+
+  it("cancels a two-finger drag but leaves the one-finger card peel alone", () => {
+    const target = fakeTarget();
+    lockViewport(target);
+
+    expect(target.fire("touchmove", { length: 2 })).toHaveBeenCalled();
+    expect(target.fire("touchmove", { length: 1 })).not.toHaveBeenCalled();
+  });
+
+  it("binds non-passively, or the browser drops every preventDefault", () => {
+    const target = fakeTarget();
+    lockViewport(target);
+
+    for (const name of target.bound()) {
+      expect(target.optionsFor(name)).toEqual({ passive: false });
+    }
+  });
+
+  it("unbinds everything it bound", () => {
+    const target = fakeTarget();
+    const release = lockViewport(target);
+    expect(target.bound()).toHaveLength(4);
+
+    release();
+    expect(target.bound()).toHaveLength(0);
+  });
+});

--- a/packages/player-client/src/lockViewport.ts
+++ b/packages/player-client/src/lockViewport.ts
@@ -1,0 +1,69 @@
+/*
+ * iOS Safari lets the user pinch-zoom and pan the visual viewport even when the
+ * page says not to. `user-scalable=no` in the viewport meta has been ignored
+ * since iOS 10, and `touch-action: manipulation` only kills double-tap zoom —
+ * pinch is handled above the touch-action layer. That is why Android's player
+ * interface stays locked while an iPhone drifts: everything we already do is
+ * enough for Chrome and not for WebKit.
+ *
+ * What does still work on WebKit is cancelling the gesture events it fires for
+ * a pinch (`gesturestart`/`gesturechange`/`gestureend`, non-standard and
+ * WebKit-only) and cancelling any multi-touch `touchmove` before it becomes a
+ * zoom or a viewport pan. Both need non-passive listeners or the
+ * `preventDefault` is dropped.
+ *
+ * Single-touch moves are left alone: the hole-card peel is a one-finger drag
+ * and does its own `preventDefault` where it wants one.
+ */
+
+/*
+ * Narrowed to what we actually use rather than derived from `EventTarget`:
+ * `gesturestart` and friends are not in lib.dom's event map, and the real
+ * signature's nullable `EventListenerOrEventListenerObject` would force a fake
+ * target in tests to accept shapes we never pass.
+ */
+export interface CancellableEvent {
+  readonly touches?: { readonly length: number };
+  preventDefault(): void;
+}
+
+export type Listener = (event: CancellableEvent) => void;
+
+interface ListenerTarget {
+  addEventListener(
+    type: string,
+    listener: Listener,
+    options?: { passive?: boolean },
+  ): void;
+  removeEventListener(type: string, listener: Listener): void;
+}
+
+const GESTURE_EVENTS = ["gesturestart", "gesturechange", "gestureend"] as const;
+
+/**
+ * Suppresses pinch-zoom on the given target. Returns a teardown that removes
+ * every listener it added.
+ */
+export function lockViewport(target: ListenerTarget): () => void {
+  const cancel: Listener = (event) => {
+    event.preventDefault();
+  };
+
+  const cancelMultiTouch: Listener = (event) => {
+    if (event.touches !== undefined && event.touches.length > 1) {
+      event.preventDefault();
+    }
+  };
+
+  for (const name of GESTURE_EVENTS) {
+    target.addEventListener(name, cancel, { passive: false });
+  }
+  target.addEventListener("touchmove", cancelMultiTouch, { passive: false });
+
+  return () => {
+    for (const name of GESTURE_EVENTS) {
+      target.removeEventListener(name, cancel);
+    }
+    target.removeEventListener("touchmove", cancelMultiTouch);
+  };
+}

--- a/packages/player-client/src/main.tsx
+++ b/packages/player-client/src/main.tsx
@@ -1,12 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App.js";
+import { lockViewport } from "./lockViewport.js";
 import "./app-shell.css";
 
 const rootEl = document.getElementById("root");
 if (!rootEl) {
   throw new Error("#root element not found");
 }
+
+// Bound on the document so it catches pinches started anywhere in the shell.
+lockViewport(document);
 
 ReactDOM.createRoot(rootEl).render(
   <React.StrictMode>


### PR DESCRIPTION
## Problem

The player interface is a fixed, single-screen controller — no scrollable content, nothing to zoom into. It holds still on Android but iPhone players are accidentally pinch-zooming and scrolling it.

Everything already in place (`touch-action: manipulation`, `overflow: hidden`, `overscroll-behavior: none`) is enough for Chrome, and not for WebKit:

- `touch-action: manipulation` only suppresses double-tap zoom. Pinch is handled above the touch-action layer.
- `user-scalable=no` in the viewport meta has been ignored by iOS Safari since iOS 10.
- `overflow: hidden` does not stop the document rubber-banding and panning the visual viewport.

## Change

**`src/lockViewport.ts`** (new) — cancels the WebKit-only `gesturestart` / `gesturechange` / `gestureend` events a pinch fires, and any `touchmove` carrying more than one touch. Bound non-passively; a passive listener's `preventDefault` is silently dropped. Single-touch moves pass through untouched, so the hole-card peel drag is unaffected. Returns a teardown that removes everything it bound.

**`src/main.tsx`** — binds it on `document`, so a pinch started anywhere in the shell is caught.

**`src/app-shell.css`** — `body { position: fixed; inset: 0; width: 100% }`. Taking the body out of flow leaves nothing for iOS to pan.

**`index.html`** — added `maximum-scale=1, user-scalable=no` to the viewport meta. Safari ignores it, but in-app WebViews (opening the room link from Messages, Slack, etc.) and older WebKit builds honour it. The real Safari lock is `lockViewport`.

Zoom suppression is deliberate here rather than an accessibility oversight: this is a game controller with no reachable content behind the fold, and the table view is the readable surface.

## Scope

`player-client` only, matching the reported problem. `table-client` has the same viewport meta and would drift the same way on an iPad — left alone for now, happy to mirror it in a follow-up.

## Verification

- `lockViewport.test.ts` (new, 4 tests): gesture cancellation, the one-finger/two-finger split, non-passive binding, teardown.
- `npx vitest run --project player-client` — 32 files, 372 tests pass.
- `npm run build` (tsc) clean, `npm run lint` (eslint + prettier) clean.

Not yet verified on a physical iPhone — worth a check on device before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWVDggdkK43LhJqMudvKM3