### PR TITLE
fix(table): deal in only the community cards that just arrived

### DIFF
--- a/docs/design/board-card-entry.md
+++ b/docs/design/board-card-entry.md
@@ -1,0 +1,32 @@
+# Board card entry: only new cards deal in
+
+The table's community cards animate in one at a time. The animation must fire
+for a card the moment it arrives on the felt, and never again.
+
+Two things used to make it fire again:
+
+- **Cards were keyed by board position.** A card at index 2 that changed
+  identity — or a list React chose to reconcile by index — replayed its deal.
+- **`Board` returned a structurally different tree per phase.** Crossing
+  betting → showdown moved `CommunityCards` to a new position in the element
+  tree, remounting it and re-dealing all five cards that were already down.
+
+The fix, settled on `prototype/replay-transport` (wayfinder #82, ticket #117):
+
+- Key each card by its rank and suit (`cardKey`), so a card already on the felt
+  is never remounted.
+- Remember which cards were on the felt when the render began, and give the
+  entry animation only to cards whose key is not among them (`dealBoard`). The
+  stagger is measured from the first *new* card, so a lone turn card lands
+  immediately instead of waiting out three flop cards' delays. The prototype
+  compared counts rather than keys, which silently skipped the deal whenever
+  the board shrank and refilled — a 5-card river giving way to the next hand's
+  flop. Scrubbing a replay does exactly that, so this version compares keys.
+- Render one shape for every phase that has a hand, so `CommunityCards` keeps
+  its position in the tree as the phase changes.
+
+A folded-out hand shows no board at all — nobody paid to see it.
+
+The remount behaviour is invisible in live play, where the board only ever
+grows one street at a time, and obvious the moment a replay is scrubbed
+backwards and forwards. This change is the prefactor the replay scrub consumes.

--- a/packages/table-client/src/Board.test.tsx
+++ b/packages/table-client/src/Board.test.tsx
@@ -1,4 +1,4 @@
-import type { TableView } from "@table-top-poker/protocol";
+import type { Card, TableView } from "@table-top-poker/protocol";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
@@ -133,5 +133,49 @@ describe("Board", () => {
     expect(html).not.toContain("Pair of Aces");
     expect(html).toMatch(/data-testid="community-cards"/);
     expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(5);
+  });
+
+  it("renders the same shape for betting and showdown on an unchanged board", () => {
+    const board: readonly Card[] = [
+      { rank: "A", suit: "spades" },
+      { rank: "K", suit: "hearts" },
+      { rank: "2", suit: "clubs" },
+      { rank: "7", suit: "diamonds" },
+      { rank: "9", suit: "clubs" },
+    ];
+    const betting: TableView = {
+      phase: "betting",
+      button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
+      street: "river",
+      turnEndsAt: null,
+      board,
+      toAct: [1],
+      seats: [
+        { seatId: 0, folded: false },
+        { seatId: 1, folded: false },
+      ],
+    };
+    const showdown: TableView = {
+      phase: "showdown",
+      button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
+      board,
+      winners: [0],
+      results: [],
+    };
+
+    const stripPhase = (html: string) =>
+      html
+        .replace(/ data-phase="[^"]*"/, "")
+        .replace(/ data-street="[^"]*"/, "");
+
+    expect(stripPhase(renderToStaticMarkup(<Board view={showdown} />))).toBe(
+      stripPhase(renderToStaticMarkup(<Board view={betting} />)),
+    );
   });
 });

--- a/packages/table-client/src/Board.tsx
+++ b/packages/table-client/src/Board.tsx
@@ -5,6 +5,8 @@ import type {
 } from "@table-top-poker/protocol";
 import { Card, color, font } from "@table-top-poker/ui-shared";
 import { motion } from "motion/react";
