### PR TITLE
fix(player): keep the burger menu reachable on narrow screens

### DIFF
--- a/docs/adr/0005-players-can-release-their-own-seat.md
+++ b/docs/adr/0005-players-can-release-their-own-seat.md
@@ -6,6 +6,10 @@ Accepted. Complements [ADR-0003](0003-eviction-is-a-manual-table-action.md):
 the table's manual evict frees *someone else's* seat; this adds a player
 freeing *their own*. Neither revives the automatic eviction ADR-0003 removed.
 
+Putting the seat actions behind the burger makes that button the only route
+to them; [ADR-0006](0006-the-player-menu-is-always-reachable.md) is what
+keeps it reachable.
+
 ## Context
 
 A player could sit out (skip hands while keeping their seat) but had no way

--- a/docs/adr/0006-the-player-menu-is-always-reachable.md
+++ b/docs/adr/0006-the-player-menu-is-always-reachable.md
@@ -71,6 +71,12 @@ out > player name > connection.** Concretely:
 - Top-bar pills are tracked at `0.1em` rather than `0.16em`, trimmed on the
   shared style so the row still reads as one set.
 
+The last three rules are not about the burger and so are not the player's
+alone: any status bar with more content than width picks something to
+sacrifice, and picking by shrink weight beats picking by accident. The
+table's bar follows them too — its badge collapses to the dot, and its room
+pill drops the `ROOM` kicker before the code.
+
 Because jsdom has no layout engine, the automated guard is on this structure
 — the reserved track, the shrinkable column, the truncation target — and not
 on measured widths, which would pass on a bar that still overflows. The
@@ -89,6 +95,13 @@ to this bar want a real render at 320px with every pill forced on.
   seat number, waiting can only mean the next hand.
 - Anything added to the reserved track in future shares a fixed column with
   the burger and so competes with it directly. Prefer the flexible column.
-- `table-client`'s status bar still uses the unshrinkable-flex pattern this
-  supersedes for the player. It has no menu to lose, so it is a latent
-  layout bug rather than a trap, and is left for a separate change.
+- `table-client`'s status bar carried the same unshrinkable-flex pattern and
+  now follows the same rule: its connection badge yields its label to the
+  bare dot, and the room pill gives up its `ROOM` kicker before the code.
+  There is no menu to strand there, so the stake is only a badge pushed off
+  the edge below ~293px — but the discipline is the same one, and applying it
+  in both places is what stops the pattern being reintroduced by copying the
+  other client. Below ~215px the room pill and the badge cannot both fit at
+  their minimums and will overlap; no table display is that narrow, and
+  making the room code itself truncate would cost the one thing on that
+  screen a player has to be able to read.

