### PR TITLE
refactor: strip inline comments, move rationale to docs/design

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,25 @@
 # table-top-poker
 
+## Code comments
+
+Code documents itself through names, types, and structure. Reach for a clearer
+name or a smaller function before reaching for a comment. A comment is a last
+resort, and a rare one.
+
+Write an inline comment only when the reasoning is genuinely non-obvious *and*
+has nowhere better to live — and even then keep it to a line. Everything with a
+home elsewhere goes there instead:
+
+- Business logic, domain rules, and design rationale live in `CONTEXT.md`,
+  `docs/adr/`, or `docs/design/`. Reference the decision (`ADR-0002`, issue
+  number), don't restate it inline.
+- Machine-readable directives that must sit in the code stay — `eslint-disable`,
+  `@ts-expect-error`, `prettier-ignore` — each with the reason it's needed.
+
+Do not add comments that restate the code, label sections, narrate the obvious,
+or duplicate a type or name. When you touch a file, delete such comments you
+find.
+
 ## Commit convention
 
 This repository uses [Conventional Commits](https://www.conventionalcommits.org/). Every commit message must start with a type, an optional scope, and a description:

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,31 @@
+# Design notes
+
+Rationale that used to live in code comments. The code documents *what* it does
+through names and types; these notes hold the *why* — the non-obvious decisions,
+invariants, and trade-offs — so the source can stay comment-light (see the
+"Code comments" standard in `CLAUDE.md`).
+
+These are a companion to, not a replacement for, the canonical specs and
+decisions:
+
+- **ADRs** (`docs/adr/`) — accepted decisions with lasting consequences.
+- **`CONTEXT.md`** — the domain model and vocabulary.
+- **GitHub issues** — the PRDs/specs each feature was built to (referenced as
+  `#NNN`, and section references like `§7` point into those specs).
+
+A design note captures reasoning that has no better home among those. When a
+decision graduates to an ADR, trim the note to a pointer.
+
+## Notes
+
+- [`holecards.md`](holecards.md) — the player's hole-card gesture surface
+  (spec #138): the pure lifecycle, the pointer recognizer, coaching hints, and
+  the React binding.
+- [`engine.md`](engine.md) — the pure rules engine: value-less pot, positional
+  blinds, action order, determinism, and view derivation.
+- [`protocol.md`](protocol.md) — wire types and schemas: the single
+  trust-boundary schema pattern, room-wide settings, seat-state predicates.
+- [`server.md`](server.md) — transport layer: view secrecy/redaction, the
+  connection-independent action clock, seat lifecycle, caching, and bots.
+- [`clients.md`](clients.md) — player/table client and `ui-shared` notes: the
+  audio engine, viewport locking, reconnect, and rendering rationale.

--- a/docs/design/clients.md
+++ b/docs/design/clients.md
@@ -1,0 +1,80 @@
+# Clients and ui-shared
+
+Cross-cutting rationale for the player client, table client, and shared UI
+(`packages/player-client`, `packages/table-client`, `packages/ui-shared`).
+Per-component layout and styling choices live in the code; this captures the
+non-obvious, load-bearing decisions. The hole-card surface has its own note in
+[`holecards.md`](holecards.md).
+
+## Tactile sound (#186)
+
+Split into a pure engine and a browser-bound half so the event→cue mapping is
+unit-testable without Web Audio:
+
+- **`ui-shared/sound/engine.ts`** — a pure state machine over injected effects
+  (`play`, `now`, `schedule`). Cue ownership (revised #180): a **phone** voices
+  only its *own* two hole cards, plus its own fold/check/flip and your-turn
+  prompt; the **table** is the community voice and voices only the shared board,
+  staying silent through the deal. Multi-card deals fire one cue per card,
+  staggered (`dealStaggerMs` wider than `boardStaggerMs`) so they read as
+  distinct. The your-turn prompt is edge-detected (fires once when the turn
+  arrives, not per view) and **deferred** until the deal sweep finishes
+  (`lastHoleCardAt + turnAfterDealMs`) so cards land first; a `turnToken`
+  cancels a stale deferred prompt if the player acts or the hand ends before it
+  fires.
+- **Sounds fire only from `hand-update`, never `view-snapshot`** (the WS hooks
+  enforce this by only calling `onHandUpdate` for the former), so a
+  reconnect/refresh mid-hand can't replay a burst of cues (#175). The engine
+  never sees a snapshot.
+- **`ui-shared/sound/webAudio.ts`** — the production effects: one `AudioContext`,
+  a warm-decoded buffer per cue, gesture unlock. The context, buffer cache, and
+  engine are pinned to `globalThis` because the module is a stateful singleton
+  shared by the WS hook and the hole-card hook — a partial HMR update could
+  otherwise leave importers on different instances, each with its own suspended
+  context, so a cue would play through a context the gesture never unlocked.
+  `unlockAudio` (idempotent, called from any gesture that might be first) resumes
+  the context, arms the iOS workaround, and warm-decodes every cue so the first
+  real cue has no decode gap. Inert without Web Audio (jsdom/SSR).
+- **iOS silent-switch workaround (#178):** the hardware ringer switch mutes Web
+  Audio. A silently-looping `HTMLAudioElement` plays through the media channel
+  (which the switch doesn't gate), and keeping one active routes Web Audio to
+  that channel too. Armed on the unlock gesture; re-nudged on visibility change
+  (a woken phone can leave the context suspended).
+- **Assets are WAV/PCM, not AAC** (`cues.ts`, #185): iOS Safari's
+  `decodeAudioData` rejected the AAC set on some devices ("Decoding failed" on an
+  iPadOS table while an iPhone decoded the same build); PCM needs no codec and
+  decodes everywhere. Asset URLs are base-relative (`import.meta.env.BASE_URL`)
+  so they resolve under each client's deploy base (`/table/…`, `/player/…`) in a
+  release build and at root in dev. `call`/`raise` cues are unallocated (no chip
+  asset yet). Cue → room-settings category mapping lives in `CUE_CATEGORY`;
+  `cueAllowed` is the real mute path (master switch + category, #182).
+
+## iOS viewport lock (`player-client/lockViewport.ts`)
+
+iOS Safari lets the user pinch-zoom and pan the visual viewport even when the
+page forbids it: `user-scalable=no` has been ignored since iOS 10, and
+`touch-action: manipulation` only kills double-tap zoom. What *does* work on
+WebKit is cancelling the non-standard `gesturestart`/`gesturechange`/`gestureend`
+events and any multi-touch `touchmove` before it becomes a zoom or pan — both
+need **non-passive** listeners or the `preventDefault` is dropped. Single-touch
+moves are left alone: the hole-card peel is a one-finger drag that does its own
+`preventDefault`. This is why Android stays locked with the meta tag alone while
+iPhone needs this shim.
+
+## WebSocket reconnect
+
+A socket receives one fresh **snapshot** on connect (`view-snapshot`), never
+event replay (Phase 1 spec #130 §7, §9) — which is also why sound is gated to
+`hand-update`. A reconnecting seat resumes silently with no penalty; the server
+clears its presence badge. A player reconnecting after a positional repack
+(ADR-0004) may still hold the pre-repack seat in localStorage, so the client
+handles a `seat-moved` resync notice; the token, not the stored position,
+authenticates.
+
+## Rendering (`ui-shared`)
+
+`ui-shared` deliberately holds **no gesture concepts** — bend/turn/peel live in
+the player client (see `holecards.md`). The shared `Card`, theme tokens, and
+position marker are the whole cross-surface surface. Theme values are TypeScript
+tokens (not just CSS variables) because components style inline from them and
+there is no CSS-variable bridge; a cross-surface change is a one-token edit.

--- a/docs/design/engine.md
+++ b/docs/design/engine.md
@@ -1,0 +1,90 @@
+# Engine
+
+The pure poker rules engine (`packages/engine`). Event-sourced and side-effect
+free: `decide(state, command)` returns events or a `Rejection`, `apply(state,
+event)` folds one event into the next state, and `view(state, seat)` derives a
+restricted snapshot. See `CONTEXT.md` for vocabulary and `docs/adr/0001` for the
+value-less-pot decision.
+
+## No tracked pot, positional blinds
+
+The engine **never stores a chip amount** — no pot, no stack, no bet size
+(CONTEXT.md; Phase 1 spec #130 §1). Blinds are tracked *positionally*, exactly
+like the button. This is the single most load-bearing invariant, and several
+rules exist only to keep legality mirroring the physical chips without a value:
+
+- `facingBet` (`table.ts`): a seat faces a bet once someone has raised
+  (`raiseOccurred`); **preflop, before any raise, every seat except the big
+  blind also faces a bet** — the big blind's own post already matches it, which
+  is why the big blind alone may check an unraised preflop, and why that turn is
+  also their "option" (it's the last of the preflop lap).
+- `legalActions` is the **single source of truth** for action legality, consumed
+  by both `decide` (enforcement) and `view` (the client's `legalActions` field)
+  so the two can never drift. Fold and raise are always legal; check and call
+  are mutually exclusive and follow `facingBet`.
+
+## Positions and action order
+
+- The **ring** is the fixed positional order for the whole hand: button+1, …,
+  button (button last). Folds never change it; `toAct` is the live sub-sequence
+  owed a decision this street, `toAct[0]` being the current actor.
+- `isHeadsUp` is decided off the **ring** (the seats dealt), not the live seats.
+  Every position rule that reads differently heads-up — both blind seats and the
+  preflop order — asks this one question, so a short-handed lap can never read as
+  heads-up and disagree with the blind positions it was dealt with.
+- `smallBlindSeat`/`bigBlindSeat` use ring order, never seat-number arithmetic
+  (seats need not be contiguous). Heads-up the button posts the small blind, so
+  `smallBlind === button`; `bigBlind` is the non-button seat.
+- `initialToAct` (`table.ts`): postflop runs the ring as-is (SB→button). Preflop
+  with 3+ seats opens "with the first player to the left of the blinds" (Robert's
+  Rules) — the ring rotated past the two blinds (`ring[2]`). Heads-up opens on
+  the button/SB. The big blind is last in every case, so their option needs no
+  special machinery: every street closes the same way, when `toAct` drains.
+- `requeueAfterRaise`: after a raise, every *other* live seat gets one more turn
+  in position order starting after the raiser; the raiser isn't re-added, so the
+  street closes when the queue drains.
+
+## `apply` details
+
+- `ActionTaken` removes the acting seat from `toAct` **by identity**, not by
+  popping the head: ordinary actions belong to `toAct[0]`, but an eviction can
+  fold a live seat later in the queue while leaving the current actor at the
+  head.
+- `resolvedBlinds` snapshots `smallBlind`/`bigBlind`/`dealtSeatCount` at hand
+  completion, while `ring` is still in scope, so a completed hand (which drops
+  `ring`) reports the same positions `view` derives during betting — and so the
+  button's rotation on `HandComplete` can't reach back and change what the
+  finished hand says about itself. `dealtSeatCount` is fixed for the hand (folds
+  don't reduce it), so `2` identifies a heads-up hand in every phase.
+- `HandComplete` rotates the *engine* button (`nextButtonAfter`) but keeps the
+  completed hand's own recorded button, so the finished hand and the forecast
+  for the next one are independent.
+
+## Determinism
+
+Hole cards and board cards are all sliced from one seed-derived deck
+(`shuffledDeck(seed)`) by fixed position — no deck state is ever stored, so the
+remaining deck order is never reachable from engine state. `dealCommunityCards`
+starts at `numSeats * 2 + boardLenSoFar`.
+
+## Types and visibility
+
+- `SeatId` is a stable table position (0–7), never re-derived from an index into
+  a filtered/live array. A `Card`'s identity is its rank+suit, never its
+  position.
+- `RevealedResult` (a `ShowdownResult` with hole cards attached) is the **only**
+  place another seat's hole cards are structurally reachable, and only ever for
+  a seat that reached showdown live (Phase 1 spec #130 §4). Built once in
+  `apply` from the betting players map.
+
+## `view` derivation
+
+- Player and table views derive from the same authoritative state so the table
+  device is never privileged over a player (§4). The `"table"` sentinel selects
+  the table overload.
+- **Between hands there are no blind fields** (`NoHandView`): the engine button
+  has already rotated on, so `button` is a forecast, and the blinds are likelier
+  than the button to move again before the deal (seats can be claimed, vacated,
+  or set to sit out).
+- A seat's `yourHoleCards` is null once folded; `legalActions` is populated only
+  when it is that seat's turn (`toAct[0] === seatId`).

--- a/docs/design/holecards.md
+++ b/docs/design/holecards.md
@@ -1,0 +1,412 @@
+# Hole-card gesture surface
+
+The player's own hole cards, modelled as **an object they handle, not a picture
+they read** (spec #138). Cards arrive face-down and stay that way until the
+player asks for them; nothing in this module touches the server, changes poker
+visibility, or affects showdown. Section references (`§4`, `§11`, `story 27`)
+point into spec #138.
+
+Directory: `packages/player-client/src/holecards/`.
+
+## Module seam
+
+The module (`index.ts`) exports exactly **two** names: `HoleCardPair` (the
+component) and `CardActions` (the Action port it defines for itself). Everything
+else — the reducer, the hook, the view adapter, the bendable card, the
+constants, the coaching selector — is module-internal and imported by nothing
+outside this directory.
+
+That narrow seam is load-bearing. It keeps pointers, bends, and recognizer
+states out of `Hand`, and it is what lets each later gesture be an *addition
+inside* `holecards/` rather than surgery on the component tree. Two specific
+things must never cross the seam: the coaching **selector** (every in-gesture
+hint depends on recognizer state nothing outside may see, #135) and any
+lifecycle state. Only the persisted discovery set crosses.
+
+## Split by cardinality of change (§13)
+
+The organizing principle. State that changes a handful of times per hand is
+**discrete** and goes through `useReducer`; state that changes continuously
+under a moving finger is a Motion `MotionValue` written straight from the
+pointer handlers.
+
+Consequence: between threshold crossings a drag dispatches nothing, so it
+re-renders nothing — not `HoleCardPair`, not `Hand`, not `ActionBar`, not the
+turn banner. Peel progress, bend axis, fold offset, and fold fade are all
+`MotionValue`s for this reason. Rendering a continuous value through React
+(e.g. choosing a hint variant by axis) would re-render the pair every time a
+bend wandered across the diagonal — so both variants are rendered and a
+`MotionValue` toggles their opacity instead.
+
+## The pure lifecycle (`cardState.ts`)
+
+Presentation and Recognizer are modelled as two orthogonal machines but reduced
+by **one** pure `reduce` function, so a coupled event applies atomically and
+cannot half-land. Nothing here touches React or the DOM, which is why the whole
+behaviour contract is verifiable as plain function calls — no store, no socket,
+no simulated pointer.
+
+- `Presentation`: `Absent | FaceDown | Peeking | Turning | Revealed | Leaving`.
+  Pair-scoped — both cards always share one presentation.
+- `Recognizer`: `Idle | Pressing | Bending | FoldDragging | Ignored | Committed`.
+- `armed`: whether releasing now commits the Fold. Only ever true while
+  `FoldDragging`.
+- `locked`: showdown reached with this seat still live (story 48). Its own field
+  rather than a recognizer state or presentation, because the lock is not a
+  gesture outcome and `Revealed` is reachable two ways where only one is final.
+
+`CardState`/`CardEvent` are intentionally **complete**: every event name the
+phase needs is declared even where an arm does not yet answer it, so later
+slices add arms against this shape rather than reshaping it.
+
+### Key reducer rules
+
+- **Lock allow-list.** A locked pair hears only `DEALT`, `CARDS_GONE`,
+  `SHOWDOWN_REVEAL`, `TURN_FINISHED` (`survivesLock`). Enforced once at the top
+  of `reduce`, so tap/gesture events added later are inert against a decided
+  hand *by default* and cannot reach one by being forgotten. `RESET` is
+  deliberately **not** on the list: backgrounding must not conceal a showdown
+  reveal (public table truth), and a reload remounts straight to `Revealed` off
+  the `locked` prop — honouring `RESET` here would make the two paths §9 names
+  in one breath disagree.
+- **Deal detection.** `DEALT` is unconditional from every presentation: it is
+  what makes every hand start face-down, so no face-up frame of the previous
+  hand survives into the next. It also ends a showdown lock.
+- **First pointer wins (§4).** While a gesture is live, a second finger landing
+  (`PRESSED`) is ignored until the first releases/cancels. Latest-pointer-wins
+  would let a stray thumb silently retarget a fold drag.
+- **Classification stickiness.** `CLASSIFIED` is accepted only from `Pressing`,
+  so `classify` runs once and a second classification is a no-op; `Ignored`
+  stays terminal until release.
+- **Bend is atomic.** Classifying as `Bending` moves the recognizer *and* opens
+  the peel (`Peeking`) in one reduce — no frame where the pair is bending but
+  still face-down.
+- **Reveal via bend has no separate flip.** `BEND_CROSSED` (peel past the
+  reveal threshold) *is* the commit: the same sheet carries past the opposite
+  corner and lands face-up (`Turning` → `Committed`). A keyboard reveal
+  (`ACTIVATED` from `FaceDown`) starts at 0 and gets the identical `Turning`
+  motion, which is what makes Enter and a bend produce the same object behaving.
+- **Peeking is not self-stable.** A peek is held open by the finger; letting go
+  for any reason closes it to `FaceDown` (`settled`). A glance costs nothing and
+  leaves nothing exposed.
+- **`RELEASED` is the one commitment.** Crossing the fold threshold only *arms*;
+  the completing release commits (`Leaving`). So an accidental crossing during a
+  scroll-like motion cannot fold, and putting the cards back down is always a
+  way out (§10). The pair leaves with **whatever face it had** — presentation is
+  not consulted, so a revealed pair flies away face-up rather than flipping over
+  inside a 280ms departure (§7). Every non-committing release falls through to
+  the same settle as `CANCELLED`; the only thing the two don't share is that
+  cancellation is never a commitment, which is the sole reason `RELEASED` has
+  its own arm.
+- **`Turning`/`Leaving` are points of no return** for both lift and
+  cancellation: the flip completes (mid-turn is not a *stable* presentation),
+  and a committed Fold can only be answered by the server.
+- **Conceal is instant, reveal is a flip.** `ACTIVATED`/`TAPPED` on `Revealed`
+  go straight to `FaceDown`; a tap on an already-face-down pair does nothing —
+  which is what makes the first tap of a double-tap Check free (§5). A revealing
+  tap would put a face-up frame between the two taps and charge the commonest
+  free Action a reveal.
+- **`DOUBLE_TAPPED` changes no presentation.** The first tap already concealed;
+  the second buys a Check, which is an *effect* the reducer cannot have. The
+  hook sends it through `actions.check`, so gesture and button reach
+  `intent.check` by the identical route and `canAct` stays the single legality
+  gate (§2). Reducing it here anyway is what makes it inert against a decided
+  hand for free via `survivesLock`.
+- **Arm/disarm are the same shape.** `FOLD_ARMED`/`FOLD_DISARMED` just move the
+  flag; the drag keeps tracking the finger either way, so the surface never
+  freezes under the player's hand. A drag pulled back below threshold and one
+  whose legality vanished mid-motion (#146) both disarm through here — the
+  recognizer can't tell them apart and doesn't need to.
+- **`PENDING_RESOLVED` is scoped to `Leaving`.** Every Action resolves through
+  it but only a Fold left the pair waiting; Call/Raise/Check must leave the
+  cards untouched (§9). Acknowledged → `Absent`; rejected → **`FaceDown`, never
+  `Revealed`** (a rejection leaves the player holding a live hand, not one they
+  have shown themselves).
+- **`SHOWDOWN_REVEAL`** turns face-up and locks, using the *same* animated flip
+  a bend commits to (story 47) — except when the player already turned the cards
+  over, where re-flipping would be motion with nothing to say. Withheld by the
+  adapter for a folded-out seat, but the reducer also guards `Absent`/`Leaving`
+  so folding stays final (story 49) without resting on being called correctly.
+
+`releaseCommitsFold(state)` is exported so the release rule is a tested function
+rather than a buried condition; its counterpart is `endGesture`'s `commitsFold`
+(below), and the two agree because both are driven by the same
+`FOLD_ARMED`/`FOLD_DISARMED` events.
+
+## The pointer recognizer (`gesture.ts`, `classify.ts`, `geometry.ts`)
+
+A live gesture is a **value** (`GestureSession`) the hook holds in a ref, never
+in React state. Discrete facts on it (`classification`, `crossed`) become
+reducer events; continuous ones (peel, offset) become `MotionValue`s.
+
+- `crossed` is **one-way**: the reveal commit happens on crossing, so dragging
+  back cannot un-commit and must not re-announce it.
+- `armed` is deliberately **not** one-way (unlike `crossed`): crossing the fold
+  line only arms; the commitment is the release, so pulling the cards back down
+  disarms and the player can always change their mind.
+
+`classify` is the whole of the §4 table as a pure function (no "undecided"
+member — classification happens once, past the slop):
+
+- **Bend zone wins outright while face-down**, so a press on the corner locks
+  into `Bending` and a later upward swipe keeps bending. Fold stays available
+  from the whole rest of the pair. The alternative (a bend→fold promotion rule)
+  would need a second, more decisive upward threshold, weakening the fold
+  threshold everywhere else to recover one corner. On an already-revealed pair
+  there is nothing to peel, so the corner is ordinary surface and a fold may
+  start from it.
+- **`Ignored` is terminal**: a drag that starts sideways/downward cannot become
+  a fold by curving upward.
+- **Fold legality is sampled once**, at classification. A drag that outlives the
+  player's turn disarms (via `FOLD_DISARMED` from the prop change, applied to
+  the session by `applyCardEvent`) rather than reclassifying. `applyCardEvent`
+  touches the session on *only* that event — ending the session on any other
+  would strand the release, so `finish` would bail on a pointer it has no
+  session for and nothing would disown the synthetic click.
+
+Geometry (§15, read from the spec rather than re-derived):
+
+- **Peel progress** counts leftward and upward inward travel *equally*. So a
+  pure leftward drag drives the peel at full rate (finger clear of the rank/suit
+  being read), and because leftward alone suffices, the bend can't be stolen by
+  the fold recognizer, which needs upward dominance.
+- **Bend axis** ties read as `up` (finger over the face — the case the "drag
+  left" prompt fixes).
+- **Fold threshold** is a *distance* proportional to viewport height with a px
+  floor, so the swipe is the same gesture on every phone and a short/split
+  screen can't put the one irreversible, money-losing Action inside an ordinary
+  thumb flick. Re-measured per move (a keyboard or rotation changes it under a
+  running gesture).
+- **Fold flight distance** carries the committed pair off-screen (at least a
+  viewport, or twice the threshold), so the departure reads as *gone*.
+
+A flick fast enough to classify and cross in one move emits both events, in
+order, and the reducer applies them in order.
+
+## Finishing a gesture (`finishPlan.ts`, `taps.ts`)
+
+`planFinish` is the seam where a finger movement turns into a sent poker Action,
+pushed out of the renderer so it's tested by construction rather than by a
+simulated pointer (#156). It returns an ordered `effects` list; the hook owns
+only the imperative replay (dispatch events, call the named Action functions,
+seed the confirmation timer).
+
+The order encodes the two sequences that cost money:
+
+- **conceal before Check** — the `TAPPED`/`DOUBLE_TAPPED` dispatch precedes the
+  `check` send, so the player sees the cards go down then the confirmation, with
+  no timer between (story 31);
+- **depart before Fold** — `leaving` is applied and `RELEASED` dispatched before
+  the `fold` send, so the pair is already flying to the muck when the Action
+  goes and the departure is the player's own answer, not the server's (§7).
+
+Legality (`foldLegal`/`checkLegal`/`pending`) is for **arming and rendering
+only**. `canAct` inside `intent.fold`/`intent.check` stays the single gate on
+whether an Action is sent, so a stale flag can at worst arm a gesture `canAct`
+then refuses — never send one. `planFinish` re-samples fold legality (and
+`pending`, so a Fold can't stack on an in-flight Action) because a release can
+beat the view that would have disarmed it; a drag that armed but outlived its
+turn emits `FOLD_DISARMED` before `RELEASED`, with no rejection message because
+the turn banner already explains it (§6).
+
+Tap window (§5, story 27) — **no timer arbitration**. A tap is answered the
+moment it lands: the Check goes on the second tap's *arrival*, not on a timer
+deciding 280ms later that no second tap is coming. That makes the gesture a
+reflex, and it's why the conceal from the first tap is visible before the Check
+it may become. Accepted trade-off: a Check can't be sent while keeping the cards
+face-up (the first tap already put them down); one tap gets them back. A
+completed pair closes the window rather than carrying the second tap forward, so
+three quick taps send **one** Check. `confirmsCheck` decides only whether to
+*tell* the player it landed (rendering), never whether it's sent.
+
+The clock is monotonic (`performance.now()`) throughout, so a wall clock
+stepping backwards mid-hand can't pair two unrelated taps into a Check.
+
+## View adapter (`viewEvents.ts`)
+
+`eventsForPropChange` is the one place a server-shaped `PlayerView` becomes
+lifecycle events (§8) — the reducer never sees a view and the hook decides
+nothing, which makes "an incoming view is inert" a tested property. The
+**default return is the empty array**: `hand-update` fires for every event in
+the hand, and peeking at your cards is exactly what you do while others act, so
+a new street, board card, another player's bet, or changed `toAct` must all
+produce nothing.
+
+- Cards arriving is the deal signal (there is no hand id on `PlayerView`), by
+  card *identity* not reference, with a value comparison as a defensive second
+  signal for a betting→betting swap without an intervening empty view.
+- `SHOWDOWN_REVEAL` is ordered *after* `DEALT`, so a seat whose cards only
+  arrive at showdown is dealt in before it's revealed.
+- Only the falling edge of `pending` produces `PENDING_RESOLVED` (the pair
+  already moved itself to `Leaving` on release); acknowledged vs rejected is
+  read off the cards, not off any rejection state.
+- Fold legality disappearing under a live `FoldDragging` is the one §8
+  disturbance that reaches an in-progress gesture; if the same view also removes
+  the cards (clock expiry/eviction), `CARDS_GONE` ends the gesture and is the
+  only event needed.
+
+`eventsForVisibility` handles the one reset that isn't a prop change: the app
+leaving the foreground (`visibilitychange`, a document event the hook
+subscribes). Only the outbound (`hidden`) edge produces `RESET` — coming back is
+not a second disturbance, and concealing cards the player has since turned over
+would be. The other two §9 resets need no subscription: a new hand arrives as
+`DEALT`, a reload remounts through `initialCardState`.
+
+## React binding (`useHoleCards.ts`)
+
+`useHoleCards` binds the pure lifecycle to React and holds no rules worth
+testing through a renderer — every decision is delegated (`eventsForPropChange`,
+`moveGesture`, `reduce`, `planFinish`). Notable choices:
+
+- The prop-change adapter runs in a **layout** effect
+  (`useIsomorphicLayoutEffect` — `useEffect` on the server to avoid the SSR
+  warning), deliberately un-keyed: the adapter compares props itself and returns
+  nothing for the vast majority of renders. A layout effect means a new hand's
+  cards are never painted under the previous hand's presentation.
+- `leavingFaceUp` and `departing` are React state (read during render) but
+  written only in the same event as the commit, so they land in the same render
+  as `Leaving` — no frame shows the wrong face or an empty seat.
+- `departing` keeps the committed pair rendered for exactly one flight
+  (`FOLD_FLIGHT_MS`) after the `cards` prop is taken away. The flight is
+  fire-and-forget on its own ~280ms schedule and **not** gated on the round trip
+  (§7): on a LAN the ack lands tens of ms in and would otherwise make the
+  promised departure a blink (story 20).
+- `inFlight` = `Leaving`, or (`departing` set and `Absent`) — the ack resolves
+  the reducer to `Absent` within ms, and the flight isn't gated on it. The
+  flight effect depends on nothing but `inFlight`, and **stopping the animation
+  on cleanup is what makes a rejection interrupt the departure** rather than
+  finish it: the flight is a prediction of server truth, and finishing it after
+  a contradiction would lie to the player.
+- `disownClicksUntil` is a *deadline*, not a flag: every completed gesture
+  (including a tap) disowns the synthetic `click` the browser raises afterwards,
+  which would otherwise re-answer the gesture (re-reveal a just-concealed pair,
+  or reveal on the first tap of a Check). A flag would go stale because a click
+  isn't guaranteed to arrive (touch drags usually produce none; cancelled
+  pointers never do) and would swallow the next real activation, including the
+  Enter/Space §12 guarantees.
+- `finish` reads off the `session` ref (as current as the events the reducer has
+  been given), because the rendered state can lag a threshold crossed one
+  pointer event ago and a fast flick is the commonest way to fold.
+- Contact tracking (`pointersDown`, `contact`) is separate from the
+  gesture-owning pointer: a stray second thumb is ignored as a *gesture* but is
+  still a finger on the cards, so a hint must not reappear under it. `quiet` is
+  the ~2s of stillness the teaching hints wait for, keyed on the eligible
+  gesture *and* contact so it's an interval, not a one-time delay.
+- `coarsePointer` is **subscribed**, not read once, so a tablet gaining/losing a
+  trackpad follows the pointer actually in use. `(pointer: coarse)` (primary),
+  not `any-pointer: coarse` — the latter is true for any touchscreen laptop,
+  exactly the case the touch gate excludes.
+- The return spring for the pair coming to rest is a spring, not a duration:
+  the cards were being *carried*, and letting go of something carried has weight
+  and a little overshoot.
+
+## Coaching hints (`coaching.ts`)
+
+The four teachable gestures, **in teaching order**: `bend`, `conceal`, `check`,
+`fold`. Bend is Peek *and* Reveal (one gesture at two depths), which is why
+there are four and not five. The order *is* the list — the selector offers the
+first gesture not yet found — so "at most one hint" and "Bend before Conceal
+before Check before Fold" are the same fact, not two rules that could disagree.
+
+`selectHint` returns the one hint to show, or none, with a strict precedence:
+
+1. **Check confirmation** (`checkConfirmed`) outranks everything, including the
+   pending gate it necessarily trips — it's the answer to a gesture just made
+   (story 31), and without it the only sign a double-tap landed is the ActionBar
+   the gesture exists to stop the player watching.
+2. Nothing while `pending`, `locked`, or `Absent`.
+3. **In-gesture prompts** (bend / fold feedback) — permanent for *every* player
+   forever, **not** gated on the discovery set or the coarse-pointer gate. They
+   say what releasing will do, and for the fold that text *is* the arming
+   signal: there is no rendered fold-threshold marker and browser vibration is
+   Blink-only, so on iPhone/Safari the fold line plus the card motion is the
+   whole signal. Card motion and text must never disagree.
+4. **Teaching hints** — instruction, gated on `coarsePointer` (don't tell a
+   keyboard player to bend corners), an idle recognizer, the quiet interval, and
+   a held presentation (`FaceDown`/`Revealed`).
+
+`nextTeachable` is separate from `selectHint` because the quiet interval is
+measured *from the moment eligibility becomes true*: the caller must know which
+gesture is up before deciding whether it has waited long enough. Otherwise only
+the first hint of a session would observe the interval and Fold would appear the
+instant a turn made it legal.
+
+`discoveredBy` decides which gesture a card event proves found — **on-pair,
+never on a button**: every event it sees comes from the recognizer, and pressing
+Fold/Check in the ActionBar reaches the module only as a prop change. That's the
+point: the hint exists to move the player off the button, so the button must not
+retire it. Discovery is on the *classification* (the motion made), and a tap
+retires the conceal hint only where it actually hid something.
+
+Copy and eligibility live together in `TEACHING` so each gesture is defined
+once. Check sits above Fold in the overlap, which is quieter than it looks: a
+legal Check means no bet to face, so teaching someone to fold for free is bad
+advice; where a bet *is* faced, Check is illegal and Fold is the only eligible
+hint — so the irreversible, money-losing Action is never pushed at a player two
+hands into their first session. The bend's corner is derived from the rendered
+affordance (`BEND_CORNER`), so if the layout ever mirrors, the words follow.
+
+Only the Check confirmation is announced to a screen reader (`announce`);
+teaching hints and in-gesture prompts describe what the player *could* do, and
+announcing those over a live gesture would be noise.
+
+Discovery persists (`hintStorage.ts`) per-device and permanently — a returning
+player is not re-taught. Absent/malformed storage both read as "nothing
+discovered" (an extra hint is the cheapest way to be wrong); an allow-list on
+read/write keeps a name from a later version or a hand edit from reaching the
+selector. Writes swallow their exception: Safari private browsing throws, and
+the write shares a handler with a Fold/Check that must not be lost over a hint.
+
+## Components (`HoleCardPair.tsx`, `BendableCard.tsx`, `CheckStamp.tsx`)
+
+`HoleCardPair` is a real focusable `button`: Enter/Space toggle reveal/conceal,
+so reading your own cards never depends on a gesture's timing (§12). It renders
+off the **lifecycle's** `locked`, not the prop (the prop is the adapter's
+input), so keyboard and gesture can't part company. A committed pair renders
+from `departing` once the prop drops it; an `Absent` presentation during the
+deal-observation gap renders as `FaceDown` (the honest entry state).
+
+- The pair claims the whole card region (`flex: 1`, auto margins) so spare
+  height on a tall phone is placed *inside* the column, collapsing to the tight
+  stack on a short screen.
+- `touchAction: none`, `userSelect/WebkitTouchCallout/WebkitUserSelect: none`,
+  and `onContextMenu={preventDefault}` stop the OS callout/selection menu and
+  the browser claiming the drag as a pan or the second tap as a zoom (§16). The
+  app shell is fixed and non-scrolling, so taking the whole gesture loses
+  nothing. `WebkitTapHighlightColor: transparent` kills the Android Chrome
+  press wash that a long-press holds long enough to read as a highlight (#195).
+- A locked pair is inert but keeps its accessible name and tab order (at
+  showdown that name is where a screen-reader user reads their hand; `disabled`
+  would remove it). The accessible name carries state, the activation outcome,
+  and — once revealed — the card faces themselves.
+- The deal-in `motion.span` is keyed on **card identity** so a new hand replays
+  the face-down deal-in (§17), replacing `Hand`'s per-card face-up animation;
+  the key is on the motion element so it restarts an animation without
+  discarding lifecycle state. A nested `motion.span` carries the fold offset/fade
+  from `MotionValue`s so they compose with the declarative deal-in instead of
+  fighting over `y`/`opacity` on one element.
+- `Announcer` is a `role="status"` live region mounted for the pair's lifetime
+  and empty until there's news: a live region inserted *with* its text isn't
+  reliably announced, so it must pre-exist. The visible hint copy is hidden from
+  AT so news is read once.
+
+`BendableCard` (§14) keeps bend/turn in the player client so `ui-shared` gains
+no gesture concepts. The bend is a real corner curl via `react-peel`, not a
+wipe: you read the card's own face on the *underside* of a lifted sheet, which
+is what makes it feel like lifting a physical card. Because `react-peel` pins
+the back layer's bottom-left corner for a bottom-right peel, the face's own
+bottom-right index falls outside the visible curl (a bend used to show bare
+white card) — `CurlIndex` is that index remapped to where the geometry puts it,
+rotated 180° to read upright, and hidden from AT (the accessible reveal is
+`Revealed`). The face's own corner indices are suppressed on the curl copy
+(`app-shell.css`) because they land arbitrarily once the sheet rotates. Crossing
+the threshold carries the same sheet past the opposite corner rather than
+starting a different animation — which is why the peel is mounted for `Turning`
+as well as `Peeking`. The face is in the document only while looked at
+(`curling`), so a face-down pair carries no rank/suit at all.
+
+`CheckStamp` is the sighted Check confirmation: non-interactive
+(`pointerEvents: none`, so a tap on it is still a tap on the cards) and hidden
+from AT (the live region already speaks it). Styled from theme tokens because
+there's no CSS-variable bridge to them. Reduced motion gets the stamp already at
+rest rather than the same movement hurried into an imperceptible duration.

--- a/docs/design/protocol.md
+++ b/docs/design/protocol.md
@@ -1,0 +1,53 @@
+# Protocol
+
+Shared wire types, Zod schemas, and small predicates between server and clients
+(`packages/protocol`).
+
+## Single trust-boundary schema
+
+Every value that crosses the untrusted HTTP/WS boundary has **one** schema that
+is the sole definition of its valid range, parsed by both the server edge and
+shared by the clients so the bounds can never drift between wire and store:
+
+- `SeatCountSchema` (`MIN_SEAT_COUNT`=2 … `MAX_SEAT_COUNT`=8) — 2 is heads-up,
+  the smallest dealable table; 8 is the physical felt limit. The count is
+  per-room (the creator picks it), not a global constant. `RoomStore.create` and
+  `POST /rooms` both parse through it.
+- `ShotClockSettingsSchema` (5…600s) is the single trust-boundary definition for
+  the action clock.
+- `ClaimSeatRequestSchema` enforces the required display name (1…10 chars).
+
+Because the range lives in the schema, an out-of-range value is a caller bug in
+the store (it throws) but a 400 at the HTTP edge (it parses first).
+
+## Room-wide settings
+
+- **Sound** (`SoundSettings`, #182): `sounds` is the master switch; `cards`,
+  `actions`, `notifications` are the three cue categories under it (cards = card
+  foley: deal/board/flip; actions = fold/check; notifications = your-turn
+  prompt). A cue plays only when the master *and* its category are on. Owned by
+  the table and pushed to every surface on `room-view`; phones hold no local
+  override and obey verbatim. The whole set is sent every write, so it stays one
+  atomic update with no partial-ordering to reason about.
+- **Shot clock** is queued until the next deal-in (`pendingShotClock`), so an
+  edit never disturbs the active hand's timer.
+
+## Seat state predicates
+
+- `isDealtInNextHand` is the client mirror of the server's `eligibleSeats`
+  (ADR-0002): claimed, connected, not *voluntarily* sitting out. A
+  `waiting-for-next-hand` seat sets `sittingOut` on the view but *is* dealt in
+  next hand, so the **reason**, not the flag, is what excludes a seat.
+- `SeatView` never carries a claim token; `disconnected` is a presence-only
+  badge (ticket 33 §7) that never affects folding or legal actions (ADR-0002
+  gates deal-in on it, not legality).
+- `isHandLive`/`isHandComplete` accept an `EngineState`, `PlayerView`,
+  `TableView`, or null, so both server and client answer "is a hand live" the
+  same way regardless of which shape they hold.
+
+## Messages
+
+`ViewSnapshotMessage` is pushed once after a socket opens when a hand is already
+in progress — a snapshot only, never replayed events (Phase 1 spec #130 §7, §9).
+`RoomEndedMessage` covers both manual "End session" and the table's 60s
+reconnect grace elapsing; both discard in-memory state identically.

--- a/docs/design/server.md
+++ b/docs/design/server.md
@@ -1,0 +1,104 @@
+# Server
+
+The Fastify HTTP/WebSocket server (`packages/server`): the `RoomStore`
+in-memory aggregate, the socket fan-out, the action clock, and test-mode bots.
+See `docs/adr/` (0002–0005) for the seat-lifecycle decisions this layer
+enforces, and Phase 1 spec #130 for the transport contract.
+
+## Secrecy lives in `view`, redaction guards the wire
+
+`HandEvent` is the engine's full, unredacted truth by design; all secrecy lives
+in `view` (Phase 1 spec #130 §3/§4). The wire event carried alongside a view is
+a transport-level exception: `redactEventFor` strips `HoleCardsDealt` per
+recipient before it leaves the server (table gets none; a seat gets only its
+own), or the "raw event for audit/animation" allowance in §6 would leak every
+seat's cards to every socket.
+
+`fanOutHandUpdate` sends each socket `view(state, identity)` **only if that seat
+was dealt into the hand** (`state.seats.includes(identity)`) — a sitting-out
+seat's socket gets nothing, never another seat's cards. `isSeat` is the single
+guard that excludes the `table`/`lobby` identities from any per-seat path, so
+those never reach `view(state, seatId)` or presence tracking.
+
+## Presence is cosmetic; the clock is connection-independent
+
+- `markPresence`/`setSeatDisconnected` toggle a **cosmetic** badge only — never
+  `rooms.dispatch`. Missed pongs (`missedPongLimit`) flip it on, a pong or
+  reconnect flips it off. A reconnecting seat resumes silently with no penalty
+  (§7).
+- The **action clock** (`action-clock.ts`, `rescheduleActionClock`) is fully
+  decoupled from socket state (§7): folding is strictly clock-driven, and only
+  `dispatch` outcomes move the clock. It re-arms against the live actor after
+  every accepted command (real or synthesized), and arms *before* the first
+  hand-update so every live view (including `HandStarted`) carries the deadline
+  and a reconnect snapshot reads the same `room.turnEndsAt`. On timeout it
+  preserves a free check (reads `legalActions` at fire time), else folds.
+- Timers everywhere here **re-read room state at fire time** (bot actions, clock
+  timeouts): a scheduled callback may outlive an intervening human action,
+  eviction, hand completion, or teardown, even after its own timer was replaced.
+  A synthesized action being rejected is not expected (the actor was live at
+  schedule time and any real action would have replaced the timer), but the
+  recovery path re-arms rather than stalls.
+
+## Seat lifecycle at the transport
+
+- **Eviction** (ADR-0003) vs **leave** (ADR-0005) are twins: leave is the
+  token-gated version. `closeSeatSockets` removes *currently open* sockets for a
+  freed seat too (a token only protects the next connection attempt), flagging
+  them so their close handler skips the disconnect toggle; a voluntary leave
+  passes `notify=false` (no `player-evicted` notice). A current-actor
+  evict/leave folds and reschedules the clock; a non-actor one is dispatched as
+  an engine `evict` with `actionClock: "preserve"`, leaving the live actor's
+  deadline untouched.
+- **Seat moves** (positional repack, ADR-0004): `applySeatMoves` updates each
+  open socket's transport identity to follow its moved seat before the new view
+  is sent — the token stays with the player, the identity follows the seat. A
+  reconnecting player may still hold the pre-repack seat in localStorage; the
+  token authenticates them and the stale position only sources the `seat-moved`
+  resync notice.
+- **Sit-out/in** (ADR-0002) is a seat-only room-store mutation that never
+  reaches the engine.
+- **Room end**: `endRoom` handles both "End session" and the table's grace
+  window elapsing identically — notify, close, discard transport bookkeeping,
+  discard the room. Only in-memory state; hand logs on disk are untouched. The
+  table socket closing arms a single `graceWindowMs` timer; a table reconnect
+  clears it.
+
+## Roles and auth
+
+`UNAUTHENTICATED_ROLES` (`table`, `lobby`) skip seat-token auth and are kept in
+one list so the unauthenticated surface is reviewable at a glance; everything
+else must present a valid seat token (`authenticateSeat`). `lobby` is an
+unclaimed watcher — it may receive views but is rejected from issuing commands.
+
+## Static serving and caching
+
+`index: false` on the static plugin leaves index resolution to the explicit `/`
+and `/join/:code` routes, which serve a staged release build
+(`public/table`, `public/player`, from `build:release`) or fall back to the
+placeholder when unstaged (dev/tests). Both serve the HTML shell with
+`cache-control: no-store`: the shell names the current fingerprinted bundle, so
+a cached shell would pin a long-lived kiosk to an old build across restarts; the
+hashed assets it points at stay cacheable. `PLAYER_CLIENT_ORIGIN` redirects
+`/join/:code` to the player-client's dev server when set.
+
+## Test-mode bots
+
+Gated by `testMode`; the `/bots` route isn't even registered otherwise, so the
+production surface is a plain 404. `bot-policy.ts` is pure (no engine state): it
+weights the engine-supplied legal-action list (a free check/call far outweighs
+fold/raise, but every legal action stays reachable) and rolls sit-out/in cadence
+between hands. `rollBotSitStates` runs at `HandComplete` before `nextHand`, so
+the next deal-in sees the results; it considers returning bots first and has a
+recovery override so a failed roll never strands a room below two eligible
+seats. RNG draws are guarded so a seat that can't act never consumes a draw
+(keeping a deterministic RNG stable across the sequence). `unitRandom` clamps
+injected values into `[0, 1)` without rounding a valid `MAX_UNIT_RANDOM`.
+
+## Persistence (`packages/persistence`)
+
+`HandLog` is an append-as-you-go JSONL logger: a seats manifest written once,
+then a command/event file pair per hand. Every write is a single synchronous
+`fs` call, so a killed process loses at most the one record it was mid-write on,
+never a batch. The game id is validated (it becomes a directory name). Records
+carry `ENGINE_LOG_VERSION` for replay/audit.

--- a/packages/engine/src/apply.ts
+++ b/packages/engine/src/apply.ts
@@ -20,13 +20,6 @@ function seatState(hand: BettingHandState, seat: number) {
   return must(hand.players.get(seat), `unknown seat ${String(seat)}`);
 }
 
-/**
- * The positional facts a completed hand has to keep once `ring` is dropped:
- * both blind seats and the size of the field they were dealt from. Resolved
- * here, while `ring` is still in scope, so `view` reports the same ids in
- * every phase — and so the button's rotation on `HandComplete` can't reach
- * back and change what the finished hand says about itself.
- */
 function resolvedBlinds(hand: BettingHandState) {
   return {
     smallBlind: smallBlindSeat(hand.ring, hand.button),
@@ -35,7 +28,6 @@ function resolvedBlinds(hand: BettingHandState) {
   };
 }
 
-/** Pure reducer: folds one event into state. Never mutates its input. */
 export function apply(state: EngineState, event: HandEvent): EngineState {
   switch (event.type) {
     case "HandStarted": {
@@ -96,9 +88,6 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
       }
       const raiseOccurred = hand.raiseOccurred || event.action === "raise";
 
-      // Ordinary actions always belong to `toAct[0]`; an eviction may fold a
-      // live seat later in the queue, so remove the event's seat by identity
-      // and leave the current actor at the head of the queue.
       const toAct =
         event.action === "raise"
           ? requeueAfterRaise(hand.ring, players, event.seatId)

--- a/packages/engine/src/blinds.test.ts
+++ b/packages/engine/src/blinds.test.ts
@@ -13,7 +13,6 @@ function bettingView(state: EngineState) {
 
 describe("smallBlindSeat", () => {
   it("is the seat immediately after the button in ring order, not by seat number", () => {
-    // Seat 5 has the button; ring order wraps to seat 1 before seat 3.
     expect(smallBlindSeat([1, 3, 5], 5)).toBe(1);
     expect(bigBlindSeat([1, 3, 5], 5)).toBe(3);
   });
@@ -26,7 +25,6 @@ describe("smallBlindSeat", () => {
 
 describe("view: blinds during betting", () => {
   it("reports the blinds by ring order for a three-handed hand", () => {
-    // Seats 2, 5, 7 with the button on 5: ring = [7, 2, 5].
     let state = createInitialState([2, 5, 7]);
     state = { ...state, button: 5 };
     state = playAll(state, [{ type: "startHand", seatId: 2, seed: "blinds" }]);
@@ -53,7 +51,6 @@ describe("view: blinds during betting", () => {
     let state = createInitialState([0, 1, 2]);
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "fixed" }]);
     const before = bettingView(state);
-    // Preflop opens on the button three-handed, so seat 0 is the folder.
     state = playAll(state, [{ type: "fold", seatId: 0 }]);
     const after = bettingView(state);
 
@@ -74,8 +71,6 @@ describe("view: blinds on a completed hand", () => {
       { type: "fold", seatId: 1 },
     ]);
 
-    // `HandComplete` has rotated the engine button on to the next seat, but
-    // the completed hand still describes the hand that was just played.
     expect(state.button).not.toBe(betting.button);
 
     const v = view(state, "table");
@@ -91,7 +86,6 @@ describe("view: blinds on a completed hand", () => {
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "sd" }]);
     const betting = bettingView(state);
 
-    // Preflop runs button, SB, BB; every later street runs SB, BB, button.
     state = playAll(state, [
       { type: "call", seatId: 0 },
       { type: "call", seatId: 1 },

--- a/packages/engine/src/complete-hand-state.test.ts
+++ b/packages/engine/src/complete-hand-state.test.ts
@@ -6,7 +6,6 @@ describe("CompleteHandState carries how the hand ended", () => {
   it("tags a fold-out completion with reason 'folded-out' and the winner", () => {
     let state = createInitialState([0, 1, 2]);
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "foldout" }]);
-    // Preflop runs button, SB, BB — the BB is left holding the pot.
     state = playAll(state, [
       { type: "fold", seatId: 0 },
       { type: "fold", seatId: 1 },

--- a/packages/engine/src/deck.ts
+++ b/packages/engine/src/deck.ts
@@ -28,7 +28,6 @@ function orderedDeck(): Card[] {
   return deck;
 }
 
-/** djb2 string hash, folded into a 32-bit seed for the PRNG below. */
 function hashSeed(seed: string): number {
   let hash = 5381;
   for (let i = 0; i < seed.length; i++) {
@@ -37,7 +36,6 @@ function hashSeed(seed: string): number {
   return hash >>> 0;
 }
 
-/** mulberry32 — small, deterministic, sufficient for a shuffle (not crypto). */
 function mulberry32(seed: number): () => number {
   let state = seed;
   return () => {
@@ -49,7 +47,6 @@ function mulberry32(seed: number): () => number {
   };
 }
 
-/** The full 52-card deck shuffled deterministically from `seed`. */
 export function shuffledDeck(seed: string): Card[] {
   const deck = orderedDeck();
   const random = mulberry32(hashSeed(seed));

--- a/packages/engine/src/evaluate.split.test.ts
+++ b/packages/engine/src/evaluate.split.test.ts
@@ -26,7 +26,6 @@ describe("evaluate: split and tie cases", () => {
   });
 
   it("does not split when kickers differ within the same category and rank", () => {
-    // Both have aces and kings two pair, but one has a queen kicker, the other a jack.
     const seatA = evaluate(cards("Ac Ah Kd Kh Qc 2s 3d"));
     const seatB = evaluate(cards("As Ad Ks Kc Jc 2s 3d"));
     expect(seatA.rank).toBeGreaterThan(seatB.rank);

--- a/packages/engine/src/evaluate.ts
+++ b/packages/engine/src/evaluate.ts
@@ -9,11 +9,6 @@ export interface HandEvaluation {
   readonly description: string;
 }
 
-/**
- * Evaluates 5-7 cards (a hold'em showdown always passes 7: two hole cards
- * plus a five-card board) and returns a comparable rank, the winning five
- * cards, and a human-readable description of the made hand.
- */
 export function evaluate(cards: readonly Card[]): HandEvaluation {
   const { category, tiebreak, bestHand } = categorize(cards);
   return {
@@ -23,10 +18,6 @@ export function evaluate(cards: readonly Card[]): HandEvaluation {
   };
 }
 
-/**
- * Every seat tied for the best rank — split-aware, since Phase 1 tracks no
- * chip value and "split" just means multiple winners reported.
- */
 export function winnersOf(
   results: readonly { seatId: SeatId; rank: HandRank }[],
 ): SeatId[] {

--- a/packages/engine/src/fold-out.test.ts
+++ b/packages/engine/src/fold-out.test.ts
@@ -9,8 +9,6 @@ describe("fold-out early exit", () => {
     let state = createInitialState([0, 1, 2]);
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "foldout" }]);
 
-    // Preflop: 0 (button, first to act) folds, then 1 (SB) folds — only seat
-    // 2 remains live, mid-street with the BB never having acted.
     state = playAll(state, [{ type: "fold", seatId: 0 }]);
     expect(state.hand?.status).toBe("betting");
 
@@ -31,7 +29,6 @@ describe("fold-out early exit", () => {
       next = apply(next, event);
     }
     expect(next.hand?.status).toBe("complete");
-    // Button rotates on HAND_COMPLETE.
     expect(next.button).toBe(1);
   });
 });

--- a/packages/engine/src/heads-up.test.ts
+++ b/packages/engine/src/heads-up.test.ts
@@ -12,9 +12,6 @@ describe("heads-up (2 live players)", () => {
     let state = createInitialState([0, 1]);
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "hu" }]);
 
-    // Button (0) is also the Small Blind and acts first preflop — they face
-    // the BB's post, so they must call/fold/raise, not check; only the BB
-    // (seat 1) can check an unraised preflop.
     expect(betting(state).street).toBe("preflop");
     expect(betting(state).toAct).toEqual([0, 1]);
 
@@ -23,7 +20,6 @@ describe("heads-up (2 live players)", () => {
       { type: "check", seatId: 1 },
     ]);
 
-    // Postflop: the non-button seat (BB) now acts first, button last.
     expect(betting(state).street).toBe("flop");
     expect(betting(state).toAct).toEqual([1, 0]);
 

--- a/packages/engine/src/lifecycle.test.ts
+++ b/packages/engine/src/lifecycle.test.ts
@@ -10,12 +10,9 @@ describe("a full hand, 3 seats, start to showdown", () => {
     let state = createInitialState([0, 1, 2]);
     expect(state.button).toBe(0);
 
-    // ring (button 0) = [1, 2, 0]; preflop order = [0, 1, 2], BB = seat 2.
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "seed-1" }]);
     expect(state.hand?.status).toBe("betting");
 
-    // Preflop: 0 and 1 call the BB (not free to check — only the BB itself
-    // is), 2 (BB) raises, 0 calls, 1 calls (closes back to raiser).
     state = playAll(state, [
       { type: "call", seatId: 0 },
       { type: "call", seatId: 1 },
@@ -28,7 +25,6 @@ describe("a full hand, 3 seats, start to showdown", () => {
       state.hand && "street" in state.hand ? state.hand.street : null,
     ).toBe("flop");
 
-    // Flop: everyone checks around (order = [1, 2, 0], no BB special-case).
     state = playAll(state, [
       { type: "check", seatId: 1 },
       { type: "check", seatId: 2 },
@@ -38,7 +34,6 @@ describe("a full hand, 3 seats, start to showdown", () => {
       state.hand && "street" in state.hand ? state.hand.street : null,
     ).toBe("turn");
 
-    // Turn: 1 folds, 2 and 0 remain live, betting continues.
     state = playAll(state, [
       { type: "fold", seatId: 1 },
       { type: "check", seatId: 2 },
@@ -48,7 +43,6 @@ describe("a full hand, 3 seats, start to showdown", () => {
       state.hand && "street" in state.hand ? state.hand.street : null,
     ).toBe("river");
 
-    // River: 2 checks, 0 raises, 2 calls -> showdown.
     const beforeRiver = state;
     const riverEvents = playAndCollect(beforeRiver, [
       { type: "check", seatId: 2 },
@@ -62,9 +56,7 @@ describe("a full hand, 3 seats, start to showdown", () => {
     const showdown = riverEvents.find((e) => e.type === "ShowdownReached");
     expect(showdown).toBeDefined();
     if (showdown?.type === "ShowdownReached") {
-      // Seat 1 folded on the turn — never revealed, even though it was live earlier.
       expect(showdown.results.map((r) => r.seatId).sort()).toEqual([0, 2]);
-      // Deterministic for seed "seed-1": seat 2 holds the clear best hand.
       expect(showdown.winners).toEqual([2]);
     }
     expect(riverEvents.at(-1)?.type).toBe("HandComplete");

--- a/packages/engine/src/next-hand.test.ts
+++ b/packages/engine/src/next-hand.test.ts
@@ -8,7 +8,6 @@ describe("nextHand", () => {
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "hand-1" }]);
     expect(state.button).toBe(0);
 
-    // Fold everyone but seat 2 out to reach HAND_COMPLETE quickly.
     state = playAll(state, [
       { type: "fold", seatId: 0 },
       { type: "fold", seatId: 1 },

--- a/packages/engine/src/poker/categorize.test.ts
+++ b/packages/engine/src/poker/categorize.test.ts
@@ -54,7 +54,6 @@ describe("categorize", () => {
   });
 
   it("does not treat A-K-Q-J-10 wraparound (K-Q-J-10-A... low) as a straight", () => {
-    // Q,K,A,2,3 is not a straight in either direction.
     const result = categorize(cards("Qc Kh Ad 2c 3s"));
     expect(result.category).toBe("high-card");
   });
@@ -96,8 +95,6 @@ describe("categorize", () => {
   });
 
   it("prefers a flush over a straight when seven cards offer both", () => {
-    // Diamonds 4-5-6-9-10 make a flush (not a straight); 6-7-8-9-10 across
-    // suits makes a straight. Flush must win.
     const result = categorize(cards("4d 5d 6d 7h 8h 9d 10d"));
     expect(result.category).toBe("flush");
   });
@@ -110,7 +107,6 @@ describe("categorize", () => {
   });
 
   it("resolves a full house from seven cards using the best trips and best pair", () => {
-    // trips of 9s, trips of 2s -> full house should be 9s full of 2s (best trip + best remaining pair-or-trip)
     const result = categorize(cards("9c 9h 9d 2c 2h 2d Kc"));
     expect(result.category).toBe("full-house");
     expect(result.tiebreak).toEqual([9, 2]);

--- a/packages/engine/src/poker/categorize.ts
+++ b/packages/engine/src/poker/categorize.ts
@@ -19,15 +19,10 @@ export type HandCategory =
 
 export interface Categorized {
   readonly category: HandCategory;
-  /**
-   * Tiebreak ranks in significance order (highest first), enough to compare
-   * any two hands of the same category. Length varies by category.
-   */
   readonly tiebreak: readonly number[];
   readonly bestHand: readonly [Card, Card, Card, Card, Card];
 }
 
-/** Highest 5-in-a-row rank present, wheel-aware (A-2-3-4-5 plays as five-high); 0 if none. */
 function highestStraight(present: readonly boolean[]): number {
   const wheel =
     present[HIGHEST_RANK_VALUE] &&
@@ -49,7 +44,6 @@ function highestStraight(present: readonly boolean[]): number {
   return wheel ? 5 : 0;
 }
 
-/** Cards of the given ranks (highest rank first), each appearing once, from `pool`. */
 function pickByRank(pool: readonly Card[], ranks: readonly number[]): Card[] {
   const remaining = [...pool];
   const picked: Card[] = [];
@@ -77,16 +71,11 @@ function highCardsExcluding(
   return ranks;
 }
 
-/**
- * Scores every card of a straight of the given high rank, wheel-aware (ace
- * plays low in a five-high straight).
- */
 function straightRanks(high: number): number[] {
   if (high === 5) return [5, 4, 3, 2, HIGHEST_RANK_VALUE];
   return [high, high - 1, high - 2, high - 3, high - 4];
 }
 
-/** Best 5-card poker hand out of 5-7 cards: category, tiebreak ranks, and the winning cards. */
 export function categorize(cards: readonly Card[]): Categorized {
   const byRank = new Map<number, Card[]>();
   const bySuit = new Map<Card["suit"], Card[]>();

--- a/packages/engine/src/poker/describe.ts
+++ b/packages/engine/src/poker/describe.ts
@@ -45,7 +45,6 @@ function plural(rank: number): string {
   return must(PLURAL[rank], `no plural name for rank ${String(rank)}`);
 }
 
-/** A human-readable name for a category + tiebreak, e.g. "Full house, nines full of twos". */
 export function describe(
   category: HandCategory,
   tiebreak: readonly number[],

--- a/packages/engine/src/poker/exhaustive-5card.test.ts
+++ b/packages/engine/src/poker/exhaustive-5card.test.ts
@@ -54,8 +54,6 @@ for (const suit of SUITS) {
   }
 }
 
-// Canonical 5-card category frequencies over all C(52,5) = 2,598,960 hands —
-// settled combinatorics, independent of any evaluator implementation.
 const CANONICAL_5CARD_FREQUENCIES: Record<string, number> = {
   "straight-flush": 40,
   "four-of-a-kind": 624,
@@ -131,8 +129,6 @@ describe("exhaustive 5-card enumeration vs phe", () => {
     expect(pheToOurScore.size).toBe(7462);
     expect(ourScoreToPhe.size).toBe(7462);
 
-    // Ordering must agree: as phe's strength value increases (weaker),
-    // our score must strictly decrease (also weaker).
     const orderedByPhe = [...pheToOurScore.entries()].sort(
       (x, y) => x[0] - y[0],
     );

--- a/packages/engine/src/poker/exhaustive-7card.test.ts
+++ b/packages/engine/src/poker/exhaustive-7card.test.ts
@@ -54,9 +54,6 @@ for (const suit of SUITS) {
   }
 }
 
-// Canonical 7-card category frequencies over all C(52,7) = 133,784,560 hands
-// — settled combinatorics (only 4,824 of the 7,462 5-card classes are
-// reachable from seven cards), independent of any evaluator implementation.
 const CANONICAL_7CARD_FREQUENCIES: Record<string, number> = {
   "straight-flush": 41584,
   "four-of-a-kind": 224848,
@@ -129,8 +126,6 @@ describe("exhaustive 7-card enumeration vs phe", () => {
     expect(categoryFrequencies).toEqual(CANONICAL_7CARD_FREQUENCIES);
     expect(pheToOurScore.size).toBe(4824);
 
-    // Ordering must agree: as phe's strength value increases (weaker),
-    // our score must strictly decrease (also weaker).
     const orderedByPhe = [...pheToOurScore.entries()].sort(
       (x, y) => x[0] - y[0],
     );

--- a/packages/engine/src/poker/phe.d.ts
+++ b/packages/engine/src/poker/phe.d.ts
@@ -1,8 +1,3 @@
-/**
- * Minimal ambient typing for the `phe` dev-only test oracle (issue #22).
- * `phe` ships no TypeScript types; only the members these tests use are
- * declared. Never imported from runtime code.
- */
 declare module "phe" {
   const phe: {
     cardCode(rank: string, suit: string): number;

--- a/packages/engine/src/poker/rank-values.ts
+++ b/packages/engine/src/poker/rank-values.ts
@@ -1,6 +1,5 @@
 import type { Rank } from "../types.js";
 
-/** Numeric rank value, ace high (14). Straight detection separately treats ace as low for the wheel. */
 export const RANK_VALUE: Record<Rank, number> = {
   "2": 2,
   "3": 3,

--- a/packages/engine/src/poker/score.ts
+++ b/packages/engine/src/poker/score.ts
@@ -2,7 +2,6 @@ import type { HandRank } from "../types.js";
 import type { HandCategory } from "./categorize.js";
 import { HIGHEST_RANK_VALUE } from "./rank-values.js";
 
-/** Worst to best; index doubles as the category's weight in the score. */
 const CATEGORY_ORDER: readonly HandCategory[] = [
   "high-card",
   "pair",
@@ -18,11 +17,6 @@ const CATEGORY_ORDER: readonly HandCategory[] = [
 const TIEBREAK_SLOTS = 5;
 const RADIX = HIGHEST_RANK_VALUE + 1;
 
-/**
- * A single comparable integer: higher is a stronger hand. Category is the
- * most significant digit; tiebreak ranks fill in descending significance
- * after it, padded so every category compares on equal footing.
- */
 export function scoreOf(
   category: HandCategory,
   tiebreak: readonly number[],

--- a/packages/engine/src/preflop-order.test.ts
+++ b/packages/engine/src/preflop-order.test.ts
@@ -2,15 +2,6 @@ import { describe, expect, it } from "vitest";
 import { initialToAct, rotateFromButton } from "./table.js";
 import type { SeatId } from "./types.js";
 
-/**
- * Preflop opens on the first seat left of the blinds and ends on the big
- * blind (Robert's Rules of Poker, "Button and Blind Use") — the button-
- * relative ring rotated to start at button+3. Heads-up is the exception:
- * the small blind is on the button and acts first preflop.
- *
- * Table-driven across the full supported field (MAX_SEAT_COUNT is 8), with
- * the button on seat 1 so the expected orders read as plain seat numbers.
- */
 const BUTTON: SeatId = 1;
 
 const cases: { n: number; expected: SeatId[]; note: string }[] = [
@@ -48,14 +39,10 @@ describe("initialToAct: postflop order", () => {
 describe("initialToAct: folded seats", () => {
   it("drops folded seats from the preflop lap, keeping the rotation", () => {
     const ring = rotateFromButton([1, 2, 3, 4, 5], BUTTON);
-    // Seat 4 (UTG) and seat 2 (SB) are out; the rest keep their order.
     expect(initialToAct(ring, [1, 3, 5], BUTTON, "preflop")).toEqual([5, 1, 3]);
   });
 
   it("keeps heads-up order off the ring, not the live seats", () => {
-    // A 3-seat ring with only 2 live seats is unreachable today, but must
-    // not read as heads-up: blind positions are decided off `ring.length`,
-    // and the action order has to agree with them.
     const ring = rotateFromButton([1, 2, 3], BUTTON);
     expect(initialToAct(ring, [1, 3], BUTTON, "preflop")).toEqual([1, 3]);
   });

--- a/packages/engine/src/properties.test.ts
+++ b/packages/engine/src/properties.test.ts
@@ -19,11 +19,6 @@ const actionArb = fc.constantFrom<"fold" | "check" | "call" | "raise">(
   "raise",
 );
 
-/**
- * Deep-freezes state so any in-place mutation throws (ES modules are always
- * strict mode) — a stronger check than snapshot-and-compare, since it also
- * catches mutation of a nested object that later gets discarded unread.
- */
 function deepFreeze<T>(value: T): T {
   if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
     Object.freeze(value);

--- a/packages/engine/src/rejections.test.ts
+++ b/packages/engine/src/rejections.test.ts
@@ -21,7 +21,6 @@ describe("rejections", () => {
   it("not-your-turn: acting out of turn", () => {
     let state = createInitialState([0, 1, 2]);
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "s" }]);
-    // Preflop first actor is seat 0 (the button, three-handed), not seat 1.
     const outcome = play(state, { type: "check", seatId: 1 });
     if (!("rejection" in outcome)) throw new Error("expected a rejection");
     expect(outcome.rejection.reason).toBe("not-your-turn");
@@ -40,8 +39,6 @@ describe("rejections", () => {
   });
 
   it("action-not-legal: checking preflop when you're not the big blind", () => {
-    // Seat 0 (the button, first to act) faces the BB's post and must
-    // call/fold/raise, not check.
     const state = createInitialState([0, 1, 2]);
     const started = playAll(state, [
       { type: "startHand", seatId: 0, seed: "s" },
@@ -52,7 +49,6 @@ describe("rejections", () => {
   });
 
   it("action-not-legal: calling when there's nothing to call", () => {
-    // The BB has nothing to call on an unraised preflop — only check/raise.
     let state = createInitialState([0, 1, 2]);
     state = playAll(state, [{ type: "startHand", seatId: 0, seed: "s" }]);
     state = playAll(state, [

--- a/packages/engine/src/room.ts
+++ b/packages/engine/src/room.ts
@@ -1,12 +1,6 @@
 import type { EngineState, SeatId } from "./types.js";
 import { must } from "./util.js";
 
-/**
- * Builds the initial Room-level state for a fixed set of seated players.
- * Seat claiming/joining (issue #13) is out of scope here — seats are fixed
- * for the state's whole life. The button starts at the first seat and
- * rotates automatically whenever a hand reaches `HAND_COMPLETE`.
- */
 export function createInitialState(seats: readonly SeatId[]): EngineState {
   if (seats.length < 2 || seats.length > 8) {
     throw new Error("a room needs between 2 and 8 seated players");

--- a/packages/engine/src/showdown.test.ts
+++ b/packages/engine/src/showdown.test.ts
@@ -20,8 +20,6 @@ function playAndCollect(state: EngineState, commands: Command[]): HandEvent[] {
   return all;
 }
 
-// Both scenarios play a heads-up hand with no raises (call/check throughout)
-// so the only thing that varies between seeds is the dealt cards.
 const headsUpToRiver: Command[] = [
   { type: "call", seatId: 0 },
   { type: "check", seatId: 1 },

--- a/packages/engine/src/street-closure.test.ts
+++ b/packages/engine/src/street-closure.test.ts
@@ -17,8 +17,6 @@ function actor(state: EngineState): SeatId {
 
 describe("street closure — limped-around preflop", () => {
   it("closes after one lap ending on the BB, with nobody raising", () => {
-    // 3 seats; button 0, small blind 1, big blind 2. Preflop opens on the
-    // first seat left of the blinds, which three-handed is the button.
     const BUTTON = 0;
     const SB = 1;
     const BB = 2;
@@ -29,7 +27,6 @@ describe("street closure — limped-around preflop", () => {
     ]);
     expect(street(state).toAct).toEqual([BUTTON, SB, BB]);
 
-    // Only the BB may check an unraised preflop; everyone else calls.
     state = playAll(state, [{ type: "call", seatId: BUTTON }]);
     expect(street(state).street).toBe("preflop");
     expect(street(state).toAct).toEqual([SB, BB]);
@@ -38,14 +35,11 @@ describe("street closure — limped-around preflop", () => {
     expect(street(state).street).toBe("preflop");
     expect(street(state).toAct).toEqual([BB]);
 
-    // The BB's option is simply their turn, and it is the last one — no
-    // second visit, and checking it closes preflop.
     state = playAll(state, [{ type: "check", seatId: BB }]);
     expect(street(state).street).toBe("flop");
   });
 
   it("rejects the small blind trying to open preflop", () => {
-    // The reported production bug: preflop opened on the small blind.
     const BUTTON = 0;
     const SB = 1;
     const BB = 2;
@@ -75,8 +69,6 @@ describe("street closure — limped-around preflop", () => {
     ]);
     expect(street(state).toAct).toEqual([BB]);
 
-    // Folding the option closes preflop exactly as checking it would; the
-    // BB must not be re-queued behind their own fold.
     state = playAll(state, [{ type: "fold", seatId: BB }]);
     expect(street(state).street).toBe("flop");
     expect(street(state).toAct).toEqual([SB, BUTTON]);
@@ -93,8 +85,6 @@ describe("street closure — limped-around preflop", () => {
       const bigBlind = bigBlindSeat(ring, 0);
       const smallBlind = smallBlindSeat(ring, 0);
 
-      // Preflop never opens on either blind with 3+ seats; heads-up the
-      // small blind is on the button and opens by rule.
       expect(actor(state)).not.toBe(bigBlind);
       if (n > 2) expect(actor(state)).not.toBe(smallBlind);
 
@@ -128,8 +118,6 @@ describe("street closure — raised and called", () => {
       { type: "startHand", seatId: BUTTON, seed: "raised" },
     ]);
 
-    // Button calls, SB raises mid-lap — the requeue runs in ring order from
-    // the raiser, so the BB (who had not yet acted) still gets their turn.
     state = playAll(state, [
       { type: "call", seatId: BUTTON },
       { type: "raise", seatId: SB },
@@ -159,7 +147,6 @@ describe("street closure — raised and called", () => {
       { type: "raise", seatId: SB },
       { type: "raise", seatId: BB },
     ]);
-    // BB re-raised: only the button and SB owe a response now, in that order.
     expect(street(state).toAct).toEqual([BUTTON, SB]);
 
     state = playAll(state, [
@@ -170,8 +157,6 @@ describe("street closure — raised and called", () => {
   });
 
   it("requeues correctly when the raiser is the BB and an earlier seat already folded", () => {
-    // 4 seats; button 0, small blind 1, big blind 2, UTG 3 — so preflop
-    // runs UTG, button, SB, BB.
     const BUTTON = 0;
     const SB = 1;
     const BB = 2;
@@ -189,7 +174,6 @@ describe("street closure — raised and called", () => {
       { type: "fold", seatId: SB },
       { type: "raise", seatId: BB },
     ]);
-    // SB already folded, so only UTG and the button owe a response.
     expect(street(state).toAct).toEqual([UTG, BUTTON]);
 
     state = playAll(state, [

--- a/packages/engine/src/table.test.ts
+++ b/packages/engine/src/table.test.ts
@@ -12,8 +12,6 @@ describe("legalActions", () => {
     if (started.hand?.status !== "betting") {
       throw new Error("expected betting");
     }
-    // ring (button 0) = [1, 2, 0]; seat 1 (SB) faces the BB's post.
-    // Preflop order is [0, 1, 2], but legality is positional, not turn-based.
     expect(legalActions(started.hand, 1)).toEqual(["fold", "call", "raise"]);
   });
 
@@ -25,8 +23,6 @@ describe("legalActions", () => {
     if (started.hand?.status !== "betting") {
       throw new Error("expected betting");
     }
-    // BB is seat 2 here — its own post already matches, so it may check on
-    // its turn, which is the last one of the preflop lap.
     const afterLap = playAll(started, [
       { type: "call", seatId: 0 },
       { type: "call", seatId: 1 },

--- a/packages/engine/src/table.ts
+++ b/packages/engine/src/table.ts
@@ -8,7 +8,6 @@ import type {
 } from "./types.js";
 import { must } from "./util.js";
 
-/** Reorders `seats` to start right after `button` and end at `button`. */
 export function rotateFromButton(
   seats: readonly SeatId[],
   button: SeatId,
@@ -33,22 +32,6 @@ export function liveSeats(hand: BettingHandState): SeatId[] {
   return hand.ring.filter((seat) => !seatState(hand, seat).folded);
 }
 
-/**
- * The action order for the start of a street: the live seats, in the order
- * they owe a decision.
- *
- * Postflop runs the ring as-is, small blind through button. Preflop with
- * 3+ seats starts "with the first player to the left of the blinds"
- * (Robert's Rules of Poker, "Button and Blind Use") — the ring rotated two
- * seats, `UTG, ..., BTN, SB, BB`. Heads-up the small blind is on the
- * button and acts first, so the order is `BTN/SB, BB`.
- *
- * The big blind is last in every case, so their one-time "option" needs no
- * special machinery: every street closes the same way, when `toAct` drains.
- * Heads-up is decided off the ring, via the same `isHeadsUp` the blind
- * seats use — a short-handed lap must never read as heads-up and disagree
- * with the blind positions it was dealt with.
- */
 export function initialToAct(
   ring: readonly SeatId[],
   live: readonly SeatId[],
@@ -64,28 +47,12 @@ export function initialToAct(
   return order.filter((seat) => live.includes(seat));
 }
 
-/**
- * The two blind seats at the head of the ring, `[SB, BB]` — the rotation
- * preflop action skips past, and the reason `initialToAct` opens at
- * `ring[2]`.
- */
 const BLIND_COUNT = 2;
 
-/**
- * Whether this hand is heads-up, off the seats it was dealt to rather than
- * the seats still live. Every position rule that reads differently heads-up
- * — both blind seats and the preflop order — asks this one question, so
- * they cannot disagree with each other partway through a hand.
- */
 function isHeadsUp(ring: readonly SeatId[]): boolean {
   return ring.length === BLIND_COUNT;
 }
 
-/**
- * The small blind's seat for the whole hand: `ring[0]` (button+1) with 3+
- * seats; in heads-up the button posts the small blind, so the two coincide.
- * Ring order, never seat-number arithmetic — seats need not be contiguous.
- */
 export function smallBlindSeat(
   ring: readonly SeatId[],
   button: SeatId,
@@ -94,11 +61,6 @@ export function smallBlindSeat(
   return must(ring[0], "the small blind needs at least 2 seated players");
 }
 
-/**
- * The big blind's seat for the whole hand: `ring[1]` (button+2) with 3+
- * seats; in heads-up (`ring` has exactly 2 seats, `[other, button]`) the
- * non-button seat is the big blind instead.
- */
 export function bigBlindSeat(ring: readonly SeatId[], button: SeatId): SeatId {
   if (isHeadsUp(ring)) {
     return must(
@@ -109,17 +71,6 @@ export function bigBlindSeat(ring: readonly SeatId[], button: SeatId): SeatId {
   return must(ring[1], "the big blind needs at least 3 seated players");
 }
 
-/**
- * Whether `actorSeat` still owes a call/fold/raise this street, absent a
- * value-tracked pot: no chip amount is ever stored (CONTEXT.md, §1 of the
- * Phase 1 spec still hold — the engine never tracks a Pot), but the blinds'
- * *legality* still has to mirror physical chips already in the middle. Every
- * seat faces a bet once someone has actually raised; preflop, before that,
- * every seat except the big blind also faces a bet — the big blind's own
- * post already matches it, which is exactly why the big blind alone may
- * check on an unraised preflop. Preflop that turn is the last of the lap,
- * so it is also the big blind's "option".
- */
 export function facingBet(
   hand: Pick<BettingHandState, "street" | "ring" | "button" | "raiseOccurred">,
   actorSeat: SeatId,
@@ -131,14 +82,6 @@ export function facingBet(
   );
 }
 
-/**
- * The full set of actions `actorSeat` may legally take right now — fold and
- * raise are always available; check and call are mutually exclusive and
- * follow `facingBet` (see its own doc comment for the preflop/big-blind
- * subtlety). The single source of truth for action legality, consumed by
- * both `decide` (server-side enforcement) and `view` (the client-facing
- * `legalActions` field) so the two can never drift apart.
- */
 export function legalActions(
   hand: Pick<BettingHandState, "street" | "ring" | "button" | "raiseOccurred">,
   actorSeat: SeatId,
@@ -148,11 +91,6 @@ export function legalActions(
     : ["fold", "check", "raise"];
 }
 
-/**
- * After a raise, every other live seat gets one more turn, in position order
- * starting right after the raiser, ending right before them again — the
- * raiser isn't re-added; the street closes once this queue drains.
- */
 export function requeueAfterRaise(
   ring: readonly SeatId[],
   players: ReadonlyMap<SeatId, { readonly folded: boolean }>,
@@ -182,11 +120,6 @@ export function nextStreetOf(street: Street): "flop" | "turn" | "river" | null {
   return street === "river" ? null : STREET_AFTER[street];
 }
 
-/**
- * Hole cards and board cards are all drawn from the same seed-derived deck,
- * sliced deterministically by position — no deck state is ever stored, so
- * the remaining deck order is never reachable from engine state.
- */
 export function dealHoleCards(
   seed: string,
   seats: readonly SeatId[],

--- a/packages/engine/src/test-utils.ts
+++ b/packages/engine/src/test-utils.ts
@@ -2,7 +2,6 @@ import { apply } from "./apply.js";
 import { decide } from "./decide.js";
 import type { Command, EngineState, HandEvent, Rejection } from "./types.js";
 
-/** Runs one command, folding any resulting events into state via `apply`. */
 export function play(
   state: EngineState,
   command: Command,
@@ -20,7 +19,6 @@ export function play(
   return { state: next, events: result };
 }
 
-/** Runs a sequence of commands, throwing on the first rejection. */
 export function playAll(state: EngineState, commands: Command[]): EngineState {
   let current = state;
   for (const command of commands) {

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -3,32 +3,22 @@ export type Suit = "clubs" | "diamonds" | "hearts" | "spades";
 export type Rank =
   "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "10" | "J" | "Q" | "K" | "A";
 
-/** A card's identity is its rank+suit value — never its position in a hand or deck. */
 export interface Card {
   readonly rank: Rank;
   readonly suit: Suit;
 }
 
-/**
- * A Seat's stable identity — the seat's fixed position at the table (0-7).
- * Never re-derived from an index into a filtered/live-players array.
- */
 export type SeatId = number;
 
 export type Street = "preflop" | "flop" | "turn" | "river";
 
 export type ActionType = "fold" | "check" | "call" | "raise";
 
-/**
- * Placeholder pending the hand evaluator (issue #6). A comparable numeric
- * rank; the evaluator ticket fixes the exact ordering convention.
- */
 export type HandRank = number;
 
 export type Command =
   | { type: "startHand"; seatId: SeatId; seed: string }
   | { type: ActionType; seatId: SeatId }
-  /** Server-synthesized table action; never accepted from a player client. */
   | { type: "evict"; seatId: SeatId }
   | { type: "nextHand"; seatId: SeatId; seed: string };
 
@@ -77,12 +67,10 @@ export interface BettingHandState {
   readonly status: "betting";
   readonly seed: string;
   readonly button: SeatId;
-  /** Fixed positional ring for the whole hand: button+1, ..., button (button last). */
   readonly ring: readonly SeatId[];
   readonly street: Street;
   readonly board: readonly Card[];
   readonly players: ReadonlyMap<SeatId, SeatHandState>;
-  /** Seats still owed a decision this street, in order; `toAct[0]` is the current actor. */
   readonly toAct: readonly SeatId[];
   readonly raiseOccurred: boolean;
 }
@@ -94,30 +82,10 @@ export interface ShowdownResult {
   readonly description: string;
 }
 
-/**
- * A live seat's showdown result with its hole cards attached — the only
- * place another seat's hole cards are structurally reachable, and only
- * ever for a seat that actually reached showdown live (see
- * Phase 1 spec #130 §4, Visibility). Built once, in `apply`, from the
- * betting hand's players map; nothing downstream needs that map again.
- */
 export interface RevealedResult extends ShowdownResult {
   readonly holeCards: readonly [Card, Card];
 }
 
-/**
- * Where a hand's three fixed positions sit, plus the size of the field they
- * were dealt from. Seat ids only — no chips are implied, the blinds are
- * tracked positionally like the button.
- *
- * `smallBlind` is the honest answer, so heads-up it equals `button` (the
- * button does post the small blind); what to draw from that is a client
- * decision, not a rules one. `dealtSeatCount` is fixed for the hand — folds
- * never reduce it — so `2` identifies a heads-up hand in every phase.
- *
- * A betting hand can derive all three from `ring`; a completed hand has
- * dropped `ring`, so it stores them.
- */
 export interface HandPositions {
   readonly button: SeatId;
   readonly smallBlind: SeatId;

--- a/packages/engine/src/util.ts
+++ b/packages/engine/src/util.ts
@@ -1,4 +1,3 @@
-/** Asserts a possibly-absent lookup is present — used in place of `!` under `noUncheckedIndexedAccess`. */
 export function must<T>(
   value: T | null | undefined,
   message = "expected a value",

--- a/packages/engine/src/version.ts
+++ b/packages/engine/src/version.ts
@@ -1,6 +1,1 @@
-/**
- * Compatibility version tag for persisted command/event log records — bumped
- * whenever command or event shapes, the shuffle, or engine behaviour would
- * break bit-identical replay. See Phase 1 spec #130 §5.
- */
 export const ENGINE_LOG_VERSION = 4;

--- a/packages/engine/src/view.test.ts
+++ b/packages/engine/src/view.test.ts
@@ -25,13 +25,9 @@ function headsUpToRiver(seed: string): EngineState {
   return state;
 }
 
-/** Three-way, preflop action closed and the flop dealt — a non-trivial board. */
 function onTheFlopThreeWay(): EngineState {
   let state = createInitialState([0, 1, 2]);
   state = playAll(state, [{ type: "startHand", seatId: 0, seed: "mid" }]);
-  // ring (button 0) = [1, 2, 0], so preflop runs [0, 1, 2] with BB = seat 2.
-  // Only the BB can check preflop absent a raise; everyone else calls. The
-  // BB acts last, so its check closes the street — no extra option turn.
   state = playAll(state, [
     { type: "call", seatId: 0 },
     { type: "call", seatId: 1 },
@@ -222,15 +218,6 @@ const actionArb = fc.constantFrom<"fold" | "check" | "call" | "raise">(
   "raise",
 );
 
-/**
- * Asserts the leak-freeness property against the state as it stands right
- * now: every seat's dealt cards are visible to every viewer (including the
- * table) exactly when that viewer is entitled to them — the owner while
- * still live, or anyone once the seat is revealed at showdown — and never
- * otherwise. Called after the deal, after every action, and at the end, so
- * every intermediate street and every partial-fold configuration gets
- * checked, not just whatever state a hand happens to finish in.
- */
 function assertNoLeak(
   state: EngineState,
   dealtCards: ReadonlyMap<SeatId, readonly [Card, Card]>,
@@ -258,8 +245,6 @@ function assertNoLeak(
       for (const card of cards) {
         const present = cardKeys.has(`${card.rank}${card.suit}`);
         if (isRevealed) {
-          // Post-showdown, every viewer — including the table — sees
-          // every live seat's cards, not just the owner.
           expect(present).toBe(true);
         } else if (isLiveOwner) {
           expect(present).toBe(true);

--- a/packages/engine/src/view.ts
+++ b/packages/engine/src/view.ts
@@ -14,12 +14,6 @@ export interface SeatSnapshot {
   readonly folded: boolean;
 }
 
-/**
- * Between hands there are no blinds: the engine button has already rotated
- * on, so the `button` reported here is a forecast, and the blinds are far
- * likelier than the button to move again before the deal (seats can be
- * claimed, vacated or set to sit out). Deliberately no blind fields.
- */
 interface NoHandView {
   readonly phase: "no-hand";
   readonly button: SeatId;
@@ -39,7 +33,6 @@ interface ShowdownView extends HandPositions {
 
 export interface PlayerViewBetting extends HandPositions {
   readonly phase: "betting";
-  /** Absolute server deadline for the current actor, or null when disabled. */
   readonly turnEndsAt: number | null;
   readonly street: Street;
   readonly board: readonly Card[];
@@ -47,13 +40,11 @@ export interface PlayerViewBetting extends HandPositions {
   readonly seats: readonly SeatSnapshot[];
   readonly yourSeatId: SeatId;
   readonly yourHoleCards: readonly [Card, Card] | null;
-  /** Empty unless it's `yourSeatId`'s turn — see `legalActions` in table.ts. */
   readonly legalActions: readonly ActionType[];
 }
 
 export interface TableViewBetting extends HandPositions {
   readonly phase: "betting";
-  /** Absolute server deadline for the current actor, or null when disabled. */
   readonly turnEndsAt: number | null;
   readonly street: Street;
   readonly board: readonly Card[];
@@ -67,11 +58,6 @@ export type PlayerView =
 export type TableView =
   NoHandView | TableViewBetting | FoldedOutView | ShowdownView;
 
-/**
- * Builds the restricted view for one seat, or the table device via the
- * `"table"` sentinel. Both are derived from the same authoritative state so
- * the table is never privileged over a player — see Phase 1 spec #130 §4.
- */
 export function view(
   state: EngineState,
   seatId: SeatId,

--- a/packages/harness/src/cli.ts
+++ b/packages/harness/src/cli.ts
@@ -4,9 +4,6 @@ import { parseLogOptions, parseSeats } from "./cli-args.js";
 import { runHarness } from "./harness.js";
 import { HandLog } from "./persistence.js";
 
-// A downstream reader (`| head`, `| less`) closing early is normal Unix
-// pipeline usage, not a harness failure — exit quietly instead of crashing
-// on the resulting EPIPE.
 process.stdout.on("error", (error: NodeJS.ErrnoException) => {
   if (error.code === "EPIPE") process.exit(0);
   throw error;

--- a/packages/harness/src/fixtures.test.ts
+++ b/packages/harness/src/fixtures.test.ts
@@ -43,8 +43,6 @@ describe("hand-1 fixture", () => {
 
 describe("hand-1 fixture: replay through the engine", () => {
   it("folds the recorded event log into a state carrying the hand's blinds", async () => {
-    // The fixture events do not carry `smallBlind`/`bigBlind`; those values
-    // resolve from the ring the replay rebuilds, not from anything in the log.
     const recorded = await readFile(`${fixturesDir}hand-1.expected.jsonl`, {
       encoding: "utf8",
     });
@@ -58,8 +56,6 @@ describe("hand-1 fixture: replay through the engine", () => {
 
     expect(ENGINE_LOG_VERSION).toBe(4);
     if (state.hand?.status !== "complete") throw new Error("expected complete");
-    // Button on seat 0, so ring order is [1, 2, 0]: seat 1 posts the small
-    // blind and seat 2 the big blind, three-handed.
     expect(state.hand.button).toBe(0);
     expect(state.hand.smallBlind).toBe(1);
     expect(state.hand.bigBlind).toBe(2);

--- a/packages/harness/src/harness.test.ts
+++ b/packages/harness/src/harness.test.ts
@@ -218,8 +218,6 @@ describe("runHarness", () => {
       const input = Readable.from(
         [
           { type: "startHand", seatId: 0, seed: "seed-1" },
-          // Seat 0 opens preflop three-handed and faces the BB's post, so
-          // checking is illegal rather than merely out of turn.
           { type: "check", seatId: 0 },
         ].map((command) => JSON.stringify(command) + "\n"),
       );

--- a/packages/harness/src/harness.ts
+++ b/packages/harness/src/harness.ts
@@ -13,14 +13,9 @@ export interface RunHarnessOptions {
   readonly state: EngineState;
   readonly input: Readable;
   readonly output: Writable;
-  /** Optional append-as-you-go persistence — see Phase 1 spec #130 §5. */
   readonly log?: HandLog;
 }
 
-// A logged command line carries an extra `v` field (see persistence.ts's
-// `LoggedCommand`) but is otherwise a bare `Command` — decide() only reads
-// the fields it knows about, so the extra field is silently ignored and a
-// persisted command log re-pipes through the harness unmodified.
 function parseCommand(line: string): Command {
   try {
     return JSON.parse(line) as Command;
@@ -29,17 +24,6 @@ function parseCommand(line: string): Command {
   }
 }
 
-/**
- * Line-delimited harness over the engine: one JSON command per input line,
- * one JSON event or rejection per output line, folding each event into
- * state via `apply` as it's produced. A recorded hand is its input command
- * stream, not this output — replay means re-piping that file.
- *
- * Input is untrusted (hand-typed or agent-generated), unlike every other
- * caller of `decide`, whose closed `Command` union is only enforced at
- * compile time — a bad line fails the whole run rather than risk silently
- * corrupting the audit stream.
- */
 export async function runHarness(options: RunHarnessOptions): Promise<void> {
   let state = options.state;
   const lines = createInterface({
@@ -52,9 +36,6 @@ export async function runHarness(options: RunHarnessOptions): Promise<void> {
 
     const command = parseCommand(line);
     options.log?.logCommand(command);
-    // decide()'s Command union is exhaustive only at compile time; this
-    // input is untrusted JSON, so an unrecognized `type` falls off the
-    // engine's switch at runtime and returns undefined, not a type error.
     const result = decide(state, command) as
       HandEvent[] | Rejection | undefined;
     if (result === undefined) {

--- a/packages/harness/src/persistence.durability.test.ts
+++ b/packages/harness/src/persistence.durability.test.ts
@@ -62,9 +62,6 @@ describe("HandLog crash durability", () => {
       stdout += chunk.toString("utf8");
     });
 
-    // Send commands one at a time, waiting for at least one new stdout line
-    // after each — proof the harness (and therefore the logger, which
-    // writes synchronously before `decide` runs) has processed it.
     for (const command of commands) {
       const before = stdout.length;
       child.stdin.write(JSON.stringify(command) + "\n");
@@ -98,8 +95,6 @@ describe("HandLog crash durability", () => {
       "hand-0001.events.jsonl",
     );
 
-    // Every line that made it to disk must be a complete, parseable record —
-    // no torn write from the kill landing mid-append.
     const loggedCommands = readJsonLines(commandsPath) as {
       v: number;
       type: string;
@@ -112,9 +107,6 @@ describe("HandLog crash durability", () => {
     expect(loggedCommands.length).toBeGreaterThan(0);
     expect(loggedEvents.length).toBeGreaterThan(0);
 
-    // The logged commands are a prefix of what was actually sent — nothing
-    // sent-and-acknowledged is missing, and nothing beyond what was sent
-    // could have leaked in.
     expect(loggedCommands.map((r) => r.type)).toEqual(
       commands.slice(0, loggedCommands.length).map((c) => c.type),
     );

--- a/packages/harness/src/replay.test.ts
+++ b/packages/harness/src/replay.test.ts
@@ -70,8 +70,6 @@ describe("replay guarantee", () => {
 
     const hand1 = handLogPaths(path.join(logDir, "game-1"), 1);
 
-    // Re-pipe the persisted command log (the file on disk, unmodified) through
-    // a fresh harness instance with no logging attached.
     const replayed = collectingWritable();
     await runHarness({
       state: createInitialState([...seats]),

--- a/packages/persistence/src/persistence.ts
+++ b/packages/persistence/src/persistence.ts
@@ -18,10 +18,8 @@ export function assertValidGameId(gameId: string): void {
   }
 }
 
-/** A logged command line is the bare `Command` plus a version tag. */
 export type LoggedCommand = Command & { readonly v: number };
 
-/** A logged event line is the bare `HandEvent`/`Rejection` plus a version tag. */
 export type LoggedEvent = (HandEvent | Rejection) & { readonly v: number };
 
 export interface GameManifest {
@@ -46,12 +44,6 @@ export function handLogPaths(gameDir: string, handIndex: number): HandLogPaths {
   };
 }
 
-/**
- * Append-as-you-go JSONL logger for one game: a seats manifest written once,
- * plus a command/event log file pair per hand. Every write is a single
- * synchronous fs call, so a killed process loses at most the record it was
- * mid-write on, never a batch of completed records.
- */
 export class HandLog {
   readonly gameDir: string;
   #handIndex = 0;

--- a/packages/player-client/src/ActionBar.test.tsx
+++ b/packages/player-client/src/ActionBar.test.tsx
@@ -87,7 +87,6 @@ describe("ActionBar", () => {
     expect(html).toContain('data-rejected-action="check"');
     expect(html).toContain("isn&#x27;t available right now");
 
-    // Inline on the triggering control: inside check's group, not fold's or call's.
     const checkGroupStart = html.indexOf('data-testid="action-group-check"');
     const callGroupStart = html.indexOf('data-testid="action-group-call"');
     const rejectionStart = html.indexOf('data-testid="action-rejection"');

--- a/packages/player-client/src/ActionBar.tsx
+++ b/packages/player-client/src/ActionBar.tsx
@@ -29,7 +29,6 @@ const LABELS: Record<ActionType, string> = {
   raise: "Raise",
 };
 
-/** Per-button sub-caption ("muck"/"no bet"/…). This copy is the spec. */
 const SUB_LABELS: Record<ActionType, string> = {
   fold: "muck",
   check: "no bet",
@@ -74,14 +73,6 @@ const rejectionStyle: CSSProperties = {
   color: "#f0aa9d",
 };
 
-/**
- * Fold/check/call/raise as the permanent base layer (Phase 1 spec #130
- * §9) — always rendered during a betting phase, never swapped out for
- * gestures. Disabled unless the action is in `legalActions` and nothing
- * else is pending; the pressed button carries `data-pending` until its
- * ack/reject lands. A rejection renders inline, once, near the buttons —
- * no toast, no persistent banner.
- */
 export function ActionBar({
   legalActions,
   pendingAction,
@@ -108,9 +99,6 @@ export function ActionBar({
         gap: "0.7em",
       }}
     >
-      {/* No pending command to attribute the reject to (no correlation id
-          on the wire, Phase 1 spec #130 §6) — falls back to a bar-level
-          message rather than guessing which button triggered it. */}
       {rejection !== null && rejection.action === null && (
         <div
           data-testid="action-rejection"

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -52,8 +52,6 @@ export function App() {
   const [seatMoveMessage, setSeatMoveMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    // Silently reclaim a stored seat on mount (Phase 1 spec #130 §7) — a
-    // cleared/absent token just falls through to the normal join flow.
     const stored = loadSeatToken(window.localStorage);
     if (stored === null) return;
     joinRoom(stored.roomCode)
@@ -74,23 +72,12 @@ export function App() {
       });
   }, [setRoomView, setSeat]);
 
-  // Keep the browser URL and the join-form prefill pointing at the room the
-  // player is actually in. Without this the address bar stays pinned to the
-  // first `/join/:code` it loaded, so a player who joins several rooms in one
-  // session keeps landing back on the join screen prefilled with the *first*
-  // code rather than the one they last used. `replaceState` (not push) so this
-  // never adds back-button history. We only rewrite on an active room; leaving
-  // keeps the last room's path, which is what the prefill should offer next.
   useEffect(() => {
     if (typeof window === "undefined" || roomCode === null) return;
     window.history.replaceState(null, "", joinPathForCode(roomCode));
     setDefaultRoomCode(roomCode);
   }, [roomCode]);
 
-  // Drop this player out of their seat locally: forget the stored and in-memory
-  // seat token, and clear the seat and hand slices so no stale seat or hole
-  // cards survive into the next room (#171). Callers that also leave the room
-  // entirely add clearRoom() themselves.
   const dropSeat = useCallback(() => {
     clearSeatToken(window.localStorage);
     setSeatToken(null);
@@ -155,7 +142,6 @@ export function App() {
     send({ type: playerSeat.sittingOut ? "sitIn" : "sitOut" });
   }, [playerSeat, send]);
 
-  // A live seat still in the hand — used to warn that leaving forfeits it.
   const inLiveHand =
     handView?.phase === "betting" &&
     handView.seats.some(
@@ -163,8 +149,6 @@ export function App() {
     );
 
   const handleLeave = useCallback(() => {
-    // Optimistic exit (ADR-0005): fire the release, then tear down locally and
-    // land on the join screen. Nulling the ws params cancels the reconnect.
     if (roomCode !== null && seatId !== null && seatToken !== null) {
       leaveSeat(roomCode, seatId, seatToken);
     }
@@ -182,9 +166,6 @@ export function App() {
         .then((view) => {
           setEvictionMessage(null);
           setSeatMoveMessage(null);
-          // A freshly joined room has no hand for this player yet; drop any
-          // hand view carried over from a previous room so the seat picker
-          // and lobby never show stale hole cards (#171).
           clearHand();
           setRoomView(view);
         })
@@ -198,8 +179,6 @@ export function App() {
   const handleClaim = useCallback(
     (seat: number, name: string) => {
       if (roomCode === null) return;
-      // The seat tap is this phone's audio-unlock gesture (#178): resume the
-      // context and warm the buffers now, while we're inside the user gesture.
       void unlockAudio();
       claimSeat(roomCode, seat, name)
         .then((claim) => {

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -83,9 +83,6 @@ describe("Hand", () => {
     };
     const html = renderToStaticMarkup(<Hand view={view} seatId={0} />);
 
-    // Cards arrive face-down and stay that way until the player asks for
-    // them (Phase 3 spec #138): nothing is exposed on deal, so the hand isn't
-    // in the document at all — not merely hidden by a style.
     expect(html).toMatch(/data-testid="hole-cards"/);
     expect(html).toContain('data-presentation="FaceDown"');
     expect((html.match(/data-face-down="true"/g) ?? []).length).toBe(2);
@@ -309,8 +306,6 @@ describe("Hand", () => {
     });
 
     it("hands the pair to showdown locked, so it renders revealed and inert", () => {
-      // `HoleCardPair.test.tsx` owns what locked *looks* like; the fact worth
-      // asserting here is that showdown is where the lock comes from.
       const html = renderToStaticMarkup(
         <Hand view={showdownView} seatId={0} />,
       );
@@ -446,9 +441,6 @@ describe("Hand", () => {
       expect(html).not.toContain('data-testid="position-badge"');
     });
 
-    // Between hands the button is a forecast of the next deal — the most
-    // useful moment to see it — and the completed phases still say where you
-    // sat, exactly as the table pod beside you does.
     const otherPhases: readonly (readonly [string, PlayerView])[] = [
       ["no-hand", { phase: "no-hand", button: 0 }],
       [
@@ -486,9 +478,6 @@ describe("Hand", () => {
     );
 
     it("shows the heads-up button its disc and the other seat nothing", () => {
-      // The table's suppression, applied to the phone on purpose (decision 2):
-      // the engine reports smallBlind === button, and neither device marks the
-      // heads-up big blind.
       const headsUp: PlayerView = {
         ...bettingView,
         button: 0,

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -25,24 +25,12 @@ export interface HandProps {
   readonly seatId: number;
   readonly seats?: readonly SeatView[];
   readonly connectionStatus?: ConnectionStatus;
-  /** Current room setting, used only to scale the countdown colour ramp. */
   readonly shotClockSeconds?: number;
-  /**
-   * The action intent `App` already owns. `Hand` narrows it to the card
-   * module's own port — the module never sees `ActionIntent`, so growing the
-   * intent layer later does not ripple into card code.
-   */
   readonly intent?: ActionIntent;
 }
 
 const noAction = () => undefined;
 
-/**
- * `actions.fold`/`actions.check` **are** `intent.fold`/`intent.check`: a
- * gesture and a button reach the same Action by the same route, and `canAct`
- * stays the single legality gate. The legality flags are arming and rendering
- * input only.
- */
 function cardActionsFrom(intent: ActionIntent | undefined): CardActions {
   if (intent === undefined) {
     return {
@@ -120,11 +108,6 @@ const bannerToneStyle: Record<
 
 type PlayerViewBetting = Extract<PlayerView, { phase: "betting" }>;
 
-/**
- * Whether the viewer's seat appears in this street's `seats` — absent means
- * sitting out of the current hand, not dealt in (distinct from folded,
- * where the seat is present with `folded: true`).
- */
 function isDealtIn(view: PlayerViewBetting): boolean {
   return view.seats.some((s) => s.seatId === view.yourSeatId);
 }
@@ -136,13 +119,6 @@ function seatLabel(seatId: number, seats: readonly SeatView[]): string {
   );
 }
 
-/**
- * Whose-turn state as `{ kicker, text, tone }`. The same box carries the
- * result once the hand's decided (issue #63), rather than a separate card
- * competing with the hole cards for attention. Connection state wins over hand state: nothing can be
- * acted on off-line, so that's surfaced first regardless of whose turn (or
- * whose win) the hand thinks it is.
- */
 function bannerFor(
   view: PlayerView,
   connectionStatus: ConnectionStatus,
@@ -237,13 +213,6 @@ function bannerFor(
   };
 }
 
-/**
- * The banner's leading slot carries one of two things. It is the marker
- * whenever this player holds a position, and the tone dot otherwise — the
- * marker is the rarer and more specific of the two, and on the hands it
- * appears the banner's own background and kicker still carry the tone
- * (issue #207, decision 1).
- */
 function TurnBanner({
   banner,
   marker,
@@ -333,12 +302,6 @@ function TurnBanner({
   );
 }
 
-/**
- * Empty slots get a sentence saying why they are empty, so it reads as prose.
- * A visible pair gets nothing: it was captioned "Your hole cards · flop" once,
- * which named what the player is plainly looking at and repeated the street
- * the banner above already gives.
- */
 const absentCaptionStyle: CSSProperties = {
   fontSize: fontSize.md,
   lineHeight: 1.5,
@@ -346,14 +309,6 @@ const absentCaptionStyle: CSSProperties = {
   maxWidth: "16em",
 };
 
-/**
- * The card region: the pair itself, plus the copy around it. `Hand` keeps
- * every caption on this screen; the pair owns card presentation and nothing
- * else, which is why the `Absent` copy is decided here (folded reads
- * differently from not-dealt-in) while the empty slots are drawn there.
- *
- * Only empty slots are captioned — a pair the player can see explains itself.
- */
 function HoleCardsRegion({
   cards,
   locked = false,
@@ -363,7 +318,6 @@ function HoleCardsRegion({
   readonly cards: readonly [CardType, CardType] | null;
   readonly locked?: boolean;
   readonly actions: CardActions;
-  /** Why the slots are empty. Absent alongside cards, which need no caption. */
   readonly caption?: string;
 }) {
   const absent = cards === null;
@@ -375,9 +329,6 @@ function HoleCardsRegion({
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-        // Only ever between the empty slots and the sentence under them: a
-        // visible pair carries its own hint down to its bottom edge and is the
-        // sole child here.
         gap: "1.1em",
         minHeight: 0,
         textAlign: "center",
@@ -389,17 +340,6 @@ function HoleCardsRegion({
   );
 }
 
-/**
- * Own hole cards, mirrored straight from the seat's `view` — nothing
- * rebuilt from the raw event locally (Phase 1 spec #130 §9). Hidden
- * again once folded, a burn-pile per §4: `yourHoleCards` is already `null`
- * in that view, this never redacts. The shared board is deliberately never
- * shown here, showdown included — the player device stays hole-cards-only,
- * the board and every seat's revealed hand live on the table device
- * (issue #63); this seat's own result comes back through the turn banner
- * above, not a second card competing with the hole cards for attention.
- * Action buttons live in `ActionBar`, rendered alongside this by `App`.
- */
 export function Hand({
   view,
   seatId,

--- a/packages/player-client/src/InlineError.tsx
+++ b/packages/player-client/src/InlineError.tsx
@@ -12,7 +12,6 @@ const style: CSSProperties = {
   textAlign: "center",
 };
 
-/** The centred inline error line shown below the join form and seat picker. */
 export function InlineError({ testId, message }: InlineErrorProps) {
   return (
     <div data-testid={testId} style={style}>

--- a/packages/player-client/src/JoinForm.tsx
+++ b/packages/player-client/src/JoinForm.tsx
@@ -17,11 +17,6 @@ export interface JoinFormProps {
 
 const CODE_LENGTH = 4;
 
-/**
- * Digits + uppercase letters, excluding characters easily confused on a
- * phone screen (0/O, 1/I/L, 2/Z, 5/S, 8/B) — mirrors the server's
- * `ROOM_CODE_ALPHABET` (packages/server/src/room-code.ts).
- */
 const KEYS = [
   "3",
   "4",

--- a/packages/player-client/src/PlayerMenu.test.tsx
+++ b/packages/player-client/src/PlayerMenu.test.tsx
@@ -70,7 +70,6 @@ describe("MenuBody", () => {
     );
 
     expect(html).toMatch(/data-testid="menu-sit-out"[^>]*disabled/);
-    // Leave stays available even when disconnected (ADR-0005).
     expect(html).toContain('data-testid="menu-leave"');
     expect(html).not.toMatch(/data-testid="menu-leave"[^>]*disabled/);
   });

--- a/packages/player-client/src/PlayerMenu.tsx
+++ b/packages/player-client/src/PlayerMenu.tsx
@@ -10,26 +10,18 @@ import { useEffect, useState, type CSSProperties } from "react";
 
 export interface PlayerMenuProps {
   readonly sittingOut: boolean;
-  /** Sit out/in needs a live socket to send; leave never does (ADR-0005). */
   readonly sitOutDisabled: boolean;
-  /** Drives the confirm copy — a live hand is forfeited on leave. */
   readonly inLiveHand: boolean;
   readonly onToggleSittingOut: () => void;
   readonly onLeave: () => void;
 }
 
-/** Context-aware confirm copy — a live hand is forfeited, otherwise a plain exit. */
 export function leaveConfirmMessage(inLiveHand: boolean): string {
   return inLiveHand
     ? "Leave now? You'll forfeit the current hand."
     : "Leave the game?";
 }
 
-/**
- * The player's burger and the side drawer it opens (ADR-0005). The drawer holds
- * the seat actions moved out of the crowded top bar — sit out/in, gated on the
- * socket, and leave, which is always available and asks to confirm first.
- */
 export function PlayerMenu({
   sittingOut,
   sitOutDisabled,
@@ -156,7 +148,6 @@ export interface MenuBodyProps {
   readonly onConfirmLeave: () => void;
 }
 
-/** The drawer's contents, split out from its animation shell so it renders flat in tests. */
 export function MenuBody({
   sittingOut,
   sitOutDisabled,

--- a/packages/player-client/src/PositionBadge.test.tsx
+++ b/packages/player-client/src/PositionBadge.test.tsx
@@ -23,7 +23,6 @@ describe("PositionBadge", () => {
   it("says what the letter means rather than leaving a screen reader to spell it", () => {
     const html = renderToStaticMarkup(<PositionBadge marker="button" />);
     expect(html).toContain('aria-label="You are on the dealer button"');
-    // The visible label is decoration once the disc is labelled.
     expect(html).toContain('aria-hidden="true"');
   });
 
@@ -31,8 +30,6 @@ describe("PositionBadge", () => {
     const html = renderToStaticMarkup(<PositionBadge marker="big-blind" />);
     const outer = /width:2\.1em;height:2\.1em/.exec(html);
     expect(outer).not.toBeNull();
-    // A font-size on that same element would shrink the true diameter to
-    // 2.1 x 0.8em — the bug #160 hit on the table.
     expect(html).toMatch(/width:2\.1em;height:2\.1em(?![^>]*font-size)/);
   });
 

--- a/packages/player-client/src/PositionBadge.tsx
+++ b/packages/player-client/src/PositionBadge.tsx
@@ -9,26 +9,9 @@ import {
 
 export interface PositionBadgeProps {
   readonly marker: PositionMarker;
-  /**
-   * Muted to match a banner that is no longer reporting live state. Nothing
-   * else on this screen dims when the socket drops, but this disc is the
-   * brightest thing on it: at full strength it would out-shout the very
-   * banner telling the player their actions won't send (issue #207,
-   * decision 5).
-   */
   readonly dimmed?: boolean;
 }
 
-/**
- * The dealer/blind disc, drawn the way the table draws it on a seat pod:
- * the same three labels and colours (from `ui-shared`, so the two can't
- * drift), the same `shadow.card` lift, and the same split of diameter and
- * font size across two elements — `width: 2.1em` and `fontSize: 0.8em` on one
- * element would make the true diameter `2.1 x 0.8em` and shrink the disc to a
- * third of its intended size.
- *
- * Sized to stand as tall as the banner's kicker-and-text block beside it.
- */
 const DIAMETER = "2.1em";
 const LABEL_FONT_SIZE = "0.8em";
 
@@ -59,8 +42,6 @@ export function PositionBadge({ marker, dimmed = false }: PositionBadgeProps) {
         opacity: dimmed ? 0.55 : 1,
       }}
     >
-      {/* "D" read aloud is a letter, not a position — `aria-label` above says
-          what it means, so the label itself is decoration to a screen reader. */}
       <span
         aria-hidden="true"
         style={{

--- a/packages/player-client/src/SeatMovedNotice.tsx
+++ b/packages/player-client/src/SeatMovedNotice.tsx
@@ -16,7 +16,6 @@ const style: CSSProperties = {
   fontSize: fontSize.md,
 };
 
-/** The inline notice shown when a table repack changes a player's position. */
 export function SeatMovedNotice({ message }: SeatMovedNoticeProps) {
   return (
     <div data-testid="seat-moved-notice" style={style}>

--- a/packages/player-client/src/SeatPanel.test.tsx
+++ b/packages/player-client/src/SeatPanel.test.tsx
@@ -4,10 +4,6 @@ import { describe, expect, it } from "vitest";
 import { SeatPanel } from "./SeatPanel.js";
 import { playerTopPillStyle } from "./topPillStyle.js";
 
-/**
- * Markup with the tags stripped — the seat pill spans several of them — and
- * its non-breaking spaces normalised, so assertions read as plain text.
- */
 function textOf(html: string): string {
   return html.replace(/<[^>]*>/g, "").replace(/\u00a0/g, " ");
 }
@@ -29,12 +25,6 @@ describe("SeatPanel", () => {
     expect(textOf(html)).toContain("Avery · Seat 3");
   });
 
-  /*
-   * The pill truncates from the name end only, so the seat number survives a
-   * squeeze (ADR-0006). jsdom has no layout, so the guard is on the structure
-   * that produces that: only the name may shrink and clip, and the seat number
-   * is fixed. A layout test would pass on a bar that still overflows.
-   */
   it("truncates the name, never the seat number", () => {
     const html = renderToStaticMarkup(
       <SeatPanel seatId={2} displayName="Bartholomew" sittingOut={false} />,
@@ -45,7 +35,6 @@ describe("SeatPanel", () => {
     expect(name).toContain("overflow:hidden");
     expect(name).toContain("text-overflow:ellipsis");
 
-    // The seat number's own span is fixed, so it is never the part clipped.
     const seatNumber = /<span style="flex:none">[^<]*Seat 3<\/span>/.exec(html);
     expect(seatNumber).not.toBeNull();
   });
@@ -68,8 +57,6 @@ describe("SeatPanel", () => {
       />,
     );
     expect(html).toContain('data-testid="sitting-out-badge"');
-    // Short by design: the label shares a narrow row with the seat pill and
-    // the menu, and "waiting" here can only mean the next hand (ADR-0006).
     expect(html).toContain("Waiting");
     expect(html).not.toContain("Waiting for next hand");
   });

--- a/packages/player-client/src/SeatPanel.tsx
+++ b/packages/player-client/src/SeatPanel.tsx
@@ -9,17 +9,8 @@ export interface SeatPanelProps {
   readonly sittingOutReason?: SittingOutReason | null;
 }
 
-/*
- * Non-breaking spaces: the separator opens a flex item, and a flex item's
- * leading whitespace is trimmed away, which closed the gap to the name.
- */
 const NAME_SEPARATOR = " · ";
 
-/**
- * The player's identity at the top of the screen: their seat (and name) plus a
- * presence-only sitting-out badge. The seat actions — sit out and leave — live
- * behind the menu (ADR-0005), so this panel carries state, never controls.
- */
 export function SeatPanel({
   seatId,
   displayName,
@@ -30,8 +21,6 @@ export function SeatPanel({
     <div
       data-testid="seat-panel"
       style={{
-        // Shrinkable, so that whatever cannot fit gives way here rather than
-        // pushing the menu out of the bar (ADR-0006).
         minWidth: 0,
         display: "flex",
         alignItems: "center",
@@ -42,12 +31,6 @@ export function SeatPanel({
         data-testid="claimed-seat"
         style={{
           ...playerTopPillStyle,
-          /*
-           * No `min-width: 0` here on purpose. The pill's automatic minimum is
-           * the width its unshrinkable content needs — the seat number — so it
-           * stops there instead of collapsing and painting `Seat 6` outside its
-           * own border. Only the name inside it may shrink.
-           */
           overflow: "hidden",
           background: color.control,
           border: `1px solid ${color.border}`,
@@ -66,9 +49,6 @@ export function SeatPanel({
             {displayName}
           </span>
         )}
-        {/* The seat number never truncates. It is how a player identifies
-         * themselves against the table screen, whereas their own name is the
-         * one thing on this bar they already know. */}
         <span style={{ flex: "none" }}>
           {displayName ? NAME_SEPARATOR : ""}Seat {seatId + 1}
         </span>

--- a/packages/player-client/src/SeatPicker.test.tsx
+++ b/packages/player-client/src/SeatPicker.test.tsx
@@ -78,8 +78,6 @@ describe("SeatPicker", () => {
     expect(html).toContain('data-testid="seat-grid"');
     expect(html).toContain('data-seat-count="6"');
     expect(html).toContain("grid-template-columns:repeat(2, minmax(0, 1fr))");
-    // Row count feeds the `.seat-grid` track template in CSS; the sizing and
-    // compact-layout behaviour live there, not in the inline styles.
     expect(html).toContain("--seat-row-count:3;");
   });
 
@@ -99,8 +97,6 @@ describe("SeatPicker", () => {
     );
 
     expect(html).toContain("--seat-row-count:4;");
-    // The classes the `@container seat` query keys on must be present so the
-    // card can flip to its horizontal layout when its own box gets short.
     expect(html).toContain('class="seat-option"');
     expect(html).toContain('class="seat-row"');
     expect(html).toContain('class="seat-avatar"');

--- a/packages/player-client/src/SeatPicker.tsx
+++ b/packages/player-client/src/SeatPicker.tsx
@@ -23,11 +23,6 @@ const seatErrorCopy: Record<string, string> = {
   "claim-failed": "Couldn't reach the table — try that seat again.",
 };
 
-/**
- * Why a pending seat selection can no longer be claimed, or null while it
- * still can. A live room view can take the seat or repack it out of the table
- * between selecting it and claiming it.
- */
 export function selectionLostMessage(
   seatId: number,
   seat: SeatView | undefined,
@@ -54,8 +49,6 @@ type SeatGridStyle = CSSProperties & {
 function seatGridStyle(seatCount: number): SeatGridStyle {
   const rowCount = Math.max(1, Math.ceil(seatCount / 2));
 
-  // Row count and column count are data, so they stay inline; the grid's
-  // sizing and shrink behaviour live in the `.seat-grid` CSS rule.
   return {
     "--seat-row-count": rowCount,
     gridTemplateColumns: seatCount <= 1 ? "1fr" : "repeat(2, minmax(0, 1fr))",
@@ -75,9 +68,6 @@ function seatStyle(claimed: boolean, selected: boolean): CSSProperties {
           border: `1px solid ${
             selected ? color.accentBright : color.accentBorder
           }`,
-          // Selection is carried by the brighter border and the ring, not by
-          // a fill: `lossBackground` is the error surface this same screen
-          // uses below, and a selected seat is not an error.
           background: color.accentWash,
           boxShadow: selected ? `0 0 0 2px ${color.accentBorder}` : undefined,
         }),
@@ -182,10 +172,6 @@ export function SeatPicker({
     !selectedSeat.claimed &&
     displayName.trim() !== "";
 
-  // Room views now arrive live over the lobby socket, so the selected seat can
-  // be claimed by someone else or repacked away while this player is still
-  // typing. Drop the selection and say why — the typed name is deliberately
-  // kept, so picking another seat doesn't mean typing it again.
   useEffect(() => {
     if (selectedSeatId === null) return;
     const lost = selectionLostMessage(selectedSeatId, selectedSeat);

--- a/packages/player-client/src/StatusBar.test.tsx
+++ b/packages/player-client/src/StatusBar.test.tsx
@@ -59,11 +59,6 @@ describe("StatusBar", () => {
     expect(html).toContain("height:30px");
   });
 
-  /*
-   * The status starts at `disconnected` before any socket is opened, so
-   * reporting it verbatim would warn every player about a drop that has not
-   * happened, on every load (ADR-0006).
-   */
   it("does not warn about a connection never yet made", () => {
     for (const connectionStatus of ["disconnected", "connecting"] as const) {
       expect(
@@ -111,13 +106,6 @@ describe("StatusBar", () => {
     expect(html).not.toContain('data-testid="player-menu-button"');
   });
 
-  /*
-   * The menu holds sit out and leave, so a burger pushed off the edge strands
-   * the player — and `.app-shell` clips rather than scrolls, so it does not
-   * merely move, it disappears. jsdom cannot measure that, so these guard the
-   * structure that prevents it: a reserved column for the menu, and a left
-   * column that shrinks below its content instead of pushing.
-   */
   it("reserves a column for the menu that content cannot consume", () => {
     const html = renderToStaticMarkup(
       <StatusBar
@@ -138,7 +126,6 @@ describe("StatusBar", () => {
     expect(header).toContain("display:grid");
     expect(header).toContain("grid-template-columns:minmax(0, 1fr) auto");
 
-    // The pills give way, not the menu.
     const seatPanel =
       /<div[^>]*data-testid="seat-panel"[^>]*>/.exec(html)?.[0] ?? "";
     expect(seatPanel).toContain("min-width:0");

--- a/packages/player-client/src/StatusBar.tsx
+++ b/packages/player-client/src/StatusBar.tsx
@@ -9,7 +9,6 @@ import type { ConnectionStatus } from "./store/connectionSlice.js";
 export interface StatusBarProps {
   readonly showBadge: boolean;
   readonly connectionStatus: ConnectionStatus;
-  /** Latched on the first successful connect; see `connectionSlice`. */
   readonly hasEverConnected: boolean;
   readonly inLiveHand: boolean;
   readonly onToggleSittingOut: () => void;
@@ -33,14 +32,6 @@ const badgeTone: Record<
 
 const badgeStyle: CSSProperties = {
   ...playerTopPillStyle,
-  /*
-   * Precedence as a shrink weight rather than a breakpoint (ADR-0006): the
-   * connection is the first thing that should give way, so this yields its
-   * label ~100× faster than the seat pill beside it yields the player's name.
-   * A width threshold cannot do this — it would have to guess how many pills
-   * are on the row. Its minimum is its own dot: no `min-width: 0` here, so it
-   * stops at the unshrinkable content rather than collapsing.
-   */
   flexShrink: 100,
   overflow: "hidden",
   gap: "0.5em",
@@ -48,14 +39,6 @@ const badgeStyle: CSSProperties = {
   border: `1px solid ${color.border}`,
 };
 
-/**
- * The badge reports trouble, not health (ADR-0006). A permanent `CONNECTED`
- * pill spends width on the one state that needs no reporting, and it is the
- * state a player is in essentially always — so it is shown only while the
- * connection is not good, and only once there has been a connection to lose.
- * Without that second condition the pre-socket `disconnected` default would
- * warn about a drop that has not happened, on every load.
- */
 export function connectionBadgeVisible(
   showBadge: boolean,
   connectionStatus: ConnectionStatus,
@@ -64,7 +47,6 @@ export function connectionBadgeVisible(
   return showBadge && hasEverConnected && connectionStatus !== "connected";
 }
 
-/** No connection badge before a seat is claimed — there's nothing to connect to yet. */
 export function StatusBar({
   showBadge,
   connectionStatus,
@@ -86,15 +68,6 @@ export function StatusBar({
       data-testid="player-status-bar"
       style={{
         flex: "none",
-        /*
-         * Two columns, and the second one is not negotiable: the menu holds
-         * sit out and leave, so a top bar that pushes the burger off the edge
-         * strands the player (ADR-0006). A flex row cannot promise that —
-         * any sibling added with `flex: none` silently reclaims the space —
-         * whereas a fixed track is a property of the container that no future
-         * pill can take back. `minmax(0, 1fr)` is what lets the left column
-         * shrink below its content instead of overflowing.
-         */
         display: "grid",
         gridTemplateColumns: "minmax(0, 1fr) auto",
         alignItems: "center",
@@ -102,10 +75,6 @@ export function StatusBar({
         padding: "16px 18px 0",
       }}
     >
-      {/* Every pill shares the flexible column. The badge belongs here rather
-       * than beside the burger: anything in the reserved track competes with
-       * the menu for it, and the connection is the *first* thing that should
-       * give way, not the last (ADR-0006). */}
       <div
         style={{
           display: "flex",
@@ -137,9 +106,6 @@ export function StatusBar({
                 background: tone.dot,
               }}
             />
-            {/* First to go when the row is tight — the dot beside it keeps
-             * reporting the state in colour, so the label is the cheapest
-             * thing on the bar to lose. */}
             <span
               className="connection-status-label"
               style={{

--- a/packages/player-client/src/actions/legalActionsFromView.ts
+++ b/packages/player-client/src/actions/legalActionsFromView.ts
@@ -1,11 +1,5 @@
 import type { ActionType, PlayerView } from "@table-top-poker/protocol";
 
-/**
- * The engine already scopes `PlayerViewBetting.legalActions` to empty
- * unless it's this seat's turn (engine/src/view.ts) — this just extends
- * that to the non-betting phases and the pre-connection `null` view, so
- * callers never branch on `view.phase` themselves.
- */
 export function legalActionsFromView(
   view: PlayerView | null,
 ): readonly ActionType[] {

--- a/packages/player-client/src/actions/rejectionCopy.ts
+++ b/packages/player-client/src/actions/rejectionCopy.ts
@@ -3,14 +3,6 @@ import type {
   ServerRejectionReason,
 } from "@table-top-poker/protocol";
 
-/**
- * Display copy for an inline rejection, exhaustively switched
- * (eslint's switch-exhaustiveness-check) so a new reason code added to
- * either union is a build failure here, not a silent blank message.
- * `hand-already-in-progress` and `stale-next-hand` can't actually reach an
- * action button (they're `startHand`/`nextHand`-only reasons) but the type
- * doesn't know that, so they get terse copy rather than a `default`.
- */
 export function rejectionCopy(
   reason: RejectionReason | ServerRejectionReason,
 ): string {

--- a/packages/player-client/src/actions/useActionIntent.ts
+++ b/packages/player-client/src/actions/useActionIntent.ts
@@ -14,12 +14,6 @@ export interface ActionIntent {
   readonly raise: () => void;
 }
 
-/**
- * Whether `action` may be sent right now: it must be legal in the latest
- * view and nothing else already in flight. Buttons are expected to disable
- * themselves off this same state (`legalActions`/`pendingAction`) — this is
- * the belt-and-braces guard against a stale click slipping through.
- */
 export function canAct(
   legalActions: readonly ActionType[],
   pendingAction: ActionType | null,
@@ -28,11 +22,6 @@ export function canAct(
   return pendingAction === null && legalActions.includes(action);
 }
 
-/**
- * The action-intent module (Phase 1 spec #130 §9): `fold`/`check`/
- * `call`/`raise`, plus `legalActions` derived from the latest view
- * snapshot.
- */
 export function useActionIntent(
   send: (command: ClientCommand) => void,
 ): ActionIntent {

--- a/packages/player-client/src/api/rooms.ts
+++ b/packages/player-client/src/api/rooms.ts
@@ -41,11 +41,6 @@ export async function claimSeat(
   return (await response.json()) as SeatClaim;
 }
 
-/**
- * Releases the player's own seat (ADR-0005). Fire-and-forget with `keepalive`
- * so it survives the client's optimistic teardown, and never throws — the
- * client returns to the join screen regardless of whether this lands.
- */
 export function leaveSeat(code: string, seatId: number, token: string): void {
   void fetch(`/rooms/${code}/seats/${String(seatId)}/leave`, {
     method: "POST",

--- a/packages/player-client/src/claimError.ts
+++ b/packages/player-client/src/claimError.ts
@@ -6,12 +6,6 @@ export type ClaimErrorCode =
   | "duplicate-display-name"
   | "claim-failed";
 
-/**
- * Keep server claim errors specific when a claim races a room update. Anything
- * the server did not name — a network failure, a 500 — falls back to
- * `claim-failed` rather than to an occupied seat: telling a player someone
- * took the seat sends them hunting for another one when the seat was fine.
- */
 export function claimErrorCode(error: unknown): ClaimErrorCode {
   const code = error instanceof Error ? error.message : "";
   if (

--- a/packages/player-client/src/holecards/BendableCard.test.tsx
+++ b/packages/player-client/src/holecards/BendableCard.test.tsx
@@ -36,10 +36,6 @@ describe("BendableCard", () => {
   });
 
   it("puts an index where the curl actually uncovers it", () => {
-    // `react-peel` pins the back layer by the *horizontally flipped* corner, so
-    // a bottom-right peel uncovers the face's bottom-left — where an ordinary
-    // card carries no ink. Without this remapped copy a bend shows bare white
-    // card, which is precisely the bug this asserts against.
     const html = render("Peeking");
 
     expect(html).toContain("hole-card-curl-index");
@@ -48,25 +44,15 @@ describe("BendableCard", () => {
   });
 
   it("keeps the remapped index off the class the flap rule suppresses", () => {
-    // `.peel-back .card-index { display: none }` in `app-shell.css` hides the
-    // face's own corner indices on the lifted sheet, so that the rank is not
-    // printed twice on it. The remapped index must not answer to that
-    // selector — if it ever did, the flap would go blank again.
     const html = render("Peeking");
     const curl = /<span class="([^"]*hole-card-curl-index[^"]*)"/.exec(html);
 
     expect(curl).not.toBeNull();
     expect(curl?.[1]).not.toMatch(/\bcard-index\b/);
-    // And the face's own indices really are in the flap, for the rule to bite.
     expect(html).toMatch(/<div class="peel-back[\s\S]*?class="card-index/);
   });
 
   it("suppresses the flap's inline display, not merely a class", () => {
-    // These tests render to static markup, so no stylesheet is ever applied
-    // and the rule cannot be observed working. What *can* be checked is the
-    // thing that made an earlier attempt fail silently: `Card` sets `display`
-    // inline, so an ordinary declaration loses to it however specific the
-    // selector, and only `!important` actually suppresses the index.
     expect(render("Peeking")).toMatch(
       /class="card-index[^"]*"[^>]*display:flex/,
     );
@@ -80,15 +66,11 @@ describe("BendableCard", () => {
 
     expect(html).not.toContain("hole-card-curl-index");
     expect(html).toContain('data-rank="Q"');
-    // The flat card keeps both its printed corners: the rule above is scoped
-    // to the flap, and must not have reached the ordinary face.
     expect((html.match(/class="card-index/g) ?? []).length).toBe(2);
   });
 
   describe("leaving for the muck", () => {
     it("flies away face-up when that is the face it had", () => {
-      // Flipping face-down inside a 280ms departure is illegible motion, and
-      // the privacy boundary is the physical table rather than the flight (§7).
       const html = render("Leaving", true);
 
       expect(html).toContain('data-rank="Q"');

--- a/packages/player-client/src/holecards/BendableCard.tsx
+++ b/packages/player-client/src/holecards/BendableCard.tsx
@@ -19,29 +19,6 @@ import {
 import type { Presentation } from "./cardState.js";
 import { REVEAL_THRESHOLD } from "./constants.js";
 
-/**
- * The player-side wrapper around the shared `Card` (Phase 3 spec #138 §14).
- * Bend and turn live here, in the player client, so `ui-shared` gains no
- * gesture concepts — including the one piece of ink that exists purely because
- * of the curl, which is a player-client component rather than a `Card` prop.
- *
- * The bend is a real corner curl, not a wipe: `react-peel` lifts the
- * bottom-right corner as a sheet, and what you read is the card's **own face
- * on the underside of that sheet** — which is what makes it feel like lifting
- * a physical card rather than watching one dissolve. `PeelTop` is the flat
- * remainder of the back, `PeelBack` is the lifted flap, and `PeelBottom` is
- * the table showing through where the corner used to be. Which *part* of that
- * flap is visible is not the part you would guess — see `CurlIndex`.
- *
- * Crossing the threshold does not start a *different* animation: the same
- * sheet is carried on past the opposite corner until the card has turned all
- * the way over. That is why the peel is mounted for `Turning` as well as
- * `Peeking`, and why a keyboard reveal — which starts at 0 — produces exactly
- * the same motion as a bend that committed.
- *
- * The peel is driven entirely by a `MotionValue` (§13). This component
- * re-renders when the *presentation* changes and never while a finger moves.
- */
 export function BendableCard({
   card,
   presentation,
@@ -51,16 +28,8 @@ export function BendableCard({
 }: {
   readonly card: CardType;
   readonly presentation: Presentation;
-  /** Peel progress, 0 → 1, shared by both cards so the pair opens together. */
   readonly bend: MotionValue<number>;
-  /** The card's resting angle in the overlapped pair. */
   readonly tiltDegrees: number;
-  /**
-   * Whether the pair was face-up when the Fold committed. The cards leave with
-   * whatever face they had (§7): flipping face-down inside a 280ms departure
-   * is illegible motion, and the privacy boundary is the physical table rather
-   * than the flight.
-   */
   readonly leavingFaceUp: boolean;
 }) {
   const peeking = presentation === "Peeking";
@@ -68,9 +37,6 @@ export function BendableCard({
   const revealed =
     presentation === "Revealed" ||
     (presentation === "Leaving" && leavingFaceUp);
-  // The face is in the document only while it is being looked at. A face-down
-  // pair carries no rank or suit at all, and closing a peek removes it again
-  // instantly, as concealment does: a glance must leave nothing exposed.
   const curling = peeking || turning;
 
   return (
@@ -96,12 +62,6 @@ export function BendableCard({
   );
 }
 
-/**
- * The lifted sheet. `react-peel` measures its own box and takes peel positions
- * in that box's pixel coordinates, so the travel is derived from the measured
- * card rather than from a constant — the pair is sized in `em` and inherits
- * whatever font-size the surface gives it.
- */
 function CurlingCard({
   card,
   bend,
@@ -118,8 +78,6 @@ function CurlingCard({
       const { width, height } = current;
 
       if (progress <= REVEAL_THRESHOLD) {
-        // A gentle diagonal curl: the corner travels in towards the middle
-        // of the card as the bend deepens.
         const travel = (progress / REVEAL_THRESHOLD) * CURL_TRAVEL;
         current.setPeelPosition(
           width - width * travel,
@@ -128,8 +86,6 @@ function CurlingCard({
         return;
       }
 
-      // Committed: carry the same sheet on past the opposite corner so it
-      // completes the turn, rather than cutting to a separate flip.
       const finish = (progress - REVEAL_THRESHOLD) / (1 - REVEAL_THRESHOLD);
       const fromX = width - width * CURL_TRAVEL;
       const fromY = height - height * CURL_TRAVEL;
@@ -160,8 +116,6 @@ function CurlingCard({
       <PeelTop>
         <Card faceDown />
       </PeelTop>
-      {/* Positioned, so the remapped index below anchors to the lifted sheet
-       * and travels with it rather than to the card's resting box. */}
       <PeelBack style={{ position: "relative", width: "100%", height: "100%" }}>
         <Card rank={card.rank} suit={card.suit} />
         <CurlIndex rank={card.rank} suit={card.suit} />
@@ -171,26 +125,6 @@ function CurlingCard({
   );
 }
 
-/**
- * The rank and suit as they appear *on the curl*.
- *
- * `react-peel` pins the back layer by `flipPointHorizontally(corner)`, so for a
- * bottom-right peel it is the back's **bottom-left** corner that is pinned to
- * the fingertip and the bottom-left region that the lifted flap uncovers. The
- * face's own bottom-right index therefore falls outside the visible curl
- * entirely — which is why a bend showed bare white card. This is that index
- * remapped to where the geometry actually puts it.
- *
- * The face's *own* corner indices are suppressed on this copy — see
- * `.peel-back .card-index` in `app-shell.css`. They are printed for a flat
- * card and land arbitrarily once the sheet is rotated about the fold, so
- * leaving them on showed the rank twice: once here, upright at the lifted
- * tip, and once more sideways-on wherever the rotation happened to put it.
- *
- * Presentational only, and a duplicate of ink the face already carries, so it
- * is hidden from assistive technology: the accessible reveal is `Revealed`,
- * announced by the pair, not this.
- */
 function CurlIndex({
   rank,
   suit,
@@ -206,19 +140,11 @@ function CurlIndex({
         ...cardIndexStyle,
         left: "0.235em",
         bottom: "0.21em",
-        // A half-turn, so the index reads upright once the flap's own rotation
-        // is applied on top of it.
         transform: "rotate(180deg)",
         color: isRedSuit(suit) ? color.suitRed : color.suitBlack,
       }}
     >
       {rank}
-      {/* Larger than the face's own suit, which is the one place this index
-       * deliberately departs from `cardIndexSuitStyle`. The markup is
-       * otherwise identical, so this is not correcting a size difference but
-       * a legibility one: on the flap the symbol is rotated and sits under
-       * the peel's shadow and reflection wash, and at the face's size it
-       * reads lighter and smaller than the same symbol lying flat. */}
       <span style={{ ...cardIndexSuitStyle, fontSize: "0.9em" }}>
         {suitSymbols[suit]}
       </span>
@@ -226,19 +152,8 @@ function CurlIndex({
   );
 }
 
-/**
- * How far the corner travels, as a fraction of the card, by the moment the
- * bend commits. Short of the full diagonal on purpose: the corner is still a
- * lifted corner at the threshold, not a card folded in half.
- */
 const CURL_TRAVEL = 0.86;
 
-/**
- * The affordance the whole gesture hangs off: a corner that looks liftable.
- * `data-bend-zone` is what the recognizer hit-tests against, so the classifier
- * never needs to know where the corner is drawn — and the coaching copy can
- * follow the rendered zone rather than hard-coding "bottom-right".
- */
 function BendZone() {
   return (
     <span

--- a/packages/player-client/src/holecards/CheckStamp.test.tsx
+++ b/packages/player-client/src/holecards/CheckStamp.test.tsx
@@ -3,12 +3,6 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { CheckStamp } from "./CheckStamp.js";
 
-/**
- * The stamp is presentation, so what is worth pinning is the contract the
- * surrounding surface leans on rather than the markup it happens to emit: it
- * must not take a gesture off the cards, and it must not speak, because
- * `HoleCardPair`'s live region already announces the same Check.
- */
 describe("CheckStamp", () => {
   it("says the Action, so the confirmation is legible without the ActionBar", () => {
     const html = renderToStaticMarkup(<CheckStamp />);

--- a/packages/player-client/src/holecards/CheckStamp.tsx
+++ b/packages/player-client/src/holecards/CheckStamp.tsx
@@ -7,21 +7,8 @@ import {
 } from "@table-top-poker/ui-shared";
 import { motion, useReducedMotion } from "motion/react";
 
-/** Pressed on slightly larger than life, so the mark reads as sitting above. */
 const RESTING_SCALE = 1.25;
 
-/**
- * The sighted confirmation for a gesture Check. The surrounding card surface
- * decides when this exists; the stamp itself is deliberately non-interactive
- * so it cannot steal or replay a card gesture, and hidden from assistive
- * technology because `HoleCardPair`'s live region already speaks the same news.
- *
- * Styled from the theme tokens rather than a stylesheet: there is no
- * CSS-variable bridge to them, so a class would have meant re-hardcoding the
- * palette, and #144 asks this surface to align with the app's tokens. The entry
- * animation is Motion's for the same reason every other animation here is —
- * one system driving the surface, with reduced motion answered in one place.
- */
 export function CheckStamp() {
   const reducedMotion = useReducedMotion();
 
@@ -29,8 +16,6 @@ export function CheckStamp() {
     <motion.span
       data-testid="check-stamp"
       aria-hidden="true"
-      // A player who asked for less motion gets the stamp already at rest,
-      // rather than the same movement hurried into an imperceptible duration.
       initial={
         reducedMotion === true
           ? false
@@ -51,8 +36,6 @@ export function CheckStamp() {
         gap: "0.5em",
         minHeight: "3.2em",
         padding: "0 1em 0 0.55em",
-        // The pair below stays reachable: a tap that lands on the stamp is
-        // still a tap on the cards.
         pointerEvents: "none",
         whiteSpace: "nowrap",
         color: color.winText,

--- a/packages/player-client/src/holecards/HoleCardPair.test.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.test.tsx
@@ -68,8 +68,6 @@ describe("HoleCardPair", () => {
     expect(html).toContain('data-rank="J"');
     expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(2);
     expect(html).toContain('aria-disabled="true"');
-    // Inert, but still in the tab order with its name intact: at showdown
-    // that name is where a screen-reader user reads their own hand.
     expect(html).not.toMatch(/<button[^>]*\sdisabled/);
   });
 
@@ -85,8 +83,6 @@ describe("HoleCardPair", () => {
   });
 
   it("carries the bend affordance on both cards", () => {
-    // The recognizer hit-tests this attribute, so the classifier never needs
-    // to know where the corner is drawn.
     const html = renderToStaticMarkup(
       <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
     );
@@ -110,8 +106,6 @@ describe("HoleCardPair", () => {
     expect(html).toContain("touch-action:none");
     expect(html).toContain("-webkit-touch-callout:none");
     expect(html).toContain("user-select:none");
-    // Android Chrome's press wash reads as a highlight on the cards during a
-    // long-press; the surface does its own press feedback, so it is turned off.
     expect(html).toContain("-webkit-tap-highlight-color:transparent");
   });
 
@@ -123,11 +117,6 @@ describe("HoleCardPair", () => {
     expect(html).not.toContain('data-testid="hole-cards-hint"');
   });
 
-  // The confirmation is transient, so a settled pair claiming a Check just
-  // landed would be a lie. The other half of this — that the stamp *does*
-  // arrive on a gesture Check, and takes the sighted hint's place when it
-  // does — needs a rendered double-tap, which is the DOM test layer #156 is
-  // still deciding on.
   it("stamps no Check confirmation over a pair that has not just checked", () => {
     const html = renderToStaticMarkup(
       <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
@@ -142,15 +131,10 @@ describe("HoleCardPair", () => {
       <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
     );
 
-    // A live region inserted along with its own text is not reliably
-    // announced, so the region has to be here first — with nothing in it.
     expect(html).toMatch(/<span role="status"[^>]*><\/span>/);
   });
 
   it("renders the words the selector chose, for every hint it can choose", () => {
-    // The copy lives in the selector and this is the only thing that prints it,
-    // so the surface can never teach a gesture in different words from the ones
-    // the §11 table settles.
     const cases: readonly {
       readonly state: Partial<CardState & { bendAxis: BendAxis }>;
       readonly ctx?: Partial<HintContext>;
@@ -204,13 +188,10 @@ describe("HoleCardPair", () => {
       return hint.id;
     });
 
-    // All nine of them, each rendered by the same block.
     expect(new Set(rendered).size).toBe(9);
   });
 
   it("names the corner the bend affordance is actually drawn in", () => {
-    // "bottom-right" tracks the rendered zone rather than being hard-coded: if
-    // the overlapped layout ever mirrors, the copy follows it.
     const html = renderToStaticMarkup(
       <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
     );

--- a/packages/player-client/src/holecards/HoleCardPair.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.tsx
@@ -12,9 +12,7 @@ import type { CardActions } from "./ports.js";
 import { useHoleCards } from "./useHoleCards.js";
 
 export interface HoleCardPairProps {
-  /** `null` ⇒ `Absent`: not dealt in, folded, or mucked. */
   readonly cards: readonly [CardType, CardType] | null;
-  /** Showdown: revealed and inert. */
   readonly locked: boolean;
   readonly actions: CardActions;
 }
@@ -42,37 +40,22 @@ const suitWords: Record<Suit, string> = {
   spades: "spades",
 };
 
-/**
- * The font-size the whole pair is drawn at — every card dimension is an `em`
- * of it. `--hole-card-unit` is set by `.hand`, which sizes it from the phone
- * column's own width and the viewport height; the fallback is the fixed size
- * this used to be, for any surface that renders a pair outside that shell
- * (tests included).
- */
 const HOLE_CARD_UNIT = "var(--hole-card-unit, 2.6em)";
 
 function cardWords(card: CardType): string {
   return `${rankWords[card.rank]} of ${suitWords[card.suit]}`;
 }
 
-/** A pair's identity as a value — a hand's cards, never their position. */
 function cardKey(cards: readonly [CardType, CardType]): string {
   return cards.map((card) => `${card.rank}${card.suit}`).join("-");
 }
 
-/**
- * The accessible name carries the state and the outcome of activating, and —
- * once revealed — the cards themselves, since a screen-reader user reads them
- * here rather than off the card faces.
- */
 function accessibleName(
   cards: readonly [CardType, CardType],
   presentation: Presentation,
   locked: boolean,
 ): string {
   const faces = `${cardWords(cards[0])} and ${cardWords(cards[1])}`;
-  // Inert, and there is no undo once the Fold is sent — so the name says what
-  // is happening and offers nothing to activate.
   if (presentation === "Leaving") return "Your hole cards, folding";
   if (locked) return `Your hole cards, ${faces}`;
   if (presentation === "Revealed" || presentation === "Turning") {
@@ -81,12 +64,6 @@ function accessibleName(
   return "Your hole cards, face down. Activate to reveal them.";
 }
 
-/**
- * The `Absent` presentation: a seat holding no cards — not dealt in, folded,
- * or mucked. Two empty slots, so the surface never implies the player is
- * holding something. The surrounding copy belongs to `Hand`, which owns every
- * caption on this screen.
- */
 function Absent() {
   return (
     <div
@@ -111,21 +88,6 @@ function Absent() {
   );
 }
 
-/**
- * The player's own hole cards as an object they handle, not a picture they
- * read (Phase 3 spec #138). Cards arrive **face-down** and stay that way until
- * the player asks for them; nothing here touches the server, changes poker
- * visibility, or affects showdown.
- *
- * This is one of the module's two public names. Everything it is built from —
- * the reducer, the hook, the bendable card — is module-internal, so nothing
- * outside can reach a lifecycle state and no consumer learns what a pointer is.
- *
- * The pair is a real focusable `button`: Enter and Space toggle reveal and
- * conceal, so reading your own cards never depends on getting a gesture's
- * timing right (§12). A pointer, by contrast, is answered by the recognizer —
- * bend to peek, tap to conceal, double-tap to Check, and swipe up to Fold.
- */
 export function HoleCardPair(props: HoleCardPairProps) {
   const { cards, actions } = props;
   const {
@@ -143,25 +105,11 @@ export function HoleCardPair(props: HoleCardPairProps) {
     coarsePointer,
     discovered,
   } = useHoleCards(props);
-  // The lifecycle's lock, not the prop: the prop is the *input* the adapter
-  // turns into `SHOWDOWN_REVEAL`, and once locked the pair stays locked until
-  // the next hand deals it back in. Rendering off the prop would let the two
-  // disagree about whether the button does anything — and the gesture
-  // recognizer gates on the same field, so pointer and keyboard cannot part
-  // company either.
   const { locked } = state;
 
-  // A committed pair outlives the prop that carried it, for exactly as long as
-  // its flight to the muck runs: the server usually takes the cards away tens
-  // of milliseconds in, and the departure the player was promised must not be a
-  // blink (§7, story 20).
   const shown = cards ?? departing;
   if (shown === null) return <Absent />;
 
-  // A render can land between cards arriving and the deal being observed;
-  // face-down is the entry state for every hand, so it is also the honest
-  // presentation for that gap. A pair still in the air is the mirror case: the
-  // lifecycle has resolved past it, and the flight is what is on screen.
   const presentation =
     cards === null
       ? "Leaving"
@@ -174,16 +122,10 @@ export function HoleCardPair(props: HoleCardPairProps) {
     foldLegal: actions.foldLegal,
     pending: actions.pending,
     locked,
-    // The two device inputs the hook watches on the selector's behalf: the
-    // touch gate, and the ~2s of stillness the teaching hints wait for (§11).
-    // In-gesture prompts consult neither.
     coarsePointer,
     quiet,
     checkConfirmed,
   };
-  // Both variants of the live hint, because the axis they swap on is a
-  // **continuous** value: choosing between them in React would re-render the
-  // pair every time a bend wandered across the diagonal (§13).
   const hintDragLeft = selectHint(
     { ...state, presentation, bendAxis: "left" },
     discovered,
@@ -194,8 +136,6 @@ export function HoleCardPair(props: HoleCardPairProps) {
     discovered,
     hintContext,
   );
-  // An announced hint is news, and news does not depend on which way a finger
-  // is going: the selector returns the same hint on both axes for it.
   const announced = hintDragLeft?.announce === true ? hintDragLeft : null;
 
   return (
@@ -204,28 +144,15 @@ export function HoleCardPair(props: HoleCardPairProps) {
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
-        // The pair claims the whole card region rather than only the height its
-        // cards need, so the spare height on a tall phone is *inside* this
-        // column where it can be placed, instead of padding the region around
-        // a group that stays tight however much screen it is given.
         flex: 1,
         minHeight: 0,
-        // The floor under the hint on a screen with nothing spare to give.
         gap: "1.1em",
       }}
     >
-      {/* The positioning parent for the Check stamp, which is painted over the
-       * pair rather than laid out beside it. */}
       <div
         style={{
           position: "relative",
           display: "flex",
-          // Auto margins take the column's free space above and below the
-          // cards, which leaves the hint sitting at the bottom of the pair —
-          // next to `Hand`'s caption and just over the action buttons, where
-          // the two lines of copy read as one block. The cards float centred in
-          // whatever is left. On a short screen there is no free space to take
-          // and this collapses to the stack the phone already had.
           margin: "auto 0",
         }}
       >
@@ -233,11 +160,7 @@ export function HoleCardPair(props: HoleCardPairProps) {
           type="button"
           data-testid="hole-cards"
           data-presentation={presentation}
-          // A locked pair is inert but stays in the tab order and keeps its
-          // accessible name: at showdown that name is where a screen-reader user
-          // reads their own hand, and `disabled` would take it away.
           onClick={locked ? undefined : activate}
-          // Long-press must not raise the OS callout menu over the cards (§16).
           onContextMenu={preventDefault}
           {...(locked ? {} : handlers)}
           aria-disabled={locked}
@@ -249,28 +172,14 @@ export function HoleCardPair(props: HoleCardPairProps) {
             background: "none",
             color: "inherit",
             cursor: locked ? "default" : "pointer",
-            // Handling cards must not raise the OS text-selection or callout
-            // menu over them, and the browser must not claim the vertical drag
-            // as a pan or the second tap as a zoom (§16). The app shell is fixed
-            // and non-scrolling, so nothing is lost by taking the whole gesture.
             userSelect: "none",
             WebkitTouchCallout: "none",
             WebkitUserSelect: "none",
             touchAction: "none",
-            // Android Chrome paints a blue box over any tappable element while
-            // it is pressed, and a long-press holds that state long enough to
-            // read as a highlight sitting on the cards (#195). The cards do
-            // their own press feedback (the bend, the flip); this OS wash on top
-            // is noise, so it is turned off.
             WebkitTapHighlightColor: "transparent",
           }}
         >
           <motion.span
-            // Keyed on card identity so a new hand replays the deal-in: the cards
-            // arrive face-down (§17), replacing `Hand`'s per-card face-up deal
-            // animation. The key is on the motion element, not the component, so
-            // it restarts an animation without discarding lifecycle state —
-            // `DEALT` stays the one thing that resets presentation.
             key={cardKey(shown)}
             initial={{ opacity: 0, y: "-18%" }}
             animate={{ opacity: 1, y: 0 }}
@@ -280,10 +189,6 @@ export function HoleCardPair(props: HoleCardPairProps) {
             }}
             style={{ display: "flex", fontSize: HOLE_CARD_UNIT }}
           >
-            {/* A layer of its own, so the fold drag and the muck flight can drive
-             * `y` and `opacity` from `MotionValue`s while the deal-in above keeps
-             * animating the same two properties declaratively. The two would
-             * fight on one element; nested, they simply compose. */}
             <motion.span
               style={{
                 display: "flex",
@@ -307,10 +212,6 @@ export function HoleCardPair(props: HoleCardPairProps) {
         </button>
         {checkConfirmed && <CheckStamp />}
       </div>
-      {/* One value decides where the Check confirmation is painted, so the
-       * stamp and the hint below can never both claim it — or both drop it.
-       * The selector still returns the confirmation as a hint, because that is
-       * what `Announcer` speaks; only its sighted copy moves onto the cards. */}
       {!checkConfirmed && (
         <GestureHint
           dragLeft={hintDragLeft}
@@ -323,17 +224,6 @@ export function HoleCardPair(props: HoleCardPairProps) {
   );
 }
 
-/**
- * The live region the announced hints speak through — mounted for the pair's
- * lifetime and empty until there is news.
- *
- * It cannot be the visible hint's own element: a live region inserted into the
- * document *together with* its text is not reliably announced, because there
- * was no region there to observe the change. The region has to already exist
- * when the text arrives, which means it outlives every hint that passes
- * through it. The visible copy is hidden from assistive technology, so the
- * news is read once rather than twice.
- */
 function Announcer({ hint }: { readonly hint: Hint | null }) {
   return (
     <span role="status" style={visuallyHidden}>
@@ -344,7 +234,6 @@ function Announcer({ hint }: { readonly hint: Hint | null }) {
   );
 }
 
-/** Present to a screen reader, absent to everything else. */
 const visuallyHidden: CSSProperties = {
   position: "absolute",
   width: 1,
@@ -361,18 +250,6 @@ function preventDefault(event: { preventDefault: () => void }) {
   event.preventDefault();
 }
 
-/**
- * The one hint the selector chose, if any. The pair renders it itself: the
- * selector is module-internal because every in-gesture hint depends on
- * recognizer state nothing outside the module may see (§11).
- *
- * Where the two variants differ, both are in the document at once and the axis
- * `MotionValue` decides which is visible — so a bend that wanders across the
- * diagonal swaps the advice without re-rendering anything. That pair is hidden
- * from assistive technology, because two contradictory instructions are both
- * present and only the sighted player can see which one applies; the pair's own
- * `aria-label` is the non-visual path, and every Action keeps its button.
- */
 function GestureHint({
   dragLeft,
   dragUp,
@@ -387,16 +264,10 @@ function GestureHint({
 
   if (dragLeft === null || dragUp === null) return null;
 
-  // One hint, not two: the axis is only a distinction while a bend is live.
   if (dragLeft.id === dragUp.id) return <HintBlock hint={dragLeft} />;
 
   return (
-    <span
-      aria-hidden="true"
-      // Stacked in one grid cell so the swap costs no layout. Each variant
-      // carries both its own lines, so neither depends on the other's copy.
-      style={{ display: "grid" }}
-    >
+    <span aria-hidden="true" style={{ display: "grid" }}>
       <motion.span style={{ gridArea: "1 / 1", opacity: leftOpacity }}>
         <HintBlock hint={dragLeft} />
       </motion.span>
@@ -412,10 +283,6 @@ export function HintBlock({ hint }: { readonly hint: Hint }) {
     <p
       data-testid="hole-cards-hint"
       data-hint={hint.id}
-      // Everything that reaches here is advice about a gesture in progress,
-      // never news: the one announced hint is the Check confirmation, and that
-      // one is painted as a stamp over the cards instead of passing through
-      // this block. So there is nothing here for `Announcer` to double up on.
       style={{
         margin: 0,
         display: "grid",

--- a/packages/player-client/src/holecards/cardState.test.ts
+++ b/packages/player-client/src/holecards/cardState.test.ts
@@ -19,7 +19,6 @@ function state(
 
 const reset: CardEvent = { type: "RESET" };
 
-/** A showdown-locked pair: face-up and inert. */
 function lockedState(presentation: Presentation): CardState {
   return { ...state(presentation), locked: true };
 }
@@ -176,9 +175,6 @@ describe("reduce", () => {
     });
 
     it("survives the release that follows it — the commit is on crossing", () => {
-      // Lifting a finger after the threshold must not put the cards back down:
-      // `Turning` is a point of no return, so release only clears the
-      // recognizer and the flip finishes on its own.
       const committed = reduce(state("Peeking", "Bending"), {
         type: "BEND_CROSSED",
       });
@@ -243,9 +239,6 @@ describe("reduce", () => {
     });
 
     it("is inert to a finger as well as to the keyboard", () => {
-      // The lock is enforced once, above every arm, so a gesture cannot even
-      // begin against a decided hand: no press, and therefore nothing for a
-      // classification to land on.
       const locked = lockedState("Revealed");
       expect(reduce(locked, { type: "PRESSED" })).toEqual(locked);
       expect(reduce(locked, { type: "CLASSIFIED", as: "Bending" })).toEqual(
@@ -262,9 +255,6 @@ describe("reduce", () => {
     });
 
     it("is not what a committed gesture produces — only showdown locks", () => {
-      // The recognizer reaches `Committed` on an ordinary bend past the reveal
-      // threshold. A player who bent their way to face-up must still be able
-      // to conceal, so the lock cannot live in the recognizer.
       const bendCommitted = state("Revealed", "Committed");
       expect(reduce(bendCommitted, { type: "ACTIVATED" }).presentation).toBe(
         "FaceDown",
@@ -337,8 +327,6 @@ describe("reduce", () => {
 
   describe("CLASSIFIED", () => {
     it("opens the peel and moves the recognizer in one reduce", () => {
-      // Coupled, and therefore atomic: there is no intermediate state in which
-      // the recognizer is bending but the pair still presents face-down.
       expect(
         reduce(state("FaceDown", "Pressing"), {
           type: "CLASSIFIED",
@@ -426,9 +414,6 @@ describe("reduce", () => {
     });
 
     it("flies an armed fold drag to the muck — but only on the release", () => {
-      // The commitment is on release, never on crossing the line: the armed
-      // state is what a crossing produced, and this is the pointer lift that
-      // answers it.
       expect(
         reduce(state("FaceDown", "FoldDragging", true), { type: "RELEASED" }),
       ).toEqual(state("Leaving"));
@@ -441,8 +426,6 @@ describe("reduce", () => {
     });
 
     it("commits nothing when the browser takes the pointer away mid-flick", () => {
-      // Cancellation is never a commitment: the player never completed the
-      // gesture, so the cards go back down rather than into the muck.
       for (const presentation of ["FaceDown", "Revealed"] as const) {
         expect(
           reduce(state(presentation, "FoldDragging", true), {
@@ -453,9 +436,6 @@ describe("reduce", () => {
     });
 
     it("returns a below-threshold fold drag to the face it started from", () => {
-      // A fold drag moves the pair around without turning it over, so the
-      // presentation it was carrying *is* the stable state to restore — from
-      // face-down and from revealed alike.
       for (const ending of endings) {
         expect(reduce(state("FaceDown", "FoldDragging"), ending)).toEqual(
           state("FaceDown"),
@@ -579,9 +559,6 @@ describe("reduce", () => {
     });
 
     it("never returns a rejected Fold to Revealed", () => {
-      // The pair left face-up, but it comes back face-down: a rejection leaves
-      // the player holding a live hand, not the one they had already shown
-      // themselves.
       const revealedThenLeaving = reduce(
         state("Revealed", "FoldDragging", true),
         { type: "RELEASED" },
@@ -595,9 +572,6 @@ describe("reduce", () => {
     });
 
     it("leaves every other presentation exactly as it was", () => {
-      // Only a Fold is waiting on this. A Call, a Raise or a button Check
-      // resolves through the same prop, and pressing one must not make the
-      // player's cards vanish or turn over unbidden (§9).
       for (const presentation of [
         "Absent",
         "FaceDown",
@@ -633,24 +607,16 @@ describe("reduce", () => {
     });
 
     it("snaps out of Turning rather than letting the flip finish", () => {
-      // The one thing that interrupts a turn: no face-up frame of the previous
-      // hand may survive into the next. Landing on `FaceDown` is also what
-      // makes it a snap — `BendableCard` animates only while `Turning`.
       expect(reduce(state("Turning", "Committed"), reset)).toEqual(
         state("FaceDown"),
       );
     });
 
     it("leaves a seat holding no cards holding none", () => {
-      // There is nothing to turn face-down. Every other presentation implies
-      // cards in hand; `Absent` is the one that would be a lie.
       expect(reduce(state("Absent"), reset)).toEqual(state("Absent"));
     });
 
     it("does not disturb a decided showdown", () => {
-      // Backgrounding the app must not conceal a public reveal — and a reload
-      // remounts straight back to `Revealed` off the `locked` prop, so
-      // honouring `RESET` here would make the two paths disagree.
       for (const presentation of ["Revealed", "Turning"] as const) {
         expect(reduce(lockedState(presentation), reset)).toEqual(
           lockedState(presentation),
@@ -667,8 +633,6 @@ describe("reduce", () => {
     });
 
     it("does nothing to a face-down pair, so the first tap of a Check is free", () => {
-      // A tap that revealed would put a face-up frame between the two taps of
-      // a double-tap Check, and make the commonest free Action cost a reveal.
       expect(reduce(state("FaceDown"), { type: "TAPPED" })).toEqual(
         state("FaceDown"),
       );
@@ -697,8 +661,6 @@ describe("reduce", () => {
 
   describe("DOUBLE_TAPPED", () => {
     it("changes no presentation — the Check is an Action, not a card movement", () => {
-      // The first tap has already concealed; the second sends. Turning the
-      // cards over again here would undo the conceal the player just saw.
       for (const presentation of [
         "Absent",
         "FaceDown",

--- a/packages/player-client/src/holecards/cardState.ts
+++ b/packages/player-client/src/holecards/cardState.ts
@@ -1,27 +1,5 @@
-/**
- * The Hole-card lifecycle (Phase 3 spec #138 §3): Presentation and Recognizer
- * modelled as orthogonal machines but reduced by **one** pure function, so a
- * coupled event applies atomically and cannot half-land.
- *
- * Nothing here touches React or the DOM — every rule in the behaviour contract
- * is verifiable as a function call, which is why the module needs no store, no
- * socket and no simulated pointer to test.
- *
- * `CardState` and `CardEvent` are **complete**: every event name the phase
- * needs is declared here, including the ones no arm answers yet. Later slices
- * add reducer arms against this shape rather than reshaping it, so the
- * gestures that follow are additions rather than surgery.
- *
- * Answered so far: the deal-in, the emptying and the keyboard reveal/conceal
- * toggle (#139), the showdown reveal and lock (#140), the press, the
- * classification and the release that make up a bend (#141), cancellation
- * and resets (#143), the tap and double-tap that conceal and Check (#144), and
- * the armed swipe that folds and the server answer that resolves it (#145).
- */
-
 import type { Classification } from "./classify.js";
 
-/** Pair-scoped: both cards always share one presentation. */
 export type Presentation =
   "Absent" | "FaceDown" | "Peeking" | "Turning" | "Revealed" | "Leaving";
 
@@ -31,84 +9,32 @@ export type Recognizer =
 export interface CardState {
   readonly presentation: Presentation;
   readonly recognizer: Recognizer;
-  /**
-   * Whether releasing now would commit the Fold. Only ever true while
-   * `FoldDragging` — crossing the threshold arms, and release commits (§10).
-   */
   readonly armed: boolean;
-  /**
-   * Showdown reached with this seat still live: the hand is decided, so the
-   * pair is face-up and inert (story 48).
-   *
-   * Its own field rather than a recognizer state, because the lock is not a
-   * gesture outcome — `Committed` is what an ordinary bend past the reveal
-   * threshold enters, and a Player who bent their way to face-up must not end
-   * up holding a pair they can no longer conceal. It is not a presentation
-   * either: `Revealed` is reachable both ways and only one of them is final.
-   */
   readonly locked: boolean;
 }
 
 export type CardEvent =
-  /** Cards arrived: a fresh deal, or a new hand's cards swapping in. */
   | { readonly type: "DEALT" }
-  /** Cards left: folded, mucked, or dealt out. */
   | { readonly type: "CARDS_GONE" }
-  /** The pair was activated as a button — Enter, Space or a click. */
   | { readonly type: "ACTIVATED" }
-  /** The committed flip to face-up finished animating. */
   | { readonly type: "TURN_FINISHED" }
-  /** A pointer landed on the pair. */
   | { readonly type: "PRESSED" }
-  /** The drag passed the slop and resolved, once and for all, to one thing. */
   | { readonly type: "CLASSIFIED"; readonly as: Classification }
-  /** The peel passed the reveal threshold: recognizer and presentation both. */
   | { readonly type: "BEND_CROSSED" }
-  /** The fold drag passed the distance threshold; releasing now commits. */
   | { readonly type: "FOLD_ARMED" }
-  /** Fold stopped being legal mid-drag; the cards keep tracking regardless. */
   | { readonly type: "FOLD_DISARMED" }
-  /** The pointer completing the gesture lifted. */
   | { readonly type: "RELEASED" }
-  /** The browser took the pointer away, or capture was lost. */
   | { readonly type: "CANCELLED" }
-  /**
-   * A §9 reset: back to face-down, cancelling any gesture. The app leaving
-   * the foreground is the producer — the other two §9 resets arrive by their
-   * own routes (a new hand as `DEALT`, a fresh client through
-   * `initialCardState`), and neither needs to be re-derived here.
-   */
   | { readonly type: "RESET" }
-  /** A single tap landed on the pair. */
   | { readonly type: "TAPPED" }
-  /** A second tap landed inside the double-tap window. */
   | { readonly type: "DOUBLE_TAPPED" }
-  /** An in-flight Action resolved, one way or the other. */
   | { readonly type: "PENDING_RESOLVED"; readonly hasCards: boolean }
-  /** Showdown reached with this seat still live: turn face-up and lock. */
   | { readonly type: "SHOWDOWN_REVEAL" };
 
-/** The live, un-gestured, unlocked pair every hand starts from. */
 function idle(presentation: Presentation): CardState {
   return { presentation, recognizer: "Idle", armed: false, locked: false };
 }
 
-/**
- * Whether a locked pair still hears an event. Only four do, and none of them
- * is the Player handling the cards: the two hand boundaries that end the lock,
- * the reveal that starts it, and the flip it starts finishing.
- *
- * Stated as one allow-list and enforced once, at the top of `reduce`, rather
- * than arm by arm — so the tap and gesture events later tickets add are inert
- * against a decided hand by default, and cannot reach one by being forgotten.
- *
- * **`RESET` is deliberately not on the list.** Backgrounding the app must not
- * conceal a showdown reveal: that reveal is public table truth rather than
- * something the Player chose to look at, and a reload remounts straight back
- * to `Revealed` off the `locked` prop — so honouring `RESET` here would make
- * two paths that §9 names in the same breath disagree. The hand boundary that
- * genuinely ends the lock arrives as `DEALT` or `CARDS_GONE`.
- */
 function survivesLock(event: CardEvent): boolean {
   switch (event.type) {
     case "DEALT":
@@ -121,11 +47,6 @@ function survivesLock(event: CardEvent): boolean {
   }
 }
 
-/**
- * Mount state. A pair that mounts holding cards has not been dealt in as far
- * as this module is concerned — there is no deal-in event to observe — so it
- * simply starts face-down, and a locked (showdown) pair starts face-up.
- */
 export function initialCardState({
   hasCards,
   locked,
@@ -138,12 +59,6 @@ export function initialCardState({
   return idle("FaceDown");
 }
 
-/**
- * Where a gesture puts the pair down. `Peeking` is the only presentation a
- * gesture creates that is not stable in itself: a peek is held open by the
- * finger, so letting go — for any reason — closes it, and a glance costs the
- * player nothing and leaves nothing exposed.
- */
 function settled(state: CardState): CardState {
   return {
     ...state,
@@ -154,19 +69,6 @@ function settled(state: CardState): CardState {
   };
 }
 
-/**
- * Whether lifting the finger right now sends the Fold (§10).
- *
- * Exported so the rule is a tested function call rather than a condition
- * buried in the `RELEASED` arm below. Its counterpart is `endGesture`'s
- * `commitsFold`, which answers the same question about the live pointer
- * session so the Action — an **effect** this function cannot have — is sent by
- * the hook on exactly the releases that land here.
- *
- * It reads `armed` rather than any notion of how far the cards travelled:
- * arming is the only thing a threshold crossing does, and a drag whose
- * legality disappeared underneath it is disarmed while still moving (§6).
- */
 export function releaseCommitsFold(state: CardState): boolean {
   return state.recognizer === "FoldDragging" && state.armed;
 }
@@ -174,9 +76,6 @@ export function releaseCommitsFold(state: CardState): boolean {
 function classified(state: CardState, as: Classification): CardState {
   switch (as) {
     case "Bending":
-      // Coupled, and therefore atomic: one reduce moves the recognizer *and*
-      // opens the peel. There is no frame in which the pair is bending but
-      // still presenting face-down.
       return {
         ...state,
         presentation: "Peeking",
@@ -195,19 +94,12 @@ export function reduce(state: CardState, event: CardEvent): CardState {
 
   switch (event.type) {
     case "DEALT":
-      // Unconditional, from every presentation: deal detection is what makes
-      // every hand start face-down, so no face-up frame of the previous hand
-      // can survive into the next one. It also ends a showdown lock — a new
-      // hand is live again by definition.
       return idle("FaceDown");
 
     case "CARDS_GONE":
       return idle("Absent");
 
     case "ACTIVATED":
-      // Reveal is a flip; conceal is instant. `Turning` is revealing-only —
-      // there is no concealing flip, and an activation mid-turn is dropped
-      // rather than queued.
       if (state.presentation === "FaceDown") {
         return { ...state, presentation: "Turning" };
       }
@@ -222,59 +114,22 @@ export function reduce(state: CardState, event: CardEvent): CardState {
         : state;
 
     case "PRESSED":
-      // **First pointer wins** (§4): while a gesture is live, a second finger
-      // landing is ignored until the first releases or cancels. Latest-pointer
-      // -wins would let a stray thumb silently retarget a fold drag.
       if (state.recognizer !== "Idle") return state;
-      // Nothing to handle: no cards, or a Fold already in flight (§7).
       if (state.presentation === "Absent" || state.presentation === "Leaving") {
         return state;
       }
       return { ...state, recognizer: "Pressing" };
 
     case "CLASSIFIED":
-      // **Stickiness lives here.** `classify` is run once by the pointer
-      // handler and never revisited; the reducer enforces that by accepting
-      // the result only from `Pressing`, so a second classification — however
-      // it arises — is a no-op, and `Ignored` stays terminal until release.
       if (state.recognizer !== "Pressing") return state;
       return classified(state, event.as);
 
     case "RELEASED":
-      // **The one commitment a pointer lift makes.** Crossing the fold
-      // threshold only armed; this is the completing release that answers it,
-      // so an accidental crossing during a scroll-like motion cannot fold for
-      // the player and putting the cards back down is always a way out (§10).
-      //
-      // The pair leaves with whatever face it had — `presentation` is not
-      // consulted, so a revealed pair flies away face-up rather than flipping
-      // over inside a 280ms departure (§7).
       if (releaseCommitsFold(state)) {
         return idle("Leaving");
       }
     // falls through: every other release settles exactly as a cancellation does
     case "CANCELLED":
-      // An interrupted gesture lands on the last *stable* presentation, which
-      // for everything except a peek is the one it is already carrying: a fold
-      // drag moves the pair around without turning it over, so it restores to
-      // the face it started from by not being touched.
-      //
-      // A peek closes to `FaceDown` because that is the only face it can have
-      // opened from — §3 gives `Peeking` one entry arrow, and §4 refuses to
-      // classify a bend as `Bending` on an already-revealed pair. A bend arm
-      // that ever admits `Revealed → Peeking` breaks that, and `settled` is
-      // where it would have to start remembering.
-      //
-      // `Turning` is a point of no return for both lift and cancellation: the
-      // flip completes, because cancellation must restore *stable*
-      // presentation and mid-turn is not stable (§10). A `Committed`
-      // recognizer therefore only clears itself. `Leaving` likewise: the Fold
-      // is committed and only the server can answer it.
-      //
-      // Cancellation is never a commitment (§10: Actions commit on the
-      // completing release), so it needs to know nothing about `armed` beyond
-      // clearing it. That is the one thing the two events do not share, and
-      // the only reason `RELEASED` has an arm of its own above.
       if (state.recognizer === "Idle") return state;
       if (state.recognizer === "Committed") {
         return { ...state, recognizer: "Idle", armed: false };
@@ -282,97 +137,37 @@ export function reduce(state: CardState, event: CardEvent): CardState {
       return settled(state);
 
     case "BEND_CROSSED":
-      // The peel reaching the threshold *is* the commit (§3): the same sheet
-      // carries on past the opposite corner and lands face-up, so there is no
-      // separate flip to start and nothing for a release to undo. Only a live
-      // bend can cross — a fold drag or an ignored drag never peels.
       if (state.recognizer !== "Bending") return state;
       return { ...state, presentation: "Turning", recognizer: "Committed" };
 
     case "RESET":
-      // Snaps — including out of `Turning`, where the flip is abandoned
-      // rather than finished, so no face-up frame survives into the next hand.
-      // `BendableCard` animates only while `Turning`, so landing on `FaceDown`
-      // is what makes it a snap rather than a second flip.
-      //
-      // `Absent` is the one presentation left alone: there are no cards to
-      // turn face-down, and claiming otherwise would be a state the props
-      // contradict.
-      //
-      // `Leaving` is **not** left alone, though §7 calls a pending pair inert.
-      // The reset producers all say the pair's hand is over or its client is
-      // gone; face-down is the honest resting state for cards nobody is
-      // holding, and the Fold's own resolution follows a moment later as
-      // `CARDS_GONE`. Only `CANCELLED` respects the pending inertness, because
-      // a cancelled pointer is not an answer from the server.
       if (state.presentation === "Absent") return state;
       return idle("FaceDown");
 
     case "TAPPED":
-      // One tap hides the hand the moment someone leans over (story 5), and
-      // does nothing at all to a pair that is already face-down — which is
-      // what makes the first tap of a double-tap Check free (§5). A revealing
-      // tap would put a face-up frame between the two taps and charge the
-      // commonest free Action a reveal.
-      //
-      // Mid-turn it is dropped rather than queued, for the same reason
-      // `ACTIVATED` is: the flip is a point of no return.
       return state.presentation === "Revealed"
         ? { ...state, presentation: "FaceDown" }
         : state;
 
     case "DOUBLE_TAPPED":
-      // Presentation-wise, nothing: the first tap already concealed, and the
-      // second one buys a Check rather than a card movement. The Action itself
-      // is an **effect**, which this function cannot have — the hook sends it
-      // through `actions.check`, so a gesture and the button reach
-      // `intent.check` by the identical route and `canAct` stays the single
-      // legality gate (§2). Reducing it here anyway is what makes the event
-      // inert against a decided hand for free, through `survivesLock`.
       return state;
 
     case "FOLD_ARMED":
     case "FOLD_DISARMED":
-      // Arming and disarming are the *same* shape of change: the flag moves
-      // and the drag carries on. The cards keep tracking the finger either
-      // way, so the surface never freezes under the player's hand, and neither
-      // event has anything to say about presentation.
-      //
-      // A drag pulled back below the threshold disarms through here, and so
-      // does one whose legality disappears mid-motion (#146) — the recognizer
-      // cannot tell the two apart and does not need to.
       if (state.recognizer !== "FoldDragging") return state;
       return { ...state, armed: event.type === "FOLD_ARMED" };
 
     case "PENDING_RESOLVED":
-      // Scoped to `Leaving`, because every Action resolves through this event
-      // and only a Fold left the pair waiting on one. Pressing Call, Raise or
-      // Check must leave the cards exactly as they were (§9) — buttons send
-      // Actions, they do not touch presentation.
-      //
-      // Acknowledged is `Absent`, and visually a no-op if the flight has
-      // already finished. Rejected is **`FaceDown`, never `Revealed`**: the
-      // pair may have left face-up, but a rejection leaves the player holding
-      // a live hand rather than one they have already shown themselves.
       if (state.presentation !== "Leaving") return state;
       return idle(event.hasCards ? "FaceDown" : "Absent");
 
     case "SHOWDOWN_REVEAL":
-      // Folding is final (story 49), whether the cards are already gone or
-      // still flying to the muck. The adapter withholds the event for a
-      // folded-out seat anyway; the reducer holds the guarantee so it does not
-      // rest on being called correctly.
       if (state.presentation === "Absent" || state.presentation === "Leaving") {
         return state;
       }
       return {
-        // The **same** animated flip the bend commits to, so showdown reads
-        // as the same object behaving (story 47) — except when the Player
-        // already turned the cards over themselves, where re-flipping a
-        // face-up pair would be motion with nothing to say.
         presentation:
           state.presentation === "Revealed" ? "Revealed" : "Turning",
-        // Whatever the Player had a finger on is over; the hand is decided.
         recognizer: "Idle",
         armed: false,
         locked: true,

--- a/packages/player-client/src/holecards/classify.test.ts
+++ b/packages/player-client/src/holecards/classify.test.ts
@@ -26,8 +26,6 @@ describe("classify", () => {
   });
 
   it("does not bend from the bend zone once the pair is already revealed", () => {
-    // Nothing to peel back on a face-up pair: the corner is ordinary card
-    // surface, so an upward drag from it is a fold like any other.
     expect(
       classify(
         input({ fromBendZone: true, alreadyRevealed: true, dx: 0, dy: -40 }),
@@ -36,8 +34,6 @@ describe("classify", () => {
   });
 
   it("keeps bending from the bend zone even on a decisive upward swipe", () => {
-    // The accepted cost of sticky classification: fold is unavailable from
-    // this one corner while face-down, and available from all the rest.
     expect(classify(input({ fromBendZone: true, dx: 0, dy: -300 }))).toBe(
       "Bending",
     );
@@ -49,7 +45,6 @@ describe("classify", () => {
   });
 
   it("requires upward travel past the 1.05 ratio, not merely more than sideways", () => {
-    // |dy| = |dx| * 1.05 exactly: not past it.
     expect(classify(input({ dx: -40, dy: -42 }))).toBe("Ignored");
     expect(classify(input({ dx: -40, dy: -42.5 }))).toBe("FoldDragging");
   });

--- a/packages/player-client/src/holecards/classify.ts
+++ b/packages/player-client/src/holecards/classify.ts
@@ -1,41 +1,15 @@
 import { FOLD_AXIS_RATIO } from "./constants.js";
 
-/**
- * What a pointer drag turned out to be (Phase 3 spec #138 §4). There is no
- * "undecided" member: classification happens exactly once, on the first move
- * past the slop, and the recognizer is `Pressing` until then.
- */
 export type Classification = "Bending" | "FoldDragging" | "Ignored";
 
 export interface ClassifyInput {
-  /** The press landed on the bend affordance in the card's corner. */
   readonly fromBendZone: boolean;
-  /** The pair was already face-up when the press landed. */
   readonly alreadyRevealed: boolean;
   readonly dx: number;
   readonly dy: number;
-  /** Sampled **once**, here. §6 covers what happens when it later changes. */
   readonly foldLegal: boolean;
 }
 
-/**
- * The whole of the §4 table, as a pure function. Stickiness is not its
- * business — that is a property of the reducer, which accepts the
- * classification event only from `Pressing`.
- *
- * Three consequences, all intentional:
- *
- * - **A fold cannot start from the bend zone while face-down.** A press on the
- *   corner locks into `Bending` and a later upward swipe keeps bending. Fold
- *   stays available from the whole rest of the pair. The alternative — a
- *   bend→fold promotion rule — would need a second, more decisive upward
- *   threshold, weakening the fold threshold everywhere else to recover one
- *   corner.
- * - **`Ignored` is terminal.** A drag that starts sideways or downward cannot
- *   become a fold by curving upward.
- * - **Fold legality is sampled once.** A drag that outlives the player's turn
- *   disarms rather than reclassifies.
- */
 export function classify({
   fromBendZone,
   alreadyRevealed,
@@ -43,9 +17,6 @@ export function classify({
   dy,
   foldLegal,
 }: ClassifyInput): Classification {
-  // The bend zone wins outright while face-down — but there is nothing to peel
-  // back on a pair that is already face-up, so the corner is ordinary card
-  // surface then and a fold can start from it.
   if (fromBendZone && !alreadyRevealed) return "Bending";
   if (foldLegal && dy < 0 && Math.abs(dy) > Math.abs(dx) * FOLD_AXIS_RATIO) {
     return "FoldDragging";

--- a/packages/player-client/src/holecards/coaching.test.ts
+++ b/packages/player-client/src/holecards/coaching.test.ts
@@ -93,17 +93,12 @@ describe("selectHint", () => {
     });
 
     it("returns the prompt to a desktop player dragging with a mouse", () => {
-      // The `(pointer: coarse)` gate belongs to the teaching hints (#147): it
-      // exists so a keyboard player is not told to bend corners. Feedback on a
-      // motion already underway belongs to whoever is making it.
       expect(
         selectHint(bending("up"), everythingDiscovered, ctx()),
       ).not.toBeNull();
     });
 
     it("returns the prompt without waiting for the quiet interval", () => {
-      // It is feedback on a motion happening right now, not instruction that
-      // should hold off and let the player find the gesture themselves.
       expect(
         selectHint(bending("left"), nothingDiscovered, ctx({ quiet: false })),
       ).not.toBeNull();
@@ -136,10 +131,6 @@ describe("selectHint", () => {
     });
 
     it("returns both prompts regardless of the discovery set", () => {
-      // The arming signal for the one irreversible, money-losing gesture never
-      // retires, for any player, ever: there is no rendered threshold marker
-      // and haptics are Blink-only, so on iPhone/Safari this text *is* the
-      // signal (§11).
       for (const armed of [false, true]) {
         expect(
           selectHint(foldDragging(armed), everythingDiscovered, ctx()),
@@ -181,8 +172,6 @@ describe("selectHint", () => {
     });
 
     it("survives the pending Action it is confirming", () => {
-      // Sending the Check is what makes an Action pending, so a confirmation
-      // that deferred to the pending gate could never appear at all.
       expect(
         selectHint(
           idle("FaceDown"),
@@ -291,8 +280,6 @@ describe("selectHint, teaching hints", () => {
   });
 
   it("puts Check above Fold in the overlap", () => {
-    // Quieter than it looks: a legal Check means no bet to face, and teaching
-    // someone to fold for free is bad advice.
     expect(
       selectHint(idle("FaceDown"), discovered("bend", "conceal"), ctx())?.id,
     ).toBe("teach-check");
@@ -313,8 +300,6 @@ describe("selectHint, teaching hints", () => {
   });
 
   it("offers the bend and the conceal off-turn, where neither Action is legal", () => {
-    // They are local presentation, and off-turn is most of the time a player is
-    // holding cards.
     const offTurn = ctx({ checkLegal: false, foldLegal: false });
     expect(selectHint(idle("FaceDown"), nothingDiscovered, offTurn)?.id).toBe(
       "teach-bend",
@@ -333,8 +318,6 @@ describe("selectHint, teaching hints", () => {
   });
 
   it("shows nothing at all where the primary pointer is not coarse", () => {
-    // A keyboard player is not told to bend corners; the pair is a focusable
-    // button and every Action keeps its own.
     expect(
       selectHint(
         idle("FaceDown"),
@@ -345,8 +328,6 @@ describe("selectHint, teaching hints", () => {
   });
 
   it("shows nothing before the quiet interval", () => {
-    // The player gets the chance to find the gesture themselves first, and a
-    // hint yields the instant a finger lands.
     expect(
       selectHint(idle("FaceDown"), nothingDiscovered, ctx({ quiet: false })),
     ).toBeNull();
@@ -363,8 +344,6 @@ describe("selectHint, teaching hints", () => {
   });
 
   it("yields to a gesture already underway, and to the pair leaving", () => {
-    // Instruction about a different gesture must never outrank feedback on the
-    // motion a finger is making right now.
     expect(selectHint(bending("left"), nothingDiscovered, ctx())?.id).toBe(
       "bending-left",
     );
@@ -378,9 +357,6 @@ describe("selectHint, teaching hints", () => {
 
 describe("nextTeachable", () => {
   it("names the gesture whose eligibility the quiet interval is measured from", () => {
-    // The identity the hint timer restarts on: it is what makes the wait an
-    // interval rather than a one-time delay, so Fold does not appear the
-    // instant a turn makes it legal.
     const legal = { checkLegal: true, foldLegal: true };
     expect(nextTeachable(idle("FaceDown"), nothingDiscovered, legal)).toBe(
       "bend",
@@ -429,8 +405,6 @@ describe("discoveredBy", () => {
   });
 
   it("counts a tap only where it actually hides the cards", () => {
-    // The conceal hint is only ever offered on a face-up pair, so a tap on a
-    // face-down one retires a hint the player has not seen do anything.
     expect(discoveredBy({ type: "TAPPED" }, faceDown)).toBeNull();
   });
 
@@ -441,17 +415,12 @@ describe("discoveredBy", () => {
   });
 
   it("does not count an Action taken from a button", () => {
-    // Discovery is on-pair, never on a button: pressing Fold or Check in the
-    // `ActionBar` reaches this module only as a prop change, and the hint
-    // exists to move the player off the button in the first place.
     const fromButtons: readonly CardEvent[] = [
       { type: "PENDING_RESOLVED", hasCards: false },
       { type: "PENDING_RESOLVED", hasCards: true },
       { type: "CARDS_GONE" },
       { type: "DEALT" },
       { type: "SHOWDOWN_REVEAL" },
-      // Enter, Space or a mouse click on the pair: a semantic activation, not
-      // the tap gesture the conceal hint teaches.
       { type: "ACTIVATED" },
     ];
     for (const event of fromButtons) {

--- a/packages/player-client/src/holecards/coaching.ts
+++ b/packages/player-client/src/holecards/coaching.ts
@@ -2,35 +2,14 @@ import type { CardEvent, CardState } from "./cardState.js";
 import { BEND_CORNER } from "./constants.js";
 import type { BendAxis } from "./geometry.js";
 
-/**
- * The gestures the surface teaches, **in teaching order** (§11). Bend is Peek
- * *and* Reveal — one gesture at two depths — which is why there are four of
- * these and not five.
- *
- * The order is the list: the selector offers the first gesture the player has
- * not found yet, so "at most one hint" and "Bend before Conceal before Check
- * before Fold" are the same fact rather than two rules that could disagree.
- */
 export const TEACHABLE_GESTURES = ["bend", "conceal", "check", "fold"] as const;
 
 export type TeachableGesture = (typeof TEACHABLE_GESTURES)[number];
 
-/**
- * Line 1 is an imperative; line 2 is the consequence (Phase 3 spec #138 §11).
- * `id` identifies the hint for rendering and for tests; it is not the gesture,
- * because the in-gesture prompts are feedback on a motion rather than
- * instruction about one.
- */
 export interface Hint {
   readonly id: string;
   readonly line1: string;
   readonly line2: string | null;
-  /**
-   * Whether the hint is news rather than advice, and should therefore reach a
-   * screen reader when it appears. Only the Check confirmation is: every
-   * teaching hint and in-gesture prompt describes what the player *could* do,
-   * and announcing those over a live gesture would be noise.
-   */
   readonly announce: boolean;
 }
 
@@ -39,77 +18,32 @@ export interface HintContext {
   readonly foldLegal: boolean;
   readonly pending: boolean;
   readonly locked: boolean;
-  /**
-   * Whether the *primary* pointer is coarse — a finger rather than a mouse.
-   * Gates the teaching hints only: instruction about bending corners is noise
-   * to a player who cannot act on it.
-   */
   readonly coarsePointer: boolean;
-  /** ~2s since the last contact with the pair. */
   readonly quiet: boolean;
-  /** A gesture Check landed moments ago and is still being confirmed (§5). */
   readonly checkConfirmed: boolean;
 }
 
-/**
- * The one hint to show, or none (§11). At most one is ever visible, and
- * in-gesture feedback outranks every teaching hint: it describes a motion the
- * player's finger is making right now, and must never be outranked by
- * instruction about a different gesture.
- *
- * The selector is **module-internal**. #111 put hint discovery outside the
- * card module; #135 then made every in-gesture hint depend on recognizer state
- * that nothing outside may see. Keeping the selector in here — and letting
- * only the persisted discovery set cross the seam — is what holds the module's
- * public surface at two names.
- *
- * The `(pointer: coarse)` gate applies to the teaching hints alone: it exists
- * so a keyboard player is not told to bend corners. An in-gesture prompt is
- * feedback on a motion already underway, so it belongs to whoever is making it
- * — including the desktop player dragging with a mouse.
- */
 export function selectHint(
   state: CardState & { readonly bendAxis: BendAxis },
   discovered: ReadonlySet<TeachableGesture>,
   ctx: HintContext,
 ): Hint | null {
-  // Outranks every gate below, including the pending one it necessarily trips:
-  // this is not advice about a gesture, it is the answer to one the player just
-  // made (story 31). Without it the only sign a double-tap landed is the
-  // ActionBar the gesture exists to stop them watching.
   if (ctx.checkConfirmed) return checkedHint;
 
-  // A hint is only ever advice about cards the player is actually holding, in
-  // a moment where those cards will listen.
   if (ctx.pending || ctx.locked) return null;
   if (state.presentation === "Absent") return null;
 
-  // Deliberately **not** gated on the discovery set, either of them. In-gesture
-  // prompts are permanent for every player, forever: they say what releasing
-  // will do, and for the money-losing gesture that text is the arming signal
-  // itself.
   if (state.recognizer === "Bending") {
     return state.bendAxis === "up" ? bendUpHint : bendLeftHint;
   }
 
-  // There is no rendered fold-threshold marker and browser vibration is
-  // Blink-only, so on iPhone/Safari this line — with the card motion — is the
-  // *whole* arming signal (§11). It has to be able to say both things.
   if (state.recognizer === "FoldDragging") {
     return state.armed ? foldArmedHint : foldDraggingHint;
   }
 
-  // Everything below is instruction rather than feedback, and every gate on it
-  // is the same gate: teach only where the advice can be taken.
   if (!ctx.coarsePointer) return null;
-  // A finger is already on the glass — pressing, or dragging something the
-  // recognizer ignored. Instruction yields to whatever it is doing, even before
-  // the quiet interval has a chance to say so.
   if (state.recognizer !== "Idle") return null;
   if (!ctx.quiet) return null;
-  // The two presentations a player is *holding* the pair in. A peek is held
-  // open by a finger, a turn is a flip mid-flight, and a departing pair is on
-  // its way to the muck: none of them is a moment to start teaching in.
   if (state.presentation !== "FaceDown" && state.presentation !== "Revealed") {
     return null;
   }
@@ -118,16 +52,6 @@ export function selectHint(
   return teachable === null ? null : TEACHING[teachable].hint;
 }
 
-/**
- * The gesture the surface would teach next, ignoring the timing gates — the
- * first one in the teaching order the player has not found and *could* act on.
- *
- * Separate from `selectHint` because the quiet interval is measured **from the
- * moment eligibility becomes true** (§11): the caller has to know which gesture
- * is up before deciding whether it has waited long enough to say so. Without
- * that, only the first hint of a session would ever observe the interval, and
- * Fold would appear the instant a turn made it legal.
- */
 export function nextTeachable(
   state: CardState,
   discovered: ReadonlySet<TeachableGesture>,
@@ -140,64 +64,24 @@ export function nextTeachable(
   return teaching ?? null;
 }
 
-/**
- * Which gesture, if any, a card event proves the player has found (§11).
- *
- * Discovery is **on-pair, never on a button**: every event this answers comes
- * from the recognizer, and pressing Fold or Check in the `ActionBar` reaches
- * this module only as a prop change. That is the whole point — the hint exists
- * to move the player off the button, so the button must not retire it.
- *
- * A pure function rather than a line in the pointer handlers, so what counts as
- * having found a gesture is a tested rule rather than four scattered ones.
- */
 export function discoveredBy(
   event: CardEvent,
   state: CardState,
 ): TeachableGesture | null {
   switch (event.type) {
     case "CLASSIFIED":
-      // The classification, not the release: the player has made the motion,
-      // whether or not they carried it far enough to commit anything. An
-      // `Ignored` drag is not a gesture at all and teaches them nothing.
       if (event.as === "Bending") return "bend";
       if (event.as === "FoldDragging") return "fold";
       return null;
     case "TAPPED":
-      // Only where the tap actually hides something. A tap on a face-down pair
-      // does nothing by design (§5, which is what makes the first tap of a
-      // Check free), and retiring the hint for it would retire advice the
-      // player has never seen take effect.
       return state.presentation === "Revealed" ? "conceal" : null;
     case "DOUBLE_TAPPED":
       return "check";
     default:
-      // `ACTIVATED` included: Enter, Space or a mouse click is the semantic
-      // path (§12), not the tap gesture the conceal hint teaches.
       return null;
   }
 }
 
-/**
- * The four teaching hints: what each one says, and when it is worth saying.
- * Touch only, and each retires permanently the first time its gesture is used.
- *
- * Copy and eligibility live in the same entry so a gesture is defined once —
- * `TEACHABLE_GESTURES` supplies the order, and this supplies everything else.
- *
- * Bend and Conceal are local presentation and eligible **off-turn**, which is
- * most of the time a player is holding cards. Check and Fold are advice about
- * an Action, and advice you cannot take is worse than silence. Check sits above
- * Fold in the overlap, which is quieter than it looks: a legal Check means no
- * bet to face, and teaching someone to fold for free is bad advice. Where a bet
- * *is* faced, Check is illegal and Fold is the only eligible hint left — so the
- * irreversible, money-losing Action is never the one pushed at a player two
- * hands into their first session.
- *
- * The bend's corner is **derived from the rendered affordance** rather than
- * written into the copy, so if the overlapped layout ever mirrors, the words
- * follow it.
- */
 const TEACHING: Record<
   TeachableGesture,
   {
@@ -212,7 +96,6 @@ const TEACHING: Record<
     hint: {
       id: "teach-bend",
       line1: `Bend the ${BEND_CORNER.vertical}-${BEND_CORNER.horizontal} corner`,
-      // Both outcomes on one line, because they are one gesture at two depths.
       line2: "release to peek · keep bending to reveal",
       announce: false,
     },
@@ -225,7 +108,6 @@ const TEACHING: Record<
       line2: "one tap is enough",
       announce: false,
     },
-    // Nothing to hide from a pair that is already face-down.
     eligible: (state) => state.presentation === "Revealed",
   },
   check: {
@@ -248,12 +130,6 @@ const TEACHING: Record<
   },
 };
 
-/**
- * The visible confirmation a gesture Check lands with (story 31). It says the
- * Action, not the gesture, because that is what the player needs to trust: the
- * cards are already back face-down by the time it appears, so nothing else on
- * this surface has changed to say the double-tap was heard.
- */
 const checkedHint: Hint = {
   id: "checked",
   line1: "Checked",
@@ -268,11 +144,6 @@ const bendLeftHint: Hint = {
   announce: false,
 };
 
-/**
- * The upward variant swaps its second line for the one genuinely Peek-specific
- * fact worth teaching: dragging *left* peels at the same rate (§15) without
- * putting a finger over the rank and suit you are trying to read.
- */
 const bendUpHint: Hint = {
   id: "bending-up",
   line1: "Release to peek",
@@ -280,16 +151,6 @@ const bendUpHint: Hint = {
   announce: false,
 };
 
-/**
- * One line each, and no consequence line: a fold drag has the player's eyes on
- * the cards moving under their finger, and the only thing they need from the
- * text is whether letting go now costs them the hand.
- *
- * Not announced, for the same reason the bend prompts are not: a live region
- * flipping between these two as a finger wandered across the threshold would
- * talk over the player rather than tell them anything. The `Fold` button
- * remains the non-gesture path (§12).
- */
 const foldDraggingHint: Hint = {
   id: "folding",
   line1: "Keep dragging up",

--- a/packages/player-client/src/holecards/constants.ts
+++ b/packages/player-client/src/holecards/constants.ts
@@ -1,80 +1,29 @@
-/**
- * Hole-card interaction constants (Phase 3 spec #138 §15). Several are unused
- * until the pointer recognizer lands; they live here from the start so the
- * numbers are stated once, in the module that owns them.
- */
-
-/** Pointer travel before a gesture is classified, in px. */
 export const MOVE_SLOP_PX = 9;
 
-/** Fraction of bend travel past which the reveal is committed. */
 export const REVEAL_THRESHOLD = 0.9;
 
-/** Full bend travel, in px, over which peel progress runs 0 → 1. */
 export const BEND_TRAVEL_PX = 176;
 
-/**
- * The corner the bend affordance is drawn in, named once so the coaching copy
- * follows the rendered zone rather than hard-coding "bottom-right" (§11). The
- * `BendZone` and the `teach-bend` hint both read it, so if the overlapped
- * layout ever mirrors, the words the surface teaches follow it.
- */
 export const BEND_CORNER = { vertical: "bottom", horizontal: "right" } as const;
 
-/** Floor of the fold threshold, in px. */
 export const MIN_FOLD_DISTANCE_PX = 148;
 
-/** Fraction of viewport height the fold threshold scales with. */
 export const FOLD_DISTANCE_RATIO = 0.18;
 
-/**
- * How much more upward than sideways a drag must be to read as a fold rather
- * than as nothing. Ambiguous motion resolves to `Ignored` (§4), so the ratio
- * sits just above 1 rather than at it.
- */
 export const FOLD_AXIS_RATIO = 1.05;
 
-/** Window within which a second tap counts as a double-tap, in ms. */
 export const DOUBLE_TAP_MS = 280;
 
-/** Duration of the committed flip to face-up, in ms. */
 export const REVEAL_FINISH_MS = 520;
 
-/** Duration of the muck flight after a committed Fold, in ms. */
 export const FOLD_FLIGHT_MS = 280;
 
-/** Quiet interval a coaching hint waits for before appearing, in ms. */
 export const HINT_QUIET_MS = 2000;
 
-/**
- * How long after a classified gesture a synthetic `click` is disowned, in ms.
- * Not a §15 constant — §16 requires the suppression but sets no window.
- *
- * A window rather than a flag, because a gesture does **not** reliably produce
- * a click to consume it: a touch drag usually produces none, a mouse drag
- * does, and a cancelled pointer produces none at all. A flag waiting for a
- * click that never comes would go stale and swallow the next real activation,
- * including the Enter or Space that §12 guarantees.
- */
 export const CLICK_DISOWN_MS = 350;
 
-/**
- * How long the confirmation of a gesture Check stays up, in ms. Not a §15
- * constant — chosen to be long enough to be read after the eyes come back off
- * the cards, short enough to be gone before the next Player's Action lands.
- */
 export const CHECK_CONFIRM_MS = 2400;
 
-/**
- * Length of the optional threshold pulse, in ms. Not a §15 constant — §16 asks
- * for a pulse and sets no length; this one is short enough to read as a tick
- * against the fingertip rather than as a buzz.
- */
 export const HAPTIC_PULSE_MS = 10;
 
-/**
- * Duration of the face-down deal-in, in ms. Not a §15 constant — the deal-in
- * motion is §17, which sets no duration; this matches the per-card deal
- * animation it replaces in `Hand`.
- */
 export const DEAL_IN_MS = 420;

--- a/packages/player-client/src/holecards/finishPlan.test.ts
+++ b/packages/player-client/src/holecards/finishPlan.test.ts
@@ -5,13 +5,6 @@ import { endGesture, type GestureSession } from "./gesture.js";
 import { planFinish, type FinishEffect } from "./finishPlan.js";
 import type { CardActions } from "./ports.js";
 
-/**
- * These exercise the seam #156 identified: the composition from a completed
- * gesture to a *sent* poker Action, which the pure-function tests below #155
- * could not reach without a pointer. `end` comes through the real `endGesture`
- * so the event lists are the ones the hook actually replays.
- */
-
 function session(over: Partial<GestureSession>): GestureSession {
   return {
     pointerId: 1,
@@ -33,7 +26,6 @@ const armedFold = session({
 
 const tap = session({ classification: null });
 
-/** All flags open: on turn, Check and Fold both legal, nothing in flight. */
 const open: Pick<CardActions, "foldLegal" | "checkLegal" | "pending"> = {
   foldLegal: true,
   checkLegal: true,
@@ -106,7 +98,6 @@ describe("planFinish — Fold", () => {
 
     expect(sent(plan.effects)).toEqual([]);
     expect(plan.leaving).toBeNull();
-    // Disarm is announced before the release, matching the reducer's order.
     expect(dispatched(plan.effects)).toEqual(["FOLD_DISARMED", "RELEASED"]);
   });
 

--- a/packages/player-client/src/holecards/finishPlan.ts
+++ b/packages/player-client/src/holecards/finishPlan.ts
@@ -3,92 +3,29 @@ import type { GestureEnd } from "./gesture.js";
 import type { CardActions } from "./ports.js";
 import { confirmsCheck, tapLanded, type TapWindow } from "./taps.js";
 
-/**
- * One ordered thing a completed gesture does: either advance the reducer, or
- * leave the module and send a poker Action (§2). The list preserves the
- * sequence the hook must replay, so the two orderings that cost money are a
- * property the plan can be asserted on rather than glue only a real pointer
- * could exercise:
- *
- * - **conceal before Check** — the `TAPPED`/`DOUBLE_TAPPED` dispatch precedes
- *   the `check` send, so the player sees the cards go down, then the
- *   confirmation, with no timer between them (story 31);
- * - **depart before Fold** — `leaving` is applied and `RELEASED` dispatched
- *   before the `fold` send, so the pair is already on its way to the muck when
- *   the Action goes and the departure is the player's own answer, not the
- *   server's (§7).
- */
 export type FinishEffect =
   | { readonly kind: "dispatch"; readonly event: CardEvent }
   | { readonly kind: "send"; readonly action: "check" | "fold" };
 
 export interface FinishPlan {
-  /** The dispatches and sends, in the exact order the hook must replay them. */
   readonly effects: readonly FinishEffect[];
-  /**
-   * The tap window after this release. A gesture that ended as anything but a
-   * tap closes it (`null`), so tap → peek → tap cannot compose a Check out of
-   * two taps the player never meant to pair (§5).
-   */
   readonly nextTapWindow: TapWindow;
-  /**
-   * Whether a landed Check should claim, visibly, that it went (story 31).
-   * Rendering only, and only ever set alongside a `check` send — a stale prop
-   * can at worst confirm an Action the intent then refuses, never send one.
-   */
   readonly confirmCheck: boolean;
-  /**
-   * Set when this release commits the Fold: the pair leaves with whatever face
-   * it had (§7). `null` when nothing departs.
-   */
   readonly leaving: { readonly faceUp: boolean } | null;
 }
 
 export interface FinishInputs {
-  /** The completed gesture, from `endGesture(session, { cancelled })`. */
   readonly end: GestureEnd;
-  /**
-   * The legality flags, for **arming and rendering only** (§2). `canAct`
-   * inside `intent.fold`/`intent.check` stays the single gate on whether an
-   * Action is actually sent, so a release these flags wave through can still be
-   * refused there and a stale flag can at worst arm a gesture `canAct` denies.
-   */
   readonly actions: Pick<CardActions, "foldLegal" | "checkLegal" | "pending">;
-  /**
-   * The presentation the pair leaves from. Read here rather than off the
-   * session because a keyboard reveal committed before the press can land
-   * mid-drag, and `Turning` is a point of no return — a pair mid-flip is a pair
-   * that is going to be face-up (§7).
-   */
   readonly presentation: Presentation;
-  /** The tap window going in, `performance.now()`-based (§5). */
   readonly tapWindow: TapWindow;
-  /**
-   * A monotonic clock (`performance.now()`), so two unrelated taps cannot be
-   * paired into an Action by a wall clock stepping backwards mid-hand.
-   */
   readonly now: number;
 }
 
-/**
- * Decide what a completed gesture does — which reducer events fire, which
- * Actions leave the module, what happens to the tap window — as a pure
- * function of the release and the current view.
- *
- * This is the seam where a finger movement turns into a sent poker Action, and
- * #138's strategy is to push that rule out of the renderer so it can be tested
- * by construction rather than by a simulated pointer (#156). The hook that
- * calls this owns only the imperative replay: dispatching the events, calling
- * the named Action functions in order, and seeding the confirmation timer.
- */
 export function planFinish(inputs: FinishInputs): FinishPlan {
   const { end, actions, presentation, tapWindow, now } = inputs;
   const { events, commitsFold } = end;
 
-  // Fold legality is re-sampled here, not only where `eventsForPropChange`
-  // watches it, because a release can beat the view that would have disarmed
-  // it, and `pending` rides along so a Fold cannot go out on top of an Action
-  // already in flight (§6). This is arming, exactly as §2 licenses.
   const commits = commitsFold && actions.foldLegal && !actions.pending;
 
   const effects: FinishEffect[] = [];
@@ -96,10 +33,6 @@ export function planFinish(inputs: FinishInputs): FinishPlan {
   let confirmCheck = false;
   let leaving: { readonly faceUp: boolean } | null = null;
 
-  // A drag that armed a Fold but outlived the turn that made it legal disarms:
-  // the release commits nothing, and there is no rejection message because the
-  // turn banner already explains it (§6). Emitted before `RELEASED`, matching
-  // the reducer's order.
   if (commitsFold && !commits) {
     effects.push({ kind: "dispatch", event: { type: "FOLD_DISARMED" } });
   }
@@ -116,24 +49,17 @@ export function planFinish(inputs: FinishInputs): FinishPlan {
       effects.push({ kind: "dispatch", event });
       continue;
     }
-    // A tap is only *provisionally* a tap: whether it is one, or the second
-    // half of a Check, is `taps` to decide.
     const tap = tapLanded(nextTapWindow, now);
     nextTapWindow = tap.window;
     tapped = true;
-    // Dispatched first, so the conceal is on screen before the Check goes.
     effects.push({ kind: "dispatch", event: tap.event });
     if (tap.event.type === "DOUBLE_TAPPED") {
       effects.push({ kind: "send", action: "check" });
       confirmCheck = confirmsCheck(actions);
     }
   }
-  // The two taps of a Check must be *consecutive*: any other ending closes the
-  // window rather than leaving it open on a technicality of the middle gesture.
   if (!tapped) nextTapWindow = null;
 
-  // Sent after the departure is committed, so the pair is already leaving when
-  // the Action goes (§7).
   if (commits) effects.push({ kind: "send", action: "fold" });
 
   return { effects, nextTapWindow, confirmCheck, leaving };

--- a/packages/player-client/src/holecards/geometry.test.ts
+++ b/packages/player-client/src/holecards/geometry.test.ts
@@ -56,9 +56,6 @@ describe("foldThreshold", () => {
   });
 
   it("never falls below the floor on a short viewport", () => {
-    // On a small or split-screen window the proportional term would put the
-    // threshold inside an ordinary thumb flick, and Fold is the one Action
-    // that costs money.
     expect(foldThreshold(400)).toBe(MIN_FOLD_DISTANCE_PX);
     expect(foldThreshold(0)).toBe(MIN_FOLD_DISTANCE_PX);
   });
@@ -76,8 +73,6 @@ describe("foldFlightDistance", () => {
   });
 
   it("is always further than the threshold the release crossed", () => {
-    // Otherwise a committed pair could travel *back down* as the flight took
-    // over from the finger.
     for (const height of [0, 400, 812, 1400]) {
       expect(foldFlightDistance(height)).toBeGreaterThan(foldThreshold(height));
     }

--- a/packages/player-client/src/holecards/geometry.ts
+++ b/packages/player-client/src/holecards/geometry.ts
@@ -4,44 +4,17 @@ import {
   MIN_FOLD_DISTANCE_PX,
 } from "./constants.js";
 
-/** Which way a live bend is mostly going — the §11 hint swaps on it. */
 export type BendAxis = "left" | "up";
 
-/**
- * Peel progress, 0 → 1, for a drag of `dx`/`dy` from where the finger landed
- * (Phase 3 spec #138 §15) — read from the spec rather than re-derived.
- *
- * Leftward and upward travel count **equally**, and only inward travel counts
- * at all. Two consequences the formula exists for:
- *
- * - A pure leftward drag drives the peel at the full rate, so the player can
- *   peel with their finger clear of the rank and suit they are trying to read.
- * - Because leftward alone is enough, the bend cannot be stolen by the fold
- *   recognizer, which needs upward dominance (§4).
- */
 export function bendProgress(dx: number, dy: number): number {
   const inward = Math.max(0, -dx) + Math.max(0, -dy);
   return Math.min(1, inward / BEND_TRAVEL_PX);
 }
 
-/**
- * Which axis a bend is being driven along. Ties read as `up`: a bend that is
- * equally upward and leftward still has the finger over the card face, which
- * is the case the "drag left" prompt exists to fix.
- */
 export function bendAxis(dx: number, dy: number): BendAxis {
   return Math.abs(dy) >= Math.abs(dx) ? "up" : "left";
 }
 
-/**
- * How far up the pair must travel before releasing would commit the Fold
- * (§15), in px — a **distance**, so the caller compares it against upward
- * travel rather than against a coordinate.
- *
- * Proportional to the viewport so the swipe is the same gesture on every
- * phone, with a floor so a short or split-screen window cannot put the one
- * irreversible, money-losing Action inside an ordinary thumb flick.
- */
 export function foldThreshold(viewportHeight: number): number {
   return Math.max(
     MIN_FOLD_DISTANCE_PX,
@@ -49,12 +22,6 @@ export function foldThreshold(viewportHeight: number): number {
   );
 }
 
-/**
- * How far the committed pair travels on its way to the muck. Far enough to be
- * off the screen rather than merely above the cards: the departure has to read
- * as *gone*, and the pair starts the flight already at least a threshold's
- * worth of travel up.
- */
 export function foldFlightDistance(viewportHeight: number): number {
   return Math.max(viewportHeight, foldThreshold(viewportHeight) * 2);
 }

--- a/packages/player-client/src/holecards/gesture.test.ts
+++ b/packages/player-client/src/holecards/gesture.test.ts
@@ -29,13 +29,11 @@ function press(
   });
 }
 
-/** A viewport whose fold threshold is comfortably above the floor. */
 const VIEWPORT_HEIGHT = 900;
 const FOLD_THRESHOLD_PX = foldThreshold(VIEWPORT_HEIGHT);
 
 const onTurn = { foldLegal: true, foldThresholdPx: FOLD_THRESHOLD_PX };
 
-/** Drag to an absolute point, from the origin `press()` uses. */
 function to(dx: number, dy: number) {
   return { x: 100 + dx, y: 100 + dy };
 }
@@ -68,7 +66,6 @@ describe("moveGesture", () => {
   });
 
   it("keeps the first classification for the rest of the gesture", () => {
-    // The drag starts sideways — Ignored — then curves decisively upward.
     const slid = moveGesture(press(), to(-40, 0), onTurn);
     const curved = moveGesture(slid.session, to(-40, -400), onTurn);
 
@@ -78,9 +75,6 @@ describe("moveGesture", () => {
   });
 
   it("produces no events at all once classified, so a drag never re-renders", () => {
-    // The guarantee behind "a finger drag causes zero React re-renders":
-    // continuous values come back as `bend`, destined for a `MotionValue`, and
-    // the reducer is never told that a finger moved.
     const bending = moveGesture(
       press({ fromBendZone: true }),
       to(-20, 0),
@@ -132,14 +126,12 @@ describe("moveGesture", () => {
     });
     expect(offTurn.session.classification).toBe("Ignored");
 
-    // Legality returning mid-drag does not promote it.
     const later = moveGesture(offTurn.session, to(0, -400), onTurn);
     expect(later.session.classification).toBe("Ignored");
   });
 });
 
 describe("crossing the reveal threshold", () => {
-  /** Inward travel, in px, that puts the peel at a given progress. */
   function inward(progress: number) {
     return -(progress * BEND_TRAVEL_PX);
   }
@@ -174,16 +166,12 @@ describe("crossing the reveal threshold", () => {
 
     for (const progress of [0.95, 1, 0.5, 0]) {
       const step = moveGesture(crossed, to(inward(progress), 0), onTurn);
-      // Including dragging *back*: the commit happened on crossing, so it can
-      // neither be undone nor re-announced.
       expect(step.events).toEqual([]);
       expect(step.session.crossed).toBe(true);
     }
   });
 
   it("stops driving the peel from the finger once committed", () => {
-    // The turn owns the motion from the threshold on, so a finger still on the
-    // glass cannot drag the card back out of a commit it already made.
     const bending = moveGesture(
       press({ fromBendZone: true }),
       to(-20, 0),
@@ -205,7 +193,6 @@ describe("crossing the reveal threshold", () => {
       onTurn,
     );
 
-    // Order matters: the reducer only accepts a crossing from `Bending`.
     expect(flick.events).toEqual([
       { type: "CLASSIFIED", as: "Bending" },
       { type: "BEND_CROSSED" },
@@ -223,7 +210,6 @@ describe("crossing the reveal threshold", () => {
 });
 
 describe("the fold drag", () => {
-  /** A fold drag already classified, with the finger `up` px above the start. */
   function dragging(up: number) {
     return moveGesture(press(), to(0, -up), onTurn);
   }
@@ -236,8 +222,6 @@ describe("the fold drag", () => {
   });
 
   it("moves the pair up only, so a fold drag cannot push the cards downward", () => {
-    // The classifier admits an upward-dominant drag; wandering back below the
-    // start of it must not turn the gesture into a shove.
     const started = dragging(40).session;
 
     expect(moveGesture(started, to(0, 30), onTurn).fold).toEqual({ offset: 0 });
@@ -262,9 +246,6 @@ describe("the fold drag", () => {
   });
 
   it("disarms again when the player pulls the cards back down", () => {
-    // Card motion and the in-gesture text are the whole arming signal, so an
-    // armed prompt over cards that have come back below the line would be a
-    // lie — and releasing there must commit nothing.
     const armed = moveGesture(
       dragging(FOLD_THRESHOLD_PX).session,
       to(0, -(FOLD_THRESHOLD_PX + 40)),
@@ -293,8 +274,6 @@ describe("the fold drag", () => {
   });
 
   it("keeps the cards tracking the finger after a view disarms the drag", () => {
-    // §6: the surface never freezes under the player's hand. The drag is not
-    // ended, only disarmed, so the pair carries on following the finger.
     const armed = moveGesture(
       dragging(FOLD_THRESHOLD_PX).session,
       to(0, -(FOLD_THRESHOLD_PX + 40)),
@@ -313,9 +292,6 @@ describe("the fold drag", () => {
   });
 
   it("leaves the session alone for every other lifecycle event", () => {
-    // The pointer is ended by the pointer, and by nothing else: `finish` bails
-    // on a release it has no session for, so a session cleared out from under a
-    // held finger would leave the synthesised click to reveal the next pair.
     const armed = dragging(FOLD_THRESHOLD_PX).session;
 
     for (const event of [
@@ -336,7 +312,6 @@ describe("the fold drag", () => {
       onTurn,
     );
 
-    // Order matters: the reducer only arms a drag it has already classified.
     expect(flick.events).toEqual([
       { type: "CLASSIFIED", as: "FoldDragging" },
       { type: "FOLD_ARMED" },
@@ -364,7 +339,6 @@ describe("the fold drag", () => {
 });
 
 describe("endGesture", () => {
-  /** A fold drag carried `up` px, from a pair that started face-down. */
   function foldDragged(up: number): GestureSession {
     return moveGesture(press(), to(0, -up), onTurn).session;
   }
@@ -420,19 +394,12 @@ describe("endGesture", () => {
   });
 
   it("commits nothing when the browser takes the pointer away mid-flick", () => {
-    // The player never let go: crossing the line offers the Fold, and only the
-    // completing release accepts it.
     expect(
       endGesture(foldDragged(FOLD_THRESHOLD_PX + 40), { cancelled: true }),
     ).toEqual({ events: [{ type: "CANCELLED" }], commitsFold: false });
   });
 
   it("agrees with the reducer about which releases fold", () => {
-    // The Action and the presentation are decided by two different `armed`
-    // flags — the session's, read synchronously in the pointer handler, and the
-    // reducer's. Both are driven by the same `FOLD_ARMED`/`FOLD_DISARMED`
-    // events; this is the invariant that keeps them from disagreeing about
-    // whether the player just folded.
     for (const up of [
       FOLD_THRESHOLD_PX - 1,
       FOLD_THRESHOLD_PX,

--- a/packages/player-client/src/holecards/gesture.ts
+++ b/packages/player-client/src/holecards/gesture.ts
@@ -3,66 +3,35 @@ import { classify, type Classification } from "./classify.js";
 import { MOVE_SLOP_PX, REVEAL_THRESHOLD } from "./constants.js";
 import { bendAxis, bendProgress, type BendAxis } from "./geometry.js";
 
-/**
- * A live pointer gesture, as a value (Phase 3 spec #138 §4, §13).
- *
- * The hook holds one of these in a ref and never in React state — which is the
- * whole point. Splitting by **cardinality of change**, the discrete facts (has
- * it been classified, has a threshold been crossed) become reducer events, and
- * the continuous ones (peel progress, drag offset) become `MotionValue`s. A
- * finger dragging across the pair therefore produces no events at all between
- * threshold crossings, so it causes **zero** React re-renders, and `Hand`,
- * `ActionBar` and the turn banner are untouched by card handling.
- */
 export interface GestureSession {
   readonly pointerId: number;
   readonly originX: number;
   readonly originY: number;
-  /** The press landed on the bend affordance in a card's corner. */
   readonly fromBendZone: boolean;
-  /** The pair was already face-up when the press landed. */
   readonly startedRevealed: boolean;
-  /** `null` until the drag passes the slop; set exactly once thereafter. */
   readonly classification: Classification | null;
-  /**
-   * Whether the peel has already reached the reveal threshold. One-way: the
-   * commit happens *on crossing*, not on release, so dragging back afterwards
-   * cannot un-commit it and must not re-announce it either.
-   */
   readonly crossed: boolean;
-  /**
-   * Whether the fold drag is currently past its threshold. Deliberately **not**
-   * one-way, unlike `crossed`: crossing the fold line only arms, and the
-   * commitment is the release (§10) — so pulling the cards back down disarms
-   * again, and the player can always change their mind by putting them down.
-   */
   readonly armed: boolean;
 }
 
-/** Continuous peel values, destined for `MotionValue`s rather than state. */
 export interface BendMotion {
   readonly progress: number;
   readonly axis: BendAxis;
 }
 
-/** How far the pair has been carried towards the muck, in px. Never positive. */
 export interface FoldMotion {
   readonly offset: number;
 }
 
-/** What the recognizer needs from the surrounding view to answer a move. */
 export interface GestureContext {
   readonly foldLegal: boolean;
-  /** Upward travel that arms the Fold, from `foldThreshold` (§15). */
   readonly foldThresholdPx: number;
 }
 
 export interface GestureStep {
   readonly session: GestureSession;
   readonly events: readonly CardEvent[];
-  /** `null` when this move changes nothing continuous. */
   readonly bend: BendMotion | null;
-  /** `null` unless this move is carrying the pair towards the muck. */
   readonly fold: FoldMotion | null;
 }
 
@@ -85,21 +54,6 @@ export function beginGesture(press: {
   };
 }
 
-/**
- * Apply a lifecycle event to the live pointer session.
- *
- * Only `FOLD_DISARMED` has anything to say to a session: fold legality can
- * disappear while the pointer is still moving, and the session is what
- * `endGesture` answers `commitsFold` from, so it has to hear the same disarm
- * the reducer does or the two would disagree on the next release. **The drag
- * itself is untouched** — the cards keep tracking the finger (§6), and the
- * session ends where every session ends, on the pointer that lifts it.
- *
- * Every other event is the reducer's business alone. Ending the session here
- * would strand the release: `finish` bails on a pointer it has no session for,
- * so nothing would disown the click the browser synthesises afterwards, and it
- * would reveal the pair the event had just dealt or reset.
- */
 export function applyCardEvent(
   session: GestureSession | null,
   event: CardEvent,
@@ -108,14 +62,6 @@ export function applyCardEvent(
   return { ...session, armed: false };
 }
 
-/**
- * Advance a gesture to a new pointer position.
- *
- * Nothing is classified below the slop, so a tap with a wobble still reads as
- * a tap. Past it, `classify` runs **once** and its answer is kept for the rest
- * of the gesture — this function never asks a second time, and the reducer
- * refuses a second answer anyway.
- */
 export function moveGesture(
   session: GestureSession,
   point: { readonly x: number; readonly y: number },
@@ -133,10 +79,6 @@ export function moveGesture(
       alreadyRevealed: session.startedRevealed,
       dx,
       dy,
-      // Fold legality is sampled once, here, and never re-read. A drag that
-      // outlives the player's turn disarms (§6) — through `FOLD_DISARMED` off
-      // the prop change, and `applyCardEvent` on this session; it does not
-      // reclassify.
       foldLegal: ctx.foldLegal,
     });
     return step(
@@ -148,16 +90,9 @@ export function moveGesture(
     );
   }
 
-  // The steady state of a drag: continuous values only, and no events — the
-  // reducer is not told that a finger moved.
   return step(session, dx, dy, [], ctx);
 }
 
-/**
- * One advanced step, plus the threshold crossing if this move is the one that
- * reaches it. A flick fast enough to classify and cross in a single move
- * emits both, in that order, and the reducer applies them in that order.
- */
 function step(
   session: GestureSession,
   dx: number,
@@ -169,8 +104,6 @@ function step(
     return foldStep(session, dy, events, ctx);
   }
 
-  // Past the commit the turn owns the motion: the peel finishes on its own
-  // schedule, so the finger stops driving it and a release cannot pull it back.
   if (session.crossed) return { session, events, bend: null, fold: null };
 
   const bend = bendFor(session, dx, dy);
@@ -185,24 +118,12 @@ function step(
   };
 }
 
-/**
- * The pair following the finger towards the muck, and the arming that turns
- * that motion into an offer.
- *
- * The threshold is crossed **both ways**: a player who drags past it and then
- * changes their mind disarms by putting the cards back down, which is the whole
- * of §10's promise that the commitment is on release and never on crossing the
- * line. Card motion plus the in-gesture text is the entire arming signal — on
- * iPhone/Safari there is no haptic at all — so the two must never disagree.
- */
 function foldStep(
   session: GestureSession,
   dy: number,
   events: readonly CardEvent[],
   ctx: GestureContext,
 ): GestureStep {
-  // Upward only: the cards go away from the player, and a drag that wanders
-  // back below where it started must not shove them down the screen.
   const offset = Math.min(0, dy);
   const fold: FoldMotion = { offset };
   const armed = -offset >= ctx.foldThresholdPx;
@@ -226,28 +147,9 @@ function bendFor(
 
 export interface GestureEnd {
   readonly events: readonly CardEvent[];
-  /**
-   * Whether this release is the completing one that sends the Fold (§10).
-   *
-   * Answered from the **session** rather than from the reducer's state,
-   * because the caller has to act on it synchronously and a `useReducer`
-   * state read in a pointer handler can lag a threshold crossing that
-   * happened one pointer event ago. The reducer reaches the same answer from
-   * its own `armed` flag — see `releaseCommitsFold` — and the two agree
-   * because both are driven by the same `FOLD_ARMED`/`FOLD_DISARMED` events.
-   */
   readonly commitsFold: boolean;
 }
 
-/**
- * End a gesture. A release that never classified is a tap; a release from
- * `Ignored` is not — a drag that started sideways or downward does nothing at
- * all, including on the way out.
- *
- * **Cancellation commits nothing**, however far the cards were carried: the
- * player never completed the gesture, and Actions commit on the completing
- * release alone.
- */
 export function endGesture(
   session: GestureSession,
   { cancelled }: { readonly cancelled: boolean },

--- a/packages/player-client/src/holecards/haptics.ts
+++ b/packages/player-client/src/holecards/haptics.ts
@@ -1,16 +1,3 @@
-/**
- * A threshold pulse, where the platform allows one (Phase 3 spec #138 §16).
- *
- * **Never semantic feedback.** Browser vibration is Blink-only: there is no
- * Vibration API in Safari at all, so the iPhone path has to work with none of
- * this. Everything the pulse says is already said by the cards moving and by
- * the permanent in-gesture text (§11), and this only adds weight to the moment
- * for the players whose browser can.
- *
- * Reached through `Reflect` rather than `navigator.vibrate?.()` because the DOM
- * lib types the method as always present, which is exactly the assumption the
- * Safari path breaks.
- */
 export function pulse(durationMs: number): void {
   if (typeof navigator === "undefined") return;
   const vibrate = Reflect.get(navigator, "vibrate") as unknown;
@@ -18,6 +5,6 @@ export function pulse(durationMs: number): void {
   try {
     Reflect.apply(vibrate, navigator, [durationMs]);
   } catch {
-    // Best-effort: a browser may refuse without a user gesture, or at all.
+    // best-effort: a browser may refuse without a user gesture, or at all
   }
 }

--- a/packages/player-client/src/holecards/hintStorage.test.ts
+++ b/packages/player-client/src/holecards/hintStorage.test.ts
@@ -34,9 +34,6 @@ describe("saveDiscovered", () => {
   });
 
   it("survives a storage that refuses to write", () => {
-    // Safari in private browsing throws from `setItem`. Losing the record of a
-    // discovered gesture costs the player a hint they have already outgrown;
-    // losing the Fold it was written during would cost them the hand.
     const storage = fakeStorage();
     vi.spyOn(storage, "setItem").mockImplementation(() => {
       throw new DOMException("QuotaExceededError");
@@ -63,9 +60,6 @@ describe("loadDiscovered", () => {
   });
 
   it("reads malformed storage as nothing discovered", () => {
-    // A cleared or corrupted localStorage re-teaches the gestures rather than
-    // guessing: an extra hint is a small cost, and there is nothing else the
-    // set could honestly be.
     for (const raw of ["", "not json", "{}", '"bend"', "null", "42"]) {
       expect(
         loadDiscovered(fakeStorage({ "ttp:discovered-gestures": raw })),
@@ -74,8 +68,6 @@ describe("loadDiscovered", () => {
   });
 
   it("keeps the gestures it recognises and drops everything else", () => {
-    // A key written by a later version of the surface, or by hand: the set is
-    // an allow-list, so an unknown name never reaches the selector.
     const storage = fakeStorage({
       "ttp:discovered-gestures": JSON.stringify(["bend", "shuffle", 7, null]),
     });

--- a/packages/player-client/src/holecards/hintStorage.ts
+++ b/packages/player-client/src/holecards/hintStorage.ts
@@ -2,40 +2,20 @@ import { TEACHABLE_GESTURES, type TeachableGesture } from "./coaching.js";
 
 const KEY = "ttp:discovered-gestures";
 
-/**
- * The one thing the coaching hints persist: which gestures this device has
- * already found (Phase 3 spec #138 §11). Per-device, permanent, never
- * re-taught — a returning player is not re-shown a hint weeks later.
- *
- * Takes an injected `Storage` exactly as `storage/seatToken.ts` does, so tests
- * pass a double rather than reaching for a global. This is also the only thing
- * in the coaching path that crosses a seam at all: the selector itself stays
- * module-internal, because every in-gesture hint depends on recognizer state
- * nothing outside the module may see.
- */
 export function saveDiscovered(
   storage: Storage,
   discovered: ReadonlySet<TeachableGesture>,
 ): void {
-  // Ordered by the teaching order rather than by insertion, so the stored value
-  // is the same for a device that folded before it checked.
   const ordered = TEACHABLE_GESTURES.filter((gesture) =>
     discovered.has(gesture),
   );
   try {
     storage.setItem(KEY, JSON.stringify(ordered));
   } catch {
-    // Safari in private browsing throws rather than storing. The write happens
-    // in the same handler as a Fold or a Check, and an Action must not be lost
-    // over a hint that will simply be offered again next time.
+    // storage may throw (e.g. Safari private browsing); the hint is re-offered
   }
 }
 
-/**
- * Reads the discovery set back on mount. Absent and malformed storage both read
- * as "nothing discovered": there is nothing else the set could honestly be, and
- * an extra hint is the cheapest possible way to be wrong.
- */
 export function loadDiscovered(
   storage: Storage,
 ): ReadonlySet<TeachableGesture> {
@@ -44,8 +24,6 @@ export function loadDiscovered(
   try {
     const parsed: unknown = JSON.parse(raw);
     if (!Array.isArray(parsed)) return new Set();
-    // An allow-list, so a name written by a later version of this surface — or
-    // by hand — never reaches the selector as a gesture it cannot teach.
     return new Set(
       TEACHABLE_GESTURES.filter((gesture) => parsed.includes(gesture)),
     );

--- a/packages/player-client/src/holecards/index.ts
+++ b/packages/player-client/src/holecards/index.ts
@@ -1,13 +1,2 @@
-/**
- * The Hole-card module's seam (Phase 3 spec #138 §1). It exports **two**
- * names and nothing else: the component, and the Action port the module
- * defines for itself.
- *
- * Everything else — the reducer, the hook, the view adapter, the bendable
- * card, the constants — is module-internal and imported by nothing outside
- * this directory. That is what keeps pointers, bends and recognizer states
- * out of `Hand`, and what lets every later gesture be an addition inside
- * `holecards/` rather than surgery on the component tree.
- */
 export { HoleCardPair } from "./HoleCardPair.js";
 export type { CardActions } from "./ports.js";

--- a/packages/player-client/src/holecards/ports.ts
+++ b/packages/player-client/src/holecards/ports.ts
@@ -1,13 +1,3 @@
-/**
- * The Action port the Hole-card module defines for itself (Phase 3 spec #138
- * §2). `fold` and `check` **are** `intent.fold`/`intent.check` — a gesture and
- * a button reach the same Action by the same route, and `canAct` stays the
- * single legality gate.
- *
- * `foldLegal`, `checkLegal` and `pending` are for arming and rendering only.
- * The module never uses them to decide whether an Action is permitted, so a
- * stale prop can at worst arm a gesture that `canAct` then refuses.
- */
 export interface CardActions {
   readonly foldLegal: boolean;
   readonly checkLegal: boolean;

--- a/packages/player-client/src/holecards/taps.test.ts
+++ b/packages/player-client/src/holecards/taps.test.ts
@@ -42,7 +42,6 @@ describe("tapLanded", () => {
     const third = tapLanded(second.window, 1200);
 
     expect(second.event).toEqual({ type: "DOUBLE_TAPPED" });
-    // Without this, a triple-tap would send two Checks 100ms apart.
     expect(third).toEqual({ window: 1200, event: { type: "TAPPED" } });
   });
 

--- a/packages/player-client/src/holecards/taps.ts
+++ b/packages/player-client/src/holecards/taps.ts
@@ -2,42 +2,13 @@ import type { CardEvent } from "./cardState.js";
 import { DOUBLE_TAP_MS } from "./constants.js";
 import type { CardActions } from "./ports.js";
 
-/**
- * The double-tap window as a value (Phase 3 spec #138 §5, story 27).
- *
- * **No timer arbitration.** A tap is answered the moment it lands — the Check
- * goes on the second tap's arrival rather than on a timer deciding, 280ms
- * later, that no second tap is coming. That is what makes the gesture a reflex
- * instead of a delay, and it is why the conceal a first tap performs is visible
- * before the Check it may turn out to be half of.
- *
- * The accepted trade-off (§5): a Check cannot be sent while keeping the cards
- * face-up, because the first of the two taps has already put them down. One tap
- * gets them back.
- *
- * `null` when no window is open. Otherwise the timestamp of the last tap that
- * did not itself complete a pair.
- */
 export type TapWindow = number | null;
 
 export interface TapStep {
   readonly window: TapWindow;
-  /**
-   * Narrowed to the two events a tap can possibly be, so the caller reading
-   * `DOUBLE_TAPPED` off it is checking an outcome this function can actually
-   * produce rather than a name from the whole lifecycle union.
-   */
   readonly event: Extract<CardEvent, { type: "TAPPED" | "DOUBLE_TAPPED" }>;
 }
 
-/**
- * Answer a tap that has just landed: on its own, or as the second half of a
- * double-tap.
- *
- * A completed pair closes the window rather than carrying the second tap
- * forward, so three taps in quick succession send **one** Check and start
- * counting again — a stream of taps cannot become a stream of Actions.
- */
 export function tapLanded(window: TapWindow, now: number): TapStep {
   if (window !== null && now - window <= DOUBLE_TAP_MS) {
     return { window: null, event: { type: "DOUBLE_TAPPED" } };
@@ -45,16 +16,6 @@ export function tapLanded(window: TapWindow, now: number): TapStep {
   return { window: now, event: { type: "TAPPED" } };
 }
 
-/**
- * Whether a double-tap Check should claim, visibly, that it landed (story 31).
- *
- * **Rendering only.** Whether the Action is *sent* is not decided here and not
- * decided by these two flags: `check` is `intent.check`, and `canAct` on the
- * latest view is the single gate (§2). This function answers the different
- * question of whether to tell the player it went — so a double-tap off-turn,
- * or while a Fold is in flight, is silent as well as inert, and a stale prop
- * can at worst confirm an Action the intent then refuses.
- */
 export function confirmsCheck(
   actions: Pick<CardActions, "checkLegal" | "pending">,
 ): boolean {

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -48,14 +48,9 @@ import type { HoleCardPairProps } from "./HoleCardPair.js";
 import type { TapWindow } from "./taps.js";
 import { eventsForPropChange, eventsForVisibility } from "./viewEvents.js";
 
-/**
- * `useLayoutEffect` warns when it is called during server rendering, and the
- * component tests render to static markup — where no effect runs either way.
- */
 const useIsomorphicLayoutEffect =
   typeof window === "undefined" ? useEffect : useLayoutEffect;
 
-/** The pointer handlers the pair binds. */
 export interface PairHandlers {
   readonly onPointerDown: (event: ReactPointerEvent<HTMLElement>) => void;
   readonly onPointerMove: (event: ReactPointerEvent<HTMLElement>) => void;
@@ -68,53 +63,20 @@ export interface PairHandlers {
 
 export interface HoleCards {
   readonly state: CardState;
-  /** Keyboard and mouse activation: Enter, Space or a click (§12). */
   readonly activate: () => void;
   readonly handlers: PairHandlers;
-  /** Peel progress, 0 → 1. Never React state (§13). */
   readonly bend: MotionValue<number>;
-  /** Which way the live bend is going, for the §11 second-line swap. */
   readonly bendAxis: MotionValue<BendAxis>;
-  /** How far the pair has been carried towards the muck, in px. Never state. */
   readonly foldOffset: MotionValue<number>;
-  /** The pair fading out on its way to the muck, 1 → 0. */
   readonly foldFade: MotionValue<number>;
-  /**
-   * Whether the pair was face-up at the moment the Fold committed. Only
-   * meaningful while it is departing: the cards leave with whatever face they
-   * had (§7), and once the reducer is in `Leaving` the presentation they left
-   * from is no longer recoverable from the state.
-   */
   readonly leavingFaceUp: boolean;
-  /**
-   * The committed pair for as long as its flight is still running, or `null`.
-   *
-   * The flight is **fire-and-forget, on its own ~280ms schedule and not gated
-   * on the round trip** (§7) — which cuts *both* ways. On a LAN the
-   * acknowledgement lands tens of milliseconds in and takes `cards` away with
-   * it, so without this the departure the player was promised would be a blink
-   * (story 20). The pair renders from here once the props no longer carry it.
-   */
   readonly departing: readonly [Card, Card] | null;
-  /** A gesture Check landed and is still being confirmed (story 31). */
   readonly checkConfirmed: boolean;
-  /**
-   * The teaching hints' two device inputs, watched here because only the hook
-   * can (§11): `coarsePointer` is a media query it subscribes to, and `quiet`
-   * is the ~2s of stillness it times off contact with the pair. The component
-   * folds them into the `HintContext` it hands the selector.
-   */
   readonly quiet: boolean;
   readonly coarsePointer: boolean;
-  /** The gestures this device has already found, for the teaching hints. */
   readonly discovered: ReadonlySet<TeachableGesture>;
 }
 
-/**
- * `window.localStorage`, or `null` where there is none to reach: server
- * rendering, and the browsers that throw on the property itself when storage is
- * disabled. A player without it is simply taught the gestures again next time.
- */
 function localStorageOrNull(): Storage | null {
   if (typeof window === "undefined") return null;
   try {
@@ -124,36 +86,13 @@ function localStorageOrNull(): Storage | null {
   }
 }
 
-/**
- * The touch gate (§11): the **primary** pointer, subscribed rather than read
- * once, so a tablet that gains or loses a trackpad follows the pointer the
- * player is actually using. `any-pointer: coarse` is deliberately not asked —
- * it is true for any touchscreen laptop, exactly the case the gate excludes.
- */
 function coarsePointerQuery(): MediaQueryList | null {
   if (typeof window === "undefined") return null;
   return window.matchMedia("(pointer: coarse)");
 }
 
-/**
- * A spring rather than a duration: the cards were being *carried*, and letting
- * go of something you are carrying has weight and a little overshoot.
- */
 const RETURN_SPRING = { type: "spring", stiffness: 480, damping: 36 } as const;
 
-/**
- * Binds the pure lifecycle to React: prop changes and pointer events in,
- * discrete state out. Every decision it makes is delegated —
- * `eventsForPropChange` decides what a changed prop means, `moveGesture`
- * decides what a finger is doing, `reduce` decides what either means for the
- * pair — so the hook itself holds no rules worth testing through a renderer.
- *
- * The split it exists to enforce is §13's: discrete states go through
- * `useReducer`, a handful of times per hand; continuous values are
- * `MotionValue`s written straight from the pointer handlers. Between threshold
- * crossings a drag dispatches nothing, so it re-renders nothing — not this
- * component, and not `Hand`, `ActionBar` or the turn banner above it.
- */
 export function useHoleCards(props: HoleCardPairProps): HoleCards {
   const [state, dispatch] = useReducer(reduce, props, (initial) =>
     initialCardState({
@@ -167,64 +106,20 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
   const foldOffset = useMotionValue(0);
   const foldFade = useMotionValue(1);
   const session = useRef<GestureSession | null>(null);
-  /**
-   * React state rather than refs, because both are read during render — but
-   * both are only ever written in the same event as the commit, so they land in
-   * the same render as `Leaving` and no frame shows the wrong face or an empty
-   * seat where the departure should be.
-   */
   const [leavingFaceUp, setLeavingFaceUp] = useState(false);
   const [departing, setDeparting] = useState<readonly [Card, Card] | null>(
     null,
   );
-  /**
-   * §16: `preventDefault` at a lower level does not suppress the later `click`
-   * consistently across browsers, so suppression is handled here, at the
-   * recognizer. A gesture that classified has already been answered, and the
-   * click the browser synthesises after it must not toggle the reveal on top.
-   *
-   * A deadline rather than a flag: the click is not guaranteed to arrive — a
-   * touch drag usually produces none and a cancelled pointer never does — and
-   * a flag left waiting would swallow the next real activation instead.
-   */
   const disownClicksUntil = useRef(0);
-  /**
-   * When the last tap landed, for the double-tap Check (§5). A ref, not state:
-   * a tap that opens the window changes nothing on screen, so re-rendering for
-   * it would be a render per touch with nothing to paint.
-   */
   const tapWindow = useRef<TapWindow>(null);
-  /**
-   * When the last gesture Check was confirmed, or `null`. A timestamp rather
-   * than a flag, so two Checks in a row restart the cue instead of the second
-   * one landing silently inside the first one's window.
-   */
   const [checkConfirmedAt, setCheckConfirmedAt] = useState<number | null>(null);
-  /**
-   * The gestures this device has already found, seeded from storage on mount so
-   * a returning player is not re-taught. Per-device and permanent (§11); a
-   * player without reachable storage is simply offered each hint again.
-   */
   const [discovered, setDiscovered] = useState<ReadonlySet<TeachableGesture>>(
     () => {
       const storage = localStorageOrNull();
       return storage === null ? new Set() : loadDiscovered(storage);
     },
   );
-  /**
-   * Every pointer currently down on the pair, not just the one the recognizer
-   * is answering. A stray second thumb is ignored as a *gesture* (§4), but it
-   * is still a finger on the cards, and lifting it must not restart the quiet
-   * interval underneath the finger that is still there.
-   */
   const pointersDown = useRef<Set<number>>(new Set());
-  /**
-   * The teaching hints' two live inputs. `contact` is a finger on the pair;
-   * `quiet` is the ~2s of stillness a hint waits for. They are separate because
-   * a hint hides the *instant* a pointer lands and only returns after the
-   * interval — an aborted half-touch does not buy silence for the rest of the
-   * hand.
-   */
   const [contact, setContact] = useState(false);
   const [quiet, setQuiet] = useState(false);
   const [coarsePointer, setCoarsePointer] = useState(
@@ -232,14 +127,6 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
   );
 
   const previous = useRef(props);
-  // Deliberately un-keyed: the adapter compares the props itself and returns
-  // nothing for the overwhelming majority of renders, which is exactly the
-  // "inert by default" guarantee. A dependency list here would be a second,
-  // weaker copy of that comparison.
-  //
-  // A **layout** effect, so a new hand's cards can never be painted under the
-  // previous hand's presentation: `DEALT` lands between commit and paint, and
-  // no face-up frame survives from one hand into the next.
   useIsomorphicLayoutEffect(() => {
     const events = eventsForPropChange(previous.current, props, state);
     previous.current = props;
@@ -249,14 +136,6 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     }
   });
 
-  // `Turning` is a point of no return: once the flip is committed it finishes
-  // on its own schedule, whatever the pointer does.
-  //
-  // The turn is the *same sheet* the finger was bending, carried on past the
-  // opposite corner rather than a separate flip animation — so the peel runs
-  // from wherever the player let go to 1 and the face lands flat. A keyboard
-  // reveal starts from 0 and gets the identical motion, which is what makes
-  // Enter and a bend produce the same object behaving.
   useEffect(() => {
     if (state.presentation !== "Turning") return;
     const peel = animate(bend, 1, {
@@ -272,8 +151,6 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     };
   }, [state.presentation, bend]);
 
-  // Face-down and face-up are both flat: the peel only exists in between, so
-  // it is reset once the pair settles rather than left at wherever it landed.
   useEffect(() => {
     if (
       state.presentation === "FaceDown" ||
@@ -283,10 +160,6 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     }
   }, [state.presentation, bend]);
 
-  // A card-flip cue on reveal/conceal (#186). Entering `Turning` is every
-  // reveal (keyboard, bend-peel, showdown); `Revealed → FaceDown` is a
-  // conceal. A fresh deal reaches `FaceDown` from elsewhere and keeps its own
-  // deal cue instead.
   const prevPresentation = useRef(state.presentation);
   useEffect(() => {
     const from = prevPresentation.current;
@@ -297,21 +170,10 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     }
   }, [state.presentation]);
 
-  /**
-   * Whether the pair is on its way to the muck **right now**.
-   *
-   * `Leaving` alone is not enough: an acknowledgement resolves the reducer to
-   * `Absent` within milliseconds on a LAN, and the flight is explicitly not
-   * gated on that round trip. A rejection is the opposite — it takes the pair
-   * out of the air immediately, from wherever it has got to.
-   */
   const inFlight =
     state.presentation === "Leaving" ||
     (departing !== null && state.presentation === "Absent");
 
-  // The flight itself. Deliberately depends on nothing but `inFlight`, so the
-  // acknowledgement arriving mid-departure neither restarts the animation nor
-  // interrupts it — it simply does not reach this effect at all.
   useEffect(() => {
     if (!inFlight) return;
     const seconds = FOLD_FLIGHT_MS / 1000;
@@ -324,33 +186,21 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
       },
     );
     const fade = animate(foldFade, 0, { duration: seconds, ease: "linear" });
-    // Stopping on cleanup is what makes a rejection **interrupt** the departure
-    // rather than complete it first (§7). The flight is a *prediction* of
-    // server truth; when the server contradicts it, finishing the animation
-    // would actively lie to the player.
     return () => {
       flight.stop();
       fade.stop();
     };
   }, [inFlight, foldOffset, foldFade]);
 
-  // Coming to rest: the counterpart, and the only thing that puts the pair back
-  // where it belongs. Keyed on the discrete facts that decide where that is —
-  // whether the pair is in the air, and whether a finger is still carrying it.
   useEffect(() => {
     if (inFlight) return;
 
     if (state.presentation === "Absent") {
-      // Nothing is rendered to see the snap, and the next hand must deal in
-      // from rest rather than sliding down from wherever the flight got to.
       foldOffset.set(0);
       foldFade.set(1);
       return;
     }
 
-    // A finger still on the glass owns the offset; this effect must not fight
-    // it. Every way a drag can end — release, cancellation, a §9 reset out from
-    // under it — clears the recognizer, which is what brings the pair home.
     if (state.recognizer !== "Idle") return;
     if (foldOffset.get() === 0 && foldFade.get() === 1) return;
     const home = animate(foldOffset, 0, RETURN_SPRING);
@@ -361,9 +211,6 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     };
   }, [inFlight, state.presentation, state.recognizer, foldOffset, foldFade]);
 
-  // The departure outlives the cards prop by exactly one flight, and no longer:
-  // a pair the player is holding again after a rejection renders from `cards`,
-  // and this only has to stop standing in for one that is genuinely gone.
   useEffect(() => {
     if (departing === null) return;
     const timer = setTimeout(() => {
@@ -374,17 +221,6 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     };
   }, [departing]);
 
-  // The one disturbance that is not a prop change (§8): the app leaving the
-  // foreground resets the pair face-down, cancelling any gesture in flight.
-  // Subscribed once for the pair's lifetime — `dispatch` is stable, and what
-  // "hidden" means is `eventsForVisibility`'s decision, not this effect's.
-  //
-  // §9's other two resets need no subscription: a new hand arrives as `DEALT`,
-  // and a reload mounts through `initialCardState`. A socket reconnect while
-  // the page stays in the foreground is the gap — the pair stays mounted with
-  // unchanged props, and §2 fixes those props to `cards`, `locked` and
-  // `actions`, so no signal for it exists inside the seam. Backgrounding, the
-  // way a phone actually loses its socket, is covered here.
   useEffect(() => {
     const onVisibilityChange = () => {
       for (const event of eventsForVisibility(document.visibilityState)) {
@@ -397,8 +233,6 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     };
   }, []);
 
-  // The confirmation is transient by construction: nothing has to remember to
-  // take it down, and a re-check simply replaces the timestamp and the timer.
   useEffect(() => {
     if (checkConfirmedAt === null) return;
     const timer = setTimeout(() => {
@@ -409,20 +243,8 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     };
   }, [checkConfirmedAt]);
 
-  // Which gesture is up for teaching, if any. Only its *identity* is used here
-  // — to know when the interval below should start over — so a legality prop
-  // flapping without changing the answer costs nothing.
   const teachable = nextTeachable(state, discovered, props.actions);
 
-  /**
-   * The quiet interval: ~2s of no contact with the pair **after the hint became
-   * eligible** (§11).
-   *
-   * Keyed on the eligible gesture as well as on contact, which is what makes it
-   * an interval rather than a one-time delay: a hint the player half-reached for
-   * comes back after another quiet moment, and Fold does not appear the instant
-   * a turn makes it legal.
-   */
   useEffect(() => {
     setQuiet(false);
     if (contact) return;
@@ -434,8 +256,6 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     };
   }, [contact, teachable]);
 
-  // Subscribed, not read once (§11): a tablet that gains or loses a trackpad
-  // follows the pointer the player is holding it with now.
   useEffect(() => {
     const query = coarsePointerQuery();
     if (query === null) return;
@@ -449,12 +269,6 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     };
   }, []);
 
-  /**
-   * A card event on its way to the reducer, checked for what it teaches on the
-   * way past. Discovery is decided by `discoveredBy` — a pure rule — and every
-   * event that reaches here came from a finger on the pair, which is what makes
-   * "never on a button" true by construction rather than by discipline.
-   */
   const dispatchFromPointer = (event: CardEvent): void => {
     const found = discoveredBy(event, state);
     if (found !== null && !discovered.has(found)) {
@@ -478,53 +292,22 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     const active = session.current;
     if (active?.pointerId !== event.pointerId) return;
     session.current = null;
-    // Every completed gesture disowns its click, a tap included: the tap is
-    // answered here, by the recognizer, and the click the browser synthesises
-    // afterwards would answer it a second time — re-revealing the pair the tap
-    // just concealed, or revealing on the first tap of a Check that §5 requires
-    // to cost nothing. §12's non-gesture path is unaffected: Enter and Space
-    // raise a click with no pointer sequence in front of it.
     disownClicksUntil.current = Date.now() + CLICK_DISOWN_MS;
-    // The peel closes the instant the finger lifts — a glance costs nothing
-    // and leaves nothing exposed, so there is no wind-down to watch. A bend
-    // that already crossed the threshold is exempt: it committed on crossing,
-    // and the turn is mid-flight with the peel under its control.
     if (!active.crossed) bend.set(0);
-    // Everything a pointer lift decides — which events fire, which Actions
-    // leave the module, what the tap window becomes — is `planFinish`'s to
-    // answer (§156). Decided off the session, which is a ref and therefore
-    // exactly as current as the events the reducer has been given: the state
-    // this hook renders with can lag a threshold crossed one pointer event ago,
-    // and a fast flick is the commonest way to fold, not an edge case.
     const plan = planFinish({
       end: endGesture(active, { cancelled }),
       actions: props.actions,
       presentation: state.presentation,
       tapWindow: tapWindow.current,
-      // The clock is monotonic, because a wall clock stepping backwards
-      // mid-hand would turn two unrelated taps into a Check (§5).
       now: performance.now(),
     });
     tapWindow.current = plan.nextTapWindow;
-    // The pair leaves with whatever face it had (§7). Set here, before the
-    // effects replay, so it lands in the same commit as the `RELEASED` that
-    // moves the reducer into `Leaving`.
     if (plan.leaving !== null) {
       setLeavingFaceUp(plan.leaving.faceUp);
       setDeparting(props.cards);
     }
-    // The hook owns only the imperative replay: the plan already fixed the
-    // order, and the two orderings that cost money — conceal before Check, and
-    // depart before Fold — are carried by the effect list, not by this loop.
-    // `fold`/`check` **are** `intent.fold`/`intent.check`, so gesture and
-    // button enter the identical function and `canAct` on the latest view stays
-    // the single legality gate: an armed release the server would refuse sends
-    // nothing here that the intent does not then drop.
     for (const effect of plan.effects) {
       if (effect.kind === "dispatch") {
-        // Through the discovery wrapper: the `TAPPED`/`DOUBLE_TAPPED` a finish
-        // dispatches are what retire the conceal and Check hints, and every one
-        // of them came from a finger on the pair (§11).
         dispatchFromPointer(effect.event);
       } else if (effect.action === "check") {
         props.actions.check();
@@ -535,12 +318,6 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     if (plan.confirmCheck) setCheckConfirmedAt(Date.now());
   };
 
-  /**
-   * Contact with the pair, tracked for the hint timer alone — separately from
-   * `finish`, which answers only the pointer that owns the gesture. A hint must
-   * not reappear under a second finger the recognizer is ignoring, so the pair
-   * is being touched until *every* pointer has left it.
-   */
   const contacted = (event: ReactPointerEvent<HTMLElement>): void => {
     pointersDown.current.add(event.pointerId);
     setContact(true);
@@ -554,17 +331,9 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
 
   const handlers: PairHandlers = {
     onPointerDown: (event) => {
-      // Before every guard below: instruction yields to a finger on the glass
-      // whether or not the recognizer takes any interest in this one.
       contacted(event);
-      // A second finger landing mid-gesture is ignored until the first one
-      // releases or cancels: a stray thumb must not silently retarget a drag.
       if (session.current !== null || event.button !== 0) return;
-      // The lifecycle's lock rather than the prop, so a decided hand is inert
-      // to a finger for exactly as long as it is inert to the keyboard.
       if (state.locked) return;
-      // Inertness while a Fold is in flight rides on `Leaving`, not on
-      // `pending`: a pending Call or Raise leaves the cards entirely alone.
       if (state.presentation === "Absent" || state.presentation === "Leaving") {
         return;
       }
@@ -588,9 +357,6 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
         { x: event.clientX, y: event.clientY },
         {
           foldLegal: props.actions.foldLegal,
-          // Measured per move rather than once: the threshold scales with the
-          // viewport, and a phone keyboard or a rotation changes it under a
-          // gesture that is already running.
           foldThresholdPx: foldThreshold(window.innerHeight),
         },
       );
@@ -599,19 +365,10 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
         bend.set(step.bend.progress);
         bendAxis.set(step.bend.axis);
       }
-      // The cards track the finger, so the player can feel how far they are
-      // from committing — continuous, and therefore never React state (§13).
       if (step.fold !== null) foldOffset.set(step.fold.offset);
-      // Once the drag belongs to the recognizer, the browser must not also
-      // treat it as a pan or a selection.
       if (step.session.classification !== null) event.preventDefault();
       for (const cardEvent of step.events) {
-        // Optional, best-effort polish and **never** semantic feedback: the
-        // arming signal proper is the card motion and the in-gesture text, both
-        // of which the iPhone/Safari path has and this pulse it does not (§16).
         if (cardEvent.type === "FOLD_ARMED") pulse(HAPTIC_PULSE_MS);
-        // Through the discovery wrapper: a `CLASSIFIED` bend or fold swipe is
-        // where those two hints retire (§11).
         dispatchFromPointer(cardEvent);
       }
     },

--- a/packages/player-client/src/holecards/viewEvents.test.ts
+++ b/packages/player-client/src/holecards/viewEvents.test.ts
@@ -34,21 +34,18 @@ const absent: CardState = {
   armed: false,
   locked: false,
 };
-/** A pair the showdown has decided: face-up and inert. */
 const lockedRevealed: CardState = {
   presentation: "Revealed",
   recognizer: "Idle",
   armed: false,
   locked: true,
 };
-/** A bend in progress: the state an incoming view must not disturb. */
 const peeking: CardState = {
   presentation: "Peeking",
   recognizer: "Bending",
   armed: false,
   locked: false,
 };
-/** The same pair, still live: the Player turned it over themselves. */
 const revealed: CardState = {
   presentation: "Revealed",
   recognizer: "Idle",
@@ -69,8 +66,6 @@ describe("eventsForPropChange", () => {
   });
 
   it("produces nothing for a new street, a new board card or another player's bet", () => {
-    // None of those reach this module at all: they change `PlayerView`, not
-    // any of the three props, so the adapter sees an identical pair of props.
     const before = props({ cards: queenJack });
     const after = props({ cards: before.cards });
     expect(eventsForPropChange(before, after, faceDown)).toEqual([]);
@@ -116,19 +111,12 @@ describe("eventsForPropChange", () => {
   });
 
   it("leaves a peek in flight alone when a server update arrives", () => {
-    // `fanOutHandUpdate` sends a view for every event in the hand, and peeking
-    // at your cards is exactly what you do while others act. A new board card
-    // or another player's bet reaches this module as an identical pair of
-    // props; nothing may touch the recognizer.
     const before = props({ cards: queenJack });
     const after = props({ cards: queenJack });
     expect(eventsForPropChange(before, after, peeking)).toEqual([]);
   });
 
   it("produces nothing when the player acts — a button sends an Action, not a presentation change", () => {
-    // Pressing Call, Raise or Check changes the view (stack, pot, `toAct`) and
-    // hands the turn on, so legality goes away. The cards stay exactly as they
-    // were.
     const before = props({
       cards: queenJack,
       actions: { ...actions, foldLegal: true, checkLegal: true },
@@ -217,7 +205,6 @@ describe("eventsForPropChange", () => {
 
   describe("a resolving Action", () => {
     const pending = { ...actions, pending: true };
-    /** The pair mid-flight to the muck, waiting on the server's answer. */
     const leaving: CardState = {
       presentation: "Leaving",
       recognizer: "Idle",
@@ -254,8 +241,6 @@ describe("eventsForPropChange", () => {
     });
 
     it("produces nothing when an Action *starts* — sending is not a lifecycle event", () => {
-      // The pair moved itself to `Leaving` on the release that sent the Fold;
-      // the prop going true afterwards has nothing left to say.
       expect(
         eventsForPropChange(
           props({ cards: queenJack }),
@@ -300,8 +285,6 @@ describe("eventsForPropChange", () => {
     });
 
     it("deals the cards in before revealing them when both land at once", () => {
-      // A seat whose cards were withheld until showdown: the deal has to be
-      // observed first, or the reveal would land on an `Absent` pair.
       expect(
         eventsForPropChange(
           props(),
@@ -325,9 +308,6 @@ describe("eventsForVisibility", () => {
   });
 
   it("produces nothing on return to the foreground", () => {
-    // The reset already happened on the way out; coming back is not a second
-    // disturbance, and re-hiding cards the Player has since turned over would
-    // be one.
     expect(eventsForVisibility("visible")).toEqual([]);
   });
 });

--- a/packages/player-client/src/holecards/viewEvents.ts
+++ b/packages/player-client/src/holecards/viewEvents.ts
@@ -14,23 +14,6 @@ function samePair(
   return sameCard(a[0], b[0]) && sameCard(a[1], b[1]);
 }
 
-/**
- * The one place a server-shaped input becomes a lifecycle event (Phase 3 spec
- * #138 §8). The reducer never sees a `PlayerView`, and the hook decides
- * nothing. Keeping the derivation pure is what makes "an incoming view is
- * inert" a tested property rather than a remembered one.
- *
- * **The default return is the empty array.** `fanOutHandUpdate` sends a
- * `hand-update` for every event in the hand, and peeking at your cards is
- * exactly what you do while others act — so a new street, a new board card,
- * another player's bet and a changed `toAct` must all produce nothing.
- *
- * `state` is the current lifecycle state; `CARDS_GONE` and `FOLD_DISARMED`
- * consult it. Fold legality disappearing under a live drag is the one §8
- * disturbance that must reach an in-progress gesture. If the same view also
- * removes the cards (clock expiry or eviction), `CARDS_GONE` ends the gesture
- * and is the only event needed.
- */
 export function eventsForPropChange(
   prev: HoleCardPairProps,
   next: HoleCardPairProps,
@@ -39,29 +22,15 @@ export function eventsForPropChange(
   const events: CardEvent[] = [];
 
   if (next.cards === null) {
-    // An event is a transition, never a restatement: a pair already showing
-    // nothing has nothing to be told.
     if (prev.cards !== null && state.presentation !== "Absent") {
       events.push({ type: "CARDS_GONE" });
     }
   } else {
-    // Card identity, not reference: `PlayerView` carries no hand id, so cards
-    // arriving is the deal signal — with a value comparison as the defensive
-    // second signal for a betting→betting view that swaps cards without an
-    // intervening empty one.
     if (!samePair(prev.cards, next.cards)) events.push({ type: "DEALT" });
 
-    // Ordered after the deal deliberately: a seat whose cards only arrive at
-    // showdown must be dealt in before it is revealed, or the reveal lands on a
-    // pair that is still `Absent`. Losing the lock produces nothing — showdown
-    // does not un-reveal, and the next hand's `DEALT` is what turns the cards
-    // back over.
     if (!prev.locked && next.locked) events.push({ type: "SHOWDOWN_REVEAL" });
   }
 
-  // A Fold drag keeps following the finger when its legality disappears. The
-  // card removal that accompanies an expiry or eviction ends the gesture
-  // through `CARDS_GONE`, so there is no separate disarm event in that case.
   if (
     next.cards !== null &&
     prev.actions.foldLegal &&
@@ -71,12 +40,6 @@ export function eventsForPropChange(
     events.push({ type: "FOLD_DISARMED" });
   }
 
-  // Only the falling edge, and only a Fold is waiting on it: the pair moved
-  // itself to `Leaving` on the release that sent the Action, so the prop going
-  // *true* has nothing left to say (§7). Whether the answer was an
-  // acknowledgement or a rejection is read off the cards rather than off any
-  // rejection state — the server taking them is what "acknowledged" means here,
-  // and the reducer needs no second opinion.
   if (prev.actions.pending && !next.actions.pending) {
     events.push({ type: "PENDING_RESOLVED", hasCards: next.cards !== null });
   }
@@ -84,16 +47,6 @@ export function eventsForPropChange(
   return events;
 }
 
-/**
- * The app leaving the foreground is a reset (§9), and it is the one
- * disturbance that does not arrive as a prop change — `visibilitychange` is a
- * document event, subscribed by the hook (§8). It is derived here anyway so
- * the rule is a tested function call rather than a condition buried in an
- * effect, which is the same reason `eventsForPropChange` exists.
- *
- * Only the outbound edge produces anything: coming back is not a second
- * disturbance, and concealing cards the Player has since turned over would be.
- */
 export function eventsForVisibility(
   visibility: DocumentVisibilityState,
 ): readonly CardEvent[] {

--- a/packages/player-client/src/join/parseRoomCodeFromPath.ts
+++ b/packages/player-client/src/join/parseRoomCodeFromPath.ts
@@ -1,17 +1,10 @@
 const JOIN_PATH = /^\/join\/([A-Za-z0-9]{4})$/;
 
-/** Prefills the room-code field from a QR-scanned `/join/:code` URL. */
 export function parseRoomCodeFromPath(pathname: string): string | null {
   const code = JOIN_PATH.exec(pathname)?.[1];
   return code ? code.toUpperCase() : null;
 }
 
-/**
- * The player-client URL path that names a joined room — the inverse of
- * `parseRoomCodeFromPath`. The server only serves the SPA at `/join/:code`
- * (the site root serves the table client), so a joined player always lives on
- * one of these paths.
- */
 export function joinPathForCode(code: string): string {
   return `/join/${code}`;
 }

--- a/packages/player-client/src/lockViewport.test.ts
+++ b/packages/player-client/src/lockViewport.test.ts
@@ -2,10 +2,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { Listener } from "./lockViewport.js";
 import { lockViewport } from "./lockViewport.js";
 
-/**
- * Stands in for `document`: records what was bound and lets a test fire an
- * event at whatever is listening for it.
- */
 function fakeTarget() {
   const listeners = new Map<string, { handler: Listener; options?: unknown }>();
   return {

--- a/packages/player-client/src/lockViewport.ts
+++ b/packages/player-client/src/lockViewport.ts
@@ -1,27 +1,3 @@
-/*
- * iOS Safari lets the user pinch-zoom and pan the visual viewport even when the
- * page says not to. `user-scalable=no` in the viewport meta has been ignored
- * since iOS 10, and `touch-action: manipulation` only kills double-tap zoom —
- * pinch is handled above the touch-action layer. That is why Android's player
- * interface stays locked while an iPhone drifts: everything we already do is
- * enough for Chrome and not for WebKit.
- *
- * What does still work on WebKit is cancelling the gesture events it fires for
- * a pinch (`gesturestart`/`gesturechange`/`gestureend`, non-standard and
- * WebKit-only) and cancelling any multi-touch `touchmove` before it becomes a
- * zoom or a viewport pan. Both need non-passive listeners or the
- * `preventDefault` is dropped.
- *
- * Single-touch moves are left alone: the hole-card peel is a one-finger drag
- * and does its own `preventDefault` where it wants one.
- */
-
-/*
- * Narrowed to what we actually use rather than derived from `EventTarget`:
- * `gesturestart` and friends are not in lib.dom's event map, and the real
- * signature's nullable `EventListenerOrEventListenerObject` would force a fake
- * target in tests to accept shapes we never pass.
- */
 export interface CancellableEvent {
   readonly touches?: { readonly length: number };
   preventDefault(): void;
@@ -40,10 +16,6 @@ interface ListenerTarget {
 
 const GESTURE_EVENTS = ["gesturestart", "gesturechange", "gestureend"] as const;
 
-/**
- * Suppresses pinch-zoom on the given target. Returns a teardown that removes
- * every listener it added.
- */
 export function lockViewport(target: ListenerTarget): () => void {
   const cancel: Listener = (event) => {
     event.preventDefault();

--- a/packages/player-client/src/main.tsx
+++ b/packages/player-client/src/main.tsx
@@ -9,7 +9,6 @@ if (!rootEl) {
   throw new Error("#root element not found");
 }
 
-// Bound on the document so it catches pinches started anywhere in the shell.
 lockViewport(document);
 
 ReactDOM.createRoot(rootEl).render(

--- a/packages/player-client/src/storage/seatToken.ts
+++ b/packages/player-client/src/storage/seatToken.ts
@@ -4,15 +4,9 @@ export interface StoredSeatToken {
   readonly roomCode: string;
   readonly seatId: number;
   readonly token: string;
-  /** Added with named claims; absent tokens still reconnect for migration. */
   readonly displayName?: string;
 }
 
-/**
- * Persists a claimed seat's token for reconnect (ticket 33 reads it back).
- * Takes an injected `Storage` so callers can pass `window.localStorage` or a
- * test double without reaching for a global.
- */
 export function saveSeatToken(
   storage: Storage,
   seatToken: StoredSeatToken,
@@ -20,11 +14,6 @@ export function saveSeatToken(
   storage.setItem(KEY, JSON.stringify(seatToken));
 }
 
-/**
- * Reads back a stored seat token for auto-reconnect on mount. Malformed or
- * absent storage both read as "nothing to reclaim" — a cleared/corrupted
- * localStorage must never fall back to any other seat (Phase 1 spec #130 §7).
- */
 export function loadSeatToken(storage: Storage): StoredSeatToken | null {
   const raw = storage.getItem(KEY);
   if (raw === null) return null;

--- a/packages/player-client/src/store/actionSlice.ts
+++ b/packages/player-client/src/store/actionSlice.ts
@@ -6,12 +6,6 @@ import type {
 import type { StateCreator } from "zustand";
 
 export interface ActionRejection {
-  /**
-   * The action `reason` was rejecting, or `null` if a `command-rejected`
-   * arrived with nothing pending — `command-rejected` carries no
-   * correlation id (Phase 1 spec #130 §6), so this is a best-effort
-   * attribution, not a guarantee.
-   */
   readonly action: ActionType | null;
   readonly reason: RejectionReason | ServerRejectionReason;
 }
@@ -26,13 +20,6 @@ export interface ActionSlice {
   readonly viewSnapshotReceived: () => void;
 }
 
-/**
- * Tracks the one command a player may have in flight. `sendStarted` also
- * clears any stale rejection, so pressing another button dismisses the old
- * failure message even before a fresh view arrives — matching the "clears
- * on the player's next legal action or next view snapshot" rule in
- * Phase 1 spec #130 §9.
- */
 export const createActionSlice: StateCreator<ActionSlice> = (set) => ({
   pendingAction: null,
   rejection: null,

--- a/packages/player-client/src/store/connectionSlice.ts
+++ b/packages/player-client/src/store/connectionSlice.ts
@@ -4,16 +4,8 @@ export type ConnectionStatus = "disconnected" | "connecting" | "connected";
 
 export interface ConnectionSlice {
   readonly connectionStatus: ConnectionStatus;
-  /**
-   * Latched on the first `connected`. The status starts at `disconnected`
-   * before a socket has ever been opened, which is indistinguishable from a
-   * dropped one by status alone — this bit is what tells them apart, so the
-   * player is never warned about a connection they have not yet made
-   * (ADR-0006).
-   */
   readonly hasEverConnected: boolean;
   readonly setConnectionStatus: (status: ConnectionStatus) => void;
-  /** Back to the pre-socket state — the latch clears with the connection. */
   readonly resetConnection: () => void;
 }
 

--- a/packages/player-client/src/store/store.test.ts
+++ b/packages/player-client/src/store/store.test.ts
@@ -26,8 +26,6 @@ describe("usePlayerStore", () => {
     usePlayerStore.getState().setConnectionStatus("connected");
     expect(usePlayerStore.getState().hasEverConnected).toBe(true);
 
-    // A later drop is a real one — the latch is what distinguishes it from
-    // the pre-socket default (ADR-0006).
     usePlayerStore.getState().setConnectionStatus("disconnected");
     expect(usePlayerStore.getState().hasEverConnected).toBe(true);
   });
@@ -160,10 +158,6 @@ describe("usePlayerStore", () => {
     expect(usePlayerStore.getState().handView).toBeNull();
   });
 
-  // Regression for #172: rejoining a new room used to render the previous
-  // room's hand result. The root cause lived in the seam below — clearing the
-  // room slice never touched the hand slice — so a teardown that only called
-  // clearRoom left the old result behind for the next room to display.
   it("does not clear a stale hand result when only the room is torn down (#172)", () => {
     usePlayerStore.getState().setRoomView({
       code: "ABCD",
@@ -193,15 +187,10 @@ describe("usePlayerStore", () => {
 
     usePlayerStore.getState().clearRoom();
 
-    // The room is gone but the previous hand result survives — this is exactly
-    // why the teardown/join handlers must clear the hand as well.
     expect(usePlayerStore.getState().roomCode).toBeNull();
     expect(usePlayerStore.getState().handView).not.toBeNull();
   });
 
-  // Regression for #172: the full room-ended reset the handler performs must
-  // leave no residue from the previous room, so a rejoin into the same seat
-  // position renders no prior-room result until a fresh hand-update arrives.
   it("leaves a clean slate for the next room when the hand is cleared too (#172)", () => {
     usePlayerStore.getState().setRoomView({
       code: "ABCD",
@@ -229,8 +218,6 @@ describe("usePlayerStore", () => {
       winner: 0,
     });
 
-    // The room-ended teardown the handler runs: drop the seat and hand, then
-    // the room.
     usePlayerStore.getState().clearSeat();
     usePlayerStore.getState().clearHand();
     usePlayerStore.getState().clearRoom();

--- a/packages/player-client/src/topPillStyle.ts
+++ b/packages/player-client/src/topPillStyle.ts
@@ -1,14 +1,6 @@
 import { font, fontSize, radius } from "@table-top-poker/ui-shared";
 import type { CSSProperties } from "react";
 
-/**
- * The geometry every pill along the top of the player screen shares — name,
- * seat number and connection. One height and one padding, so the row reads as a
- * set of chips rather than controls that happen to be adjacent. The seat
- * actions now live behind the menu button (ADR-0005), which matches this height.
- *
- * Colour is deliberately absent: each pill carries its own.
- */
 export const playerTopPillStyle: CSSProperties = {
   display: "flex",
   alignItems: "center",
@@ -18,12 +10,6 @@ export const playerTopPillStyle: CSSProperties = {
   fontFamily: font.mono,
   fontSize: fontSize.xs,
   fontWeight: 600,
-  /*
-   * Tighter than the 0.16em used elsewhere: at this size the extra tracking is
-   * decoration, and it costs roughly a character of width per pill on a row
-   * that has none to spare. Trimmed here rather than on one pill so the row
-   * still reads as a set (ADR-0006).
-   */
   letterSpacing: "0.1em",
   textTransform: "uppercase",
   whiteSpace: "nowrap",

--- a/packages/player-client/src/ws/getWebSocketUrl.ts
+++ b/packages/player-client/src/ws/getWebSocketUrl.ts
@@ -3,7 +3,6 @@ export interface WsLocation {
   readonly host: string;
 }
 
-/** Derives the WebSocket scheme from `location.protocol` — never hard-coded. */
 export function getWebSocketUrl(
   location: WsLocation,
   params: Record<string, string> = {},

--- a/packages/player-client/src/ws/useLobbyWebSocket.ts
+++ b/packages/player-client/src/ws/useLobbyWebSocket.ts
@@ -8,23 +8,8 @@ export interface LobbyWebSocketOptions {
 }
 
 const RETRY_DELAY_MS = 1500;
-/**
- * A lobby socket has no token that can go stale, so a refused upgrade means
- * either the room is gone or the server is briefly unreachable. Only after
- * this many consecutive refusals is the room declared gone — a single failed
- * connect is far more often a restart or a dropped link than an ended room.
- */
 const MAX_REFUSED_CONNECTS = 3;
 
-/**
- * Keeps the unclaimed seat picker subscribed to room-level changes. A lobby
- * socket receives room views only; it has no seat identity and cannot issue
- * table or player commands.
- *
- * Unlike a seat socket, this one retries a close that never opened: there is
- * no equivalent of a stale seat token to spin against, and a room that really
- * has ended says so on the wire (`room-ended`) before closing.
- */
 export function useLobbyWebSocket(
   roomCode: string | null,
   options: LobbyWebSocketOptions = {},
@@ -73,8 +58,6 @@ export function useLobbyWebSocket(
         if (message.type === "room-view") {
           setRoomView(message.view);
         } else if (message.type === "room-ended") {
-          // The room said so itself — the close that follows is expected and
-          // must not restart the retry loop.
           ended = true;
           optionsRef.current.onRoomEnded?.();
         }

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -19,24 +19,13 @@ export interface SeatConnectionParams {
 }
 
 export interface UseWebSocketOptions {
-  /**
-   * The socket closed before ever opening — an upgrade-time rejection (a
-   * bad or stale seat token), not a network blip. Retrying would spin
-   * forever against a seat that's gone, so the caller drops back to the
-   * seat picker instead (Phase 1 spec #130 §7 — a cleared token never
-   * auto-reclaims a seat).
-   */
   readonly onRejected?: () => void;
-  /** The room ended — manual "End session" or the table's grace window elapsing. */
   readonly onRoomEnded?: () => void;
-  /** The seat was evicted by the table device. */
   readonly onEvicted?: () => void;
-  /** The table repacked this player's seat during a seat-count change. */
   readonly onSeatMoved?: (move: SeatMove) => void;
 }
 
 export interface SeatSocket {
-  /** No-ops silently unless the socket is open — calling `WebSocket.send` before then throws. */
   readonly send: (command: ClientCommand) => void;
 }
 
@@ -48,23 +37,6 @@ interface ActiveConnection {
 
 const RETRY_DELAY_MS = 1500;
 
-/**
- * Opens a seat-scoped WebSocket connection once a seat is claimed and
- * reflects its lifecycle into the connection slice. Every `room-view` push
- * replaces the seat list; every `hand-update`/`view-snapshot` replaces the
- * hand slice with the fresh `view(state, seatId)` the server just computed
- * for this seat — the view is source of truth (Phase 1 spec #130 §6),
- * never rebuilt from the raw event locally. That same snapshot also clears
- * any pending/rejected action, since the view is what "next legal action or
- * next view snapshot" (§9) resolves against. `command-rejected` is
- * delivered to the sender only, so it's always this player's own action
- * being rejected — it feeds the action slice's rejection, never a
- * broadcast.
- *
- * A socket that closes after having opened retries after a fixed delay —
- * a transient drop, not a rejection. One that closes without ever opening
- * is treated as terminal and is not retried; see `onRejected`.
- */
 export function useWebSocket(
   params: SeatConnectionParams | null,
   options: UseWebSocketOptions = {},
@@ -98,18 +70,9 @@ export function useWebSocket(
     connectionRef.current = { roomCode, token, seatId };
   }
 
-  // Keep the existing socket open after a seat move. The transport seat is
-  // updated for reconnects without making the server briefly mark the player
-  // disconnected while the effect restarts.
-  // The effect is keyed by room and token; the mutable seat in the connection
-  // ref deliberately does not appear in its dependencies because a repack
-  // must not bounce the socket.
   useEffect(() => {
     const connection = connectionRef.current;
     if (connection === null) {
-      // No params means no seat — leaving, or not yet joined. Clear the
-      // has-connected latch with the connection so a later session starts
-      // silent again rather than inheriting this one's history (ADR-0006).
       resetConnection();
       return;
     }
@@ -150,8 +113,6 @@ export function useWebSocket(
         switch (message.type) {
           case "room-view":
             setRoomView(message.view);
-            // Phones obey the table's sound settings (#182); mirror them into
-            // the audio engine's gate so cue playback honours the room.
             applyRoomSoundSettings(message.view.soundSettings);
             {
               const seat = message.view.seats.find(
@@ -168,11 +129,8 @@ export function useWebSocket(
             }
             break;
           case "hand-update":
-            // The server only ever sends a seat's socket its own `view(state, seatId)`.
             setHandView(message.view as PlayerView);
             viewSnapshotReceived();
-            // Cues fire on the live event only, never on the `view-snapshot`
-            // below — so a reconnect/refresh can't replay a burst (#175).
             onHandUpdate({
               surface: "player",
               event: message.event,

--- a/packages/player-client/vite.config.ts
+++ b/packages/player-client/vite.config.ts
@@ -1,13 +1,6 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv } from "vite";
 
-// A release build (ticket 34) is staged at packages/server/public/player and
-// served for GET /join/:code — its asset URLs need that prefix baked in. The
-// dev server still serves everything from "/", so only `build` gets it.
-
-// Hostnames the dev server may be reached by, comma separated. Set it to open
-// the client from another device (e.g. a tailnet name); unset keeps the dev
-// server bound to localhost.
 const repoRoot = new URL("../..", import.meta.url).pathname;
 
 export default defineConfig(({ command, mode }) => {

--- a/packages/protocol/src/command-schema.ts
+++ b/packages/protocol/src/command-schema.ts
@@ -1,14 +1,5 @@
 import { z } from "zod";
 
-/**
- * Wire-level shape of a command a client sends over the room WebSocket —
- * deliberately thinner than the engine's `Command` type. `seatId` is
- * never trusted from the client: the server derives it from the
- * authenticated socket (room/seat/token query params, §6). `seed` is
- * never client-supplied either: the server generates it via CSPRNG
- * (Phase 1 spec #130 §3). Both fields get filled in server-side before
- * reaching `decide`.
- */
 export const ClientCommandSchema = z.discriminatedUnion("type", [
   z.strictObject({ type: z.literal("startHand") }),
   z.strictObject({ type: z.literal("fold") }),
@@ -16,7 +7,6 @@ export const ClientCommandSchema = z.discriminatedUnion("type", [
   z.strictObject({ type: z.literal("call") }),
   z.strictObject({ type: z.literal("raise") }),
   z.strictObject({ type: z.literal("nextHand") }),
-  /** Voluntary seat state (ADR-0002) — never reaches the engine, handled at the room-store layer only. */
   z.strictObject({ type: z.literal("sitOut") }),
   z.strictObject({ type: z.literal("sitIn") }),
 ]);

--- a/packages/protocol/src/hand.ts
+++ b/packages/protocol/src/hand.ts
@@ -5,19 +5,12 @@ import type {
   TableView,
 } from "@table-top-poker/engine";
 
-/**
- * Pushed once per domain event produced by a command, to every socket
- * entitled to see it. Carries both the raw event (future audit/animation)
- * and a fresh per-recipient view — the view is source of truth
- * (Phase 1 spec #130 §6), the event is not replayed against local state.
- */
 export interface HandUpdateMessage {
   readonly type: "hand-update";
   readonly event: HandEvent;
   readonly view: PlayerView | TableView;
 }
 
-/** A server-rejected command, reason-coded, delivered to the sender only. */
 export type ServerRejectionReason =
   "invalid-command" | "room-not-found" | "not-enough-players" | "not-permitted";
 

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -7,59 +7,37 @@ import type {
 import { z } from "zod";
 import type { CommandRejectedMessage, HandUpdateMessage } from "./hand.js";
 
-/**
- * How many seats a room may be created with (issue #74). Two is the
- * smallest table a hand can be dealt at — heads-up; eight is the physical
- * limit the felt is laid out for. The creator picks a size in this range
- * per room; it is not a global constant.
- */
 export const MIN_SEAT_COUNT = 2;
 export const MAX_SEAT_COUNT = 8;
-/** What the picker starts on, and the size a room gets absent any choice — a full table. */
 export const DEFAULT_SEAT_COUNT = MAX_SEAT_COUNT;
-/** Maximum display-name length accepted during a seat claim. */
 export const MAX_DISPLAY_NAME_LENGTH = 10;
 
-/**
- * The one definition of "a size a room may have". Both the HTTP edge and
- * `RoomStore.create` parse through it, so the range can never drift
- * between the wire and the store.
- */
 export const SeatCountSchema = z.int().min(MIN_SEAT_COUNT).max(MAX_SEAT_COUNT);
 
-/**
- * Body of `POST /rooms`. The seat count crosses an untrusted boundary, so
- * the bounds live here rather than in the picker UI — the server parses
- * with this schema and the table client shares its range.
- */
 export const CreateRoomRequestSchema = z.strictObject({
   seatCount: SeatCountSchema,
 });
 
 export type CreateRoomRequest = z.infer<typeof CreateRoomRequestSchema>;
 
-/** Body of a player's required display-name seat claim. */
 export const ClaimSeatRequestSchema = z.strictObject({
   displayName: z.string().trim().min(1).max(MAX_DISPLAY_NAME_LENGTH),
 });
 
 export type ClaimSeatRequest = z.infer<typeof ClaimSeatRequestSchema>;
 
-/** Body of the test-mode table action that fills free seats with bots. */
 export const AddBotsRequestSchema = z.strictObject({
   count: z.int().nonnegative(),
 });
 
 export type AddBotsRequest = z.infer<typeof AddBotsRequestSchema>;
 
-/** Body of a player releasing their own seat (ADR-0005) — the seat's token. */
 export const LeaveSeatRequestSchema = z.strictObject({
   token: z.string().min(1),
 });
 
 export type LeaveSeatRequest = z.infer<typeof LeaveSeatRequestSchema>;
 
-/** Body of the table-only room settings request (issue #77). */
 export const ChangeSeatCountRequestSchema = z.strictObject({
   seatCount: SeatCountSchema,
 });
@@ -68,22 +46,12 @@ export type ChangeSeatCountRequest = z.infer<
   typeof ChangeSeatCountRequestSchema
 >;
 
-/** Errors returned by the table device's seat-count settings route. */
 export type SeatCountChangeError =
   | "room-not-found"
   | "invalid-request-body"
   | "invalid-seat-count"
   | "seat-count-below-floor";
 
-/**
- * The room-wide tactile-sound settings (#182), owned by the table and pushed to
- * every surface on `room-view`. `sounds` is the master switch; `cards`,
- * `actions` and `notifications` are the three cue categories under it (cards =
- * the tactile card foley — deal, board, flip; actions = player actions —
- * fold, check; notifications = the your-turn prompt). A cue plays only when the
- * master and its category are both on. Phones hold no local override in this
- * cut — they obey these settings verbatim.
- */
 export interface SoundSettings {
   readonly sounds: boolean;
   readonly cards: boolean;
@@ -91,7 +59,6 @@ export interface SoundSettings {
   readonly notifications: boolean;
 }
 
-/** A fresh room starts fully audible. */
 export const DEFAULT_SOUND_SETTINGS: SoundSettings = {
   sounds: true,
   cards: true,
@@ -99,11 +66,6 @@ export const DEFAULT_SOUND_SETTINGS: SoundSettings = {
   notifications: true,
 };
 
-/**
- * Body of the table-only sound-settings request (#182). The whole set is
- * sent every time, so the master and all categories stay a single atomic
- * write — no partial-update ordering to reason about.
- */
 export const ChangeSoundSettingsRequestSchema = z.strictObject({
   sounds: z.boolean(),
   cards: z.boolean(),
@@ -115,40 +77,33 @@ export type ChangeSoundSettingsRequest = z.infer<
   typeof ChangeSoundSettingsRequestSchema
 >;
 
-/** Errors returned by the table device's sound-settings route. */
 export type SoundSettingsChangeError =
   "room-not-found" | "invalid-request-body";
 
-/** Inclusive bounds for a room's player action timer. */
 export const MIN_SHOT_CLOCK_SECONDS = 5;
 export const MAX_SHOT_CLOCK_SECONDS = 600;
 
-/** A room-owned player action timer configuration. */
 export interface ShotClockSettings {
   readonly enabled: boolean;
   readonly seconds: number;
 }
 
-/** A fresh room has an unbounded action clock, with 90 seconds ready to enable. */
 export const DEFAULT_SHOT_CLOCK: ShotClockSettings = {
   enabled: false,
   seconds: 90,
 };
 
-/** The single trust-boundary definition for shot-clock settings. */
 export const ShotClockSettingsSchema = z.strictObject({
   enabled: z.boolean(),
   seconds: z.int().min(MIN_SHOT_CLOCK_SECONDS).max(MAX_SHOT_CLOCK_SECONDS),
 });
 
-/** Body of the table-only deferred shot-clock settings request. */
 export const ChangeShotClockRequestSchema = ShotClockSettingsSchema;
 
 export type ChangeShotClockRequest = z.infer<
   typeof ChangeShotClockRequestSchema
 >;
 
-/** The sources from which a client or server can answer whether a hand is live. */
 export type HandStateSource = EngineState | PlayerView | TableView | null;
 
 export function isHandLive(source: HandStateSource): boolean {
@@ -170,7 +125,6 @@ export interface SeatMove {
   readonly to: SeatId;
 }
 
-/** Why a claimed seat is currently absent from the next deal-in. */
 export type SittingOutReason = "voluntary" | "waiting-for-next-hand";
 
 export interface SeatCountChange {
@@ -180,35 +134,22 @@ export interface SeatCountChange {
   readonly moves: readonly SeatMove[];
 }
 
-/** A seat's public state — never carries its claim token. */
 export interface SeatView {
   readonly id: SeatId;
   readonly claimed: boolean;
-  /** The required display name for newer claims; absent on pre-name seats. */
   readonly displayName?: string | null;
-  /** Present only for test-mode bot seats. */
   readonly bot?: boolean;
   readonly sittingOut: boolean;
-  /** Why a claimed seat is absent from the current/next deal-in. */
   readonly sittingOutReason: SittingOutReason | null;
-  /** Presence-only badge (ticket 33 §7) — never affects folding or legal actions. */
   readonly disconnected: boolean;
 }
 
-/**
- * Whether a seat joins the next deal-in — the client-side mirror of the
- * server's `eligibleSeats` (ADR-0002): claimed, connected, and not
- * voluntarily sitting out. A `waiting-for-next-hand` seat sets `sittingOut`
- * on the view but *is* dealt in next hand, so the reason, not the flag, is
- * what excludes a seat here.
- */
 export function isDealtInNextHand(seat: SeatView): boolean {
   return (
     seat.claimed && !seat.disconnected && seat.sittingOutReason !== "voluntary"
   );
 }
 
-/** How many seats the next `startHand`/`nextHand` would deal in. */
 export function countDealInSeats(seats: readonly SeatView[]): number {
   return seats.filter(isDealtInNextHand).length;
 }
@@ -216,47 +157,30 @@ export function countDealInSeats(seats: readonly SeatView[]): number {
 export interface RoomView {
   readonly code: string;
   readonly seats: readonly SeatView[];
-  /** A shrink queued until the next deal-in, or null when none is queued. */
   readonly pendingSeatCount: number | null;
-  /** A shot-clock change queued until the next deal-in, or null when none is queued. */
   readonly pendingShotClock: ShotClockSettings | null;
-  /** Room-wide tactile-sound settings (#182), replayed on join/reconnect. */
   readonly soundSettings: SoundSettings;
-  /** Room-wide action-clock settings, replayed on join/reconnect. */
   readonly shotClockSettings: ShotClockSettings;
 }
 
-/** Pushed over the room's WebSocket whenever seat state changes. */
 export interface RoomViewMessage {
   readonly type: "room-view";
   readonly view: RoomView;
 }
 
-/** Sent to a player's socket immediately before the server closes it after eviction. */
 export interface PlayerEvictedMessage {
   readonly type: "player-evicted";
 }
 
-/** Pushed to a player when a table shrink renumbers their claimed seat. */
 export interface SeatMovedMessage extends SeatMove {
   readonly type: "seat-moved";
 }
 
-/**
- * Pushed once, right after a socket opens (fresh join or reconnect), when a
- * hand is already in progress — a snapshot only, never replayed events
- * (Phase 1 spec #130 §7, §9).
- */
 export interface ViewSnapshotMessage {
   readonly type: "view-snapshot";
   readonly view: PlayerView | TableView;
 }
 
-/**
- * Pushed to every socket in a room when it ends — manual "End session" or
- * the table device's own 60s reconnect grace window elapsing (§7). Both
- * paths discard in-memory state the same way.
- */
 export interface RoomEndedMessage {
   readonly type: "room-ended";
 }

--- a/packages/server/src/action-clock.ts
+++ b/packages/server/src/action-clock.ts
@@ -1,11 +1,5 @@
 const DEFAULT_TIMEOUT_MS = 90_000;
 
-/**
- * Per-room "you have N ms to act" timer, fully decoupled from WebSocket
- * connection state — see Phase 1 spec #130 §7 (folding stays strictly
- * clock-driven). Scheduling and clearing functions are injectable so tests
- * can run this at real-but-tiny durations instead of faking global timers.
- */
 type TimerHandle = ReturnType<typeof setTimeout>;
 
 export class ActionClock {
@@ -24,9 +18,7 @@ export class ActionClock {
     this.#clearTimeoutFn = clearTimeoutFn;
   }
 
-  /** Replaces any timer already running for `key` with a fresh one. */
   schedule(key: string, onTimeout: () => void): void;
-  /** Replaces any timer with a fresh timer at a room-specific duration. */
   schedule(key: string, timeoutMs: number, onTimeout: () => void): void;
   schedule(
     key: string,

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -33,7 +33,6 @@ const publicPlayerDir = fileURLToPath(
   new URL("../public/player", import.meta.url),
 );
 
-/** Stages a fake release build (ticket 34) so tests can assert it's served in place of the placeholder. */
 function stageBuiltIndex(dir: string, marker: string): void {
   mkdirSync(dir, { recursive: true });
   writeFileSync(`${dir}/index.html`, `<!doctype html><p>${marker}</p>`);
@@ -1411,8 +1410,6 @@ describe("hand command dispatch over WebSocket", () => {
     table.socket.send(JSON.stringify({ type: "startHand" }));
     await settle();
 
-    // A socket that joins mid-hand takes the connect-time snapshot path,
-    // which is the other place a seat view is handed out.
     const lateLobby = connect(`room=${room.code}&role=lobby`);
     await opened(lateLobby.socket);
     await settle();
@@ -1425,8 +1422,6 @@ describe("hand command dispatch over WebSocket", () => {
       expect(JSON.stringify(watcher.messages)).not.toContain("yourHoleCards");
     }
 
-    // The seat itself still got its cards — the guard is about identity, not
-    // about the hand having failed to start.
     expect(JSON.stringify(seat0.messages)).toContain("yourHoleCards");
 
     lobby.socket.close();
@@ -1551,10 +1546,6 @@ describe("hand command dispatch over WebSocket", () => {
     table.socket.send(JSON.stringify({ type: "startHand" }));
     await settle();
 
-    // button = seat 0, ring = [1, 2, 0], BB = seat 2 (see rooms.ts/room.ts),
-    // so preflop runs [0, 1, 2]. Button and SB call, BB raises — forcing
-    // seat 0 and seat 1 to act again (street closure waits for every live
-    // player since the raise, not just one lap), both call, street closes.
     seat0.socket.send(JSON.stringify({ type: "call" }));
     await settle();
     seat1.socket.send(JSON.stringify({ type: "call" }));
@@ -1566,7 +1557,6 @@ describe("hand command dispatch over WebSocket", () => {
     seat1.socket.send(JSON.stringify({ type: "call" }));
     await settle();
 
-    // Flop: everyone checks.
     seat1.socket.send(JSON.stringify({ type: "check" }));
     await settle();
     seat2.socket.send(JSON.stringify({ type: "check" }));
@@ -1574,8 +1564,6 @@ describe("hand command dispatch over WebSocket", () => {
     seat0.socket.send(JSON.stringify({ type: "check" }));
     await settle();
 
-    // Turn: seat 0 folds instead of its final check — two live players
-    // remain, so the hand keeps going rather than folding out.
     seat1.socket.send(JSON.stringify({ type: "check" }));
     await settle();
     seat2.socket.send(JSON.stringify({ type: "check" }));
@@ -1583,7 +1571,6 @@ describe("hand command dispatch over WebSocket", () => {
     seat0.socket.send(JSON.stringify({ type: "fold" }));
     await settle();
 
-    // River: the two remaining live seats check down to showdown.
     seat1.socket.send(JSON.stringify({ type: "check" }));
     await settle();
     seat2.socket.send(JSON.stringify({ type: "check" }));
@@ -1782,7 +1769,6 @@ describe("hand command dispatch over WebSocket", () => {
     table.socket.send(JSON.stringify({ type: "startHand" }));
     await settle();
 
-    // Preflop's first actor is seat 0 (the button, three-handed), not seat 1.
     seat1.socket.send(JSON.stringify({ type: "check" }));
     await settle();
 
@@ -1810,7 +1796,6 @@ describe("hand command dispatch over WebSocket", () => {
     table.socket.send(JSON.stringify({ type: "startHand" }));
     await settle();
 
-    // Seat 0 (the button, first to act) faces the BB's post and can't check.
     seat0.socket.send(JSON.stringify({ type: "check" }));
     await settle();
 
@@ -2063,7 +2048,6 @@ describe("action clock", () => {
     table.socket.send(JSON.stringify({ type: "startHand" }));
     await settle();
 
-    // Preflop's first actor is seat 0 (the button) — takes no action at all.
     await settle(ACTION_CLOCK_MS + 60);
 
     const folds = actionsSeen(table.messages).filter(
@@ -2178,7 +2162,6 @@ describe("action clock", () => {
       (event) => event.action === "check" && event.seatId === 1,
     ).length;
 
-    // The flop's first actor has a free check; expiry should preserve it.
     await settle(ACTION_CLOCK_MS + 60);
 
     const seatOneChecksAfterExpiry = actionsSeen(table.messages).filter(
@@ -2254,8 +2237,6 @@ describe("action clock", () => {
     table.socket.send(JSON.stringify({ type: "startHand" }));
     await settle();
 
-    // Seat 0 (the button, first to act) acts immediately; seat 1 (SB) then
-    // sits idle and should be the one auto-folded, not seat 0.
     seat0.socket.send(JSON.stringify({ type: "call" }));
     await settle(ACTION_CLOCK_MS + 60);
 
@@ -2284,17 +2265,12 @@ describe("action clock", () => {
     table.socket.send(JSON.stringify({ type: "startHand" }));
     await settle();
 
-    // Preflop, no raise: one lap of [0, 1, 2]. The button and SB never
-    // matched the BB's post, so they must call rather than check.
     seat0.socket.send(JSON.stringify({ type: "call" }));
     await settle();
     seat1.socket.send(JSON.stringify({ type: "call" }));
     await settle();
-    // The BB acts last, so its check is the option and closes the street.
     seat2.socket.send(JSON.stringify({ type: "check" }));
     await settle();
-    // Preflop closes; the flop's first actor (seat 1, SB) now idles out. A
-    // free check is preserved when the shot clock expires.
     await settle(ACTION_CLOCK_MS + 60);
 
     const streetsStarted = table.messages
@@ -2391,8 +2367,6 @@ describe("action clock duration selection", () => {
       expect(room.shotClockSettings).toEqual(oldSettings);
       expect(room.pendingShotClock).toEqual(newSettings);
 
-      // Firing the timer that was armed before the edit still applies the
-      // old in-flight behavior to the current actor.
       initialTimer.callback();
       await new Promise((resolve) => setTimeout(resolve, 5));
       expect(room.engine?.hand?.status).toBe("complete");
@@ -2430,8 +2404,6 @@ describe("action clock duration selection", () => {
     const app = await buildApp({
       rooms,
       actionClock,
-      // This must not mask the per-room duration when an injected clock is
-      // used; it remains here to guard that test-only override explicitly.
       actionClockMs: 1,
     });
     await app.listen({ port: 0, host: "127.0.0.1" });
@@ -2575,11 +2547,9 @@ describe("presence and reconnection", () => {
     );
     await opened(seat0.socket);
 
-    // Two ping intervals elapse with no pong reply.
     await settle(50);
 
     expect(seatDisconnected(table.messages, 0)).toBe(true);
-    // A presence-only badge never causes a rejection or a fold.
     expect(rooms.get(room.code)?.seats[0]?.claimed).toBe(true);
   });
 
@@ -2674,7 +2644,6 @@ describe("presence and reconnection", () => {
     seat0.socket.close();
     await settle();
 
-    // Whoever's turn it is gets auto-folded by ticket 14's action clock.
     const engine = rooms.get(room.code)?.engine;
     if (engine?.hand?.status !== "betting") {
       throw new Error("expected a betting hand in progress");
@@ -2695,8 +2664,6 @@ describe("presence and reconnection", () => {
     }
     const view = snapshot.view;
     if (!("yourSeatId" in view) || toAct !== 0) {
-      // Only assert the burn-pile shape when seat 0 was the one who folded;
-      // otherwise it just resumes normally, covered by the prior test.
       return;
     }
     expect(view.yourHoleCards).toBeNull();

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -50,13 +50,6 @@ const publicDir = fileURLToPath(new URL("../public", import.meta.url));
 const publicIndexPath = fileURLToPath(
   new URL("../public/index.html", import.meta.url),
 );
-/**
- * A release build (ticket 34's `build:release` script) stages the real
- * table/player apps here, under their own subpath so each is servable at
- * its own base URL from the same origin; unstaged (dev, tests, a checkout
- * that hasn't run the release script), these don't exist and every route
- * below falls back to `publicIndexPath`'s placeholder.
- */
 const publicTableIndexPath = fileURLToPath(
   new URL("../public/table/index.html", import.meta.url),
 );
@@ -70,29 +63,15 @@ function readIndexOr(stagedPath: string): Buffer {
 
 export interface BuildAppOptions {
   readonly rooms?: RoomStore;
-  /** Root directory for append-as-you-go per-game hand logs. */
   readonly handLogDir?: string;
-  /** Enables test-only server features such as bot players. */
   readonly testMode?: boolean;
-  /** Randomness for bot actions, delays, and between-hand sit rolls. */
   readonly botRng?: BotRng;
-  /**
-   * Bot action delay in milliseconds. A scalar is useful for deterministic
-   * tests; a two-item range is sampled for each scheduled action in the
-   * form `[minimum, maximum)`.
-   */
   readonly botActionDelayMs?: number | readonly [number, number];
-  /** Overridable for tests only; production uses each room's configured seconds. */
   readonly actionClockMs?: number;
-  /** Injectable action clock for deterministic server tests. */
   readonly actionClock?: ActionClock;
-  /** Injectable wall clock for deterministic deadline assertions. */
   readonly now?: () => number;
-  /** How often the server pings every open socket (Phase 1 spec #130 §7). */
   readonly pingIntervalMs?: number;
-  /** Missed pongs before a seat's badge flips to "disconnected". */
   readonly missedPongLimit?: number;
-  /** How long the table device's own socket may stay down before the room ends. */
   readonly graceWindowMs?: number;
 }
 
@@ -104,12 +83,6 @@ interface RoomSeatRoute {
   Params: { code: string; seatId: string };
 }
 
-/**
- * The two roles that skip seat-token authentication, kept in one place so the
- * set of unauthenticated connections is reviewable at a glance: `table` is the
- * shared table device, `lobby` is an unclaimed player watching the room view.
- * Anything else must present a seat token.
- */
 const UNAUTHENTICATED_ROLES = ["table", "lobby"] as const;
 type UnauthenticatedRole = (typeof UNAUTHENTICATED_ROLES)[number];
 
@@ -164,12 +137,6 @@ function sampleBotActionDelay(delay: BotActionDelay, rng: BotRng): number {
   return minimum + unitRandom(rng) * (maximum - minimum);
 }
 
-/**
- * Narrows a socket's identity to a seat. Only a seat may be handed
- * `view(state, seatId)` or have its presence tracked; the table and lobby
- * identities are deliberately excluded, so every per-seat path goes through
- * this one guard rather than its own `!== "lobby"` check.
- */
 function isSeat(identity: SocketIdentity | undefined): identity is SeatId {
   return identity !== undefined && identity !== "table" && identity !== "lobby";
 }
@@ -182,7 +149,6 @@ const CLAIM_ERROR_STATUS: Record<ClaimSeatError, number> = {
   "duplicate-display-name": 409,
 };
 
-/** Looks up a room, replying 404 and returning undefined when it's not live. */
 function findRoomOrReject(
   rooms: RoomStore,
   code: string,
@@ -196,14 +162,6 @@ function findRoomOrReject(
   return room;
 }
 
-/**
- * `HandEvent` is the engine's full, unredacted truth by design (secrecy
- * lives solely in `view` — Phase 1 spec #130 §3/§4). The *wire* event
- * carried alongside that view is a transport-level exception: `HoleCardsDealt`
- * must be redacted per recipient before it ever leaves the server, or the
- * "raw event for audit/animation" bullet in §6 would leak every seat's cards
- * to every socket regardless of what `view` shows.
- */
 function redactEventFor(
   event: HandEvent,
   identity: SeatId | "table",
@@ -218,7 +176,6 @@ function redactEventFor(
   };
 }
 
-/** Seat ids arrive as route/query strings — reject anything that isn't a bare integer. */
 function parseSeatId(raw: string): number | undefined {
   return /^\d+$/.test(raw) ? Number(raw) : undefined;
 }
@@ -277,9 +234,7 @@ export async function buildApp(
   const socketRoomCode = new Map<WebSocket, string>();
   const pingMissed = new Map<WebSocket, number>();
   const evictedSockets = new WeakSet<WebSocket>();
-  /** One timer per room, armed the moment its table-role socket closes. */
   const tableGraceTimers = new Map<string, NodeJS.Timeout>();
-  /** At most one pending bot action per room; replaced when the actor moves. */
   const botActionTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const app = Fastify();
 
@@ -307,7 +262,6 @@ export async function buildApp(
     }
   }
 
-  /** Refreshes the displayed completed hand after an immediate between-hand repack. */
   function broadcastDisplayedHand(code: string): void {
     const room = rooms.get(code);
     const sockets = roomSockets.get(code);
@@ -329,11 +283,6 @@ export async function buildApp(
     }
   }
 
-  /**
-   * Applies a positional repack to every currently open player socket before
-   * the new room view or hand snapshot is sent. The token stays with the
-   * player, while this transport identity follows the moved seat.
-   */
   function applySeatMoves(code: string, moves: readonly SeatMove[]): void {
     const sockets = roomSockets.get(code);
     if (!sockets) return;
@@ -346,16 +295,6 @@ export async function buildApp(
     }
   }
 
-  /**
-   * A seat token only protects the next connection attempt. Remove all
-   * currently open sockets for an evicted seat too, otherwise that socket
-   * could keep issuing commands until it disconnected on its own.
-   *
-   * `notify` sends the `player-evicted` notice; a voluntary leave (ADR-0005)
-   * passes `false`, since it isn't an eviction and its client has already
-   * torn itself down. Either way the socket is flagged so its own close
-   * handler skips the disconnected-presence toggle on the freed seat.
-   */
   function closeSeatSockets(code: string, seatId: SeatId, notify = true): void {
     const sockets = roomSockets.get(code);
     if (!sockets) return;
@@ -372,7 +311,6 @@ export async function buildApp(
     }
   }
 
-  /** Cosmetic presence toggle for a seat's socket — never touches `rooms.dispatch`. */
   function markPresence(socket: WebSocket, disconnected: boolean): void {
     const identity = socketIdentity.get(socket);
     const code = socketRoomCode.get(socket);
@@ -381,13 +319,6 @@ export async function buildApp(
     broadcastRoomView(code);
   }
 
-  /**
-   * Ends a room the same way whether triggered by "End session" or the
-   * table device's own reconnect grace window elapsing (Phase 1 spec #130
-   * §7): notify every socket, close them, discard the transport bookkeeping,
-   * then discard the room itself. Hand logs on disk are untouched — this
-   * only ever touches in-memory state.
-   */
   function endRoom(code: string): void {
     const sockets = roomSockets.get(code);
     if (sockets) {
@@ -411,7 +342,6 @@ export async function buildApp(
     rooms.end(code);
   }
 
-  /** Persists the exact engine command and resulting events for replay/audit. */
   function logDispatch(
     code: string,
     result: DispatchRejection | DispatchSuccess,
@@ -449,7 +379,7 @@ export async function buildApp(
       try {
         socket.ping();
       } catch {
-        // Socket is already on its way down; its 'close' handler cleans up.
+        // socket already closing; its 'close' handler cleans up
       }
     }
   }, pingIntervalMs);
@@ -461,13 +391,6 @@ export async function buildApp(
     done();
   });
 
-  /**
-   * Fans one event out to every socket in the room, per-recipient: the
-   * table gets `view(state, 'table')`, a seat gets `view(state, seatId)`
-   * only if it was actually dealt into the hand that produced this state —
-   * a sitting-out seat's socket gets nothing, never another seat's cards
-   * (Phase 1 spec #130 §4, §6).
-   */
   function fanOutHandUpdate(code: string, step: DispatchStep): void {
     const sockets = roomSockets.get(code);
     if (!sockets) return;
@@ -497,12 +420,6 @@ export async function buildApp(
     botActionTimers.delete(code);
   }
 
-  /**
-   * Rolls the between-hand cadence for every bot. This runs when the prior
-   * hand reaches HandComplete, before the table can issue nextHand, so the
-   * next deal-in sees the resulting voluntary seat states. A bot never
-   * releases its claim; only the sitting-out bit changes.
-   */
   function rollBotSitStates(code: string): boolean {
     if (!testMode) return false;
     const room = rooms.get(code);
@@ -510,17 +427,10 @@ export async function buildApp(
 
     let changed = false;
     const bots = room.seats.filter((seat) => seat.claimed && seat.bot === true);
-    // Remember which bots were already sitting out. A bot that returns for
-    // this boundary should remain in for the next deal rather than being
-    // immediately asked to sit out again in the same roll.
     const sittingOutBots = bots.filter((seat) => seat.sittingOut);
     const activeBots = bots.filter((seat) => !seat.sittingOut);
 
-    // Returning bots are considered first so a table can recover from a
-    // previous roll that left only one eligible seat.
     for (const seat of sittingOutBots) {
-      // Guard before the roll so a disconnected bot never consumes an RNG
-      // draw it cannot act on, matching the recovery and sit-out loops below.
       if (seat.disconnected) continue;
       if (shouldSitIn(botRng)) {
         rooms.setSittingOut(code, seat.id, false);
@@ -534,9 +444,6 @@ export async function buildApp(
       ).length;
     let eligibleCount = dealInEligible();
 
-    // A failed sit-in roll must not permanently strand a room that still has
-    // two connected claimed seats available. This is a recovery override, not
-    // a normal cadence decision, and is only used until two seats can deal in.
     if (eligibleCount < 2) {
       for (const seat of sittingOutBots) {
         if (eligibleCount >= 2) break;
@@ -548,12 +455,7 @@ export async function buildApp(
       }
     }
 
-    // Active bots may opt out only while the table would still have two
-    // connected, claimed, non-sitting-out seats for the next deal-in.
     for (const seat of activeBots) {
-      // Guard before the roll so the draw is only consumed when the seat can
-      // actually sit out; drawing first would let the two-seat floor shift
-      // every later action-selection draw for a deterministic RNG.
       if (seat.disconnected || seat.sittingOut || eligibleCount <= 2) continue;
       if (!shouldSitOut(botRng)) continue;
       rooms.setSittingOut(code, seat.id, true);
@@ -563,10 +465,6 @@ export async function buildApp(
     return changed;
   }
 
-  /**
-   * Arms the one pending bot action for a room, replacing any stale timer
-   * left behind by a real action, eviction, or another room-store mutation.
-   */
   function scheduleBotAction(code: string): void {
     clearBotActionTimer(code);
     if (!testMode) return;
@@ -581,9 +479,6 @@ export async function buildApp(
       () => {
         botActionTimers.delete(code);
 
-        // Everything below is deliberately read again at fire time. A timer
-        // may outlive an intervening human action, eviction, hand completion,
-        // or room teardown.
         const currentRoom = rooms.get(code);
         if (!currentRoom || rooms.currentActor(code) !== actor) return;
         const currentSeat = currentRoom.seats[actor];
@@ -602,11 +497,6 @@ export async function buildApp(
         const action = chooseBotAction(actorView.legalActions, botRng);
         const result = rooms.dispatch(code, actor, action);
         if (!("steps" in result)) {
-          // `action` came straight from the engine's `legalActions`, so a
-          // rejection is not expected. If it somehow happens, re-arm the
-          // clock and the bot so the seat still faces a deadline and the bot
-          // retries rather than stalling — an eviction path may have left the
-          // clock preserved (unarmed) while this actor remains on it.
           rescheduleActionClock(code);
           scheduleBotAction(code);
           return;
@@ -618,13 +508,6 @@ export async function buildApp(
     botActionTimers.set(code, timer);
   }
 
-  /**
-   * Re-arms the room's action clock against whoever is now on the clock —
-   * called after every command a room accepts, real or synthesized, so the
-   * clock always reflects the live actor. A disconnected socket plays no
-   * part here; only `dispatch` outcomes move this clock, per
-   * Phase 1 spec #130 §7.
-   */
   function rescheduleActionClock(code: string): void {
     const room = rooms.get(code);
     const actor = rooms.currentActor(code);
@@ -641,9 +524,6 @@ export async function buildApp(
       return;
     }
 
-    // `actionClockMs` is only a convenience override for the default clock
-    // used by the existing timer tests. An injected clock is authoritative so
-    // tests can observe each room's configured duration directly.
     const timeoutMs =
       options.actionClock === undefined && options.actionClockMs !== undefined
         ? options.actionClockMs
@@ -656,9 +536,6 @@ export async function buildApp(
         return;
       }
 
-      // A timeout should preserve a free check. Read legal actions at fire
-      // time because the scheduled callback may outlive another room-store
-      // mutation even after its timer has been replaced.
       const actorView =
         currentRoom.engine === null
           ? undefined
@@ -669,11 +546,6 @@ export async function buildApp(
           ? "check"
           : "fold";
       const result = rooms.dispatch(code, actor, action);
-      // `actor` was read as the live current actor at schedule time, and
-      // any real action in between would have rescheduled (and thus
-      // replaced) this very timer — so `dispatch` rejecting the synthesized
-      // action isn't expected to happen. If it somehow does, the clock still
-      // re-arms below.
       if ("steps" in result) {
         publishDispatch(code, result);
         return;
@@ -682,7 +554,6 @@ export async function buildApp(
     });
   }
 
-  /** Publishes an accepted dispatch, including any positional seat moves. */
   function publishDispatch(
     code: string,
     result: DispatchSuccess,
@@ -701,9 +572,6 @@ export async function buildApp(
         if (room !== undefined) room.turnEndsAt = null;
       }
     } else {
-      // Arm before the first hand-update is sent: every live view, including
-      // the HandStarted view, carries the deadline that governs the resulting
-      // actor. A reconnect snapshot reads the same room field.
       rescheduleActionClock(code);
     }
     for (const step of result.steps) {
@@ -718,18 +586,10 @@ export async function buildApp(
     scheduleBotAction(code);
   }
 
-  // `index: false` — the explicit "/" route below owns index resolution
-  // (placeholder vs. a staged table build), so the static plugin only ever
-  // serves fingerprinted assets (`/table/assets/*`, `/player/assets/*`),
-  // never racing its own directory-index behaviour against that route.
   await app.register(fastifyStatic, { root: publicDir, index: false });
   await app.register(fastifyWebsocket);
 
   app.get("/", (_request, reply) => {
-    // The HTML shell names the current fingerprinted bundle, so it must never
-    // be cached: a stale shell pins a long-lived kiosk to an old build even
-    // across app restarts (the disk cache survives them). `no-store` forces a
-    // fresh shell every load; the hashed assets it points at stay cacheable.
     return reply
       .type("text/html")
       .header("cache-control", "no-store")
@@ -739,8 +599,6 @@ export async function buildApp(
   app.get("/config", () => ({ testMode }));
 
   app.post("/rooms", async (request, reply) => {
-    // The table client picks a seat count (issue #74); this is the trust
-    // boundary that decides whether it's a size a room may actually have.
     const body = CreateRoomRequestSchema.safeParse(request.body);
     if (!body.success) {
       return reply.code(400).send({
@@ -754,11 +612,6 @@ export async function buildApp(
     return { code: room.code, joinUrl: url, qrCodeDataUrl };
   });
 
-  /**
-   * Test-mode table action: fill existing free seats with virtual players.
-   * Keeping this route out of the Fastify registration entirely when the gate
-   * is off makes the production surface a plain 404.
-   */
   if (testMode) {
     app.post<RoomCodeRoute>("/rooms/:code/bots", (request, reply) => {
       const body = AddBotsRequestSchema.safeParse(request.body);
@@ -798,11 +651,6 @@ export async function buildApp(
     return reply.code(204).send();
   });
 
-  /**
-   * Table-device house rules: change the room's seat count (issue #77). The
-   * HTTP boundary is intentionally the same ungated table-action boundary as
-   * `/end` and `/evict`; role authentication is not part of this transport.
-   */
   const changeSeatCount = (
     request: FastifyRequest<RoomCodeRoute>,
     reply: FastifyReply,
@@ -835,12 +683,6 @@ export async function buildApp(
 
   app.post<RoomCodeRoute>("/rooms/:code/seats/count", changeSeatCount);
 
-  /**
-   * Table-device sound settings (#182): the room-wide
-   * master/cards/actions/notifications toggles. Same ungated table-action
-   * boundary as `/seats/count` — the table
-   * owns these and pushes them to every surface via the broadcast `room-view`.
-   */
   app.post<RoomCodeRoute>("/rooms/:code/sound", (request, reply) => {
     const body = ChangeSoundSettingsRequestSchema.safeParse(request.body);
     if (!body.success) {
@@ -856,11 +698,6 @@ export async function buildApp(
     return result;
   });
 
-  /**
-   * Table-device shot-clock settings: every edit is queued for the next hand,
-   * so this route never re-arms or clears a live hand's action timer. The
-   * resulting pending value is pushed through the room-view broadcast.
-   */
   app.post<RoomCodeRoute>("/rooms/:code/shot-clock", (request, reply) => {
     const body = ChangeShotClockRequestSchema.safeParse(request.body);
     if (!body.success) {
@@ -878,12 +715,6 @@ export async function buildApp(
     return result;
   });
 
-  /**
-   * Where the QR code's join URL lands. `PLAYER_CLIENT_ORIGIN` points dev at
-   * the player-client's own Vite server; unset, it serves a release build
-   * staged at `public/player` (ticket 34's `build:release`), or the
-   * placeholder if none has been staged.
-   */
   app.get<RoomCodeRoute>("/join/:code", (request, reply) => {
     const room = findRoomOrReject(rooms, request.params.code, reply);
     if (!room) return;
@@ -891,7 +722,6 @@ export async function buildApp(
     if (playerOrigin) {
       return reply.redirect(`${playerOrigin}/join/${room.code}`);
     }
-    // See the table shell above: never cache the HTML that names the bundle.
     return reply
       .type("text/html")
       .header("cache-control", "no-store")
@@ -933,7 +763,6 @@ export async function buildApp(
     },
   );
 
-  /** The table device's manual evict action (ADR-0003) — no automatic trigger. */
   app.post<RoomSeatRoute>(
     "/rooms/:code/seats/:seatId/evict",
     (request, reply) => {
@@ -946,9 +775,6 @@ export async function buildApp(
       const eviction = rooms.evictSeat(request.params.code, seatId);
       if (eviction.dispatch !== undefined) {
         publishDispatch(request.params.code, eviction.dispatch, {
-          // A non-current eviction leaves the actor and its existing deadline
-          // untouched; a current-seat eviction uses a normal fold command and
-          // starts the next actor's clock as usual.
           actionClock:
             eviction.dispatch.command.type === "evict"
               ? "preserve"
@@ -961,7 +787,6 @@ export async function buildApp(
     },
   );
 
-  /** A player releasing their own seat (ADR-0005) — the token-gated twin of evict. */
   app.post<RoomSeatRoute>(
     "/rooms/:code/seats/:seatId/leave",
     (request, reply) => {
@@ -985,8 +810,6 @@ export async function buildApp(
       }
       if (result.dispatch !== undefined) {
         publishDispatch(request.params.code, result.dispatch, {
-          // Same fold/queue handling as evict: a non-actor leave preserves the
-          // current actor's clock, a current-actor leave folds and reschedules.
           actionClock:
             result.dispatch.command.type === "evict"
               ? "preserve"
@@ -994,7 +817,6 @@ export async function buildApp(
         });
       }
       broadcastRoomView(request.params.code);
-      // Voluntary leave, not an eviction — close the socket without the notice.
       closeSeatSockets(request.params.code, seatId, false);
       return reply.code(204).send();
     },
@@ -1057,22 +879,16 @@ export async function buildApp(
             tableGraceTimers.delete(code);
           }
         } else if (isSeat(identity)) {
-          // A reconnecting seat resumes silently, no penalty (§7) — clear
-          // any presence badge a prior drop had set.
           rooms.setSeatDisconnected(code, identity, false);
         }
 
         if (movedFrom !== undefined && isSeat(identity)) {
-          // A disconnected player may still have the pre-repack seat in
-          // localStorage. The token authenticates the player; this stale
-          // position is only the source for the resync notice.
           send(socket, { type: "seat-moved", from: movedFrom, to: identity });
         }
 
         const room = rooms.get(code);
         if (room) {
           broadcastRoomView(code);
-          // One fresh snapshot on connect, never event replay (§7, §9).
           if (room.engine !== null) {
             if (identity === "table") {
               send(socket, {
@@ -1114,8 +930,6 @@ export async function buildApp(
             return;
           }
 
-          // Voluntary sit-out/in (ADR-0002) never reaches the engine — it's
-          // a seat-only room-store mutation, not a hand command.
           if (
             parseResult.data.type === "sitOut" ||
             parseResult.data.type === "sitIn"
@@ -1159,8 +973,6 @@ export async function buildApp(
           }
 
           publishDispatch(code, dispatchResult);
-          // A fresh deal-in (new join, reconnect) changes seat state the
-          // routine hand-update fan-out above doesn't cover.
           if (
             parseResult.data.type === "startHand" ||
             parseResult.data.type === "nextHand"
@@ -1179,9 +991,6 @@ export async function buildApp(
           if (evictedSockets.delete(socket)) return;
 
           if (currentIdentity === "table") {
-            // Room may already be gone (this close came from `endRoom` itself
-            // closing every socket) — only arm a fresh grace window for a
-            // room that's still live.
             if (rooms.get(code) && !tableGraceTimers.has(code)) {
               tableGraceTimers.set(
                 code,

--- a/packages/server/src/bot-driver.test.ts
+++ b/packages/server/src/bot-driver.test.ts
@@ -191,8 +191,6 @@ describe("bot driver", () => {
       firstNextHandMessage,
     );
 
-    // This claim happens after deal-in, so its room view must explain that it
-    // is waiting for the next hand rather than calling it voluntary sit-out.
     const claimedMidHand = await app.inject({
       method: "POST",
       url: `/rooms/${code}/bots`,

--- a/packages/server/src/bot-policy.ts
+++ b/packages/server/src/bot-policy.ts
@@ -1,17 +1,7 @@
 import type { ActionType } from "@table-top-poker/protocol";
 
-/** A source of values in the usual half-open random range [0, 1). */
 export type BotRng = () => number;
 
-/**
- * Action weights used by the default policy.  The weights are relative rather
- * than percentages because the policy receives a different set of legal
- * actions depending on whether the actor is facing a bet.
- *
- * A free check (or a call) is deliberately much more likely than folding or
- * raising, while fold and raise retain positive weights so every legal action
- * remains reachable.
- */
 export const DEFAULT_BOT_ACTION_WEIGHTS: Readonly<Record<ActionType, number>> =
   Object.freeze({
     fold: 1,
@@ -20,21 +10,15 @@ export const DEFAULT_BOT_ACTION_WEIGHTS: Readonly<Record<ActionType, number>> =
     raise: 2,
   });
 
-/** Default chance for a bot to skip the next hand between hands. */
 export const DEFAULT_SIT_OUT_PROBABILITY = 0.1;
 
-/** Default chance for a sitting-out bot to return for the next hand. */
 export const DEFAULT_SIT_IN_PROBABILITY = 0.35;
 
-/** The greatest representable JavaScript number below 1. */
 const MAX_UNIT_RANDOM = 1 - Number.EPSILON / 2;
 
 export function unitRandom(rng: BotRng): number {
   const value = rng();
 
-  // Math.random() is in [0, 1). Clamp invalid injected values to the nearest
-  // boundary, but do not round a valid value in that range: MAX_UNIT_RANDOM
-  // is itself a valid value and must remain unchanged.
   if (Number.isNaN(value)) return 0;
   return Math.min(Math.max(value, 0), MAX_UNIT_RANDOM);
 }
@@ -47,11 +31,6 @@ function assertProbability(probability: number): void {
   }
 }
 
-/**
- * Chooses a currently legal action without consulting or mutating engine
- * state.  The caller supplies the engine's legal-action list; this function
- * only weights those entries and never derives a replacement list.
- */
 export function chooseBotAction(
   legalActions: readonly ActionType[],
   rng: BotRng = Math.random,
@@ -72,18 +51,14 @@ export function chooseBotAction(
     if (target < cumulative) return action;
   }
 
-  // unitRandom() keeps target < total, so the loop always returns above; this
-  // throw exists only to satisfy the return type.
   throw new Error("chooseBotAction lost its supplied legal action");
 }
 
-/** Rolls the RNG and reports whether it falls below the given probability. */
 function rollBelow(rng: BotRng, probability: number): boolean {
   assertProbability(probability);
   return unitRandom(rng) < probability;
 }
 
-/** Returns whether a bot should sit out the next hand. */
 export function shouldSitOut(
   rng: BotRng = Math.random,
   probability: number = DEFAULT_SIT_OUT_PROBABILITY,
@@ -91,7 +66,6 @@ export function shouldSitOut(
   return rollBelow(rng, probability);
 }
 
-/** Returns whether a sitting-out bot should sit back in for the next hand. */
 export function shouldSitIn(
   rng: BotRng = Math.random,
   probability: number = DEFAULT_SIT_IN_PROBABILITY,

--- a/packages/server/src/qr.ts
+++ b/packages/server/src/qr.ts
@@ -1,6 +1,5 @@
 import QRCode from "qrcode";
 
-/** Builds the join address from the request's own Host header, never a hard-coded origin. */
 export function joinUrl(host: string, code: string): string {
   return `http://${host}/join/${code}`;
 }

--- a/packages/server/src/room-code.ts
+++ b/packages/server/src/room-code.ts
@@ -1,10 +1,6 @@
 const DIGITS = "0123456789".replace(/[01258]/g, "");
 const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".replace(/[BILOSZ]/g, "");
 
-/**
- * Digits + uppercase letters, excluding confusable characters
- * (0/O, 1/I/L, 2/Z, 5/S, 8/B) — 25 characters.
- */
 export const ROOM_CODE_ALPHABET = DIGITS + LETTERS;
 
 const ROOM_CODE_LENGTH = 4;
@@ -22,10 +18,6 @@ function rollCode(random: () => number): string {
   return code;
 }
 
-/**
- * Generates a room code, re-rolling on collision against `isTaken`.
- * `random` defaults to `Math.random`; inject a deterministic source for tests.
- */
 export function generateRoomCode(
   isTaken: (code: string) => boolean,
   random: () => number = Math.random,

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -520,8 +520,6 @@ describe("RoomStore", () => {
       expect(room.pendingSeatCount).toBeNull();
       expect(room.seats).toHaveLength(3);
       expect(room.engine?.seats).toEqual([0, 1, 2]);
-      // The completed hand's next button was old seat 5; after repacking it
-      // is seat 1 and the new hand keeps it there.
       expect(room.engine?.button).toBe(1);
       expect(room.engine?.hand?.status).toBe("betting");
     });
@@ -717,7 +715,6 @@ describe("RoomStore", () => {
       );
     });
 
-    /** Folds every actor in turn until only one live player remains (fold-out). */
     function completeHand(store: RoomStore, room: Room): void {
       for (let i = 0; i < DEFAULT_SEAT_COUNT; i++) {
         if (room.engine?.hand?.status === "complete") return;

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -30,51 +30,25 @@ import {
 } from "@table-top-poker/protocol";
 import { generateRoomCode } from "./room-code.js";
 
-/**
- * `Seat` and `Room` are `RoomStore`'s internal mutable aggregate state, not
- * wire DTOs — mutated in place by the store rather than replaced, unlike
- * the `readonly` view/slice types elsewhere that cross a render or wire
- * boundary. `toRoomView` is the seam that turns them into an immutable
- * snapshot for broadcast.
- */
 export interface Seat {
   readonly id: SeatId;
   claimed: boolean;
-  /** Required for new claims; absent only for rooms created before names existed. */
   displayName?: string;
-  /** Present only for a test-mode bot claim. */
   bot?: boolean;
-  /** Explicit claim/deal lifecycle state; avoids treating a reused seat id as identity. */
   waitingForNextHand?: boolean;
   token: string | null;
-  /**
-   * Voluntary opt-out only (ADR-0002) — set solely by the `sitOut`/`sitIn`
-   * commands via `setSittingOut`. Excludes the seat from deal-in.
-   */
   sittingOut: boolean;
-  /**
-   * Presence badge (ticket 33 §7): missed pongs or a closed socket flip it
-   * on, a reconnect flips it off. Beyond the cosmetic badge, it also gates
-   * deal-in (ADR-0002) — `dispatch`'s own fold/check/call/raise legality
-   * still never consults it directly.
-   */
   disconnected: boolean;
 }
 
 export interface Room {
   readonly code: string;
   readonly seats: Seat[];
-  /** Null until the room's first `startHand` — see `RoomStore.dispatch`. */
   engine: EngineState | null;
-  /** A live-hand shrink waits here until the next deal-in recompute. */
   pendingSeatCount: number | null;
-  /** Absolute deadline for the current actor, or null when no clock is armed. */
   turnEndsAt: number | null;
-  /** A shot-clock change waits here until the next deal-in. */
   pendingShotClock: ShotClockSettings | null;
-  /** Room-wide tactile-sound settings (#182), set by the table. */
   soundSettings: SoundSettings;
-  /** Room-wide action-clock settings, set by the table. */
   shotClockSettings: ShotClockSettings;
 }
 
@@ -87,7 +61,6 @@ export type ClaimSeatError =
 
 export type ClaimSeatResult = { seat: Seat } | { error: ClaimSeatError };
 
-/** The engine dispatch, when eviction resolves a seat during a live hand. */
 export interface EvictSeatResult {
   readonly dispatch?: DispatchSuccess;
 }
@@ -101,7 +74,6 @@ export type ChangeSeatCountResult =
   | SeatCountChange
   | { readonly error: ChangeSeatCountError; readonly minimum?: number };
 
-/** A step of engine state produced by one dispatched command, event by event. */
 export interface DispatchStep {
   readonly event: HandEvent;
   readonly state: EngineState;
@@ -126,10 +98,6 @@ export type DispatchResult =
   | { readonly error: "room-not-found" | "not-permitted" }
   | DispatchRejection;
 
-/**
- * `sitOut`/`sitIn` are seat commands that never reach the engine (ADR-0002)
- * — `dispatch` only ever runs the commands the engine understands.
- */
 export type SeatCommandType = Exclude<ClientCommandType, "sitOut" | "sitIn">;
 
 const TABLE_ONLY_COMMANDS: ReadonlySet<SeatCommandType> = new Set([
@@ -152,11 +120,6 @@ interface SeatRepack {
   readonly mapping: ReadonlyMap<SeatId, SeatId>;
 }
 
-/**
- * Shrinking is a positional repack, not a deletion of the seats above the
- * new limit. Claimed seats are sorted by their old position and copied into
- * the surviving positions, carrying every player-owned field with them.
- */
 function repackSeats(room: Room, seatCount: number): SeatRepack {
   const claimed = room.seats.filter((seat) => seat.claimed);
   const replacement = makeSeats(seatCount);
@@ -197,7 +160,6 @@ function remapSeatId(
   return mapping.get(seatId) ?? seatId;
 }
 
-/** Keeps a displayed completed hand aligned with an immediate between-hand repack. */
 function remapCompletedEngineState(
   state: EngineState,
   mapping: ReadonlyMap<SeatId, SeatId>,
@@ -249,7 +211,6 @@ function applyPendingShrink(room: Room): SeatRepack {
   return repack;
 }
 
-/** Applies the latest shot-clock edit only when a new hand is dealt. */
 function applyPendingShotClock(room: Room): void {
   if (room.pendingShotClock === null) return;
   room.shotClockSettings = room.pendingShotClock;
@@ -268,19 +229,12 @@ function appliedSeatCountChange(
   };
 }
 
-/** Seats eligible for the next deal-in: claimed, connected, not voluntarily sitting out. */
 function eligibleSeats(room: Room): SeatId[] {
   return room.seats
     .filter((seat) => seat.claimed && !seat.disconnected && !seat.sittingOut)
     .map((seat) => seat.id);
 }
 
-/**
- * Records which claimed seats belong to the newly dealt hand. This explicit
- * marker is deliberately separate from numeric seat membership: an evicted
- * seat can be reclaimed before the old hand is complete, and the new claim
- * must still wait even though its id remains in the old engine ring.
- */
 function updateWaitingForNextHand(room: Room, dealIn: readonly SeatId[]): void {
   const dealt = new Set(dealIn);
   for (const seat of room.seats) {
@@ -299,7 +253,6 @@ function claimedSeatFloor(room: Room): number {
   );
 }
 
-/** Resets a seat to its unclaimed default — used by the manual evict action. */
 function freeSeat(seat: Seat): void {
   seat.claimed = false;
   delete seat.displayName;
@@ -310,13 +263,6 @@ function freeSeat(seat: Seat): void {
   seat.disconnected = false;
 }
 
-/**
- * Derives the public lifecycle reason for a seat omitted from the current
- * deal-in: a voluntary opt-out, or a claim that missed the current deal-in
- * (issue #13). The waiting marker is explicit because a reclaimed seat may
- * reuse an id still present in the old engine ring. Shared by `toRoomView`
- * and single-seat lookups.
- */
 function sittingOutReason(room: Room, seatId: SeatId): SittingOutReason | null {
   const seat = room.seats[seatId];
   if (!seat) return null;
@@ -332,13 +278,6 @@ function isSittingOut(room: Room, seatId: SeatId): boolean {
   return sittingOutReason(room, seatId) !== null;
 }
 
-/**
- * Carries the button forward into a freshly recomputed deal-in list: stays
- * put if the previous button is still eligible, otherwise advances to the
- * next eligible seat in physical (ascending id) order, wrapping around —
- * the button skipping an empty/sitting-out/disconnected seat, same as at a
- * real table.
- */
 function resolveButtonFor(
   previousButton: SeatId,
   dealIn: readonly SeatId[],
@@ -352,7 +291,6 @@ function resolveButtonFor(
   return ordered.find((id) => id > previousButton) ?? first;
 }
 
-/** In-memory room registry, with the engine wired in behind `dispatch`. */
 export class RoomStore {
   readonly #rooms = new Map<string, Room>();
   readonly #random: () => number;
@@ -369,12 +307,6 @@ export class RoomStore {
     this.#generateSeed = generateSeed;
   }
 
-  /**
-   * Creates a room sized to the creator's chosen seat count (issue #74).
-   * The range is a domain rule, not a UI one, so an out-of-range count is
-   * a caller bug and throws — the HTTP edge parses the untrusted body with
-   * `CreateRoomRequestSchema` and answers 400 before ever reaching here.
-   */
   create(seatCount: number = DEFAULT_SEAT_COUNT): Room {
     if (!SeatCountSchema.safeParse(seatCount).success) {
       throw new RangeError(
@@ -406,7 +338,6 @@ export class RoomStore {
       ?.seats.find((seat) => seat.claimed && seat.token === token);
   }
 
-  /** The seat currently owed a decision in `code`'s hand, or undefined between/after hands. */
   currentActor(code: string): SeatId | undefined {
     const hand = this.#rooms.get(code)?.engine?.hand;
     if (hand?.status !== "betting") return undefined;
@@ -417,11 +348,6 @@ export class RoomStore {
     this.#rooms.delete(code);
   }
 
-  /**
-   * A name is required of every new claim (issue #88) — the seat, not just the
-   * HTTP edge, owns that rule. `Seat.displayName` stays optional only because
-   * rooms created before names existed still have nameless claimed seats.
-   */
   claimSeat(
     code: string,
     seatId: SeatId,
@@ -461,11 +387,6 @@ export class RoomStore {
     return { seat };
   }
 
-  /**
-   * Claims currently-free seats as test-mode bots through the same claim path
-   * as a real player. The caller owns the test-mode gate; this store method
-   * only handles the aggregate mutation and returns the seats that joined.
-   */
   addBots(room: Room, count: number): { seats: readonly Seat[] } {
     if (!Number.isFinite(count) || count <= 0) return { seats: [] };
 
@@ -495,14 +416,6 @@ export class RoomStore {
     return `Bot ${String(number)}`;
   }
 
-  /**
-   * Frees any claimed seat — active, sitting-out, or disconnected alike —
-   * back into the join picker and invalidates its token. The table
-   * device's manual "evict" action (ADR-0003); there is no automatic trigger.
-   * Any live seat evicted during a live hand is folded first. If it is not the
-   * current actor, the engine removes it from the outstanding queue without
-   * disturbing whoever is currently to act.
-   */
   evictSeat(code: string, seatId: SeatId): EvictSeatResult {
     const room = this.#rooms.get(code);
     const seat = room?.seats[seatId];
@@ -510,10 +423,6 @@ export class RoomStore {
 
     if (this.currentActor(code) === seatId) {
       const result = this.dispatch(code, seatId, "fold");
-      // `currentActor` was read as the live actor, and fold is unconditionally
-      // legal for that seat. If that invariant ever breaks, leave the seat
-      // claimed so the action clock can recover instead of freeing an actor the
-      // engine is still waiting on.
       if (!("steps" in result)) return {};
 
       freeSeat(seat);
@@ -530,9 +439,6 @@ export class RoomStore {
       !player.folded
     ) {
       const result = this.#dispatchEviction(room, seatId);
-      // The engine must accept a live in-hand seat eviction. If that invariant
-      // ever breaks, leave the claim intact so a later action-clock fold can
-      // recover rather than freeing a seat the engine still considers live.
       if (result === undefined) return {};
 
       freeSeat(seat);
@@ -543,12 +449,6 @@ export class RoomStore {
     return {};
   }
 
-  /**
-   * A player releasing their own seat (ADR-0005) — the free-the-seat
-   * operation of {@link evictSeat}, gated on the caller presenting the
-   * seat's own token rather than on being the table device. Frees only the
-   * seat that token owns; a mismatched or stale token is `not-permitted`.
-   */
   leaveSeat(
     code: string,
     seatId: SeatId,
@@ -562,13 +462,6 @@ export class RoomStore {
     return this.evictSeat(code, seatId);
   }
 
-  /**
-   * Changes the room's physical seat count. Growing is always safe and
-   * immediate. A shrink would renumber the live engine ring, so it is queued
-   * until the next deal-in recompute; outside a live hand it applies
-   * immediately. The claimed-seat floor includes disconnected and sitting-out
-   * players because neither state releases a claim.
-   */
   changeSeatCount(code: string, seatCount: number): ChangeSeatCountResult {
     const room = this.#rooms.get(code);
     if (!room) return { error: "room-not-found" };
@@ -610,12 +503,6 @@ export class RoomStore {
     return appliedSeatCountChange(room, repack.moves);
   }
 
-  /**
-   * Replaces the room's tactile-sound settings (#182). The whole triple is
-   * written atomically; the table owns these and phones simply obey them, so
-   * there is nothing to validate beyond the room existing (the HTTP edge has
-   * already parsed the booleans).
-   */
   changeSoundSettings(
     code: string,
     settings: SoundSettings,
@@ -626,10 +513,6 @@ export class RoomStore {
     return room.soundSettings;
   }
 
-  /**
-   * Queues a room action-clock edit for the next deal-in. Applying the shared
-   * schema here keeps direct callers from constructing invalid room state.
-   */
   changeShotClockSettings(
     code: string,
     settings: ShotClockSettings,
@@ -640,30 +523,20 @@ export class RoomStore {
     if (!parsed.success) {
       return { error: "invalid-shot-clock" };
     }
-    // Keep the active hand's timer untouched. The pending value is drained
-    // after the next successful `startHand`/`nextHand` dispatch, before the
-    // application re-arms the clock for that new hand.
     room.pendingShotClock = parsed.data;
     return parsed.data;
   }
 
-  /** Whether `seatId` reads as "sitting out" in the room's public view — see `isSittingOut`. */
   isSittingOut(code: string, seatId: SeatId): boolean {
     const room = this.#rooms.get(code);
     return room ? isSittingOut(room, seatId) : false;
   }
 
-  /** The public lifecycle reason for a seat omitted from the next deal-in. */
   sittingOutReason(code: string, seatId: SeatId): SittingOutReason | null {
     const room = this.#rooms.get(code);
     return room ? sittingOutReason(room, seatId) : null;
   }
 
-  /**
-   * Voluntary seat-state toggle (ADR-0002), driven by the `sitOut`/`sitIn`
-   * commands. Never reaches the engine — a sitting-out seat is simply
-   * excluded the next time deal-in is recomputed.
-   */
   setSittingOut(code: string, seatId: SeatId, sittingOut: boolean): void {
     const room = this.#rooms.get(code);
     const seat = room?.seats[seatId];
@@ -671,12 +544,6 @@ export class RoomStore {
     seat.sittingOut = sittingOut;
   }
 
-  /**
-   * Presence-only badge toggle (ticket 33 §7): missed pongs or a socket
-   * closing flip it on, a reconnect or fresh pong flips it off. Cosmetic to
-   * `dispatch`'s fold/check/call/raise legality, which never consults it —
-   * but ADR-0002 has it gate deal-in.
-   */
   setSeatDisconnected(
     code: string,
     seatId: SeatId,
@@ -688,16 +555,6 @@ export class RoomStore {
     seat.disconnected = disconnected;
   }
 
-  /**
-   * Runs one command through the engine on behalf of an authenticated
-   * socket. `identity` is derived server-side from the WS connection, never
-   * from the message payload — see Phase 1 spec #130 §6. `startHand` and
-   * `nextHand` are table-only at this layer (the engine itself places no
-   * such restriction); everything else is seat-only. Every `startHand`/
-   * `nextHand` recomputes deal-in from the seats currently claimed,
-   * connected, and not sitting out (ADR-0002), carrying the button forward
-   * into whatever that recompute leaves eligible.
-   */
   dispatch(
     code: string,
     identity: SeatId | "table",
@@ -778,12 +635,6 @@ export class RoomStore {
     return { command, steps };
   }
 
-  /**
-   * `seatId` is unused by the engine for `startHand`/`nextHand` (no
-   * issuer restriction at that layer, per Phase 1 spec #130 §3) — the
-   * table isn't a seat, so there's no meaningful id to supply; `0` is an
-   * arbitrary placeholder.
-   */
   #buildCommand(identity: SeatId | "table", type: SeatCommandType): Command {
     if (type === "startHand" || type === "nextHand") {
       return { type, seatId: 0, seed: this.#generateSeed() };
@@ -792,7 +643,6 @@ export class RoomStore {
   }
 }
 
-/** Public seat/room projection — never carries a seat's claim token. */
 export function toRoomView(room: Room): RoomView {
   return {
     code: room.code,

--- a/packages/table-client/src/App.interaction.test.tsx
+++ b/packages/table-client/src/App.interaction.test.tsx
@@ -30,7 +30,6 @@ vi.mock("./store/store.js", async (importOriginal) => {
   };
 });
 
-/** Captures the button's onClick prop so the node test can exercise it. */
 vi.mock("./TableControls.js", () => ({
   TableControls: (props: TableControlsProps) => {
     addBotClick.current =

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -6,13 +6,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App.js";
 import type { TableStore } from "./store/store.js";
 
-/**
- * These tests render on the server, and zustand serves `getInitialState` to
- * `useSyncExternalStore` there — a plain `setState` would never reach the
- * markup. So the hook reads a per-test override instead; the real slices still
- * supply every value the test does not name, including the setters
- * `useWebSocket` reads.
- */
 const store = vi.hoisted((): { overrides: Partial<TableStore> } => ({
   overrides: {},
 }));
@@ -54,7 +47,6 @@ const liveHand: TableView = {
   ],
 };
 
-/** A finished hand: the rail offers "Next hand" in this state. */
 const completeHand: TableView = {
   phase: "folded-out",
   button: 0,
@@ -64,7 +56,6 @@ const completeHand: TableView = {
   winner: 0,
 };
 
-/** A showdown: the reveal overlay owns the result here. */
 const showdownHand: TableView = {
   phase: "showdown",
   button: 0,
@@ -99,7 +90,6 @@ const showdownHand: TableView = {
   ],
 };
 
-/** Puts the table in a room, with the seats claimed and hand state given. */
 function enterRoom(
   claimedSeats: number,
   handView: TableView | null,
@@ -153,8 +143,6 @@ describe("App", () => {
     expect(html).toContain('data-testid="join-panel"');
     expect(html).toContain('data-placement="join-panel"');
     expect(html).not.toContain('data-placement="rail"');
-    // The join card is the room-join surface in the lobby; a second copy of
-    // the code in the status bar would be redundant.
     expect(html).not.toContain('data-testid="join-code-toggle"');
     expect(html).toContain('data-testid="connection-status"');
   });
@@ -221,8 +209,6 @@ describe("App", () => {
     expect(html).not.toMatch(
       /data-testid="showdown-next-hand-button"[^>]*disabled/,
     );
-    // The rail offers "View showdown" to reopen the overlay, not "Next hand" —
-    // dealing the next hand lives in the overlay itself.
     expect(html).toContain('data-testid="view-showdown-button"');
     expect(html).not.toContain('data-testid="next-hand-button"');
   });

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -54,14 +54,6 @@ export function App() {
   const clearHand = useTableStore((state) => state.clearHand);
 
   useEffect(() => {
-    // Silently re-attach to the room this table was hosting on mount (#175) —
-    // a refresh keeps the room alive server-side for the grace window (#130
-    // §7). Confirm the room is still live over HTTP before restoring: the WS
-    // handshake 404s once the room is gone, but the socket can't tell that
-    // from a transient drop and would retry forever, so this check is what
-    // decides the fall-through. A live room restores its code/QR and the
-    // socket reconnects; a gone room (or absent/malformed storage) clears the
-    // stored room and falls through to the create-room screen.
     const stored = loadHostedRoom(window.localStorage);
     if (stored === null) return;
     fetchRoom(stored.code)
@@ -81,9 +73,6 @@ export function App() {
   const [menuSeatId, setMenuSeatId] = useState<number | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
 
-  // "View table" collapses the showdown overlay without leaving showdown, so
-  // the felt's controls are reachable; the Showdown chip reopens it. Reset
-  // whenever the table is not at showdown, so each new showdown opens featured.
   const [showdownCollapsed, setShowdownCollapsed] = useState(false);
   const atShowdown = handView?.phase === "showdown";
   useEffect(() => {
@@ -116,7 +105,6 @@ export function App() {
 
   const [seatCount, setSeatCount] = useState(DEFAULT_SEAT_COUNT);
   const handleCreateRoom = useCallback(() => {
-    // Hosting the table is the kiosk's audio-unlock gesture (#178).
     void unlockAudio();
     createRoom(seatCount)
       .then((room) => {
@@ -157,8 +145,6 @@ export function App() {
     [roomCode],
   );
 
-  // Sound toggles apply the instant they're flipped (a mute you can hear stop),
-  // unlike seat count which commits on Done. The whole triple is sent each time.
   const handleChangeSoundSettings = useCallback(
     (next: SoundSettings) => {
       if (roomCode === null) return;
@@ -178,8 +164,6 @@ export function App() {
   );
 
   const handleStartHand = useCallback(() => {
-    // Also an unlock gesture, so a table that rejoined after a refresh (with no
-    // fresh create-room tap) still wakes its audio before the deal.
     void unlockAudio();
     send({ type: "startHand" });
   }, [send]);
@@ -191,8 +175,6 @@ export function App() {
 
   const claimedSeatCount = seats.filter((seat) => seat.claimed).length;
   const handInProgress = handView !== null;
-  // The server rejects startHand/nextHand below two deal-in seats, so both
-  // controls key off the same count rather than a raw claimed-seat tally.
   const enoughPlayers = countDealInSeats(seats) >= MIN_SEAT_COUNT;
   const canStartHand = !handInProgress && enoughPlayers;
   const handComplete = isHandComplete(handView);

--- a/packages/table-client/src/Board.test.tsx
+++ b/packages/table-client/src/Board.test.tsx
@@ -129,11 +129,9 @@ describe("Board", () => {
     const html = renderToStaticMarkup(<Board view={view} />);
 
     expect(html).toMatch(/data-testid="board"[^>]*data-phase="showdown"/);
-    // The overlay owns the result now, so the felt drops the banner entirely.
     expect(html).not.toContain('data-testid="hand-complete-banner"');
     expect(html).not.toContain("Pair of Aces");
     expect(html).toMatch(/data-testid="community-cards"/);
-    // Only the 5 board cards — no seat's hole cards duplicated in the board.
     expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(5);
   });
 });

--- a/packages/table-client/src/Board.tsx
+++ b/packages/table-client/src/Board.tsx
@@ -12,7 +12,6 @@ export interface BoardProps {
   readonly seats?: readonly SeatView[];
 }
 
-/** The community cards, dealt in one at a time via Motion rather than CSS keyframes. */
 function CommunityCards({ board }: { readonly board: readonly CardType[] }) {
   return (
     <div
@@ -33,13 +32,6 @@ function CommunityCards({ board }: { readonly board: readonly CardType[] }) {
   );
 }
 
-/**
- * "Hand complete" pill grouped directly above the community cards — the
- * two move as one unit rather than the banner pinned to the felt's edge
- * independently of the board it's describing. Never says "you" (unlike
- * player-client's identical-looking banner, decision from issue #63)
- * since the table has no single viewer to address.
- */
 function HandCompleteBanner({ text }: { readonly text: string }) {
   return (
     <div
@@ -82,11 +74,6 @@ function HandCompleteBanner({ text }: { readonly text: string }) {
   );
 }
 
-/**
- * The felt's centre content — community cards, plus a "hand complete" banner
- * naming the winner only for the fold-out ending. At showdown the reveal
- * overlay (issue #169) owns the result, so the felt shows just the board.
- */
 export function Board({ view, seats = [] }: BoardProps) {
   if (view.phase === "no-hand") {
     return (
@@ -107,10 +94,6 @@ export function Board({ view, seats = [] }: BoardProps) {
   }
 
   if (view.phase === "showdown") {
-    // The reveal overlay (issue #169) owns the showdown result — winner(s),
-    // hands, and hole cards. The felt keeps only the community cards, so that
-    // "View table" reveals them behind the collapsed overlay; the redundant
-    // "Hand complete" banner is suppressed here.
     return (
       <div
         data-testid="board"

--- a/packages/table-client/src/HouseRulesSheet.test.tsx
+++ b/packages/table-client/src/HouseRulesSheet.test.tsx
@@ -80,9 +80,7 @@ const seats: SeatView[] = [
   },
 ];
 
-const noop = () => {
-  /* unused */
-};
+const noop = () => undefined;
 
 const shotClockProps = {
   pendingShotClock: null,
@@ -232,10 +230,6 @@ describe("HouseRulesSheet", () => {
     );
 
     expect(html).toContain('data-testid="sound-master-toggle"');
-    // Attribute order in the rendered tag is aria-checked, aria-label,
-    // data-testid, [disabled], style — so these contiguous substrings pin both
-    // the checked state and, via data-testid → style, that no disabled sits
-    // between them (master on ⇒ categories interactive).
     expect(html).toContain(
       'aria-checked="false" aria-label="Cards" data-testid="sound-cards-toggle" style=',
     );
@@ -304,9 +298,6 @@ describe("HouseRulesSheet", () => {
       valid: true,
     };
 
-    // Replacing the current value with 45 emits these two input events. The
-    // first value is transient, but must remain visible so the second digit
-    // can complete the valid setting.
     draft = updateShotClockSecondsDraft(draft, "4");
     expect(draft).toEqual({ input: "4", seconds: 90, valid: false });
     draft = updateShotClockSecondsDraft(draft, "45");

--- a/packages/table-client/src/HouseRulesSheet.tsx
+++ b/packages/table-client/src/HouseRulesSheet.tsx
@@ -79,11 +79,6 @@ export interface ShotClockSecondsDraft {
   readonly valid: boolean;
 }
 
-/**
- * Keeps transient keystrokes visible while committing only valid settings.
- * For example, replacing 90 with 45 naturally produces "4" before "45";
- * "4" is retained in the input but does not overwrite the last valid value.
- */
 export function updateShotClockSecondsDraft(
   draft: ShotClockSecondsDraft,
   input: string,
@@ -100,11 +95,6 @@ export function updateShotClockSecondsDraft(
   return { ...draft, input, valid: false };
 }
 
-/**
- * A single on/off switch. `nested` renders the smaller, indented variant used
- * by the sub-settings under a master toggle; `disabled` greys it out and blocks
- * interaction (a category toggle while its master is off).
- */
 function Toggle({
   label,
   checked,
@@ -183,7 +173,6 @@ function Toggle({
   );
 }
 
-/** The table-device House rules sheet; seat count is its first setting. */
 export function HouseRulesSheet({
   seatCount,
   pendingSeatCount,
@@ -431,9 +420,6 @@ export function HouseRulesSheet({
                   {moves
                     .map(
                       (move) =>
-                        // The destination stays labelled: a bare number beside
-                        // a name reads as a score, and numeric names ("7→2")
-                        // would be unreadable otherwise.
                         `${seatLabel(move.from, seats)} → Seat ${String(move.to + 1)}`,
                     )
                     .join(", ")}

--- a/packages/table-client/src/JoinCodeToggle.test.tsx
+++ b/packages/table-client/src/JoinCodeToggle.test.tsx
@@ -3,9 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { JoinCodeToggle } from "./JoinCodeToggle.js";
 
-const noop = () => {
-  /* unused in these tests */
-};
+const noop = () => undefined;
 
 describe("JoinCodeToggle", () => {
   it("shows the room code and a Room label", () => {
@@ -26,12 +24,6 @@ describe("JoinCodeToggle", () => {
     expect(html).not.toContain("position:absolute");
   });
 
-  /*
-   * Shrinkable rather than fixed, so a narrow bar squeezes this pill instead
-   * of pushing the badge beside it off the edge (ADR-0006). The label gives
-   * way; the code is what a player has to read off the screen to join, so it
-   * is fixed.
-   */
   it("gives up its label before the room code", () => {
     const html = renderToStaticMarkup(
       <JoinCodeToggle roomCode="ABCD" onOpen={noop} />,

--- a/packages/table-client/src/JoinCodeToggle.tsx
+++ b/packages/table-client/src/JoinCodeToggle.tsx
@@ -6,13 +6,6 @@ export interface JoinCodeToggleProps {
   readonly onOpen: () => void;
 }
 
-/*
- * Shrinkable rather than fixed, so a narrow table screen squeezes this pill
- * instead of pushing the connection badge off the edge (ADR-0006). The
- * `min-width: 0` is on the wrapper, never on the button — the button's own
- * automatic minimum is what stops the room code being painted outside its
- * border.
- */
 const wrapperStyle: CSSProperties = {
   flex: "0 1 auto",
   minWidth: 0,
@@ -31,15 +24,6 @@ const buttonStyle: CSSProperties = {
   overflow: "hidden",
 };
 
-/**
- * Room pill in the status bar, letting the table device peek at the join
- * code/QR mid-hand without losing the board view.
- *
- * It opens the join card but never closes it: `App` unmounts the pill while
- * the card is up, so the card's own Hide button is the single close path. A
- * pill that could also close would need a second label and a second state for
- * a control that is off-screen whenever that state applies.
- */
 export function JoinCodeToggle({ roomCode, onOpen }: JoinCodeToggleProps) {
   return (
     <div style={wrapperStyle}>
@@ -49,8 +33,6 @@ export function JoinCodeToggle({ roomCode, onOpen }: JoinCodeToggleProps) {
         onClick={onOpen}
         style={buttonStyle}
       >
-        {/* The kicker yields first: it labels the pill, whereas the code is
-         * the thing a player has to read off the screen to join. */}
         <span
           style={{
             minWidth: 0,

--- a/packages/table-client/src/JoinPanel.test.tsx
+++ b/packages/table-client/src/JoinPanel.test.tsx
@@ -12,9 +12,7 @@ describe("JoinPanel", () => {
         qrCodeDataUrl="data:image/png;base64,xyz"
         lobbyHint="Waiting for at least two players"
         dismissable={false}
-        onDismiss={() => {
-          /* unused in this test */
-        }}
+        onDismiss={() => undefined}
       />,
     );
 
@@ -33,9 +31,7 @@ describe("JoinPanel", () => {
         qrCodeDataUrl={null}
         lobbyHint="Waiting for at least two players"
         dismissable={false}
-        onDismiss={() => {
-          /* unused in this test */
-        }}
+        onDismiss={() => undefined}
       />,
     );
 
@@ -50,9 +46,7 @@ describe("JoinPanel", () => {
         qrCodeDataUrl="data:image/png;base64,xyz"
         lobbyHint="New players are dealt in from the next hand"
         dismissable={true}
-        onDismiss={() => {
-          /* unused in this test */
-        }}
+        onDismiss={() => undefined}
       />,
     );
     const pinnedHtml = renderToStaticMarkup(
@@ -62,9 +56,7 @@ describe("JoinPanel", () => {
         qrCodeDataUrl="data:image/png;base64,xyz"
         lobbyHint="Waiting for at least two players"
         dismissable={false}
-        onDismiss={() => {
-          /* unused in this test */
-        }}
+        onDismiss={() => undefined}
       />,
     );
 
@@ -80,9 +72,7 @@ describe("JoinPanel", () => {
         qrCodeDataUrl="data:image/png;base64,xyz"
         lobbyHint="Waiting for at least two players"
         dismissable={false}
-        onDismiss={() => {
-          /* unused in this test */
-        }}
+        onDismiss={() => undefined}
         controls={<div data-testid="join-panel-controls">Controls</div>}
       />,
     );

--- a/packages/table-client/src/JoinPanel.tsx
+++ b/packages/table-client/src/JoinPanel.tsx
@@ -25,10 +25,6 @@ const overlayStyle: CSSProperties = {
   alignItems: "center",
   justifyContent: "center",
   background: color.overlay,
-  // The panel is centred and visually small, but this wrapper spans the
-  // whole felt — without this, its invisible edges swallow clicks on
-  // whatever sits behind them, like the "Deal hand" control in the
-  // bottom-right rail. Only the panel itself should be clickable.
   pointerEvents: "none",
 };
 
@@ -62,11 +58,6 @@ const kickerStyle: CSSProperties = {
   color: color.textMuted,
 };
 
-/**
- * The centred lobby overlay showing the room's QR/code/URL — pinned open
- * while `handView === null`, otherwise toggled by `JoinCodeToggle` and
- * dismissable so the board stays reachable mid-hand.
- */
 export function JoinPanel({
   roomCode,
   joinUrl,

--- a/packages/table-client/src/SeatCountPicker.test.tsx
+++ b/packages/table-client/src/SeatCountPicker.test.tsx
@@ -4,9 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { SeatCountPicker } from "./SeatCountPicker.js";
 
-const noop = () => {
-  /* unused in these tests */
-};
+const noop = () => undefined;
 
 function render(seatCount = MAX_SEAT_COUNT) {
   return renderToStaticMarkup(

--- a/packages/table-client/src/SeatCountPicker.tsx
+++ b/packages/table-client/src/SeatCountPicker.tsx
@@ -36,7 +36,6 @@ const kickerStyle: CSSProperties = {
   color: color.textMuted,
 };
 
-/** The chip is a felt token: round, weighty, and lit when it's the one chosen. */
 function chipStyle(selected: boolean): CSSProperties {
   return {
     width: 56,
@@ -64,19 +63,12 @@ function chipStyle(selected: boolean): CSSProperties {
   };
 }
 
-/** "Heads-up" reads better than "2 seats" for the smallest table we allow. */
 function describeTable(seatCount: number): string {
   return seatCount === MIN_SEAT_COUNT
     ? "Heads-up — two seats"
     : `${String(seatCount)} seats`;
 }
 
-/**
- * The room-creation step (issue #74): the creator sizes the table before
- * any room exists, so the code/QR in `JoinPanel` only ever appears for a
- * table that is already the right size. The 2-8 range comes from the
- * protocol, the same bounds the server enforces on `POST /rooms`.
- */
 export function SeatCountPicker({
   seatCount,
   onSeatCountChange,

--- a/packages/table-client/src/SeatMenu.test.tsx
+++ b/packages/table-client/src/SeatMenu.test.tsx
@@ -3,9 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { SeatMenu } from "./SeatMenu.js";
 
-const noop = () => {
-  /* unused in these tests */
-};
+const noop = () => undefined;
 
 describe("SeatMenu", () => {
   it("shows the seat number and an Evict action", () => {

--- a/packages/table-client/src/SeatMenu.tsx
+++ b/packages/table-client/src/SeatMenu.tsx
@@ -15,12 +15,6 @@ export interface SeatMenuProps {
   readonly onDismiss: () => void;
 }
 
-/**
- * The table device's manual seat action (ADR-0003) — click a claimed seat,
- * this pops up next to it with the one action currently available: Evict.
- * A full-screen backdrop dismisses it without acting, same as the join
- * panel's own dismiss pattern.
- */
 export function SeatMenu({
   seatId,
   seatCount,

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -308,8 +308,6 @@ describe("Seats", () => {
   });
 
   it("reveals nothing on the felt at showdown — no hole cards, hand, or winner mark", () => {
-    // The reveal overlay (issue #169) owns who-won and every hand; the seat
-    // pods stay plain so nothing shifts when the hand ends.
     const view: TableView = {
       phase: "showdown",
       button: 0,
@@ -386,8 +384,6 @@ describe("Seats", () => {
     };
     const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
 
-    // Reaching showdown keeps the seat in-hand rather than sitting-out, even
-    // though the felt no longer reveals its cards (the overlay does that).
     expect(html).toMatch(/data-testid="seat-pod-2"[^>]*data-status="in-hand"/);
     expect(html).not.toContain("hole-cards");
     expect(html).not.toContain('data-testid="seat-pod-2-sitting-out"');
@@ -424,7 +420,6 @@ describe("Seats", () => {
   });
 
   it("flips a top-row seat's identity placard so that side of the table reads it upright", () => {
-    // Four seats: 0 and 1 sit along the bottom edge, 2 and 3 along the top.
     const html = renderToStaticMarkup(
       <Seats
         seats={seats.map((seat) =>
@@ -442,8 +437,6 @@ describe("Seats", () => {
     expect(styleOf(html, "seat-pod-3-placard")).toContain(
       "transform:rotate(180deg)",
     );
-    // The identity is one row rather than the bottom row's column, so a
-    // top-row seat is only ever about an avatar deep however long the name.
     expect(styleOf(html, "seat-pod-3-placard")).toContain("flex-direction:row");
     expect(html).toMatch(
       /data-testid="seat-pod-3-placard"[\s\S]*data-testid="seat-pod-3-avatar"[\s\S]*data-testid="seat-pod-3-name"/,
@@ -460,8 +453,6 @@ describe("Seats", () => {
       />,
     );
 
-    // Same row, same order — only the rotation separates the two rows, so
-    // both players see an identically-shaped seat from where they sit.
     expect(html).toMatch(
       /data-testid="seat-pod-0-placard"[^>]*data-flipped="false"/,
     );
@@ -498,8 +489,6 @@ describe("Seats", () => {
       />,
     );
 
-    // The callout is a sibling of the placard, not a child of it, so it keeps
-    // its own inward footprint while still reading upright from the top side.
     expect(subtreeOf(html, "seat-pod-3-placard")).not.toContain("To act");
     expect(html).toMatch(
       /data-testid="seat-pod-3-placard"[\s\S]*data-testid="seat-pod-3-to-act"/,
@@ -561,8 +550,6 @@ describe("Seats", () => {
       />,
     );
 
-    // Seats 2 and 3 are the top row: one waiting for the next hand, one with
-    // a name long enough to need the caption's existing 8em bound.
     const waiting = subtreeOf(html, "seat-pod-2-placard");
     expect(waiting).toContain("Waiting for next hand");
     expect(waiting).toContain("Claimed after the deal");
@@ -595,8 +582,6 @@ describe("Seats", () => {
     const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
 
     expect(html).toMatch(/data-testid="seat-pod-2"[^>]*data-status="folded"/);
-    // The fade still lives on the surface, outside the rotation, so a flipped
-    // seat folds exactly as visibly as a bottom-row one.
     expect(styleOf(html, "seat-pod-2-surface")).toContain("opacity:0.34");
     expect(styleOf(html, "seat-pod-2-placard")).toContain(
       "transform:rotate(180deg)",
@@ -616,11 +601,6 @@ describe("Seats", () => {
   });
 });
 
-/**
- * The rendered markup of the `div` carrying `testid`, including its own tags —
- * enough to ask what is inside an element rather than merely near it, without
- * pinning a test to how deeply anything is nested.
- */
 function subtreeOf(html: string, testid: string): string {
   const start = html.indexOf(`<div data-testid="${testid}"`);
   expect(start).toBeGreaterThanOrEqual(0);
@@ -635,7 +615,6 @@ function subtreeOf(html: string, testid: string): string {
   throw new Error(`unclosed element for ${testid}`);
 }
 
-/** The inline `style` attribute of the span carrying `testid`, if drawn. */
 function styleOf(html: string, testid: string): string | null {
   const match = new RegExp(`data-testid="${testid}"[^>]*style="([^"]*)"`).exec(
     html,
@@ -644,8 +623,6 @@ function styleOf(html: string, testid: string): string | null {
 }
 
 const threeHanded: Extract<TableView, { phase: "betting" }> = {
-  // Seats 3, 0 and 1 are in the hand with the button on 3, so ring order
-  // (3 -> 0 -> 1) runs the opposite way to seat-number order.
   phase: "betting",
   turnEndsAt: null,
   button: 3,
@@ -690,8 +667,6 @@ describe("Seats: position markers", () => {
       <Seats seats={seats} view={threeHanded} />,
     );
 
-    // Seat 0 is the lowest seat number but sits button+1, so it is the small
-    // blind — seat-number arithmetic from the button would have said seat 4.
     expect(html).not.toContain('data-testid="seat-pod-0-button"');
     expect(html).not.toContain('data-testid="seat-pod-3-small-blind"');
     expect(html).not.toContain('data-testid="seat-pod-0-big-blind"');
@@ -717,8 +692,6 @@ describe("Seats: position markers", () => {
     expect(html).not.toContain('big-blind"');
   });
 
-  // Issue #160, decision 4: heads-up the button *is* the small blind, and the
-  // client suppresses both blinds rather than doubling up a seat.
   it.each([
     [
       "betting",
@@ -781,8 +754,6 @@ describe("Seats: position markers", () => {
     expect(sizes[0]).toBeDefined();
     expect(sizes[1]).toEqual(sizes[0]);
     expect(sizes[2]).toEqual(sizes[0]);
-    // The label's font size lives on an inner span, so the diameter resolves
-    // against the pod and not against the marker's own text.
     expect(sizes[0]?.[0]).toBe(sizes[0]?.[1]);
 
     const fontSizes = html.match(/font-size:0\.62em/g);

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -15,22 +15,13 @@ import { posFor } from "./table/posFor.js";
 export interface SeatsProps {
   readonly seats: readonly SeatView[];
   readonly view: TableView | null;
-  /** Current room setting, used only to scale the countdown colour ramp. */
   readonly shotClockSeconds?: number;
-  /** Called with a claimed seat's id when its pod is clicked — table-only, see ADR-0003. */
   readonly onSeatClick?: (seatId: number) => void;
 }
 
 type SeatStatus =
   "open" | "sitting-out" | "disconnected" | "folded" | "in-hand";
 
-/**
- * One diameter and one font size for all three markers, resolved against the
- * pod rather than against the marker's own text. The two are set on separate
- * elements on purpose: `width: 1.6em` and `fontSize: 0.6em` on the *same*
- * element made the true diameter `1.6 x 0.6em`, which is why the button
- * marker rendered at roughly a third of the avatar instead of half of it.
- */
 const MARKER_DIAMETER = "1.6em";
 const MARKER_FONT_SIZE = "0.62em";
 
@@ -43,11 +34,6 @@ interface SeatVisual {
   readonly avatarColor: string;
 }
 
-/**
- * Merges one seat's static room membership with whatever the in-progress
- * `view` knows about it — the single place `Seats` reasons about `TableView`'s
- * per-phase shape, so the render below stays a plain lookup.
- */
 function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
   const handSeat =
     view?.phase === "betting"
@@ -77,8 +63,6 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
           ? "folded"
           : "in-hand";
     } else if (participatedInCurrentHand) {
-      // `SeatView.sittingOut` may change during a hand, but the hand view is
-      // authoritative about whether this seat is still in that hand.
       status = "in-hand";
     } else {
       status = seat.disconnected
@@ -89,8 +73,6 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
     }
   }
 
-  // Showdown no longer marks a winning seat on the felt — the reveal overlay
-  // owns who-won (issue #169). Only the fold-out ending still crowns a seat.
   const isWinner =
     view?.phase === "folded-out" ? view.winner === seat.id : false;
 
@@ -119,12 +101,6 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
   };
 }
 
-/**
- * The seat pods ringing the felt's two long edges, percentage-positioned via
- * `posFor` so the layout holds across the table device's real viewport. This
- * is the only place `seats` and the in-progress `view` are merged into a
- * single per-seat picture — `Board` only ever renders the centre content.
- */
 export function Seats({
   seats,
   view,
@@ -136,17 +112,7 @@ export function Seats({
       {seats.map((seat) => {
         const visual = deriveSeat(seat, view);
         const pos = posFor(seat.id, seats.length);
-        // Bottom-row seats sit at posFor's ~90% and top-row at ~10%. The
-        // midline split below decides how a seat's contents are arranged and
-        // which way round its writing reads — it never repositions anything
-        // posFor already placed.
         const isTopRow = pos.top < 50;
-        // One rule, one place: everything a top-row seat writes turns half a
-        // revolution so the player at that edge reads it upright. Anything
-        // added to a pod later has to carry this too. The callout takes the
-        // number rather than the style because motion composes `rotate` into
-        // the same transform as its `y` and `scale`, and a CSS `transform`
-        // there would simply be overwritten.
         const flipDegrees = isTopRow ? 180 : 0;
         const flipStyle = isTopRow
           ? { transform: `rotate(${String(flipDegrees)}deg)` }
@@ -311,19 +277,6 @@ export function Seats({
           </div>
         );
 
-        // Every seat is a *placard* (issue #204): the avatar, marker, name and
-        // status in one row, avatar first. Both rows are built identically and
-        // only the top row is turned half a revolution, so each player reads
-        // an identically-shaped seat — avatar on their left, copy to its right
-        // — from wherever they are sitting.
-        //
-        // The row replaced a vertical stack, which trades depth for width: a
-        // seat now grows sideways from the anchor `posFor` placed rather than
-        // inward toward the felt's centre. That is deliberate. A row is only
-        // ever about one avatar tall however long the name, so it stays well
-        // clear of the rail behind it and the board in front, and rotation
-        // changes no layout box — the anchor and the seat's footprint are
-        // exactly what they'd be unrotated.
         const podContent = (
           <div
             data-testid={`seat-pod-${String(seat.id)}-placard`}
@@ -436,11 +389,6 @@ export function Seats({
                 <motion.div
                   data-testid={`seat-pod-${String(seat.id)}-to-act`}
                   data-flipped={isTopRow}
-                  // The callout stays a sibling of the placard, keeping its
-                  // own inward footprint below the seat; only its own text is
-                  // turned for a top-row player. `rotate` rides in the
-                  // animated transform so it composes with `y` and `scale`
-                  // rather than being overwritten by them.
                   initial={{
                     opacity: 0,
                     y: 6,
@@ -470,9 +418,6 @@ export function Seats({
             {seat.disconnected && (
               <span
                 data-testid={`seat-pod-${String(seat.id)}-disconnected`}
-                // Same copy either way; a top-row badge just turns with the
-                // rest of that seat's writing so one player never reads half
-                // their seat upside down.
                 style={flipStyle}
               >
                 Disconnected

--- a/packages/table-client/src/SettingsToggle.tsx
+++ b/packages/table-client/src/SettingsToggle.tsx
@@ -5,7 +5,6 @@ export interface SettingsToggleProps {
   readonly onToggle: () => void;
 }
 
-/** The 52px settings toggle in the top-right of the felt. */
 export function SettingsToggle({ open, onToggle }: SettingsToggleProps) {
   return (
     <button

--- a/packages/table-client/src/ShowdownOverlay.test.tsx
+++ b/packages/table-client/src/ShowdownOverlay.test.tsx
@@ -19,7 +19,6 @@ function seat(id: number, displayName?: string): SeatView {
 
 const seats: SeatView[] = [seat(0, "Mara"), seat(1, "Devin"), seat(2, "Priya")];
 
-/** A two-way showdown: seat 0 wins, seat 1 reached showdown and lost. */
 const showdown: ShowdownView = {
   phase: "showdown",
   button: 0,
@@ -93,14 +92,12 @@ describe("ShowdownOverlay", () => {
 
     expect(html).toContain('data-testid="showdown-overlay"');
     expect(html).toContain('data-testid="showdown-board"');
-    // Every seat that reached showdown appears, by name and hand description.
     expect(html).toContain('data-testid="showdown-player-0"');
     expect(html).toContain('data-testid="showdown-player-1"');
     expect(html).toContain("Mara");
     expect(html).toContain("Pair of Aces");
     expect(html).toContain("Devin");
     expect(html).toContain("Ace high");
-    // 5 board cards + 2 + 2 hole cards, all face up.
     expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(9);
   });
 

--- a/packages/table-client/src/ShowdownOverlay.tsx
+++ b/packages/table-client/src/ShowdownOverlay.tsx
@@ -9,21 +9,8 @@ import { AnimatePresence, motion } from "motion/react";
 import { useLayoutEffect, useRef, useState } from "react";
 import { seatLabel } from "./seatLabel.js";
 
-/**
- * The burger (settings) toggle lives in the top-right of the felt at
- * `top:20 right:24`, 52px square. The overlay reserves this much clearance at
- * the top so its panel never creeps under it. Kept in sync with
- * `SettingsToggle`.
- */
 const BURGER_CLEARANCE = "5.25rem";
 
-/**
- * Uniformly scales the measured content down until it fits inside the stage's
- * padding box, so every element shrinks together rather than the panel
- * clipping its own overflow. `offset*`/`client*` sizes are layout sizes and
- * ignore CSS transforms, so applying the returned scale never feeds back into
- * the measurement — no observer loop. Only ever scales down (never past 1).
- */
 function useFitToBox() {
   const stageRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -63,30 +50,17 @@ function useFitToBox() {
   return { stageRef, contentRef, scale };
 }
 
-/** The showdown shape of the table view — the only phase this overlay renders. */
 type ShowdownView = Extract<TableView, { phase: "showdown" }>;
 
 export interface ShowdownOverlayProps {
   readonly view: ShowdownView;
   readonly seats: readonly SeatView[];
-  /**
-   * `true` once "View table" is pressed: the overlay animates out so the felt
-   * and its controls are reachable, and the rail's "View showdown" button
-   * brings it back. Reset to `false` on each new showdown by the caller, so
-   * every hand opens featured.
-   */
   readonly collapsed: boolean;
-  /**
-   * Whether enough players are dealt in for the server to accept `nextHand` —
-   * mirrors the rail's own gate. False disables "Next hand" with a reason
-   * rather than dealing into a rejection.
-   */
   readonly canDealNextHand: boolean;
   readonly onNextHand: () => void;
   readonly onViewTable: () => void;
 }
 
-/** A row of face-up cards at a given em scale. */
 function CardRow({
   cards,
   scale,
@@ -105,7 +79,6 @@ function CardRow({
   );
 }
 
-/** The community cards, labelled, at the top of the overlay. */
 function BoardStrip({ board }: { readonly board: readonly CardType[] }) {
   return (
     <div
@@ -132,11 +105,6 @@ function BoardStrip({ board }: { readonly board: readonly CardType[] }) {
   );
 }
 
-/**
- * One revealed seat: cards, name, and hand description. Winners glow (a gentle
- * pulse via `.showdown-win-glow`) and, when `featured`, render larger so the
- * result reads at a glance across the table.
- */
 function OverlayPlayer({
   result,
   name,
@@ -302,18 +270,6 @@ function OverlayButtons({
   );
 }
 
-/**
- * The showdown reveal: a single centred panel over a dimmed felt (issue #169,
- * prototype variant E). It shows the board, every seat that reached showdown as
- * name + cards + hand description, and the winner(s) featured larger with a
- * pulsing green glow. It supersedes the per-seat reveal and the felt's winner
- * mark — who won lives only here.
- *
- * "View table" animates the panel out so the felt's own controls (house rules,
- * end session, join QR) are reachable; the rail's "View showdown" button brings
- * it back. The panel always fits its bounding box — content scales to the
- * viewport and never scrolls, heads-up or full ring.
- */
 export function ShowdownOverlay({
   view,
   seats,
@@ -347,7 +303,6 @@ export function ShowdownOverlay({
             background: "rgba(5,4,4,.6)",
             backdropFilter: "blur(2px)",
             padding: "1.5rem",
-            // Keep the panel out from under the top-right burger menu.
             paddingTop: BURGER_CLEARANCE,
           }}
         >

--- a/packages/table-client/src/StatusBar.test.tsx
+++ b/packages/table-client/src/StatusBar.test.tsx
@@ -3,9 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { StatusBar } from "./StatusBar.js";
 
-const noop = () => {
-  /* unused in these tests */
-};
+const noop = () => undefined;
 
 describe("StatusBar", () => {
   it("hides the connection badge before a room exists", () => {
@@ -61,12 +59,6 @@ describe("StatusBar", () => {
     expect(html).toContain("margin-left:auto");
   });
 
-  /*
-   * The badge used to be `flex: none`, so on a narrow table screen it was
-   * pushed off the right edge rather than giving way (ADR-0006). jsdom has no
-   * layout engine, so this guards the structure that fixes it: the badge
-   * shrinks first and hard, and its own minimum is the status dot.
-   */
   it("yields the connection label before the room pill gives ground", () => {
     const html = renderToStaticMarkup(
       <StatusBar
@@ -81,8 +73,6 @@ describe("StatusBar", () => {
       /<span[^>]*data-testid="connection-status"[^>]*>/.exec(html)?.[0] ?? "";
     expect(badge).toContain("flex-shrink:100");
     expect(badge).toContain("overflow:hidden");
-    // Not on the pill itself — that is what let it paint text outside its
-    // own border once it collapsed.
     expect(badge).not.toContain("min-width:0");
 
     const label =

--- a/packages/table-client/src/StatusBar.tsx
+++ b/packages/table-client/src/StatusBar.tsx
@@ -27,24 +27,10 @@ const badgeStyle: CSSProperties = {
   borderRadius: radius.pill,
   background: color.control,
   border: `1px solid ${color.border}`,
-  /*
-   * Precedence as a shrink weight, as on the player's bar (ADR-0006): the
-   * connection is the first thing to give way, yielding its label ~100×
-   * faster than the room pill beside it. No `min-width: 0` here — the pill's
-   * automatic minimum is its own dot, so it stops there rather than
-   * collapsing and painting its text outside its border.
-   */
   flexShrink: 100,
   overflow: "hidden",
 };
 
-/**
- * No connection badge before a room exists — there's nothing to connect to yet.
- *
- * The badge is pushed right by its own auto margin rather than by the header's
- * justification, because the room-code pill on the left comes and goes: with
- * `space-between` alone, a lone badge would sit hard left.
- */
 export function StatusBar({
   roomCode,
   connectionStatus,
@@ -82,8 +68,6 @@ export function StatusBar({
               background: tone.dot,
             }}
           />
-          {/* First to go when the bar is tight — the dot beside it keeps
-           * reporting the state in colour. */}
           <span
             className="connection-status-label"
             style={{

--- a/packages/table-client/src/TableControls.test.tsx
+++ b/packages/table-client/src/TableControls.test.tsx
@@ -4,9 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { TableControls } from "./TableControls.js";
 
-const noop = () => {
-  /* unused in these tests */
-};
+const noop = () => undefined;
 
 describe("TableControls", () => {
   it("shows Deal hand when a hand can start, and always shows End session", () => {

--- a/packages/table-client/src/TableControls.tsx
+++ b/packages/table-client/src/TableControls.tsx
@@ -20,8 +20,6 @@ const layoutStyles: Record<TableControlsPlacement, CSSProperties> = {
     width: "26em",
     maxWidth: "calc(100vw - 2em)",
     gap: "0.6em",
-    // The join overlay turns pointer events off so its invisible edges don't
-    // swallow clicks on the felt; the controls have to turn them back on.
     pointerEvents: "auto",
   },
 };
@@ -31,11 +29,6 @@ const actionButtonStyles: Record<TableControlsPlacement, CSSProperties> = {
   "join-panel": { flex: "1 1 0", minWidth: 0 },
 };
 
-/**
- * The reason under a disabled "Next hand". A greyed pill says the action is
- * off but not why, and the lobby hint that carries the same message is hidden
- * once a hand exists — so the rail has to say it itself.
- */
 const hintStyle: CSSProperties = {
   marginTop: "0.4em",
   textAlign: "center",
@@ -46,53 +39,18 @@ const hintStyle: CSSProperties = {
 export interface TableControlsProps {
   readonly canStartHand: boolean;
   readonly handComplete: boolean;
-  /**
-   * Whether enough players are dealt in for the server to accept `nextHand`.
-   * False leaves the button in place but disabled with a reason, rather than
-   * live-looking and inert — the server rejects it either way.
-   */
   readonly canDealNextHand: boolean;
   readonly onStartHand: () => void;
   readonly onNextHand: () => void;
   readonly onEndSession: () => void;
-  /** Test-mode-only control for filling free seats with virtual players. */
   readonly testMode?: boolean;
   readonly onAddBot?: () => void;
-  /**
-   * At showdown the reveal overlay owns "Next hand", so the rail offers "View
-   * showdown" in that slot instead — reopening the overlay the operator
-   * collapsed with "View table". True only at the showdown phase, never at the
-   * fold-out ending, which keeps its own "Next hand".
-   */
   readonly atShowdown?: boolean;
   readonly onViewShowdown?: () => void;
   readonly placement?: TableControlsPlacement;
-  /**
-   * PROTOTYPE (wayfinder #81) — opens the session hand picker. Optional so
-   * the live `App` is unaffected; Phase 2 makes it a peer of the other rail
-   * actions. Review is reachable exactly when this rail offers a Deal/Next
-   * hand button, i.e. between hands (map #79).
-   */
   readonly onReviewHands?: () => void;
 }
 
-/**
- * The table action group — a right-hand control rail during a hand, or a
- * group below the join panel while the room is waiting to start. Deal hand /
- * Next hand are mutually exclusive with the felt's hand state; Review hands
- * and End session are always available once a room exists (this component is
- * only mounted then).
- *
- * The rail is a fixed-width column and every button fills it, so the actions
- * share one left and right edge instead of ragging off the right margin at
- * whatever width each label happens to be. Sizing comes from `PillButton`'s
- * size token for all of them — an ad-hoc smaller `End session` made the rail
- * read as two unrelated controls rather than one group.
- *
- * The two secondary actions take the plain outline tone with no per-call
- * colour of their own, so the rail's only visual hierarchy is solid (deal the
- * next hand) against outline (everything else).
- */
 export function TableControls({
   canStartHand,
   handComplete,

--- a/packages/table-client/src/api/rooms.ts
+++ b/packages/table-client/src/api/rooms.ts
@@ -19,7 +19,6 @@ export interface BotsAdded {
   readonly joined: number;
 }
 
-/** Reads server-global capabilities once when the table client boots. */
 export async function fetchConfig(): Promise<ServerConfig> {
   const response = await fetch("/config", { method: "GET" });
   if (!response.ok) {
@@ -28,14 +27,6 @@ export async function fetchConfig(): Promise<ServerConfig> {
   return (await response.json()) as ServerConfig;
 }
 
-/**
- * Confirms a room is still live before the table re-attaches on refresh
- * (#175). The WebSocket handshake 404s for a dead room, but a browser socket
- * can't tell that rejection from a transient drop, so the reconnect loop would
- * retry forever — this HTTP check decides existence up front, mirroring the
- * player client's reclaim-on-mount. Rejects on a 404 (grace window elapsed) or
- * any non-2xx.
- */
 export async function fetchRoom(code: string): Promise<RoomView> {
   const response = await fetch(`/rooms/${code}/join`, { method: "POST" });
   if (!response.ok) {
@@ -44,7 +35,6 @@ export async function fetchRoom(code: string): Promise<RoomView> {
   return (await response.json()) as RoomView;
 }
 
-/** `seatCount` is the table size the creator picked — 2-8, re-validated server-side. */
 export async function createRoom(seatCount: number): Promise<CreatedRoom> {
   const response = await fetch("/rooms", {
     method: "POST",
@@ -64,7 +54,6 @@ export async function endSession(code: string): Promise<void> {
   }
 }
 
-/** The test-mode table action that fills currently-free seats with bots. */
 export async function addBots(code: string, count: number): Promise<BotsAdded> {
   const response = await fetch(`/rooms/${code}/bots`, {
     method: "POST",
@@ -77,7 +66,6 @@ export async function addBots(code: string, count: number): Promise<BotsAdded> {
   return (await response.json()) as BotsAdded;
 }
 
-/** The table device's manual evict action (ADR-0003) — no automatic trigger. */
 export async function evictSeat(code: string, seatId: number): Promise<void> {
   const response = await fetch(`/rooms/${code}/seats/${String(seatId)}/evict`, {
     method: "POST",
@@ -87,7 +75,6 @@ export async function evictSeat(code: string, seatId: number): Promise<void> {
   }
 }
 
-/** The table device's House rules setting for the room seat count. */
 export async function changeSeatCount(
   code: string,
   seatCount: number,
@@ -103,7 +90,6 @@ export async function changeSeatCount(
   return (await response.json()) as SeatCountChange;
 }
 
-/** The table device's room-wide tactile-sound settings (#182). */
 export async function changeSoundSettings(
   code: string,
   settings: SoundSettings,
@@ -121,7 +107,6 @@ export async function changeSoundSettings(
   return (await response.json()) as SoundSettings;
 }
 
-/** The table device's deferred room-wide action-clock settings. */
 export async function changeShotClockSettings(
   code: string,
   settings: ShotClockSettings,

--- a/packages/table-client/src/main.tsx
+++ b/packages/table-client/src/main.tsx
@@ -10,9 +10,6 @@ if (!rootEl) {
   throw new Error("#root element not found");
 }
 
-// Discover server-global capabilities once per page load. The store defaults
-// to the safe/off state if the endpoint is unavailable, so a transient fetch
-// failure never exposes test-only UI by accident.
 void fetchConfig()
   .then(({ testMode }) => {
     useTableStore.getState().setTestMode(testMode);

--- a/packages/table-client/src/seatLabel.ts
+++ b/packages/table-client/src/seatLabel.ts
@@ -1,11 +1,5 @@
 import type { SeatView } from "@table-top-poker/protocol";
 
-/**
- * A seat's human label: its claimed display name, or a 1-based "Seat N"
- * fallback for open or unnamed seats. The one place the table client turns a
- * `seatId` into text, shared by the board, the house-rules sheet, and the
- * showdown overlay so they never drift.
- */
 export function seatLabel(seatId: number, seats: readonly SeatView[]): string {
   return (
     seats.find((seat) => seat.id === seatId)?.displayName ??

--- a/packages/table-client/src/storage/hostedRoom.ts
+++ b/packages/table-client/src/storage/hostedRoom.ts
@@ -6,23 +6,10 @@ export interface HostedRoom {
   readonly qrCodeDataUrl: string;
 }
 
-/**
- * Persists the room this table is hosting so a refresh can re-attach to it
- * instead of dropping back to the create-room screen (#175). The QR/join URL
- * are server-derived at creation and absent from `room-view`, so they ride
- * along here to keep the lobby intact across a reload. Takes an injected
- * `Storage` so callers pass `window.localStorage` or a test double without
- * reaching for a global.
- */
 export function saveHostedRoom(storage: Storage, room: HostedRoom): void {
   storage.setItem(KEY, JSON.stringify(room));
 }
 
-/**
- * Reads back a stored hosted room for auto-rejoin on mount. Malformed or
- * absent storage both read as "nothing to rejoin" — the client then falls
- * through to the create-room screen.
- */
 export function loadHostedRoom(storage: Storage): HostedRoom | null {
   const raw = storage.getItem(KEY);
   if (raw === null) return null;

--- a/packages/table-client/src/table/posFor.ts
+++ b/packages/table-client/src/table/posFor.ts
@@ -1,16 +1,8 @@
 export interface SeatPosition {
-  /** Percent from the felt's left edge. */
   readonly left: number;
-  /** Percent from the felt's top edge. */
   readonly top: number;
 }
 
-/**
- * Lays seats out along the two long edges of the felt — 1..k left to right
- * along the bottom, then back right to left along the top. The percentages are
- * tuned for the table device's actual viewport, and are the source of truth
- * for the layout.
- */
 export function posFor(seatId: number, seatCount: number): SeatPosition {
   const bottomCount = Math.ceil(seatCount / 2);
   if (seatId < bottomCount) {

--- a/packages/table-client/src/ws/getWebSocketUrl.ts
+++ b/packages/table-client/src/ws/getWebSocketUrl.ts
@@ -3,7 +3,6 @@ export interface WsLocation {
   readonly host: string;
 }
 
-/** Derives the WebSocket scheme from `location.protocol` — never hard-coded. */
 export function getWebSocketUrl(
   location: WsLocation,
   params: Record<string, string> = {},

--- a/packages/table-client/src/ws/useWebSocket.ts
+++ b/packages/table-client/src/ws/useWebSocket.ts
@@ -8,30 +8,15 @@ import { useTableStore } from "../store/store.js";
 import { getWebSocketUrl } from "./getWebSocketUrl.js";
 
 export interface UseWebSocketOptions {
-  /** The room ended — manual "End session" or the table's own grace window elapsing. */
   readonly onRoomEnded?: () => void;
 }
 
 export interface TableSocket {
-  /** No-ops silently while disconnected — buttons are gated on connection state upstream. */
   readonly send: (command: ClientCommand) => void;
 }
 
 const RETRY_DELAY_MS = 1500;
 
-/**
- * Opens a room-scoped WebSocket connection once a room exists and reflects
- * its lifecycle into the connection slice. Every `room-view` push replaces
- * the seat slice; every `hand-update`/`view-snapshot` replaces the hand
- * slice with the fresh `view(state, 'table')` the server just computed —
- * the view is source of truth (Phase 1 spec #130 §6), never rebuilt from
- * the raw event locally. `command-rejected` renders nothing on the table
- * device by design (§9 — only the rejecting player ever sees a rejection).
- *
- * A dropped socket retries after a fixed delay — the table device is
- * expected to keep trying for the whole 60s grace window (§7); the server,
- * not this hook, is what ends the room if it never reconnects in time.
- */
 export function useWebSocket(
   roomCode: string | null,
   options: UseWebSocketOptions = {},
@@ -76,13 +61,8 @@ export function useWebSocket(
         const message: ServerMessage = JSON.parse(event.data) as ServerMessage;
         if (message.type === "room-view") {
           setRoomView(message.view);
-          // Mirror the room's sound settings (#182) into the audio engine's
-          // gate so cue playback honours the table-controlled master/category.
           applyRoomSoundSettings(message.view.soundSettings);
         } else if (message.type === "hand-update") {
-          // The server only ever sends a table-role socket a `view(state, 'table')`.
-          // Applied the moment it arrives — animation and cue together, never
-          // held back for another surface's sound.
           setHandView(message.view);
           onHandUpdate({
             surface: "table",
@@ -90,8 +70,6 @@ export function useWebSocket(
             view: message.view,
           });
         } else if (message.type === "view-snapshot") {
-          // A snapshot (fresh join/reconnect) shows the authoritative state
-          // silently — no cue, so a rejoin can't replay a burst (#175).
           setHandView(message.view);
         } else if (message.type === "room-ended") {
           optionsRef.current.onRoomEnded?.();

--- a/packages/table-client/vite.config.ts
+++ b/packages/table-client/vite.config.ts
@@ -1,13 +1,6 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv } from "vite";
 
-// A release build (ticket 34) is staged at packages/server/public/table and
-// served for GET / — its asset URLs need that prefix baked in. The dev
-// server still serves everything from "/", so only `build` gets it.
-
-// Hostnames the dev server may be reached by, comma separated. Set it to open
-// the client from another device (e.g. a tailnet name); unset keeps the dev
-// server bound to localhost.
 const repoRoot = new URL("../..", import.meta.url).pathname;
 
 export default defineConfig(({ command, mode }) => {

--- a/packages/ui-shared/src/Card.test.tsx
+++ b/packages/ui-shared/src/Card.test.tsx
@@ -22,7 +22,6 @@ describe("Card", () => {
     const html = renderToStaticMarkup(<Card rank="Q" suit="diamonds" />);
     expect(html.match(/class="card-index/g)).toHaveLength(2);
     expect(html).toContain("rotate(180deg)");
-    // Both copies carry the rank, so a card lifted from either corner reads.
     expect(html.match(/Q/g)?.length).toBeGreaterThanOrEqual(2);
   });
 

--- a/packages/ui-shared/src/Card.tsx
+++ b/packages/ui-shared/src/Card.tsx
@@ -6,11 +6,6 @@ export type CardProps =
   | { readonly faceDown: true }
   | { readonly faceDown?: false; readonly rank: Rank; readonly suit: Suit };
 
-/**
- * Exported so consumers that draw their own card-shaped surfaces — a curling
- * corner, a chip label — spell a suit the same way this component does, rather
- * than keeping a second copy of the mapping that can drift from it.
- */
 export const suitSymbols: Record<Suit, string> = {
   clubs: "♣",
   diamonds: "♦",
@@ -20,7 +15,6 @@ export const suitSymbols: Record<Suit, string> = {
 
 const redSuits: ReadonlySet<Suit> = new Set(["diamonds", "hearts"]);
 
-/** Which of the two ink colours a suit is printed in. */
 export function isRedSuit(suit: Suit): boolean {
   return redSuits.has(suit);
 }
@@ -28,29 +22,12 @@ export function isRedSuit(suit: Suit): boolean {
 const baseStyle: CSSProperties = {
   width: "3.5em",
   height: "5em",
-  // Self-relative, not `radius.card` (a fixed px token): consumers shrink
-  // this component's whole box by wrapping it in a smaller font-size
-  // context (seat-pod and multi-way showdown reveals go well under 1em),
-  // and a fixed px radius doesn't shrink with them — past a certain point
-  // it swallows the rank/suit entirely. `em` here resolves against this
-  // card's own font-size, the same one `width`/`height` scale from, so
-  // the corner stays the same small, rectangular-not-round proportion of
-  // the card (~6% of its width) at every size.
   borderRadius: "0.2em",
   boxSizing: "border-box",
   fontFamily: font.body,
   userSelect: "none",
 };
 
-/**
- * Renders a card as DOM elements, branching on `faceDown` rather than
- * swapping an `<img>` src — required so Phase 3's flip animation can
- * cross-fade between the two branches instead of a network image swap.
- *
- * Face styling follows the hole card, the larger of the two card treatments;
- * the board card differs slightly (radius, border, shadow) but the two aren't
- * different enough to justify a second component.
- */
 export function Card(props: CardProps) {
   if (props.faceDown) {
     return (
@@ -88,28 +65,11 @@ export function Card(props: CardProps) {
       >
         {suitSymbols[suit]}
       </span>
-      {/* Rotated a half-turn in the opposite corner, as a real card is
-       * printed — so the card reads the same way up whichever end you are
-       * looking at, and lifting either corner uncovers a legible index. */}
       <Index rank={rank} suit={suit} mirrored />
     </div>
   );
 }
 
-/**
- * The shared look of a corner index, exported so that a consumer drawing an
- * index of its own — the player client's curling corner draws one where the
- * fold uncovers it — matches this one instead of guessing at it.
- *
- * Sized against the card, never in px, so it holds at every scale the card is
- * used at — seat pods and multi-way reveals shrink the whole box well under
- * `1em`. An earlier `0.51em` (24px on a 164px card) read as too small on a
- * real screen; this sits between that and the `1.1em` it replaced.
- *
- * There is an upper bound worth knowing about: much past `1.1em` the index
- * stops being a corner mark and reaches into the middle of the card, far
- * enough that the player client's fold drags it onto the lifted flap.
- */
 export const cardIndexStyle: CSSProperties = {
   position: "absolute",
   display: "flex",
@@ -120,18 +80,12 @@ export const cardIndexStyle: CSSProperties = {
   lineHeight: 0.78,
 };
 
-/** The suit symbol sitting under the rank, sized against the index. */
 export const cardIndexSuitStyle: CSSProperties = {
   marginTop: "0.2em",
   fontSize: "0.75em",
   fontWeight: 400,
 };
 
-/**
- * The corner index: rank above its suit. Printed twice per face, the second
- * copy rotated, which is what lets a card be read from a lifted corner rather
- * than only from a fully exposed face.
- */
 function Index({
   rank,
   suit,

--- a/packages/ui-shared/src/Panel.tsx
+++ b/packages/ui-shared/src/Panel.tsx
@@ -12,12 +12,6 @@ const baseStyle: CSSProperties = {
   WebkitBackdropFilter: "blur(3px)",
 };
 
-/**
- * The blurred dark card container behind the settings sheet, join panel, and
- * side menu. Defaults match the join panel exactly; the settings sheet
- * (opaque gradient, no self-blur) and the side menu (drawer shape, no
- * radius) diverge, so those consumers override `background`/`style`.
- */
 export function Panel({ style, ...rest }: PanelProps) {
   return <div {...rest} style={{ ...baseStyle, ...style }} />;
 }

--- a/packages/ui-shared/src/PillButton.tsx
+++ b/packages/ui-shared/src/PillButton.tsx
@@ -29,19 +29,10 @@ const toneStyle: Record<PillButtonTone, CSSProperties> = {
     color: color.textMuted,
     fontFamily: font.mono,
     fontWeight: 600,
-    // No `textTransform` and normal tracking: every pill reads in the sentence
-    // case its label is written in, so a rail of mixed tones doesn't look like
-    // two different vocabularies. Primary vs secondary is carried by the fill.
     letterSpacing: "0.04em",
   },
 };
 
-/**
- * One disabled look for every pill, whatever its tone. A disabled action still
- * has to read as the same control it was a moment ago — same size, same
- * position — so only the fill, the ink and the cursor change. This lives here
- * rather than at the call sites: three of them had grown their own copy of it.
- */
 const disabledStyle: CSSProperties = {
   background: color.controlFill,
   color: color.disabledText,
@@ -50,14 +41,6 @@ const disabledStyle: CSSProperties = {
   cursor: "default",
 };
 
-/**
- * The rounded pill used for table/player actions. `tone="solid"` is the
- * cream gradient for primary actions ("Deal hand", "Create room"); `tone="outline"`
- * is the muted mono-label pill used for secondary actions ("End session").
- *
- * Both tones render their label as written — the distinction is the fill, not
- * the casing. Labels are therefore authored in sentence case at the call site.
- */
 export function PillButton({
   size = "md",
   tone = "solid",

--- a/packages/ui-shared/src/ShotClock.tsx
+++ b/packages/ui-shared/src/ShotClock.tsx
@@ -4,17 +4,13 @@ import { color, font, fontSize, radius } from "./theme.js";
 export type ShotClockVariant = "ring" | "number";
 
 export interface ShotClockProps {
-  /** Absolute server deadline in epoch milliseconds. */
   readonly turnEndsAt: number | null;
-  /** Configured duration, used only to scale the colour ramp. */
   readonly durationSeconds: number;
   readonly variant: ShotClockVariant;
   readonly testId: string;
-  /** Position for the avatar number badge; ring layout ignores this. */
   readonly numberPosition?: "top-right" | "bottom-right";
 }
 
-/** Green while ample time remains, through amber, to red at the deadline. */
 export function shotClockColor(fraction: number): string {
   const remaining = Math.max(0, Math.min(1, fraction));
   const hue =
@@ -44,10 +40,6 @@ function useNow(): number {
   return now;
 }
 
-/**
- * A render-only countdown. The server owns expiry and remains the only side
- * that can synthesize an action; this component never sends commands.
- */
 export function ShotClock({
   turnEndsAt,
   durationSeconds,

--- a/packages/ui-shared/src/positionMarker.test.ts
+++ b/packages/ui-shared/src/positionMarker.test.ts
@@ -42,8 +42,6 @@ describe("positionMarkerFor", () => {
   });
 
   it("reads a player view and a table view the same way", () => {
-    // The whole reason this rule left table-client: both devices must answer
-    // identically for the same seat.
     for (const seatId of [0, 1, 2, 3]) {
       expect(positionMarkerFor(seatId, bettingPlayer)).toBe(
         positionMarkerFor(seatId, bettingTable),
@@ -62,8 +60,6 @@ describe("positionMarkerFor", () => {
   });
 
   describe("heads-up (issue #160, decision 4)", () => {
-    // The engine honestly reports smallBlind === button heads-up. Rather than
-    // put two markers on one seat, the whole trio reverts to button-only.
     const headsUp = {
       button: 0,
       smallBlind: 0,
@@ -88,10 +84,7 @@ describe("positionMarkerFor", () => {
 
     it.each(cases)("marks the button and nothing else (%s)", (_phase, view) => {
       expect(positionMarkerFor(0, view)).toBe("button");
-      // Not "small-blind", though the button genuinely posts it heads-up…
       expect(positionMarkerFor(1, view)).toBeNull();
-      // …and the other seat gets no BB either, on the phone as on the table
-      // (issue #207, decision 2).
     });
 
     it("still marks the blinds once a third seat is dealt in", () => {

--- a/packages/ui-shared/src/positionMarker.ts
+++ b/packages/ui-shared/src/positionMarker.ts
@@ -1,14 +1,6 @@
 import type { PlayerView, SeatId, TableView } from "@table-top-poker/protocol";
 import { color } from "./theme.js";
 
-/**
- * Which positional marker a seat carries, if any. Never more than one.
- *
- * Both devices show the same three markers, so the rule that picks one lives
- * here rather than in either client: the table draws it on every seat pod, the
- * player screen draws it for the one seat that is theirs, and neither can drift
- * from the other's answer for the same seat.
- */
 export type PositionMarker = "button" | "small-blind" | "big-blind";
 
 export const positionMarkerLabel: Record<PositionMarker, string> = {
@@ -23,35 +15,11 @@ export const positionMarkerColor: Record<PositionMarker, string> = {
   "big-blind": color.blindBigMarker,
 };
 
-/**
- * Which marker this seat carries. All three come off the same view, so the
- * trio always moves on one tick and no seat ever carries two.
- *
- * Two suppressions, both deliberate:
- *
- * - Between hands (`no-hand`) only the button shows. The engine reports no
- *   blinds without a hand, and the button it does report is already a
- *   forecast of the next deal.
- * - **Heads-up (`dealtSeatCount === 2`) only the button shows — no `SB` on
- *   the button seat, and no `BB` on the other seat either.** The engine
- *   honestly reports `smallBlind === button` heads-up (the button does post
- *   the small blind), which would put two markers on one seat. Rather than
- *   stack or combine them, a heads-up hand reverts to exactly the display
- *   that existed before blind markers were added. This is a decision
- *   (issue #160, decision 4), not an oversight.
- *
- * The second suppression is a table-shaped rule applied to both devices on
- * purpose (issue #207, decision 2): a player screen shows one seat, so it has
- * no collision to resolve and could name the heads-up big blind — but then the
- * phone would mark a seat the table beside it deliberately leaves bare.
- */
 export function positionMarkerFor(
   seatId: SeatId,
   view: PlayerView | TableView | null,
 ): PositionMarker | null {
   if (view === null) return null;
-  // Heads-up is a property of the deal, not of who is still live: folds never
-  // change it, so this reads the same in every phase of the hand.
   const headsUp = view.phase !== "no-hand" && view.dealtSeatCount === 2;
   if (view.phase === "no-hand" || headsUp) {
     return seatId === view.button ? "button" : null;

--- a/packages/ui-shared/src/sound/cues.ts
+++ b/packages/ui-shared/src/sound/cues.ts
@@ -1,17 +1,5 @@
 import type { SoundSettings } from "@table-top-poker/protocol";
 
-/**
- * The six production cues, each backed by one canonical `.wav` asset (#185)
- * served same-origin from `public/sounds/`. Card foley — deal, board, fold,
- * flip (reveal/conceal), check-knock — plus the one non-card cue, the your-turn
- * prompt. `call`/`raise` are deliberately unallocated: no chip asset exists yet.
- *
- * WAV (uncompressed PCM), not AAC/`.m4a`: iOS Safari's `decodeAudioData` reject
- * the AAC set on some devices (an iPadOS 27 table returned "Decoding failed" for
- * every file while the same build decoded them on an iPhone) — PCM needs no
- * codec, so it decodes on every surface. The clips are short, so the size cost
- * is a few hundred KB each, warmed once on unlock.
- */
 export const CUE_FILES = {
   deal: "deal.wav",
   board: "board.wav",
@@ -25,12 +13,6 @@ export type CueName = keyof typeof CUE_FILES;
 
 export const CUE_NAMES = Object.keys(CUE_FILES) as CueName[];
 
-/**
- * Which room-level category (#182) each cue belongs to. `cards` is the tactile
- * card foley (deal, board, flip); `actions` is player actions (fold, check);
- * `notifications` is the your-turn prompt. A cue plays only when the room's
- * master switch and its category are both on — see `cueAllowed`.
- */
 export const CUE_CATEGORY: Record<
   CueName,
   "cards" | "actions" | "notifications"
@@ -43,12 +25,6 @@ export const CUE_CATEGORY: Record<
   yourTurn: "notifications",
 };
 
-/**
- * Whether the room's settings (#182) currently allow this cue: the master
- * switch on, and the cue's category (cards / actions / notifications) on. This
- * is the real mute path — the table owns it and it reaches every surface via
- * `room-view`.
- */
 export function cueAllowed(settings: SoundSettings, cue: CueName): boolean {
   if (!settings.sounds) return false;
   switch (CUE_CATEGORY[cue]) {

--- a/packages/ui-shared/src/sound/engine.test.ts
+++ b/packages/ui-shared/src/sound/engine.test.ts
@@ -19,11 +19,6 @@ const ALL_ON: SoundSettings = {
 const CARD: Card = { rank: "A", suit: "spades" };
 const pair = (): [Card, Card] => [CARD, CARD];
 
-/**
- * A test rig over a sound engine with fully deterministic effects: a `play`
- * spy, a hand-cranked clock and a scheduler that records callbacks so a test
- * can inspect the fired delays and flush the timers when it chooses.
- */
 function rig(settings: SoundSettings = ALL_ON): {
   engine: SoundEngine;
   played: CueName[];
@@ -50,7 +45,6 @@ function rig(settings: SoundSettings = ALL_ON): {
       clock = t;
     },
     flush: () => {
-      // Run in scheduled order; drain so re-flush is a no-op.
       const pending = scheduled.splice(0);
       for (const { fn } of pending) fn();
     },
@@ -76,7 +70,6 @@ const actionTaken = (
   action: "fold" | "check" | "call" | "raise",
 ): HandEvent => ({ type: "ActionTaken", seatId, action });
 
-/** A player betting view whose turn state is `myTurn`. */
 const bettingView = (myTurn: boolean): PlayerView => ({
   phase: "betting",
   turnEndsAt: null,
@@ -93,17 +86,11 @@ const bettingView = (myTurn: boolean): PlayerView => ({
   dealtSeatCount: 2,
 });
 
-/**
- * The table's redacted `HoleCardsDealt`: the server strips every seat's cards
- * before the event reaches the table role (secrecy, #130 §4), so its `deals`
- * arrive empty. The sweep count must come from the view, not this payload.
- */
 const tableHoleCardsDealt = (): HandEvent => ({
   type: "HoleCardsDealt",
   deals: [],
 });
 
-/** A table betting view for a hand dealt to `dealtSeatCount` seats. */
 const tableBettingView = (dealtSeatCount: number): TableView => ({
   phase: "betting",
   turnEndsAt: null,
@@ -125,8 +112,6 @@ const noHandView: TableView = { phase: "no-hand", button: 0 };
 describe("event → cue mapping", () => {
   it("stays silent on the table through the hole-card deal (revised #180)", () => {
     const r = rig();
-    // Hole cards are a per-player cue now: the table voices only the board, so
-    // a HoleCardsDealt on the table surface schedules and plays nothing.
     r.engine.onHandUpdate({
       surface: "table",
       event: tableHoleCardsDealt(),
@@ -167,8 +152,6 @@ describe("event → cue mapping", () => {
 
   it("keeps the board lead-in synced to the card animation, not the check knock", () => {
     const r = rig();
-    // Even when a check closed the street, the board stays on its plain lead-in
-    // so the taps track the card-drop animation instead of waiting out the knock.
     r.engine.onHandUpdate({
       surface: "table",
       event: actionTaken(1, "check"),
@@ -280,7 +263,6 @@ describe("room-settings gate", () => {
     r.flush();
     expect(r.played).toEqual([]);
 
-    // A your-turn prompt (notifications) still passes.
     r.engine.onHandUpdate({
       surface: "player",
       seatId: 0,
@@ -304,7 +286,6 @@ describe("room-settings gate", () => {
       actions: false,
       notifications: true,
     });
-    // A fold/check on the acting player's own phone is silenced.
     r.engine.onHandUpdate({
       surface: "player",
       seatId: 1,
@@ -314,7 +295,6 @@ describe("room-settings gate", () => {
     r.flush();
     expect(r.played).toEqual([]);
 
-    // A card cue (reveal flip) still passes.
     r.engine.playRevealFlip();
     r.flush();
     expect(r.played).toEqual(["flip"]);
@@ -370,7 +350,6 @@ describe("your-turn prompt", () => {
       event: holeCardsDealt([0, 1]),
       view: noHandView,
     });
-    // Two hole cards → last lands at (2-1)*dealStagger.
     r.engine.onHandUpdate({
       surface: "player",
       seatId: 0,
@@ -393,9 +372,7 @@ describe("your-turn prompt", () => {
       event: { type: "HandStarted", seed: "s", button: 0 },
       view: noHandView,
     });
-    // Mid-hand: the deal sweep is well in the past, so nothing else is holding.
     r.setNow(TIMINGS.turnAfterDealMs);
-    // Seat 1 checks mid-hand and the turn passes to me in the same update.
     r.engine.onHandUpdate({
       surface: "player",
       seatId: 0,
@@ -416,14 +393,12 @@ describe("your-turn prompt", () => {
       event: { type: "HandStarted", seed: "s", button: 0 },
       view: noHandView,
     });
-    // Turn arrives — the prompt is scheduled.
     r.engine.onHandUpdate({
       surface: "player",
       seatId: 0,
       event: { type: "StreetStarted", street: "preflop", actor: 0 },
       view: bettingView(true),
     });
-    // Turn passes (I acted) before the deferral elapses — bumps the token.
     r.engine.onHandUpdate({
       surface: "player",
       seatId: 0,
@@ -448,8 +423,6 @@ describe("your-turn prompt", () => {
       event: { type: "StreetStarted", street: "preflop", actor: 0 },
       view: bettingView(true),
     });
-    // A second identical betting view (e.g. an opponent reconnecting) must not
-    // re-arm the prompt.
     r.engine.onHandUpdate({
       surface: "player",
       seatId: 0,

--- a/packages/ui-shared/src/sound/engine.ts
+++ b/packages/ui-shared/src/sound/engine.ts
@@ -1,29 +1,3 @@
-// The production tactile-sound layer (#186), ported from the tuned logic in
-// `proto/sound-181`'s throwaway prototype — minus its A/B tuning store and
-// on-screen panel. Turns the live `HandEvent` stream into heard, tactile card
-// cues, gated by the room settings (#184) and playing the canonical WAV assets
-// (#185).
-//
-// Design decisions baked in here (per the map, #177, and its decisions):
-//  - Cue ownership (revised #180): hole cards are a per-player cue — each PHONE
-//    voices only its OWN two hole cards (plus its own fold, check knock,
-//    reveal/conceal flip and your-turn prompt). The TABLE is the community
-//    voice: it voices only the shared board, and stays silent through the deal.
-//    (The table was originally the dealer voice for the whole hole-card sweep;
-//    that felt like too much on the felt, so the deal is now phone-only.)
-//  - Multi-card deals sound per card: the flop is three distinct board taps
-//    (board gap), a phone's hole cards are two distinct slides (the wider hole
-//    gap) — one scheduled play per card. The your-turn prompt is held a beat
-//    past the last hole card so cards land first, then the prompt.
-//  - Sounds fire ONLY from `hand-update` (which carries the raw event), never
-//    from `view-snapshot` — so a reconnect/refresh mid-hand can't replay a
-//    burst of cues (the map's rejoin worry, #175). That gate lives in the WS
-//    hooks that call `onHandUpdate`; this module never sees a snapshot.
-//
-// The engine is a pure state machine over injected effects (`play`, `now`,
-// `schedule`) so the event→cue mapping, the settings gate and the your-turn
-// cancellation are all unit-testable without Web Audio. The production wiring
-// (AudioContext, buffers, unlock) lives in `webAudio.ts`.
 import {
   DEFAULT_SOUND_SETTINGS,
   type HandEvent,
@@ -35,95 +9,46 @@ import { type CueName, cueAllowed } from "./cues.js";
 
 export type Surface = "table" | "player";
 
-/** The single `hand-update` payload the WS hooks hand to the engine. */
 export interface HandUpdateArgs {
   readonly surface: Surface;
   readonly event: HandEvent;
   readonly view: PlayerView | TableView;
-  /** The phone's own seat; omitted on the table surface. */
   readonly seatId?: number;
 }
 
-/**
- * The side effects the engine drives, injected so the mapping is testable.
- * `play` is the raw sink — the engine only ever calls it for a cue that has
- * already passed the room-settings gate.
- */
 export interface SoundEffects {
-  /** Emit a single already-gated cue now. */
   readonly play: (cue: CueName) => void;
-  /** Current epoch ms. */
   readonly now: () => number;
-  /** Run `fn` after `delayMs`; fire-and-forget (cancellation is via token). */
   readonly schedule: (fn: () => void, delayMs: number) => void;
 }
 
 export interface SoundEngine {
-  /** Called on every `hand-update` (never `view-snapshot`). */
   readonly onHandUpdate: (args: HandUpdateArgs) => void;
-  /** Mirror the room-view sound settings (#182) — the WS hooks call this. */
   readonly applyRoomSoundSettings: (settings: SoundSettings) => void;
-  /**
-   * The reveal/conceal flip cue — a client-side presentation change on the
-   * player surface, not a wire event, so the hole-card hook calls it directly.
-   */
   readonly playRevealFlip: () => void;
 }
 
-/** The tuned timings the prototype settled on, in ms. */
 export const TIMINGS = {
-  /**
-   * Gap between hole cards in the dealer's sweep — wider than the board gap so
-   * each dealt card is obvious as the deal reaches around the table.
-   */
   dealStaggerMs: 600,
-  /** Gap between board cards (the flop's three taps). */
   boardStaggerMs: 250,
-  /** The deliberate beat between the last hole card and the your-turn prompt. */
   turnAfterDealMs: 700,
-  /**
-   * A small offset from the board update arriving to its first tap, so the tap
-   * lands as the card-drop animation settles rather than the instant it starts.
-   * Deliberately short: nothing here waits out another surface's cue, so the
-   * tap never detaches from the card landing.
-   */
   boardLeadInMs: 150,
 } as const;
 
-/**
- * Create a sound engine over the given effects. One instance is a stateful
- * singleton shared across a surface's WS hook and hole-card hook; the
- * production instance lives in `webAudio.ts`, tests construct their own with
- * spy effects.
- */
 export function createSoundEngine(
   effects: SoundEffects,
   initialSettings: SoundSettings = DEFAULT_SOUND_SETTINGS,
 ): SoundEngine {
   let settings = initialSettings;
 
-  /** Edge-detect "it just became my turn" so the prompt fires once, not per view. */
   let lastMyTurn = false;
-  /**
-   * Bumped every time the turn state changes. A deferred your-turn prompt
-   * captures the token when scheduled and only plays if it still matches when
-   * the timer fires — so acting (or the hand ending) before the deferral
-   * elapses cancels the stale prompt instead of firing it after the fact.
-   */
   let turnToken = 0;
-  /**
-   * When the current hand's last hole card lands (ms epoch). The your-turn
-   * prompt is deferred to this plus `turnAfterDealMs`, so a player hears their
-   * cards settle and a clear beat before the prompt. Later streets leave this
-   * well in the past, so a mid-hand turn prompts without the pause.
-   */
   let lastHoleCardAt = 0;
 
   function playCue(cue: CueName): void {
     if (cueAllowed(settings, cue)) effects.play(cue);
   }
 
-  /** Fire a cue once per card, staggered so multi-card deals read as distinct. */
   function staggeredCue(
     cue: CueName,
     count: number,
@@ -150,10 +75,6 @@ export function createSoundEngine(
         break;
 
       case "HoleCardsDealt": {
-        // Hole cards are a per-player cue only (revised #180): each phone voices
-        // its OWN two cards as two distinct slides spaced by the wider hole-deal
-        // gap; the table stays silent on the deal. The your-turn cue below is
-        // held until this phone's own sweep ends.
         if (surface !== "player") break;
         const count =
           event.deals.find((d) => d.seatId === seatId)?.cards.length ?? 0;
@@ -164,11 +85,6 @@ export function createSoundEngine(
       }
 
       case "BoardDealt":
-        // One tap per board card, staggered — three distinct taps on the flop,
-        // one each on the turn and river. Table only (the community voice —
-        // the board is the one deal the table still speaks for, revised #180).
-        // The short lead-in only keeps the taps in step with the card-drop
-        // animation; it never waits out another surface's cue.
         if (surface === "table") {
           staggeredCue(
             "board",
@@ -180,8 +96,6 @@ export function createSoundEngine(
         break;
 
       case "ActionTaken":
-        // Only the acting player's own phone voices their action. call/raise
-        // are unallocated (no chip asset yet); the table stays silent (#180).
         if (surface === "player" && event.seatId === seatId) {
           if (event.action === "fold") playCue("fold");
           else if (event.action === "check") playCue("check");
@@ -193,13 +107,9 @@ export function createSoundEngine(
       case "ShowdownReached":
       case "HandFoldedOut":
       case "HandComplete":
-        // No dedicated cue (your-turn is derived from the view below).
         break;
     }
 
-    // "Action on you": derived from the phone's view, edge-detected so it fires
-    // once when the turn arrives, and held until the deal sweep has finished so
-    // the player hears their cards land first, then the prompt.
     if (surface === "player") {
       const { view } = args;
       const myTurn =
@@ -209,15 +119,11 @@ export function createSoundEngine(
       if (myTurn !== lastMyTurn) turnToken++;
       if (myTurn && !lastMyTurn) {
         const token = turnToken;
-        // Hold the prompt past the deal-sweep beat only — nothing else waits
-        // on another surface's cue.
         const wait = Math.max(
           0,
           lastHoleCardAt + TIMINGS.turnAfterDealMs - effects.now(),
         );
         effects.schedule(() => {
-          // Still this same turn when the deferral elapses? A newer turn-state
-          // change (I acted, or the hand ended) bumps the token and cancels it.
           if (token === turnToken) playCue("yourTurn");
         }, wait);
       }

--- a/packages/ui-shared/src/sound/realClock.ts
+++ b/packages/ui-shared/src/sound/realClock.ts
@@ -1,11 +1,5 @@
-// The production clock/scheduler pair shared by the Web Audio engine and the
-// table's beat queue, so both drive off one real-timer implementation instead
-// of each repeating `Date.now()`/`setTimeout` at its own call site. Tests
-// inject their own hand-cranked clock in its place.
 export const realClock = {
-  /** Current epoch ms. */
   now: (): number => Date.now(),
-  /** Run `fn` after `delayMs`; fire-and-forget. */
   schedule: (fn: () => void, delayMs: number): void => {
     setTimeout(fn, delayMs);
   },

--- a/packages/ui-shared/src/sound/webAudio.ts
+++ b/packages/ui-shared/src/sound/webAudio.ts
@@ -1,9 +1,3 @@
-// Production Web Audio effects for the tactile-sound layer (#186): one
-// `AudioContext` singleton, a warm-decoded buffer per cue, gesture unlock and
-// the iOS silent-switch workaround. This is the thin, browser-bound half — the
-// tuned event→cue logic lives in the pure `engine.ts`. Both clients import the
-// bound API (`onHandUpdate`, `applyRoomSoundSettings`, `playRevealFlip`,
-// `unlockAudio`) from here.
 import type { SoundSettings } from "@table-top-poker/protocol";
 import { CUE_FILES, CUE_NAMES, type CueName } from "./cues.js";
 import {
@@ -13,12 +7,6 @@ import {
 } from "./engine.js";
 import { realClock } from "./realClock.js";
 
-// Pin the context, buffer cache and engine to `globalThis`. This module is a
-// stateful singleton shared by the WS hook and the hole-card hook; a partial
-// HMR update can otherwise leave those importers on different module instances,
-// each with its own suspended context, so a cue plays through a context the
-// gesture never unlocked. One instance on the global keeps every importer —
-// however HMR splits them — driving the same audio.
 const soundGlobal = globalThis as unknown as {
   __ttpAudioCtx?: AudioContext | null;
   __ttpAudioBuffers?: Map<CueName, AudioBuffer>;
@@ -35,7 +23,6 @@ function context(): AudioContext {
   return (soundGlobal.__ttpAudioCtx ??= new AudioContext());
 }
 
-/** Whether Web Audio exists — false under jsdom/SSR, where the layer is inert. */
 function audioAvailable(): boolean {
   return typeof AudioContext !== "undefined";
 }
@@ -43,11 +30,6 @@ function audioAvailable(): boolean {
 async function loadBuffer(cue: CueName): Promise<AudioBuffer | undefined> {
   const cached = buffers.get(cue);
   if (cached) return cached;
-  // Base-relative, not root-absolute: the assets are staged under each client's
-  // deploy base (`/table/sounds/…`, `/player/sounds/…`) in a release build, so a
-  // bare `/sounds/…` only resolves in dev, where Vite serves `public/` at the
-  // root. `import.meta.env.BASE_URL` ("/" in dev, "/table/" | "/player/" in the
-  // build) makes the URL land on the staged asset on both.
   try {
     const response = await fetch(
       `${import.meta.env.BASE_URL}sounds/${CUE_FILES[cue]}`,
@@ -57,20 +39,11 @@ async function loadBuffer(cue: CueName): Promise<AudioBuffer | undefined> {
     buffers.set(cue, buffer);
     return buffer;
   } catch (error) {
-    // A missing or undecodable asset must not become an unhandled rejection —
-    // the cue just stays silent. (WAV assets decode everywhere, so this is a
-    // belt-and-braces guard; see the format note in `cues.ts`.)
     console.warn(`sound: could not load cue "${cue}"`, error);
     return undefined;
   }
 }
 
-/**
- * The engine's `play` sink: fire a cue's warm-decoded buffer. Inert without
- * Web Audio (jsdom under vitest, SSR) so importing the layer never throws on
- * `new AudioContext()`. Cues are warmed on unlock, so by playtime the buffer is
- * cached and this resolves without a decode gap.
- */
 function playCueSound(cue: CueName): void {
   if (!audioAvailable()) return;
   void loadBuffer(cue).then((buffer) => {
@@ -90,47 +63,27 @@ const engine = (soundGlobal.__ttpSoundEngine ??= createSoundEngine({
 
 export type { HandUpdateArgs, Surface } from "./engine.js";
 
-/** Called on every `hand-update` (never `view-snapshot`) — see `engine.ts`. */
 export function onHandUpdate(args: HandUpdateArgs): void {
   engine.onHandUpdate(args);
 }
 
-/** Mirror the room-view sound settings (#182) into the engine's gate. */
 export function applyRoomSoundSettings(settings: SoundSettings): void {
   engine.applyRoomSoundSettings(settings);
 }
 
-/** The reveal/conceal flip cue — the player's hole-card hook calls this. */
 export function playRevealFlip(): void {
   engine.playRevealFlip();
 }
 
-/**
- * Unlock audio from a user gesture (#178: an `AudioContext` starts
- * `suspended`, and mobile browsers refuse to start one outside a gesture).
- * Resumes the context, arms the iOS silent-switch workaround and warm-decodes
- * every cue buffer so the first real cue has no decode gap. Idempotent — safe
- * to call from every gesture that might be the first.
- */
 export async function unlockAudio(): Promise<void> {
   if (!audioAvailable()) return;
   armSilentKeepAlive();
   await context().resume();
-  // Warm every cue so the first real one plays without a decode gap.
   await Promise.all(
     CUE_NAMES.map((cue) => loadBuffer(cue).catch(() => undefined)),
   );
 }
 
-// --- iOS silent-switch workaround (#178) ------------------------------------
-//
-// On iOS the hardware ringer/silent switch mutes Web Audio, so a phone with the
-// ringer off would hear nothing. A silently-looping HTMLMediaElement plays
-// through the media channel, which the switch does not gate, and keeping one
-// active routes Web Audio to that same channel — so the cues survive the switch
-// being off. Armed on the unlock gesture (media playback needs a gesture too).
-
-/** A fraction of a second of 8-bit mono PCM silence, as a `data:` WAV URL. */
 function silentWavDataUrl(): string {
   const sampleRate = 8000;
   const numSamples = Math.floor(sampleRate * 0.25);
@@ -144,16 +97,15 @@ function silentWavDataUrl(): string {
   dv.setUint32(4, 36 + numSamples, true);
   writeAscii(8, "WAVE");
   writeAscii(12, "fmt ");
-  dv.setUint32(16, 16, true); // PCM chunk size
-  dv.setUint16(20, 1, true); // PCM format
-  dv.setUint16(22, 1, true); // mono
+  dv.setUint32(16, 16, true);
+  dv.setUint16(20, 1, true);
+  dv.setUint16(22, 1, true);
   dv.setUint32(24, sampleRate, true);
-  dv.setUint32(28, sampleRate, true); // byte rate (8-bit mono)
-  dv.setUint16(32, 1, true); // block align
-  dv.setUint16(34, 8, true); // bits per sample
+  dv.setUint32(28, sampleRate, true);
+  dv.setUint16(32, 1, true);
+  dv.setUint16(34, 8, true);
   writeAscii(36, "data");
   dv.setUint32(40, numSamples, true);
-  // 8-bit PCM silence is the mid-point 128, not 0.
   for (let i = 0; i < numSamples; i++) dv.setUint8(44 + i, 128);
   let binary = "";
   const bytes = new Uint8Array(buffer);
@@ -161,7 +113,6 @@ function silentWavDataUrl(): string {
   return `data:audio/wav;base64,${btoa(binary)}`;
 }
 
-/** Nudge the keep-alive element back to playing; a no-op if it isn't armed. */
 function nudgeKeepAlive(): void {
   void soundGlobal.__ttpSilentKeepAlive?.play().catch(() => undefined);
 }
@@ -178,8 +129,6 @@ function armSilentKeepAlive(): void {
   nudgeKeepAlive();
 }
 
-// Returning to a backgrounded tab (a phone waking) can leave the context
-// suspended; re-resume on visibility and nudge the keep-alive back to playing.
 if (typeof document !== "undefined") {
   document.addEventListener("visibilitychange", () => {
     if (document.visibilityState !== "visible") return;

--- a/packages/ui-shared/src/theme.ts
+++ b/packages/ui-shared/src/theme.ts
@@ -1,11 +1,3 @@
-/**
- * Design tokens for the felt/night palette. `table-client` and
- * `player-client` both style against these rather than hard-coding values.
- *
- * These tokens are the palette's only source of truth — there is nothing else
- * to reconcile a new token against (issue #160, decision 9).
- */
-
 const feltGradient =
   "linear-gradient(180deg,#6a1a1f 0%,#4b1317 42%,#2c0c0f 100%)";
 
@@ -29,11 +21,6 @@ export const color = {
   lossBorder: "rgba(229,68,60,.34)",
   winBackground: "rgba(123,216,143,.1)",
   winBorder: "rgba(123,216,143,.4)",
-  /**
-   * The win green at plate weight: opaque enough to carry light text over a
-   * card face, where `winBackground` — tuned for a wash over the dark shell —
-   * would wash out to nothing.
-   */
   winPlate: "rgba(32,78,42,.9)",
   winBright: "#7bd88f",
   winKicker: "#8fdfa1",
@@ -75,12 +62,7 @@ export const color = {
   seatWinnerBackground: "rgba(250,234,231,.14)",
   seatActorBackground: "rgba(20,7,8,.72)",
   buttonMarker: "#faf6f0",
-  /**
-   * Saturated enough that it never reads as "the white button marker,
-   * slightly tinted" from a couple of metres away.
-   */
   blindSmallMarker: "#5aa9f0",
-  /** Amber rather than lemon, so it sits inside the warm felt palette. */
   blindBigMarker: "#f2c14e",
 } as const;
 
@@ -90,7 +72,6 @@ export const font = {
   mono: "'IBM Plex Mono', monospace",
 } as const;
 
-/** Named rungs of the type scale, from mono kicker labels up to the room-code display. */
 export const fontSize = {
   xs: "10px",
   sm: "12px",
@@ -115,7 +96,6 @@ export const shadow = {
   pill: "0 16px 40px -14px rgba(229,68,60,.6), inset 0 1px 0 rgba(255,255,255,.5)",
   card: "0 22px 44px -16px rgba(0,0,0,.85)",
   seatResting: "0 0 0 1px rgba(255,255,255,.1)",
-  /** The actor-glow pulse's three keyframes, driven by Motion's `animate`. */
   seatActorGlow: [
     "0 0 0 2px rgba(229,68,60,.95), 0 0 34px 6px rgba(229,68,60,.3)",
     "0 0 0 3px rgba(255,120,110,1), 0 0 54px 14px rgba(229,68,60,.5)",

--- a/packages/ui-shared/src/vite-env.d.ts
+++ b/packages/ui-shared/src/vite-env.d.ts
@@ -1,9 +1,3 @@
-// ui-shared is compiled by tsc, not Vite, so it has no `vite/client` types.
-// The one Vite-injected value it needs is `import.meta.env.BASE_URL` — the
-// deploy base path ("/" in dev, "/table/" or "/player/" in a release build)
-// that `webAudio.ts` prefixes onto its same-origin `sounds/` asset URLs. Vite
-// statically replaces the reference when it bundles this package's dist into
-// each client; this ambient declaration only satisfies the tsc typecheck.
 interface ImportMetaEnv {
   readonly BASE_URL: string;
 }


### PR DESCRIPTION
## What

The codebase had accumulated dense inline comments carrying a maintenance burden. This strips non-essential code comments across every package and moves the genuinely high-value rationale into a new `docs/design/` set, plus a coding standard so comments stay rare going forward.

## Changes

- **`CLAUDE.md`** — new *Code comments* standard: code documents itself; a comment is a last resort; business logic/rationale belongs in `CONTEXT.md`, `docs/adr/`, or `docs/design/`; machine directives stay.
- **`docs/design/`** — captures the rationale that was inline (invariants, timing/concurrency decisions, spec cross-references): `holecards.md`, `engine.md`, `protocol.md`, `server.md`, `clients.md`, plus a `README.md` index.
- **~3,500 comment lines removed** across 160+ files. The only comments kept are machine-necessary: `eslint-disable`, `// falls through` (`no-fallthrough`), empty-`catch` guards (`no-empty`), and `/// <reference>`.

Stripping was done with a TypeScript-scanner-based tool (not regex) so strings, template literals, regex literals, and JSX were preserved; every file was parse-checked afterwards.

## Verification

No behaviour change:

- `tsc --build` — clean
- `eslint .` — clean
- `prettier --check .` — clean
- Full test suite — **895/895 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)