+import { useEffect, useRef } from "react";
+import { boardKeys, dealBoard } from "./boardDeal.js";
 import { seatLabel } from "./seatLabel.js";
 
 export interface BoardProps {
@@ -12,18 +14,29 @@ export interface BoardProps {
   readonly seats?: readonly SeatView[];
 }
 
+/**
+ * The community cards, with a Motion deal-in for the cards that have just
+ * arrived — see `docs/design/board-card-entry.md`.
+ */
 function CommunityCards({ board }: { readonly board: readonly CardType[] }) {
+  const dealtBefore = useRef<ReadonlySet<string>>(new Set());
+  const dealt = dealBoard(board, dealtBefore.current);
+
+  useEffect(() => {
+    dealtBefore.current = boardKeys(board);
+  });
+
   return (
     <div
       data-testid="community-cards"
       style={{ display: "flex", gap: "0.4em", fontSize: "2.4em" }}
     >
-      {board.map((card, i) => (
+      {dealt.map(({ card, key, initial, duration, delay }) => (
         <motion.div
-          key={i}
-          initial={{ opacity: 0, y: -18, rotate: -6, scale: 0.9 }}
+          key={key}
+          initial={initial}
           animate={{ opacity: 1, y: 0, rotate: 0, scale: 1 }}
-          transition={{ duration: 0.4, delay: i * 0.08 }}
+          transition={{ duration, delay }}
         >
           <Card rank={card.rank} suit={card.suit} />
         </motion.div>
@@ -83,36 +96,25 @@ export function Board({ view, seats = [] }: BoardProps) {
     );
   }
 
-  if (view.phase === "folded-out") {
-    return (
-      <div data-testid="board" data-phase="folded-out">
+  return (
+    <div
+      data-testid="board"
+      data-phase={view.phase}
+      data-street={view.phase === "betting" ? view.street : undefined}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "0.6em",
+      }}
+    >
+      {view.phase === "folded-out" ? (
         <HandCompleteBanner
           text={`${seatLabel(view.winner, seats)} wins — everyone folded`}
         />
-      </div>
-    );
-  }
-
-  if (view.phase === "showdown") {
-    return (
-      <div
-        data-testid="board"
-        data-phase="showdown"
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          gap: "0.6em",
-        }}
-      >
+      ) : (
         <CommunityCards board={view.board} />
-      </div>
-    );
-  }
-
-  return (
-    <div data-testid="board" data-phase="betting" data-street={view.street}>
-      <CommunityCards board={view.board} />
+      )}
     </div>
   );
 }

--- a/packages/table-client/src/StatusBar.test.tsx
+++ b/packages/table-client/src/StatusBar.test.tsx
@@ -45,6 +45,22 @@ describe("StatusBar", () => {
     );
   });
 
+  it("renders leading content at the left end, ahead of the room code", () => {
+    const html = renderToStaticMarkup(
+      <StatusBar
+        roomCode="ABCD"
+        connectionStatus="connected"
+        showRoomCode={true}
+        onOpenJoin={noop}
+        leading={<span data-testid="leading">Hand 3</span>}
+      />,
+    );
+    expect(html).toContain("Hand 3");
+    expect(html.indexOf('data-testid="leading"')).toBeLessThan(
+      html.indexOf('data-testid="join-code-toggle"'),
+    );
+  });
+
   it("keeps the connection badge while hiding the room code before the hand starts", () => {
     const html = renderToStaticMarkup(
       <StatusBar

--- a/packages/table-client/src/StatusBar.tsx
+++ b/packages/table-client/src/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { color, font, fontSize, radius } from "@table-top-poker/ui-shared";
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { JoinCodeToggle } from "./JoinCodeToggle.js";
 import type { ConnectionStatus } from "./store/connectionSlice.js";
 
@@ -8,6 +8,8 @@ export interface StatusBarProps {
   readonly connectionStatus: ConnectionStatus;
   readonly showRoomCode: boolean;
   readonly onOpenJoin: () => void;
+  /** What the device is showing, when that isn't simply the live table. */
+  readonly leading?: ReactNode;
 }
 
 const badgeTone: Record<
@@ -36,6 +38,7 @@ export function StatusBar({
   connectionStatus,
   showRoomCode,
   onOpenJoin,
+  leading,
 }: StatusBarProps) {
   const tone = badgeTone[connectionStatus];
   return (
@@ -50,6 +53,7 @@ export function StatusBar({
         padding: "16px 22px",
       }}
     >
+      {leading}
       {roomCode !== null && showRoomCode && (
         <JoinCodeToggle roomCode={roomCode} onOpen={onOpenJoin} />
       )}

--- a/packages/table-client/src/boardDeal.test.ts
+++ b/packages/table-client/src/boardDeal.test.ts
@@ -1,0 +1,64 @@
+import type { Card } from "@table-top-poker/protocol";
+import { describe, expect, it } from "vitest";
+import { boardKeys, cardKey, dealBoard } from "./boardDeal.js";
+
+const flop: readonly Card[] = [
+  { rank: "A", suit: "spades" },
+  { rank: "K", suit: "hearts" },
+  { rank: "2", suit: "clubs" },
+];
+const turn: Card = { rank: "7", suit: "diamonds" };
+const river: Card = { rank: "9", suit: "clubs" };
+
+const animates = (dealt: readonly { readonly initial: unknown }[]) =>
+  dealt.map((card) => card.initial !== false);
+
+describe("cardKey", () => {
+  it("identifies a card by its rank and suit, not its board position", () => {
+    expect(cardKey({ rank: "A", suit: "spades" })).toBe("Aspades");
+    expect(cardKey({ rank: "A", suit: "spades" })).not.toBe(
+      cardKey({ rank: "A", suit: "hearts" }),
+    );
+  });
+});
+
+describe("dealBoard", () => {
+  it("deals in every card of an opening flop, staggered", () => {
+    const dealt = dealBoard(flop, new Set());
+    expect(animates(dealt)).toEqual([true, true, true]);
+    expect(dealt.map((card) => card.delay)).toEqual([0, 0.08, 0.16]);
+    expect(dealt[0]?.duration).toBe(0.4);
+  });
+
+  it("leaves cards already on the felt alone", () => {
+    const dealt = dealBoard(flop, boardKeys(flop));
+    expect(animates(dealt)).toEqual([false, false, false]);
+    expect(dealt.map((card) => card.duration)).toEqual([0, 0, 0]);
+  });
+
+  it("lands a lone turn card immediately rather than behind the flop's stagger", () => {
+    const dealt = dealBoard([...flop, turn], boardKeys(flop));
+    expect(animates(dealt)).toEqual([false, false, false, true]);
+    expect(dealt[3]?.delay).toBe(0);
+  });
+
+  it("deals in a new hand's flop even though more cards were on the felt before", () => {
+    const nextFlop: readonly Card[] = [
+      { rank: "3", suit: "hearts" },
+      { rank: "4", suit: "hearts" },
+      { rank: "5", suit: "hearts" },
+    ];
+    const dealt = dealBoard(nextFlop, boardKeys([...flop, turn, river]));
+    expect(animates(dealt)).toEqual([true, true, true]);
+    expect(dealt.map((card) => card.delay)).toEqual([0, 0.08, 0.16]);
+  });
+
+  it("keys each card by rank and suit so its position on the board is irrelevant", () => {
+    const dealt = dealBoard(flop, new Set());
+    expect(dealt.map((card) => card.key)).toEqual([
+      "Aspades",
+      "Khearts",
+      "2clubs",
+    ]);
+  });
+});

--- a/packages/table-client/src/boardDeal.ts
+++ b/packages/table-client/src/boardDeal.ts
@@ -1,0 +1,42 @@
+import type { Card } from "@table-top-poker/protocol";
+
+export interface DealtCard {
+  readonly card: Card;
+  readonly key: string;
+  readonly initial:
+    | {
+        readonly opacity: number;
+        readonly y: number;
+        readonly rotate: number;
+        readonly scale: number;
+      }
+    | false;
+  readonly duration: number;
+  readonly delay: number;
+}
+
+const arriving = { opacity: 0, y: -18, rotate: -6, scale: 0.9 } as const;
+
+export function cardKey(card: Card): string {
+  return `${card.rank}${card.suit}`;
+}
+
+export function boardKeys(board: readonly Card[]): ReadonlySet<string> {
+  return new Set(board.map(cardKey));
+}
+
+export function dealBoard(
+  board: readonly Card[],
+  alreadyDealt: ReadonlySet<string>,
+): readonly DealtCard[] {
+  let arrived = 0;
+  return board.map((card) => {
+    const key = cardKey(card);
+    if (alreadyDealt.has(key)) {
+      return { card, key, initial: false, duration: 0, delay: 0 };
+    }
+    const delay = arrived * 0.08;
+    arrived += 1;
+    return { card, key, initial: arriving, duration: 0.4, delay };
+  });
+}


### PR DESCRIPTION
Closes #117.

`Board` keyed its community cards by board position and returned a structurally different tree per phase, so crossing betting → showdown remounted `CommunityCards` and re-dealt all five cards already on the felt. Lifted by hand from `prototype/replay-transport` `b5d691e`, without its five prototype-only files.

- Cards are keyed by rank+suit (`cardKey`), so a card on the felt is never remounted.
- Every phase with a hand renders one shape, so `CommunityCards` keeps its tree position across the phase change. `folded-out` still shows the banner and no board; showdown still leaves the result to the overlay (#169).
- `StatusBar` gains its optional `leading` slot, unused by the live `App`.
- Rationale lives in `docs/design/board-card-entry.md`.

### One deliberate departure from the prototype

The prototype decided "is this card new?" by comparing the board's *length* against the previous render's. That silently skips the deal whenever the board shrinks and refills — a 5-card river giving way to the next hand's flop leaves all three new cards mounting with no animation. Scrubbing a replay does exactly that, so `dealBoard` compares card keys instead. The entry decision is a pure function in `boardDeal.ts` and is directly tested; the repo has no DOM test environment, so the `useRef`/`useEffect` wiring in `CommunityCards` is not covered by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ep1hXHMzWTF1w9vBmuEhcr