--- a/docs/adr/0006-the-player-menu-is-always-reachable.md
+++ b/docs/adr/0006-the-player-menu-is-always-reachable.md
@@ -1,0 +1,94 @@
+# 0006 — The player menu is always reachable; the top bar degrades around it
+
+## Status
+
+Accepted. Builds on
+[ADR-0005](0005-players-can-release-their-own-seat.md): that decision moved
+the seat actions *into* the menu; this one is about the menu still being
+there to open.
+
+## Context
+
+ADR-0005 put sit out and leave behind the burger, which made the burger the
+only route to either. The player top bar was a flex row that could not
+shrink: the seat pill carried `flex: none`, so when its pills over-ran the
+width the connection badge and burger were pushed past the container edge.
+`.app-shell` sets `overflow: hidden`, so nothing scrolled the burger back
+into view — it was clipped away entirely.
+
+Observed on both Android and iOS with a seat pill, a sitting-out pill, a
+connection pill and the burger on one row. The player could neither sit out
+nor leave; the escape hatch ADR-0005 deliberately made available while
+disconnected was itself unreachable, and the worst case is a flaky
+connection — exactly when the sitting-out pill is showing and the player
+most wants out.
+
+Display names are already capped at 10 characters
+(`MAX_DISPLAY_NAME_LENGTH`), so the driver is the *number* of pills, not the
+length of any one of them. A wider phone does not fix it; it only needs one
+more pill.
+
+## Decision
+
+**The menu button's space is reserved by the container, and everything else
+in the top bar gives way to it.**
+
+The header is a grid of `minmax(0, 1fr) auto`. The second track is the
+burger's and cannot be consumed; the first is where all content lives and
+may shrink below its natural width. This is deliberately a property of the
+container rather than of its children: a flex row can be made to behave
+identically today, but only for as long as every future sibling is added
+with the right `flex` value. A fixed track cannot be taken back by a pill
+someone adds later.
+
+Every pill — including the connection badge — lives in the flexible column.
+Nothing shares the reserved track with the burger, because anything that does
+competes with it for exactly the space this decision is protecting.
+
+Within the flexible column, precedence runs: **menu > seat number > sitting
+out > player name > connection.** Concretely:
+
+- The seat pill truncates its *name* only; `· Seat N` is fixed and always
+  legible. The seat number is how a player identifies themselves against the
+  table screen, whereas their own name is the one thing on the bar they
+  already know.
+- The connection badge reports trouble, not health. It is hidden while
+  connected, and shown only once a connection has been made and lost —
+  `connectionStatus` starts at `disconnected` before any socket opens, so
+  showing that state verbatim would warn about a drop that has not happened,
+  on every load. The `hasEverConnected` latch in `connectionSlice` is what
+  separates the two, and clears with the connection.
+- When the badge *is* showing, it is the first thing to give way: it carries
+  `flex-shrink: 100` against the seat pill's 1, so its label collapses to the
+  bare status dot — which still reports the state in colour — long before the
+  player's name starts truncating. Precedence is expressed as a shrink weight
+  rather than a width breakpoint on purpose: a breakpoint would have to guess
+  how many pills are on the row, and would drop the label at widths where it
+  fits perfectly well.
+- No pill carries `min-width: 0` itself, only the text *inside* it. A pill
+  with `min-width: 0` shrinks past its own unshrinkable content and paints it
+  outside its border, over the pill beside it — the failure this replaced.
+- Top-bar pills are tracked at `0.1em` rather than `0.16em`, trimmed on the
+  shared style so the row still reads as one set.
+
+Because jsdom has no layout engine, the automated guard is on this structure
+— the reserved track, the shrinkable column, the truncation target — and not
+on measured widths, which would pass on a bar that still overflows. The
+structure is necessary but not sufficient: both the collapsing seat pill and
+the badge's misplacement in the reserved track passed the structural tests
+and were caught only by measuring the real thing in a browser. Layout changes
+to this bar want a real render at 320px with every pill forced on.
+
+## Consequences
+
+- Adding a pill to the player top bar can no longer hide the menu. It can
+  crowd or truncate the pills beside it, which is the intended failure.
+- A steady, connected player sees one fewer pill; a badge appearing now
+  means something is actually wrong.
+- `Waiting for next hand` is shortened to `Waiting` — in a pill next to a
+  seat number, waiting can only mean the next hand.
+- Anything added to the reserved track in future shares a fixed column with
+  the burger and so competes with it directly. Prefer the flexible column.
+- `table-client`'s status bar still uses the unshrinkable-flex pattern this
+  supersedes for the player. It has no menu to lose, so it is a latent
+  layout bug rather than a trap, and is left for a separate change.

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -30,6 +30,7 @@ export function App() {
   const seatId = usePlayerStore((state) => state.seatId);
   const displayName = usePlayerStore((state) => state.displayName);
   const connectionStatus = usePlayerStore((state) => state.connectionStatus);
+  const hasEverConnected = usePlayerStore((state) => state.hasEverConnected);
   const shotClockSettings = usePlayerStore((state) => state.shotClockSettings);
   const handView = usePlayerStore((state) => state.handView);
   const setRoomView = usePlayerStore((state) => state.setRoomView);
@@ -277,6 +278,7 @@ export function App() {
       <StatusBar
         showBadge={wsParams !== null}
         connectionStatus={connectionStatus}
+        hasEverConnected={hasEverConnected}
         inLiveHand={inLiveHand}
         onToggleSittingOut={handleToggleSittingOut}
         onLeave={handleLeave}

--- a/packages/player-client/src/SeatPanel.test.tsx
+++ b/packages/player-client/src/SeatPanel.test.tsx
@@ -4,13 +4,50 @@ import { describe, expect, it } from "vitest";
 import { SeatPanel } from "./SeatPanel.js";
 import { playerTopPillStyle } from "./topPillStyle.js";
 
+/**
+ * Markup with the tags stripped — the seat pill spans several of them — and
+ * its non-breaking spaces normalised, so assertions read as plain text.
+ */
+function textOf(html: string): string {
+  return html.replace(/<[^>]*>/g, "").replace(/\u00a0/g, " ");
+}
+
+function tagWithTestId(html: string, testId: string): string {
+  const tag = new RegExp(`<[a-z]+[^>]*data-testid="${testId}"[^>]*>`).exec(
+    html,
+  );
+  expect(tag, testId).not.toBeNull();
+  return tag?.[0] ?? "";
+}
+
 describe("SeatPanel", () => {
   it("shows the player's name while retaining the seat number", () => {
     const html = renderToStaticMarkup(
       <SeatPanel seatId={2} displayName="Avery" sittingOut={false} />,
     );
 
-    expect(html).toContain("Avery · Seat 3");
+    expect(textOf(html)).toContain("Avery · Seat 3");
+  });
+
+  /*
+   * The pill truncates from the name end only, so the seat number survives a
+   * squeeze (ADR-0006). jsdom has no layout, so the guard is on the structure
+   * that produces that: only the name may shrink and clip, and the seat number
+   * is fixed. A layout test would pass on a bar that still overflows.
+   */
+  it("truncates the name, never the seat number", () => {
+    const html = renderToStaticMarkup(
+      <SeatPanel seatId={2} displayName="Bartholomew" sittingOut={false} />,
+    );
+
+    const name = tagWithTestId(html, "claimed-seat-name");
+    expect(name).toContain("min-width:0");
+    expect(name).toContain("overflow:hidden");
+    expect(name).toContain("text-overflow:ellipsis");
+
+    // The seat number's own span is fixed, so it is never the part clipped.
+    const seatNumber = /<span style="flex:none">[^<]*Seat 3<\/span>/.exec(html);
+    expect(seatNumber).not.toBeNull();
   });
 
   it("shows the claimed seat", () => {
@@ -31,7 +68,10 @@ describe("SeatPanel", () => {
       />,
     );
     expect(html).toContain('data-testid="sitting-out-badge"');
-    expect(html).toContain("Waiting for next hand");
+    // Short by design: the label shares a narrow row with the seat pill and
+    // the menu, and "waiting" here can only mean the next hand (ADR-0006).
+    expect(html).toContain("Waiting");
+    expect(html).not.toContain("Waiting for next hand");
   });
 
   it("uses the same pill height for the seat and status chips", () => {

--- a/packages/player-client/src/SeatPanel.tsx
+++ b/packages/player-client/src/SeatPanel.tsx
@@ -9,6 +9,12 @@ export interface SeatPanelProps {
   readonly sittingOutReason?: SittingOutReason | null;
 }
 
+/*
+ * Non-breaking spaces: the separator opens a flex item, and a flex item's
+ * leading whitespace is trimmed away, which closed the gap to the name.
+ */
+const NAME_SEPARATOR = " · ";
+
 /**
  * The player's identity at the top of the screen: their seat (and name) plus a
  * presence-only sitting-out badge. The seat actions — sit out and leave — live
@@ -24,7 +30,9 @@ export function SeatPanel({
     <div
       data-testid="seat-panel"
       style={{
-        flex: "none",
+        // Shrinkable, so that whatever cannot fit gives way here rather than
+        // pushing the menu out of the bar (ADR-0006).
+        minWidth: 0,
         display: "flex",
         alignItems: "center",
         gap: "0.6em",
@@ -34,26 +42,50 @@ export function SeatPanel({
         data-testid="claimed-seat"
         style={{
           ...playerTopPillStyle,
-          gap: "0.5em",
+          /*
+           * No `min-width: 0` here on purpose. The pill's automatic minimum is
+           * the width its unshrinkable content needs — the seat number — so it
+           * stops there instead of collapsing and painting `Seat 6` outside its
+           * own border. Only the name inside it may shrink.
+           */
+          overflow: "hidden",
           background: color.control,
           border: `1px solid ${color.border}`,
           color: color.textMuted,
         }}
       >
-        {displayName ? `${displayName} · ` : ""}Seat {seatId + 1}
+        {displayName && (
+          <span
+            data-testid="claimed-seat-name"
+            style={{
+              minWidth: 0,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {displayName}
+          </span>
+        )}
+        {/* The seat number never truncates. It is how a player identifies
+         * themselves against the table screen, whereas their own name is the
+         * one thing on this bar they already know. */}
+        <span style={{ flex: "none" }}>
+          {displayName ? NAME_SEPARATOR : ""}Seat {seatId + 1}
+        </span>
       </div>
       {sittingOut && (
         <div
           data-testid="sitting-out-badge"
           style={{
             ...playerTopPillStyle,
+            flex: "none",
             background: "rgba(255,255,255,.04)",
             border: `1px solid ${color.border}`,
             color: color.textFaint,
           }}
         >
           {sittingOutReason === "waiting-for-next-hand"
-            ? "Waiting for next hand"
+            ? "Waiting"
             : "Sitting out"}
         </div>
       )}

--- a/packages/player-client/src/StatusBar.test.tsx
+++ b/packages/player-client/src/StatusBar.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { StatusBar } from "./StatusBar.js";
+import { StatusBar, connectionBadgeVisible } from "./StatusBar.js";
 
 const noop = () => undefined;
 
@@ -11,12 +11,19 @@ const handlers = {
   onLeave: noop,
 } as const;
 
+const seated = {
+  seatId: 0,
+  sittingOut: false,
+  sittingOutReason: null,
+} as const;
+
 describe("StatusBar", () => {
   it("hides the connection badge before a seat is claimed", () => {
     const html = renderToStaticMarkup(
       <StatusBar
         showBadge={false}
         connectionStatus="disconnected"
+        hasEverConnected={false}
         {...handlers}
         seat={null}
       />,
@@ -24,33 +31,65 @@ describe("StatusBar", () => {
     expect(html).not.toContain('data-testid="connection-status"');
   });
 
-  it("shows the connection badge once connecting begins", () => {
+  it("stays silent while the connection is healthy", () => {
     const html = renderToStaticMarkup(
       <StatusBar
         showBadge={true}
         connectionStatus="connected"
+        hasEverConnected={true}
         {...handlers}
-        seat={null}
+        seat={seated}
+      />,
+    );
+    expect(html).not.toContain('data-testid="connection-status"');
+  });
+
+  it("shows the badge when a live connection drops", () => {
+    const html = renderToStaticMarkup(
+      <StatusBar
+        showBadge={true}
+        connectionStatus="disconnected"
+        hasEverConnected={true}
+        {...handlers}
+        seat={seated}
       />,
     );
     expect(html).toContain('data-testid="connection-status"');
-    expect(html).toContain("connected");
+    expect(html).toContain("disconnected");
     expect(html).toContain("height:30px");
   });
 
-  it("shows the seat chip, badge, and menu together on the same row", () => {
+  /*
+   * The status starts at `disconnected` before any socket is opened, so
+   * reporting it verbatim would warn every player about a drop that has not
+   * happened, on every load (ADR-0006).
+   */
+  it("does not warn about a connection never yet made", () => {
+    for (const connectionStatus of ["disconnected", "connecting"] as const) {
+      expect(
+        connectionBadgeVisible(true, connectionStatus, false),
+        connectionStatus,
+      ).toBe(false);
+      expect(
+        connectionBadgeVisible(true, connectionStatus, true),
+        connectionStatus,
+      ).toBe(true);
+    }
+  });
+
+  it("shows the seat chip and menu together on the same row", () => {
     const html = renderToStaticMarkup(
       <StatusBar
         showBadge={true}
-        connectionStatus="connected"
+        connectionStatus="disconnected"
+        hasEverConnected={true}
         {...handlers}
-        seat={{ seatId: 0, sittingOut: false, sittingOutReason: null }}
+        seat={seated}
       />,
     );
 
     expect(html).toContain('data-testid="seat-panel"');
     expect(html).toContain("Seat 1");
-    // Seat chip, connection badge and menu button all live in the header row.
     const headerMatch = /<header[^>]*>[\s\S]*<\/header>/.exec(html);
     expect(headerMatch).not.toBeNull();
     expect(headerMatch?.[0]).toContain('data-testid="seat-panel"');
@@ -63,11 +102,68 @@ describe("StatusBar", () => {
       <StatusBar
         showBadge={false}
         connectionStatus="disconnected"
+        hasEverConnected={false}
         {...handlers}
         seat={null}
       />,
     );
     expect(html).not.toContain('data-testid="seat-panel"');
     expect(html).not.toContain('data-testid="player-menu-button"');
+  });
+
+  /*
+   * The menu holds sit out and leave, so a burger pushed off the edge strands
+   * the player — and `.app-shell` clips rather than scrolls, so it does not
+   * merely move, it disappears. jsdom cannot measure that, so these guard the
+   * structure that prevents it: a reserved column for the menu, and a left
+   * column that shrinks below its content instead of pushing.
+   */
+  it("reserves a column for the menu that content cannot consume", () => {
+    const html = renderToStaticMarkup(
+      <StatusBar
+        showBadge={true}
+        connectionStatus="disconnected"
+        hasEverConnected={true}
+        {...handlers}
+        seat={{
+          seatId: 5,
+          displayName: "Bartholomew",
+          sittingOut: true,
+          sittingOutReason: "waiting-for-next-hand",
+        }}
+      />,
+    );
+
+    const header = /<header[^>]*>/.exec(html)?.[0] ?? "";
+    expect(header).toContain("display:grid");
+    expect(header).toContain("grid-template-columns:minmax(0, 1fr) auto");
+
+    // The pills give way, not the menu.
+    const seatPanel =
+      /<div[^>]*data-testid="seat-panel"[^>]*>/.exec(html)?.[0] ?? "";
+    expect(seatPanel).toContain("min-width:0");
+    expect(seatPanel).not.toContain("flex:none");
+  });
+
+  it("keeps the menu with every pill showing at once", () => {
+    const html = renderToStaticMarkup(
+      <StatusBar
+        showBadge={true}
+        connectionStatus="disconnected"
+        hasEverConnected={true}
+        {...handlers}
+        seat={{
+          seatId: 5,
+          displayName: "Bartholomew",
+          sittingOut: true,
+          sittingOutReason: "waiting-for-next-hand",
+        }}
+      />,
+    );
+
+    expect(html).toContain('data-testid="claimed-seat"');
+    expect(html).toContain('data-testid="sitting-out-badge"');
+    expect(html).toContain('data-testid="connection-status"');
+    expect(html).toContain('data-testid="player-menu-button"');
   });
 });

--- a/packages/player-client/src/StatusBar.tsx
+++ b/packages/player-client/src/StatusBar.tsx
@@ -9,6 +9,8 @@ import type { ConnectionStatus } from "./store/connectionSlice.js";
 export interface StatusBarProps {
   readonly showBadge: boolean;
   readonly connectionStatus: ConnectionStatus;
+  /** Latched on the first successful connect; see `connectionSlice`. */
+  readonly hasEverConnected: boolean;
   readonly inLiveHand: boolean;
   readonly onToggleSittingOut: () => void;
   readonly onLeave: () => void;
@@ -31,41 +33,96 @@ const badgeTone: Record<
 
 const badgeStyle: CSSProperties = {
   ...playerTopPillStyle,
+  /*
+   * Precedence as a shrink weight rather than a breakpoint (ADR-0006): the
+   * connection is the first thing that should give way, so this yields its
+   * label ~100× faster than the seat pill beside it yields the player's name.
+   * A width threshold cannot do this — it would have to guess how many pills
+   * are on the row. Its minimum is its own dot: no `min-width: 0` here, so it
+   * stops at the unshrinkable content rather than collapsing.
+   */
+  flexShrink: 100,
+  overflow: "hidden",
   gap: "0.5em",
   background: color.control,
   border: `1px solid ${color.border}`,
 };
 
+/**
+ * The badge reports trouble, not health (ADR-0006). A permanent `CONNECTED`
+ * pill spends width on the one state that needs no reporting, and it is the
+ * state a player is in essentially always — so it is shown only while the
+ * connection is not good, and only once there has been a connection to lose.
+ * Without that second condition the pre-socket `disconnected` default would
+ * warn about a drop that has not happened, on every load.
+ */
+export function connectionBadgeVisible(
+  showBadge: boolean,
+  connectionStatus: ConnectionStatus,
+  hasEverConnected: boolean,
+): boolean {
+  return showBadge && hasEverConnected && connectionStatus !== "connected";
+}
+
 /** No connection badge before a seat is claimed — there's nothing to connect to yet. */
 export function StatusBar({
   showBadge,
   connectionStatus,
+  hasEverConnected,
   inLiveHand,
   onToggleSittingOut,
   onLeave,
   seat,
 }: StatusBarProps) {
   const tone = badgeTone[connectionStatus];
+  const badgeVisible = connectionBadgeVisible(
+    showBadge,
+    connectionStatus,
+    hasEverConnected,
+  );
   return (
     <header
+      className="player-status-bar"
+      data-testid="player-status-bar"
       style={{
         flex: "none",
-        display: "flex",
+        /*
+         * Two columns, and the second one is not negotiable: the menu holds
+         * sit out and leave, so a top bar that pushes the burger off the edge
+         * strands the player (ADR-0006). A flex row cannot promise that —
+         * any sibling added with `flex: none` silently reclaims the space —
+         * whereas a fixed track is a property of the container that no future
+         * pill can take back. `minmax(0, 1fr)` is what lets the left column
+         * shrink below its content instead of overflowing.
+         */
+        display: "grid",
+        gridTemplateColumns: "minmax(0, 1fr) auto",
         alignItems: "center",
-        justifyContent: seat ? "space-between" : "flex-end",
+        gap: "0.6em",
         padding: "16px 18px 0",
       }}
     >
-      {seat && (
-        <SeatPanel
-          seatId={seat.seatId}
-          displayName={seat.displayName ?? null}
-          sittingOut={seat.sittingOut}
-          sittingOutReason={seat.sittingOutReason}
-        />
-      )}
-      <div style={{ display: "flex", alignItems: "center", gap: "0.6em" }}>
-        {showBadge && (
+      {/* Every pill shares the flexible column. The badge belongs here rather
+       * than beside the burger: anything in the reserved track competes with
+       * the menu for it, and the connection is the *first* thing that should
+       * give way, not the last (ADR-0006). */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          minWidth: 0,
+          gap: "0.6em",
+        }}
+      >
+        {seat && (
+          <SeatPanel
+            seatId={seat.seatId}
+            displayName={seat.displayName ?? null}
+            sittingOut={seat.sittingOut}
+            sittingOutReason={seat.sittingOutReason}
+          />
+        )}
+        {badgeVisible && (
           <span
             data-testid="connection-status"
             data-status={connectionStatus}
@@ -80,12 +137,19 @@ export function StatusBar({
                 background: tone.dot,
               }}
             />
+            {/* First to go when the row is tight — the dot beside it keeps
+             * reporting the state in colour, so the label is the cheapest
+             * thing on the bar to lose. */}
             <span
+              className="connection-status-label"
               style={{
+                minWidth: 0,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
                 fontFamily: font.mono,
                 fontSize: fontSize.xs,
                 fontWeight: 600,
-                letterSpacing: "0.16em",
+                letterSpacing: "0.1em",
                 textTransform: "uppercase",
                 color: tone.text,
               }}
@@ -94,6 +158,14 @@ export function StatusBar({
             </span>
           </span>
         )}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "flex-end",
+        }}
+      >
         {seat && (
           <PlayerMenu
             sittingOut={seat.sittingOut}

--- a/packages/player-client/src/store/connectionSlice.ts
+++ b/packages/player-client/src/store/connectionSlice.ts
@@ -4,12 +4,30 @@ export type ConnectionStatus = "disconnected" | "connecting" | "connected";
 
 export interface ConnectionSlice {
   readonly connectionStatus: ConnectionStatus;
+  /**
+   * Latched on the first `connected`. The status starts at `disconnected`
+   * before a socket has ever been opened, which is indistinguishable from a
+   * dropped one by status alone — this bit is what tells them apart, so the
+   * player is never warned about a connection they have not yet made
+   * (ADR-0006).
+   */
+  readonly hasEverConnected: boolean;
   readonly setConnectionStatus: (status: ConnectionStatus) => void;
+  /** Back to the pre-socket state — the latch clears with the connection. */
+  readonly resetConnection: () => void;
 }
 
 export const createConnectionSlice: StateCreator<ConnectionSlice> = (set) => ({
   connectionStatus: "disconnected",
+  hasEverConnected: false,
   setConnectionStatus: (connectionStatus) => {
-    set({ connectionStatus });
+    set(
+      connectionStatus === "connected"
+        ? { connectionStatus, hasEverConnected: true }
+        : { connectionStatus },
+    );
+  },
+  resetConnection: () => {
+    set({ connectionStatus: "disconnected", hasEverConnected: false });
   },
 });

--- a/packages/player-client/src/store/store.test.ts
+++ b/packages/player-client/src/store/store.test.ts
@@ -17,6 +17,30 @@ describe("usePlayerStore", () => {
     expect(state.seatId).toBeNull();
   });
 
+  it("latches has-ever-connected on the first successful connect", () => {
+    expect(usePlayerStore.getState().hasEverConnected).toBe(false);
+
+    usePlayerStore.getState().setConnectionStatus("connecting");
+    expect(usePlayerStore.getState().hasEverConnected).toBe(false);
+
+    usePlayerStore.getState().setConnectionStatus("connected");
+    expect(usePlayerStore.getState().hasEverConnected).toBe(true);
+
+    // A later drop is a real one — the latch is what distinguishes it from
+    // the pre-socket default (ADR-0006).
+    usePlayerStore.getState().setConnectionStatus("disconnected");
+    expect(usePlayerStore.getState().hasEverConnected).toBe(true);
+  });
+
+  it("clears the latch when the connection is reset", () => {
+    usePlayerStore.getState().setConnectionStatus("connected");
+    usePlayerStore.getState().resetConnection();
+
+    const state = usePlayerStore.getState();
+    expect(state.connectionStatus).toBe("disconnected");
+    expect(state.hasEverConnected).toBe(false);
+  });
+
   it("updates the connection slice independently of the seat slice", () => {
     usePlayerStore.getState().setConnectionStatus("connected");
     usePlayerStore.getState().setSeat({ seatId: 3, sittingOut: false });

--- a/packages/player-client/src/topPillStyle.ts
+++ b/packages/player-client/src/topPillStyle.ts
@@ -13,11 +13,18 @@ export const playerTopPillStyle: CSSProperties = {
   display: "flex",
   alignItems: "center",
   height: 30,
-  padding: "0 12px",
+  padding: "0 10px",
   borderRadius: radius.pill,
   fontFamily: font.mono,
   fontSize: fontSize.xs,
   fontWeight: 600,
-  letterSpacing: "0.16em",
+  /*
+   * Tighter than the 0.16em used elsewhere: at this size the extra tracking is
+   * decoration, and it costs roughly a character of width per pill on a row
+   * that has none to spare. Trimmed here rather than on one pill so the row
+   * still reads as a set (ADR-0006).
+   */
+  letterSpacing: "0.1em",
   textTransform: "uppercase",
+  whiteSpace: "nowrap",
 };

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -72,6 +72,7 @@ export function useWebSocket(
   const setConnectionStatus = usePlayerStore(
     (state) => state.setConnectionStatus,
   );
+  const resetConnection = usePlayerStore((state) => state.resetConnection);
   const setRoomView = usePlayerStore((state) => state.setRoomView);
   const setSeat = usePlayerStore((state) => state.setSeat);
   const moveSeat = usePlayerStore((state) => state.moveSeat);
@@ -106,7 +107,10 @@ export function useWebSocket(
   useEffect(() => {
     const connection = connectionRef.current;
     if (connection === null) {
-      setConnectionStatus("disconnected");
+      // No params means no seat — leaving, or not yet joined. Clear the
+      // has-connected latch with the connection so a later session starts
+      // silent again rather than inheriting this one's history (ADR-0006).
+      resetConnection();
       return;
     }
     const activeConnection = connection;
@@ -214,6 +218,7 @@ export function useWebSocket(
     roomCode,
     token,
     setConnectionStatus,
+    resetConnection,
     setRoomView,
     setSeat,
     moveSeat,

--- a/packages/table-client/src/JoinCodeToggle.test.tsx
+++ b/packages/table-client/src/JoinCodeToggle.test.tsx
@@ -25,4 +25,26 @@ describe("JoinCodeToggle", () => {
 
     expect(html).not.toContain("position:absolute");
   });
+
+  /*
+   * Shrinkable rather than fixed, so a narrow bar squeezes this pill instead
+   * of pushing the badge beside it off the edge (ADR-0006). The label gives
+   * way; the code is what a player has to read off the screen to join, so it
+   * is fixed.
+   */
+  it("gives up its label before the room code", () => {
+    const html = renderToStaticMarkup(
+      <JoinCodeToggle roomCode="ABCD" onOpen={noop} />,
+    );
+
+    expect(html).toContain("flex:0 1 auto");
+    expect(html).not.toContain("flex:none;min-width:0");
+
+    const label = /<span style="[^"]*">Room<\/span>/.exec(html)?.[0] ?? "";
+    expect(label).toContain("flex-shrink:100");
+    expect(label).toContain("overflow:hidden");
+
+    const code = /<span style="[^"]*">ABCD<\/span>/.exec(html)?.[0] ?? "";
+    expect(code).toContain("flex:none");
+  });
 });

--- a/packages/table-client/src/JoinCodeToggle.tsx
+++ b/packages/table-client/src/JoinCodeToggle.tsx
@@ -6,8 +6,15 @@ export interface JoinCodeToggleProps {
   readonly onOpen: () => void;
 }
 
+/*
+ * Shrinkable rather than fixed, so a narrow table screen squeezes this pill
+ * instead of pushing the connection badge off the edge (ADR-0006). The
+ * `min-width: 0` is on the wrapper, never on the button — the button's own
+ * automatic minimum is what stops the room code being painted outside its
+ * border.
+ */
 const wrapperStyle: CSSProperties = {
-  flex: "none",
+  flex: "0 1 auto",
   minWidth: 0,
 };
 
@@ -21,6 +28,7 @@ const buttonStyle: CSSProperties = {
   border: `1px solid ${color.accentBorder}`,
   backdropFilter: "blur(6px)",
   WebkitBackdropFilter: "blur(6px)",
+  overflow: "hidden",
 };
 
 /**
@@ -41,8 +49,13 @@ export function JoinCodeToggle({ roomCode, onOpen }: JoinCodeToggleProps) {
         onClick={onOpen}
         style={buttonStyle}
       >
+        {/* The kicker yields first: it labels the pill, whereas the code is
+         * the thing a player has to read off the screen to join. */}
         <span
           style={{
+            minWidth: 0,
+            flexShrink: 100,
+            overflow: "hidden",
             fontFamily: font.mono,
             fontSize: fontSize.xs,
             fontWeight: 600,
@@ -55,6 +68,7 @@ export function JoinCodeToggle({ roomCode, onOpen }: JoinCodeToggleProps) {
         </span>
         <span
           style={{
+            flex: "none",
             fontFamily: font.mono,
             fontWeight: 700,
             fontSize: fontSize.lg,

--- a/packages/table-client/src/StatusBar.test.tsx
+++ b/packages/table-client/src/StatusBar.test.tsx
@@ -60,4 +60,34 @@ describe("StatusBar", () => {
     expect(html).toContain('data-testid="connection-status"');
     expect(html).toContain("margin-left:auto");
   });
+
+  /*
+   * The badge used to be `flex: none`, so on a narrow table screen it was
+   * pushed off the right edge rather than giving way (ADR-0006). jsdom has no
+   * layout engine, so this guards the structure that fixes it: the badge
+   * shrinks first and hard, and its own minimum is the status dot.
+   */
+  it("yields the connection label before the room pill gives ground", () => {
+    const html = renderToStaticMarkup(
+      <StatusBar
+        roomCode="ABCD"
+        connectionStatus="disconnected"
+        showRoomCode={true}
+        onOpenJoin={noop}
+      />,
+    );
+
+    const badge =
+      /<span[^>]*data-testid="connection-status"[^>]*>/.exec(html)?.[0] ?? "";
+    expect(badge).toContain("flex-shrink:100");
+    expect(badge).toContain("overflow:hidden");
+    // Not on the pill itself — that is what let it paint text outside its
+    // own border once it collapsed.
+    expect(badge).not.toContain("min-width:0");
+
+    const label =
+      /<span class="connection-status-label"[^>]*>/.exec(html)?.[0] ?? "";
+    expect(label).toContain("min-width:0");
+    expect(label).toContain("text-overflow:ellipsis");
+  });
 });

--- a/packages/table-client/src/StatusBar.tsx
+++ b/packages/table-client/src/StatusBar.tsx
@@ -27,6 +27,15 @@ const badgeStyle: CSSProperties = {
   borderRadius: radius.pill,
   background: color.control,
   border: `1px solid ${color.border}`,
+  /*
+   * Precedence as a shrink weight, as on the player's bar (ADR-0006): the
+   * connection is the first thing to give way, yielding its label ~100×
+   * faster than the room pill beside it. No `min-width: 0` here — the pill's
+   * automatic minimum is its own dot, so it stops there rather than
+   * collapsing and painting its text outside its border.
+   */
+  flexShrink: 100,
+  overflow: "hidden",
 };
 
 /**
@@ -62,7 +71,7 @@ export function StatusBar({
         <span
           data-testid="connection-status"
           data-status={connectionStatus}
-          style={{ ...badgeStyle, flex: "none", marginLeft: "auto" }}
+          style={{ ...badgeStyle, marginLeft: "auto" }}
         >
           <span
             style={{
@@ -73,8 +82,14 @@ export function StatusBar({
               background: tone.dot,
             }}
           />
+          {/* First to go when the bar is tight — the dot beside it keeps
+           * reporting the state in colour. */}
           <span
+            className="connection-status-label"
             style={{
+              minWidth: 0,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
               fontFamily: font.mono,
               fontSize: fontSize.xs,
               fontWeight: 600,


### PR DESCRIPTION
Closes #230.

Two commits: the player bar (the reported bug) and the table bar (the same defect, no menu at stake).

## The bug

`StatusBar`'s header was a non-wrapping flex row whose left group carried `flex: none`, so when the pills over-ran the width the burger was pushed past the container edge — and `.app-shell` sets `overflow: hidden`, so it was clipped away rather than scrolled to. Sit out and leave both live behind that button (ADR-0005), so the player was stranded, and the worst case is a flaky connection: exactly when the extra pills appear and exactly when they most want out.

Display names are already capped at 10 characters, so the driver is the *number* of pills, not the length of any one. A wider phone doesn't fix it; it just needs one more pill.

## `fix(player)` — keep the burger reachable

**A reserved track.** The header is a grid of `minmax(0, 1fr) auto`. The burger's column is a property of the container, so no pill added later can quietly reclaim it — a flex row can be made to behave identically today, but only for as long as every future sibling is added with the right `flex` value.

**Precedence as shrink weight, not breakpoints.** Every pill (including the connection badge) shares the flexible column, and gives way in a stated order: **menu > seat number > sitting out > name > connection**. The badge carries `flex-shrink: 100` against the seat pill's 1, so its label collapses to the bare status dot — which still reports state in colour — long before the name truncates. A width breakpoint would have to guess how many pills are on the row and would drop the label at widths where it fits fine.

**The badge reports trouble, not health.** Hidden while connected, and suppressed until a connection has actually been made — `connectionStatus` starts at `disconnected` before any socket opens, so showing it verbatim warned about a drop that hadn't happened, on every load. New `hasEverConnected` latch in `connectionSlice`, cleared with the connection.

**Smaller things:** the name truncates but `· Seat N` never does; top-bar tracking trimmed `0.16em → 0.1em` on the shared style; `Waiting for next hand` → `Waiting`.

## `fix(table)` — the same pattern, one screen over

The table's bar had the identical unshrinkable pair (room pill + badge, both `flex: none`); measured, the badge starts overflowing below ~293px. Nothing is stranded when it happens — there's no menu behind it — but leaving one client on the old pattern is how it gets copied back into the other.

Same rule, minus the reserved track only the burger needs: the badge collapses to its dot first, and the room pill gives up its `ROOM` kicker before the code, which is the one thing on that screen a player has to read.

## Verification

Structural tests (jsdom has no layout engine, so a width assertion there would pass on a bar that still overflows), plus real browser renders — the player bar at 320 / 360 / 375 / 393 / 430px with every pill forced on and a max-length name, the table bar from 240px to 768px. Nothing overflows at any of them.

Worth noting: the browser pass caught two defects the structural tests happily accepted — a seat pill that shrank past its own fixed text and painted `Seat 6` over the pill beside it, and the badge sitting in the *reserved* track where it competed with the burger. Both are fixed; the ADR records that these bars want a real render, not just green tests.

## Known limits

- Table bar below ~215px: the room pill and badge can't both fit at their minimums and overlap. No table display is that narrow, and truncating the room code to fix it would cost more than it saves.
- Player bar in the true worst case at 393px (max-length name + sitting out + dropped socket): the badge reads `DISCON…`. Shortening the status words (e.g. `OFFLINE`) would fix it, but that's a copy change beyond this scope.

Records **ADR-0006**, cross-linked with ADR-0005, covering both bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWVDggdkK43LhJqMudvKM3
