### PR TITLE
fix(sound): recover iOS audio after another app takes the session

### DIFF
--- a/packages/ui-shared/src/sound/webAudio.test.ts
+++ b/packages/ui-shared/src/sound/webAudio.test.ts
@@ -26,11 +26,20 @@ function eventTarget(): {
 
 class FakeAudioContext {
   static created: FakeAudioContext[] = [];
-  /** iOS-wide gate: false models a page with no audio permission right now. */
+  /** iOS-wide gate: false models the audio session being held by another app. */
   static audioAllowed = true;
+  /**
+   * True only inside the synchronous run of a tap handler. iOS grants audio to
+   * the task a gesture started, so a `resume()` issued after an `await` has no
+   * credit — modelling that is the point, since losing it is silence from the
+   * first hand rather than only after an interruption.
+   */
+  static inGesture = false;
   state: StateName = "suspended";
-  /** Set false to model Safari holding the interruption against `resume()`. */
-  resumable = true;
+  /** A context that has never run needs a gesture for its first resume. */
+  needsGesture = true;
+  /** Set true for the interruption Safari never lifts on this context. */
+  dead = false;
   /** Buffers handed to `start()` — the proof a cue actually made sound. */
   started: unknown[] = [];
   destination = {};
@@ -46,15 +55,18 @@ class FakeAudioContext {
     this.events.dispatch("statechange");
   }
 
-  /** Model the interruption: parked, and deaf to `resume()` until released. */
+  /** Model the interruption: parked, and deaf to `resume()` while held. */
   interrupt(): void {
-    this.resumable = false;
+    FakeAudioContext.audioAllowed = false;
     this.setState("interrupted");
   }
 
   resume(): Promise<void> {
-    if (!this.resumable || !FakeAudioContext.audioAllowed)
+    if (this.dead || !FakeAudioContext.audioAllowed)
       return Promise.reject(new Error("interrupted"));
+    if (this.needsGesture && !FakeAudioContext.inGesture)
+      return Promise.reject(new Error("gesture required"));
+    this.needsGesture = false;
     this.setState("running");
     return Promise.resolve();
   }
@@ -90,10 +102,13 @@ class FakeAudioElement {
   src = "";
   /** Set false to model iOS refusing `play()` outside a user gesture. */
   playable = true;
+  /** Records whether each `play()` landed inside a gesture. */
+  playedInGesture: boolean[] = [];
   setAttribute(): void {
     // `playsinline` has no bearing on the fake.
   }
   play(): Promise<void> {
+    this.playedInGesture.push(FakeAudioContext.inGesture);
     if (!this.playable) return Promise.reject(new Error("gesture required"));
     this.paused = false;
     return Promise.resolve();
@@ -112,6 +127,7 @@ let keepAlive: FakeAudioElement;
 async function loadModule(): Promise<typeof import("./webAudio.js")> {
   FakeAudioContext.created = [];
   FakeAudioContext.audioAllowed = true;
+  FakeAudioContext.inGesture = false;
   keepAlive = new FakeAudioElement();
   documentEvents = eventTarget();
   windowEvents = eventTarget();
@@ -132,6 +148,26 @@ async function loadModule(): Promise<typeof import("./webAudio.js")> {
 
   vi.resetModules();
   return import("./webAudio.js");
+}
+
+function restoreGlobals(): void {
+  const g = globalThis as Record<string, unknown>;
+  for (const key of ["AudioContext", "document", "window", "fetch"]) {
+    Reflect.deleteProperty(g, key);
+  }
+}
+
+/**
+ * Run `fn` the way a tap handler runs: the gesture's credit covers only what
+ * `fn` does synchronously, exactly as iOS scopes it to the task.
+ */
+function inGesture<T>(fn: () => T): T {
+  FakeAudioContext.inGesture = true;
+  try {
+    return fn();
+  } finally {
+    FakeAudioContext.inGesture = false;
+  }
 }
 
 function currentContext(): FakeAudioContext {
@@ -158,26 +194,25 @@ async function settle(): Promise<void> {
 
 const SLOW = 20_000;
 
-describe("webAudio interruption recovery", () => {
+describe("webAudio unlock", () => {
   let sound: typeof import("./webAudio.js");
 
   beforeEach(async () => {
     sound = await loadModule();
-    await sound.unlockAudio();
   });
 
-  afterEach(() => {
-    const g = globalThis as Record<string, unknown>;
-    delete g.AudioContext;
-    delete g.document;
-    delete g.window;
-    delete g.fetch;
-  });
+  afterEach(restoreGlobals);
 
   it(
-    "plays cues once unlocked",
+    "unlocks from the tap that asked for it",
     async () => {
+      await inGesture(() => sound.unlockAudio());
+
       expect(currentContext().state).toBe("running");
+      // The keep-alive's `play()` has to land inside the gesture too, or the
+      // media channel that carries Web Audio past the silent switch is lost.
+      expect(keepAlive.playedInGesture[0]).toBe(true);
+
       sound.playRevealFlip();
       await settle();
       expect(currentContext().started).toHaveLength(1);
@@ -186,10 +221,48 @@ describe("webAudio interruption recovery", () => {
   );
 
   it(
+    "cannot unlock without a gesture",
+    async () => {
+      await sound.unlockAudio();
+      expect(currentContext().state).not.toBe("running");
+    },
+    SLOW,
+  );
+
+  it(
+    "ignores wake signals until the app has asked to unlock",
+    async () => {
+      // `focus` and `pageshow` both fire at load. Acting on them would build a
+      // context outside any gesture and hold the recovery guard across the
+      // real unlock tap, so the tap would find recovery busy and skip its
+      // resume — silence from the first hand.
+      windowEvents.dispatch("focus");
+      windowEvents.dispatch("pageshow");
+      documentEvents.dispatch("visibilitychange");
+      await settle();
+      expect(FakeAudioContext.created).toHaveLength(0);
+
+      await inGesture(() => sound.unlockAudio());
+      expect(currentContext().state).toBe("running");
+    },
+    SLOW,
+  );
+});
+
+describe("webAudio interruption recovery", () => {
+  let sound: typeof import("./webAudio.js");
+
+  beforeEach(async () => {
+    sound = await loadModule();
+    await inGesture(() => sound.unlockAudio());
+  });
+
+  afterEach(restoreGlobals);
+
+  it(
     "never plays through an interrupted context",
     async () => {
       const ctx = currentContext();
-      FakeAudioContext.audioAllowed = false;
       ctx.interrupt();
 
       sound.playRevealFlip();
@@ -204,7 +277,6 @@ describe("webAudio interruption recovery", () => {
     "resumes on return to the tab once the interruption lifts",
     async () => {
       const ctx = currentContext();
-      FakeAudioContext.audioAllowed = false;
       ctx.interrupt();
       keepAlive.paused = true;
 
@@ -215,7 +287,6 @@ describe("webAudio interruption recovery", () => {
       expect(FakeAudioContext.created).toHaveLength(1);
 
       FakeAudioContext.audioAllowed = true;
-      ctx.resumable = true;
       documentEvents.dispatch("visibilitychange");
       await settle();
 
@@ -231,22 +302,31 @@ describe("webAudio interruption recovery", () => {
   );
 
   it(
-    "rebuilds the context when resume stays refused",
+    "rebuilds the context on a tap when resume stays refused",
     async () => {
       const dead = currentContext();
-      FakeAudioContext.audioAllowed = false;
+      dead.dead = true; // the interruption Safari will never lift
       dead.interrupt();
-      await settle();
+      keepAlive.paused = true;
+      await settle(); // time away, with the other app holding the session
 
-      // Back on the page, with a context iOS will never resume again.
+      // Coming back: the automatic run finds resume refused, and marks it.
       FakeAudioContext.audioAllowed = true;
       documentEvents.dispatch("visibilitychange");
+      await settle();
+      expect(dead.state).not.toBe("running");
+
+      // The next tap rebuilds and resumes inside that one gesture.
+      inGesture(() => {
+        documentEvents.dispatch("pointerdown");
+      });
       await settle();
 
       expect(FakeAudioContext.created).toHaveLength(2);
       const fresh = currentContext();
       expect(fresh).not.toBe(dead);
       expect(fresh.state).toBe("running");
+      expect(keepAlive.paused).toBe(false);
 
       sound.playRevealFlip();
       await settle();
@@ -257,27 +337,54 @@ describe("webAudio interruption recovery", () => {
   );
 
   it(
-    "recovers on the next tap when every automatic path failed",
+    "recovers on the next tap when the automatic paths could not",
     async () => {
       const ctx = currentContext();
-      FakeAudioContext.audioAllowed = false;
       ctx.interrupt();
       keepAlive.paused = true;
-      keepAlive.playable = false; // no gesture credit left
+      keepAlive.playable = false; // no gesture credit for the element either
 
       documentEvents.dispatch("visibilitychange");
       await settle();
       expect(currentContext().state).not.toBe("running");
 
-      // The user taps: iOS hands audio back, and the capture-phase listener
-      // spends that gesture on the ladder.
+      // The user taps: iOS hands the session back, and the capture-phase
+      // listener spends that gesture on the ladder.
       FakeAudioContext.audioAllowed = true;
       keepAlive.playable = true;
-      documentEvents.dispatch("pointerdown");
+      inGesture(() => {
+        documentEvents.dispatch("pointerdown");
+      });
       await settle();
 
       expect(currentContext().state).toBe("running");
       expect(keepAlive.paused).toBe(false);
+    },
+    SLOW,
+  );
+
+  it(
+    "keeps cues flowing through a rebuilt context",
+    async () => {
+      const dead = currentContext();
+      dead.dead = true;
+      dead.interrupt();
+      await settle();
+      FakeAudioContext.audioAllowed = true;
+
+      // Two runs: the first marks the resume refused, the tap rebuilds.
+      documentEvents.dispatch("visibilitychange");
+      await settle();
+      inGesture(() => {
+        documentEvents.dispatch("pointerdown");
+      });
+      await settle();
+
+      // The rebuild dropped the buffer cache; recovery re-warms it, so the
+      // next cue still plays.
+      sound.playRevealFlip();
+      await settle();
+      expect(currentContext().started).toHaveLength(1);
     },
     SLOW,
   );

--- a/packages/ui-shared/src/sound/webAudio.test.ts
+++ b/packages/ui-shared/src/sound/webAudio.test.ts
@@ -1,0 +1,284 @@
+// Covers the iOS interruption-recovery ladder in `webAudio.ts` (#228): what
+// happens when another app takes the audio session mid-game and the page comes
+// back to a context that no longer makes sound. The browser side is faked —
+// there is no `AudioContext` under the node environment — so these tests are
+// about the ladder's decisions (resume, rebuild, wait for a gesture), not about
+// Web Audio itself.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type StateName = "suspended" | "running" | "closed" | "interrupted";
+
+/** A minimal `addEventListener`/dispatch pair, enough for the module's use. */
+function eventTarget(): {
+  addEventListener: (type: string, fn: () => void) => void;
+  dispatch: (type: string) => void;
+} {
+  const listeners = new Map<string, (() => void)[]>();
+  return {
+    addEventListener: (type, fn) => {
+      listeners.set(type, [...(listeners.get(type) ?? []), fn]);
+    },
+    dispatch: (type) => {
+      for (const fn of listeners.get(type) ?? []) fn();
+    },
+  };
+}
+
+class FakeAudioContext {
+  static created: FakeAudioContext[] = [];
+  /** iOS-wide gate: false models a page with no audio permission right now. */
+  static audioAllowed = true;
+  state: StateName = "suspended";
+  /** Set false to model Safari holding the interruption against `resume()`. */
+  resumable = true;
+  /** Buffers handed to `start()` — the proof a cue actually made sound. */
+  started: unknown[] = [];
+  destination = {};
+  private readonly events = eventTarget();
+  readonly addEventListener = this.events.addEventListener;
+
+  constructor() {
+    FakeAudioContext.created.push(this);
+  }
+
+  private setState(next: StateName): void {
+    this.state = next;
+    this.events.dispatch("statechange");
+  }
+
+  /** Model the interruption: parked, and deaf to `resume()` until released. */
+  interrupt(): void {
+    this.resumable = false;
+    this.setState("interrupted");
+  }
+
+  resume(): Promise<void> {
+    if (!this.resumable || !FakeAudioContext.audioAllowed)
+      return Promise.reject(new Error("interrupted"));
+    this.setState("running");
+    return Promise.resolve();
+  }
+
+  close(): Promise<void> {
+    this.setState("closed");
+    return Promise.resolve();
+  }
+
+  decodeAudioData(bytes: ArrayBuffer): Promise<AudioBuffer> {
+    return Promise.resolve(bytes as unknown as AudioBuffer);
+  }
+
+  createBufferSource(): {
+    buffer: unknown;
+    connect: () => void;
+    start: () => void;
+  } {
+    const source = {
+      buffer: null as unknown,
+      connect: (): void => undefined,
+      start: (): void => {
+        this.started.push(source.buffer);
+      },
+    };
+    return source;
+  }
+}
+
+class FakeAudioElement {
+  paused = true;
+  loop = false;
+  src = "";
+  /** Set false to model iOS refusing `play()` outside a user gesture. */
+  playable = true;
+  setAttribute(): void {
+    // `playsinline` has no bearing on the fake.
+  }
+  play(): Promise<void> {
+    if (!this.playable) return Promise.reject(new Error("gesture required"));
+    this.paused = false;
+    return Promise.resolve();
+  }
+}
+
+let documentEvents = eventTarget();
+let windowEvents = eventTarget();
+let keepAlive: FakeAudioElement;
+
+/**
+ * Install the browser fakes and import a fresh copy of the module. The module
+ * pins its context, buffers and engine to `globalThis`, so every `__ttp*` key
+ * has to go along with the module registry for a test to start clean.
+ */
+async function loadModule(): Promise<typeof import("./webAudio.js")> {
+  FakeAudioContext.created = [];
+  FakeAudioContext.audioAllowed = true;
+  keepAlive = new FakeAudioElement();
+  documentEvents = eventTarget();
+  windowEvents = eventTarget();
+  const g = globalThis as Record<string, unknown>;
+  for (const key of Object.keys(g)) {
+    if (key.startsWith("__ttp")) Reflect.deleteProperty(g, key);
+  }
+
+  g.AudioContext = FakeAudioContext;
+  g.document = {
+    visibilityState: "visible",
+    addEventListener: documentEvents.addEventListener,
+    createElement: () => keepAlive,
+  };
+  g.window = { addEventListener: windowEvents.addEventListener };
+  g.fetch = () =>
+    Promise.resolve({ arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)) });
+
+  vi.resetModules();
+  return import("./webAudio.js");
+}
+
+function currentContext(): FakeAudioContext {
+  const ctx = FakeAudioContext.created.at(-1);
+  if (!ctx) throw new Error("no AudioContext was created");
+  return ctx;
+}
+
+/**
+ * Let the recovery ladder's retries and their backoff run to completion — the
+ * resume retries alone span ~900ms, and a rebuild runs a second set.
+ */
+async function settle(): Promise<void> {
+  const g = globalThis as Record<string, unknown>;
+  const deadline = Date.now() + 8000;
+  // Poll the module's own in-flight flag rather than sleeping out the whole
+  // backoff: the ladder is done when nothing is recovering and the microtasks
+  // behind it (the cue's buffer lookup) have drained.
+  for (let quiet = 0; quiet < 3 && Date.now() < deadline;) {
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    quiet = g.__ttpAudioRecovering ? 0 : quiet + 1;
+  }
+}
+
+const SLOW = 20_000;
+
+describe("webAudio interruption recovery", () => {
+  let sound: typeof import("./webAudio.js");
+
+  beforeEach(async () => {
+    sound = await loadModule();
+    await sound.unlockAudio();
+  });
+
+  afterEach(() => {
+    const g = globalThis as Record<string, unknown>;
+    delete g.AudioContext;
+    delete g.document;
+    delete g.window;
+    delete g.fetch;
+  });
+
+  it(
+    "plays cues once unlocked",
+    async () => {
+      expect(currentContext().state).toBe("running");
+      sound.playRevealFlip();
+      await settle();
+      expect(currentContext().started).toHaveLength(1);
+    },
+    SLOW,
+  );
+
+  it(
+    "never plays through an interrupted context",
+    async () => {
+      const ctx = currentContext();
+      FakeAudioContext.audioAllowed = false;
+      ctx.interrupt();
+
+      sound.playRevealFlip();
+      await settle();
+
+      expect(ctx.started).toHaveLength(0);
+    },
+    SLOW,
+  );
+
+  it(
+    "resumes on return to the tab once the interruption lifts",
+    async () => {
+      const ctx = currentContext();
+      FakeAudioContext.audioAllowed = false;
+      ctx.interrupt();
+      keepAlive.paused = true;
+
+      // While the other app still holds the session, the state change alone
+      // must not throw the context away — the rebuild is saved for the return.
+      await settle();
+      expect(ctx.state).not.toBe("running");
+      expect(FakeAudioContext.created).toHaveLength(1);
+
+      FakeAudioContext.audioAllowed = true;
+      ctx.resumable = true;
+      documentEvents.dispatch("visibilitychange");
+      await settle();
+
+      expect(ctx.state).toBe("running");
+      expect(keepAlive.paused).toBe(false);
+      expect(FakeAudioContext.created).toHaveLength(1);
+
+      sound.playRevealFlip();
+      await settle();
+      expect(ctx.started).toHaveLength(1);
+    },
+    SLOW,
+  );
+
+  it(
+    "rebuilds the context when resume stays refused",
+    async () => {
+      const dead = currentContext();
+      FakeAudioContext.audioAllowed = false;
+      dead.interrupt();
+      await settle();
+
+      // Back on the page, with a context iOS will never resume again.
+      FakeAudioContext.audioAllowed = true;
+      documentEvents.dispatch("visibilitychange");
+      await settle();
+
+      expect(FakeAudioContext.created).toHaveLength(2);
+      const fresh = currentContext();
+      expect(fresh).not.toBe(dead);
+      expect(fresh.state).toBe("running");
+
+      sound.playRevealFlip();
+      await settle();
+      expect(fresh.started).toHaveLength(1);
+      expect(dead.started).toHaveLength(0);
+    },
+    SLOW,
+  );
+
+  it(
+    "recovers on the next tap when every automatic path failed",
+    async () => {
+      const ctx = currentContext();
+      FakeAudioContext.audioAllowed = false;
+      ctx.interrupt();
+      keepAlive.paused = true;
+      keepAlive.playable = false; // no gesture credit left
+
+      documentEvents.dispatch("visibilitychange");
+      await settle();
+      expect(currentContext().state).not.toBe("running");
+
+      // The user taps: iOS hands audio back, and the capture-phase listener
+      // spends that gesture on the ladder.
+      FakeAudioContext.audioAllowed = true;
+      keepAlive.playable = true;
+      documentEvents.dispatch("pointerdown");
+      await settle();
+
+      expect(currentContext().state).toBe("running");
+      expect(keepAlive.paused).toBe(false);
+    },
+    SLOW,
+  );
+});

--- a/packages/ui-shared/src/sound/webAudio.ts
+++ b/packages/ui-shared/src/sound/webAudio.ts
@@ -25,6 +25,8 @@ const soundGlobal = globalThis as unknown as {
   __ttpSoundEngine?: SoundEngine;
   __ttpSilentKeepAlive?: HTMLAudioElement | null;
   __ttpAudioRecovering?: boolean;
+  __ttpAudioUnlockRequested?: boolean;
+  __ttpAudioResumeRefused?: boolean;
   __ttpAudioListenersArmed?: boolean;
   __ttpAudioEverRunning?: boolean;
   __ttpAudioRecreatedAt?: number;
@@ -82,21 +84,29 @@ async function loadBuffer(cue: CueName): Promise<AudioBuffer | undefined> {
  */
 function playCueSound(cue: CueName): void {
   if (!audioAvailable()) return;
-  // A cue can be the first thing to notice the context died under us — iOS
-  // interrupts it when another app takes the audio session, and nothing else
-  // may have fired since. Recover first, then play through whatever context
+  // The healthy path stays as direct as it was: warm buffer, straight out.
+  if (contextRunning()) {
+    void loadBuffer(cue).then(emit);
+    return;
+  }
+  // Otherwise this cue is the first thing to notice the context died under us —
+  // iOS interrupts it when another app takes the audio session, and nothing
+  // else may have fired since. Recover, then play through whatever context
   // recovery left us on (it may be a fresh one, so read it after the await).
   void ensureRunning()
     .then(() => loadBuffer(cue))
-    .then((buffer) => {
-      if (!buffer) return;
-      const c = context();
-      if (c.state !== "running") return;
-      const source = c.createBufferSource();
-      source.buffer = buffer;
-      source.connect(c.destination);
-      source.start();
-    });
+    .then(emit);
+}
+
+/** Send one decoded buffer out of the live context, if it can still play. */
+function emit(buffer: AudioBuffer | undefined): void {
+  if (!buffer) return;
+  const c = context();
+  if (c.state !== "running") return;
+  const source = c.createBufferSource();
+  source.buffer = buffer;
+  source.connect(c.destination);
+  source.start();
 }
 
 const engine = (soundGlobal.__ttpSoundEngine ??= createSoundEngine({
@@ -130,8 +140,26 @@ export function playRevealFlip(): void {
  */
 export async function unlockAudio(): Promise<void> {
   if (!audioAvailable()) return;
+  soundGlobal.__ttpAudioUnlockRequested = true;
+  // Everything iOS charges to the gesture happens synchronously, in the task
+  // the tap started: arming the keep-alive element, constructing the context
+  // and *calling* `resume()`. Awaiting anything first (the element's `play()`
+  // promise included) ends that task and hands the credit back, and the resume
+  // is then refused — which is silence from the very first hand, not just
+  // after an interruption.
   armSilentKeepAlive();
-  await ensureRunning();
+  const ctx = context();
+  try {
+    // The call is synchronous; only the continuation waits, so this still
+    // spends the gesture.
+    await ctx.resume();
+  } catch {
+    // A refused first resume is not fatal: fall into the ladder below, and
+    // failing that the next tap tries again.
+  }
+  // `contextRunning()` rather than a bare state read: it is what records that
+  // audio has worked at least once, which is what later licenses a rebuild.
+  if (!contextRunning()) await ensureRunning();
   await warmCues();
 }
 
@@ -221,16 +249,20 @@ function armSilentKeepAlive(): void {
 // routinely ignored, and a context that stays interrupted plays every buffer
 // source into silence — which is exactly the "sounds never come back" symptom.
 //
-// So recovery is a ladder, tried in order and re-entered from every signal we
-// get (visibility, pageshow, focus, context state changes, and the next cue):
+// So recovery is a ladder, re-entered from every signal we get (visibility,
+// pageshow, focus, context state changes, and the next cue):
 //   1. restart the keep-alive element and `resume()` the context, retrying a
 //      few times because the first attempt after foregrounding tends to no-op;
-//   2. if it is still not running, throw the context away and build a fresh
-//      one — an interruption Safari refuses to lift only clears with a new
-//      context — re-decoding the cues against it;
-//   3. if even that fails (no gesture credit left), leave it: the capture-phase
-//      gesture listeners below re-run the ladder on the user's very next tap,
-//      which is the one moment iOS reliably grants audio again.
+//   2. on a later run, if a resume has already been tried and refused, throw
+//      the context away and build a fresh one first — an interruption Safari
+//      refuses to lift only clears with a new context — then resume that;
+//   3. if it still will not run (no gesture credit), leave it: the
+//      capture-phase gesture listeners below re-run the ladder on the user's
+//      very next tap, the one moment iOS reliably grants audio again.
+//
+// The ordering rule throughout: everything iOS charges to a gesture — building
+// a context, `resume()`, the element's `play()` — is called before the run's
+// first `await`, so a run a tap triggered still counts as that tap's work.
 
 const RESUME_ATTEMPTS = 3;
 const RESUME_BACKOFF_MS = 150;
@@ -270,25 +302,39 @@ async function resumeContext(): Promise<boolean> {
 }
 
 /**
- * Replace a context that will not come back. The decoded buffers go with it:
- * an `AudioBuffer` is portable between contexts on paper, but Safari has been
+ * Replace a context that will not come back — synchronously, so the caller can
+ * still resume the new one on the gesture that got us here. Closing the dead
+ * one is fire-and-forget for the same reason: awaiting it would push the
+ * resume out of the gesture's task. The decoded buffers go with it — an
+ * `AudioBuffer` is portable between contexts on paper, but Safari has been
  * unreliable about it, and re-decoding is cheap against the HTTP cache.
  */
-async function recreateContext(): Promise<void> {
+function recreateContext(): void {
   const dead = soundGlobal.__ttpAudioCtx;
   soundGlobal.__ttpAudioCtx = null;
   buffers.clear();
   if (dead && dead.state !== "closed") {
-    try {
-      await dead.close();
-    } catch {
-      // A context iOS has already torn down can refuse to close; dropping the
-      // reference is what matters.
-    }
+    void Promise.resolve(dead.close()).catch(() => undefined);
   }
-  const fresh = context();
-  await resumeContext();
-  if (fresh.state === "running") await warmCues();
+  context();
+}
+
+/**
+ * Whether this recovery run should start by throwing the context away. Only
+ * once a resume has actually been tried and refused: the first stall might be
+ * a context that just needs resuming, and rebuilding costs a re-decode.
+ */
+function shouldRebuild(): boolean {
+  // A context that has never run is *meant* to be suspended — it is waiting
+  // for the app's unlock gesture, not broken.
+  if (!soundGlobal.__ttpAudioEverRunning) return false;
+  if (!soundGlobal.__ttpAudioResumeRefused) return false;
+  // Only worth trying while the user is looking at the page: hidden, the
+  // interruption is probably still held by whatever they switched to, and a
+  // rebuild would burn the cooldown before they come back.
+  if (pageHidden()) return false;
+  const since = realClock.now() - (soundGlobal.__ttpAudioRecreatedAt ?? 0);
+  return since >= RECREATE_COOLDOWN_MS;
 }
 
 /**
@@ -300,26 +346,38 @@ async function ensureRunning(options?: {
   allowRecreate?: boolean;
 }): Promise<void> {
   if (!audioAvailable()) return;
+  // Never before the app's own unlock gesture. A `focus`/`pageshow` at load
+  // would otherwise build the context outside any gesture — the hardest kind
+  // for Safari to unlock — and hold the in-flight guard below across the real
+  // unlock tap, so the tap would find this busy and skip its resume.
+  if (!soundGlobal.__ttpAudioUnlockRequested) return;
   if (contextRunning() && !soundGlobal.__ttpSilentKeepAlive?.paused) return;
   if (soundGlobal.__ttpAudioRecovering) return;
   soundGlobal.__ttpAudioRecovering = true;
   try {
-    await nudgeKeepAlive();
-    context();
-    if (await resumeContext()) return;
-    if (options?.allowRecreate === false) return;
-    // Only rebuild a context that was working before: a context still waiting
-    // for its first unlock gesture is *meant* to be suspended, and replacing it
-    // would just churn.
-    if (!soundGlobal.__ttpAudioEverRunning) return;
-    // Rebuilding is only worth a try while the user is looking at the page —
-    // hidden, the interruption is probably still being held by whatever they
-    // switched to, and a rebuild would burn the cooldown before the return.
-    if (pageHidden()) return;
-    const since = realClock.now() - (soundGlobal.__ttpAudioRecreatedAt ?? 0);
-    if (since < RECREATE_COOLDOWN_MS) return;
-    soundGlobal.__ttpAudioRecreatedAt = realClock.now();
-    await recreateContext();
+    // Every step iOS charges to the gesture is taken before the first await,
+    // so a run driven by a tap spends that tap's credit: rebuild if this stall
+    // has already survived a resume, restart the keep-alive, call `resume()`.
+    if (options?.allowRecreate !== false && shouldRebuild()) {
+      soundGlobal.__ttpAudioRecreatedAt = realClock.now();
+      recreateContext();
+    } else {
+      context();
+    }
+    const nudged = nudgeKeepAlive();
+    const resumed = await resumeContext();
+    await nudged;
+    if (resumed) {
+      soundGlobal.__ttpAudioResumeRefused = false;
+      // A rebuild drops the buffer cache, so re-warm before the next cue lands.
+      await warmCues();
+    } else if (options?.allowRecreate !== false && !pageHidden()) {
+      // Only a refusal with the user *back on the page* condemns the context.
+      // A refusal during the interruption itself says nothing — the session is
+      // simply still held — and treating it as fatal would throw away a
+      // context that the return was about to resume perfectly well.
+      soundGlobal.__ttpAudioResumeRefused = true;
+    }
   } finally {
     soundGlobal.__ttpAudioRecovering = false;
   }

--- a/packages/ui-shared/src/sound/webAudio.ts
+++ b/packages/ui-shared/src/sound/webAudio.ts
@@ -24,6 +24,10 @@ const soundGlobal = globalThis as unknown as {
   __ttpAudioBuffers?: Map<CueName, AudioBuffer>;
   __ttpSoundEngine?: SoundEngine;
   __ttpSilentKeepAlive?: HTMLAudioElement | null;
+  __ttpAudioRecovering?: boolean;
+  __ttpAudioListenersArmed?: boolean;
+  __ttpAudioEverRunning?: boolean;
+  __ttpAudioRecreatedAt?: number;
 };
 
 const buffers = (soundGlobal.__ttpAudioBuffers ??= new Map<
@@ -32,7 +36,12 @@ const buffers = (soundGlobal.__ttpAudioBuffers ??= new Map<
 >());
 
 function context(): AudioContext {
-  return (soundGlobal.__ttpAudioCtx ??= new AudioContext());
+  const existing = soundGlobal.__ttpAudioCtx;
+  if (existing) return existing;
+  const created = new AudioContext();
+  soundGlobal.__ttpAudioCtx = created;
+  watchContextState(created);
+  return created;
 }
 
 /** Whether Web Audio exists — false under jsdom/SSR, where the layer is inert. */
@@ -73,14 +82,21 @@ async function loadBuffer(cue: CueName): Promise<AudioBuffer | undefined> {
  */
 function playCueSound(cue: CueName): void {
   if (!audioAvailable()) return;
-  void loadBuffer(cue).then((buffer) => {
-    if (!buffer) return;
-    const c = context();
-    const source = c.createBufferSource();
-    source.buffer = buffer;
-    source.connect(c.destination);
-    source.start();
-  });
+  // A cue can be the first thing to notice the context died under us — iOS
+  // interrupts it when another app takes the audio session, and nothing else
+  // may have fired since. Recover first, then play through whatever context
+  // recovery left us on (it may be a fresh one, so read it after the await).
+  void ensureRunning()
+    .then(() => loadBuffer(cue))
+    .then((buffer) => {
+      if (!buffer) return;
+      const c = context();
+      if (c.state !== "running") return;
+      const source = c.createBufferSource();
+      source.buffer = buffer;
+      source.connect(c.destination);
+      source.start();
+    });
 }
 
 const engine = (soundGlobal.__ttpSoundEngine ??= createSoundEngine({
@@ -115,8 +131,12 @@ export function playRevealFlip(): void {
 export async function unlockAudio(): Promise<void> {
   if (!audioAvailable()) return;
   armSilentKeepAlive();
-  await context().resume();
-  // Warm every cue so the first real one plays without a decode gap.
+  await ensureRunning();
+  await warmCues();
+}
+
+/** Warm every cue so the first real one plays without a decode gap. */
+async function warmCues(): Promise<void> {
   await Promise.all(
     CUE_NAMES.map((cue) => loadBuffer(cue).catch(() => undefined)),
   );
@@ -161,9 +181,22 @@ function silentWavDataUrl(): string {
   return `data:audio/wav;base64,${btoa(binary)}`;
 }
 
-/** Nudge the keep-alive element back to playing; a no-op if it isn't armed. */
-function nudgeKeepAlive(): void {
-  void soundGlobal.__ttpSilentKeepAlive?.play().catch(() => undefined);
+/**
+ * Nudge the keep-alive element back to playing; a no-op if it isn't armed.
+ * Resolves false when the browser refused (iOS rejects `play()` outside a
+ * gesture once an interruption has paused the element), which is the signal
+ * that only the next real tap can put the media channel back.
+ */
+async function nudgeKeepAlive(): Promise<boolean> {
+  const el = soundGlobal.__ttpSilentKeepAlive;
+  if (!el) return false;
+  if (!el.paused) return true;
+  try {
+    await el.play();
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function armSilentKeepAlive(): void {
@@ -175,15 +208,172 @@ function armSilentKeepAlive(): void {
     el.src = silentWavDataUrl();
     soundGlobal.__ttpSilentKeepAlive = el;
   }
-  nudgeKeepAlive();
+  void nudgeKeepAlive();
 }
 
-// Returning to a backgrounded tab (a phone waking) can leave the context
-// suspended; re-resume on visibility and nudge the keep-alive back to playing.
-if (typeof document !== "undefined") {
+// --- interruption recovery (iOS Safari, #228) -------------------------------
+//
+// Playing other media — an Instagram video, a call, another tab — takes the
+// audio session away from this page. iOS then parks the `AudioContext` in
+// Safari's non-standard `"interrupted"` state (older versions: `"suspended"`)
+// and pauses the silent keep-alive element. Coming back to the tab does not
+// undo either on its own: a single `resume()` right after foregrounding is
+// routinely ignored, and a context that stays interrupted plays every buffer
+// source into silence — which is exactly the "sounds never come back" symptom.
+//
+// So recovery is a ladder, tried in order and re-entered from every signal we
+// get (visibility, pageshow, focus, context state changes, and the next cue):
+//   1. restart the keep-alive element and `resume()` the context, retrying a
+//      few times because the first attempt after foregrounding tends to no-op;
+//   2. if it is still not running, throw the context away and build a fresh
+//      one — an interruption Safari refuses to lift only clears with a new
+//      context — re-decoding the cues against it;
+//   3. if even that fails (no gesture credit left), leave it: the capture-phase
+//      gesture listeners below re-run the ladder on the user's very next tap,
+//      which is the one moment iOS reliably grants audio again.
+
+const RESUME_ATTEMPTS = 3;
+const RESUME_BACKOFF_MS = 150;
+const RECREATE_COOLDOWN_MS = 5000;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    realClock.schedule(() => {
+      resolve();
+    }, ms);
+  });
+}
+
+/** Whether the context exists and is actually able to make sound right now. */
+function contextRunning(): boolean {
+  const running = soundGlobal.__ttpAudioCtx?.state === "running";
+  if (running) soundGlobal.__ttpAudioEverRunning = true;
+  return running;
+}
+
+/** `resume()` the live context, retrying — the first call after a wake no-ops. */
+async function resumeContext(): Promise<boolean> {
+  const c = soundGlobal.__ttpAudioCtx;
+  if (!c) return false;
+  for (let attempt = 0; attempt < RESUME_ATTEMPTS; attempt++) {
+    if (contextRunning()) return true;
+    try {
+      await c.resume();
+    } catch {
+      // Safari rejects `resume()` while the interruption is still held; the
+      // retry below (or the next gesture) is the real fix.
+    }
+    if (contextRunning()) return true;
+    await delay(RESUME_BACKOFF_MS * (attempt + 1));
+  }
+  return contextRunning();
+}
+
+/**
+ * Replace a context that will not come back. The decoded buffers go with it:
+ * an `AudioBuffer` is portable between contexts on paper, but Safari has been
+ * unreliable about it, and re-decoding is cheap against the HTTP cache.
+ */
+async function recreateContext(): Promise<void> {
+  const dead = soundGlobal.__ttpAudioCtx;
+  soundGlobal.__ttpAudioCtx = null;
+  buffers.clear();
+  if (dead && dead.state !== "closed") {
+    try {
+      await dead.close();
+    } catch {
+      // A context iOS has already torn down can refuse to close; dropping the
+      // reference is what matters.
+    }
+  }
+  const fresh = context();
+  await resumeContext();
+  if (fresh.state === "running") await warmCues();
+}
+
+/**
+ * Bring audio back if it has stalled. Cheap and safe to call from anywhere —
+ * it returns immediately when the context is already running, and collapses
+ * overlapping calls (visibility + focus + a cue all fire at once on a wake).
+ */
+async function ensureRunning(options?: {
+  allowRecreate?: boolean;
+}): Promise<void> {
+  if (!audioAvailable()) return;
+  if (contextRunning() && !soundGlobal.__ttpSilentKeepAlive?.paused) return;
+  if (soundGlobal.__ttpAudioRecovering) return;
+  soundGlobal.__ttpAudioRecovering = true;
+  try {
+    await nudgeKeepAlive();
+    context();
+    if (await resumeContext()) return;
+    if (options?.allowRecreate === false) return;
+    // Only rebuild a context that was working before: a context still waiting
+    // for its first unlock gesture is *meant* to be suspended, and replacing it
+    // would just churn.
+    if (!soundGlobal.__ttpAudioEverRunning) return;
+    // Rebuilding is only worth a try while the user is looking at the page —
+    // hidden, the interruption is probably still being held by whatever they
+    // switched to, and a rebuild would burn the cooldown before the return.
+    if (pageHidden()) return;
+    const since = realClock.now() - (soundGlobal.__ttpAudioRecreatedAt ?? 0);
+    if (since < RECREATE_COOLDOWN_MS) return;
+    soundGlobal.__ttpAudioRecreatedAt = realClock.now();
+    await recreateContext();
+  } finally {
+    soundGlobal.__ttpAudioRecovering = false;
+  }
+}
+
+function pageHidden(): boolean {
+  return (
+    typeof document !== "undefined" && document.visibilityState === "hidden"
+  );
+}
+
+/**
+ * Safari reports interruptions through `statechange`. Recovering straight away
+ * is usually refused while the other app still holds the session, but it costs
+ * one attempt and wins the case where the interruption has already ended.
+ */
+function watchContextState(ctx: AudioContext): void {
+  if (typeof ctx.addEventListener !== "function") return;
+  ctx.addEventListener("statechange", () => {
+    if (ctx !== soundGlobal.__ttpAudioCtx) return;
+    if (ctx.state === "running") return;
+    // Resume only: the interruption is usually still held by whatever took the
+    // session, so this is a cheap "has it already ended?" check. Rebuilding is
+    // left to the signals that mean the user is actually back.
+    void ensureRunning({ allowRecreate: false });
+  });
+}
+
+// Every signal that the page is back in front of the user, plus a capture-phase
+// gesture listener as the last resort: `passive`/`capture` keeps it out of the
+// way of the app's own handlers, and it does nothing at all while audio is
+// healthy, so the common path is one state read per tap.
+if (typeof document !== "undefined" && !soundGlobal.__ttpAudioListenersArmed) {
+  soundGlobal.__ttpAudioListenersArmed = true;
+
   document.addEventListener("visibilitychange", () => {
     if (document.visibilityState !== "visible") return;
-    if (soundGlobal.__ttpAudioCtx) void soundGlobal.__ttpAudioCtx.resume();
-    nudgeKeepAlive();
+    void ensureRunning();
   });
+  window.addEventListener("pageshow", () => void ensureRunning());
+  window.addEventListener("focus", () => void ensureRunning());
+
+  const onGesture = (): void => {
+    if (!audioAvailable()) return;
+    // Only spend work when something is actually wrong — and only once the
+    // context exists, so a tap before the unlock gesture stays a no-op.
+    if (!soundGlobal.__ttpAudioCtx) return;
+    if (contextRunning() && !soundGlobal.__ttpSilentKeepAlive?.paused) return;
+    void ensureRunning();
+  };
+  for (const type of ["pointerdown", "touchend", "click"] as const) {
+    document.addEventListener(type, onGesture, {
+      capture: true,
+      passive: true,
+    });
+  }
 }


### PR DESCRIPTION
> **Status: does not fix #228.** Real-device testing shows sound still never returns after an interruption — and a page refresh or a Safari restart does not restore it either, which puts the cause outside anything this page can control. See https://github.com/ewanhardingham/table-top-poker/issues/228#issuecomment-5309496867. Held pending the diagnostics listed there.

Relates to #228 — on iPhone/Safari, playing other media (an Instagram video, a call, another tab) and returning to the game tab left the page silent for good.

## What was wrong

iOS parks the `AudioContext` in Safari's `"interrupted"` state and pauses the silent keep-alive element that routes Web Audio through the media channel (#178). Coming back undid neither: the single `resume()` on `visibilitychange` is routinely ignored right after foregrounding, an interruption Safari refuses to lift only clears with a *new* context, and every cue afterwards started a buffer source into silence with nothing noticing.

## What this does

A recovery ladder in `webAudio.ts`, re-entered from every signal that the page is back — `visibilitychange`, `pageshow`, `focus`, the context's own `statechange`, and the next cue itself:

1. restart the keep-alive element and `resume()` the context, retrying with backoff;
2. if it is still not running **and the page is visible**, rebuild the `AudioContext` and re-decode the cues — rate-limited to once per 5s, and never for a context still waiting on its first unlock gesture;
3. otherwise leave it: capture-phase `pointerdown`/`touchend`/`click` listeners re-run the ladder on the user's next tap, the one moment iOS reliably grants audio again.

`statechange` only takes step 1 — while the other app still holds the session a rebuild is wasted, so it is saved for the return. Cues no longer start sources against a context that is not `running`.

## Testing

New `webAudio.test.ts` fakes `AudioContext`/`<audio>`/the DOM events and covers the ladder's decisions: resume-on-return, no rebuild while the interruption is held, rebuild when resume stays refused, and recovery on the next tap when every automatic path failed. Three of the five fail against the old implementation.

`npm run lint`, `npm run build` and the ui-shared/player-client/table-client suites pass locally. The real-device check (interrupt with an Instagram video, return to the tab) still wants a human on an iPhone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWVDggdkK43LhJqMudvKM3
