### PR TITLE
refactor(server): commit-seam transaction handle and clock-safe operation queue

### DIFF
--- a/docs/design/server.md
+++ b/docs/design/server.md
@@ -29,16 +29,53 @@ those never reach `view(state, seatId)` or presence tracking.
 - The **action clock** (`action-clock.ts`, `rescheduleActionClock`) is fully
   decoupled from socket state (§7): folding is strictly clock-driven, and only
   `dispatch` outcomes move the clock. It re-arms against the live actor after
-  every accepted command (real or synthesized), and arms *before* the first
-  hand-update so every live view (including `HandStarted`) carries the deadline
-  and a reconnect snapshot reads the same `room.turnEndsAt`. On timeout it
-  preserves a free check (reads `legalActions` at fire time), else folds.
+  every committed command (real or synthesized) and *before* the first
+  hand-update, so every live view (including `HandStarted`) carries the deadline
+  and a reconnect snapshot reads the same `room.turnEndsAt`. Arming after the
+  commit is what keeps append latency out of a player's thinking time. On
+  timeout it preserves a free check (reads `legalActions` at fire time), else
+  folds.
+- `"preserve"` (a non-actor eviction) keeps the actor's existing deadline rather
+  than granting a fresh interval, but still re-arms the timer so it carries the
+  revision that eviction produced — see the commit seam below.
 - Timers everywhere here **re-read room state at fire time** (bot actions, clock
   timeouts): a scheduled callback may outlive an intervening human action,
   eviction, hand completion, or teardown, even after its own timer was replaced.
-  A synthesized action being rejected is not expected (the actor was live at
-  schedule time and any real action would have replaced the timer), but the
-  recovery path re-arms rather than stalls.
+  A synthesized action being rejected is not expected, but the recovery path
+  re-arms rather than stalls.
+
+## The commit seam and the Room operation queue
+
+Nothing is broadcast before it is recorded (Phase 2 spec #129 §3, issue #118).
+
+- `RoomStore.dispatch` is **pure and synchronous**: it decides the Command
+  against the Room and returns a `DispatchTransaction` — the staged steps plus
+  the `RoomOperation` the recording takes — having changed nothing. The engine
+  reassignment, the pending seat shrink, the `pendingSeatCount` clear, the
+  `waitingForNextHand` recompute, the pending shot-clock take-up and an evicted
+  seat's release all happen in `commit()`, not before the outcome is known.
+  That ordering is what retires the class of bug #95 was an instance of, where a
+  rejected `nextHand` had already rewritten the live hand's seats and button.
+  Settling a transaction twice throws: the obligation rides on the handle rather
+  than on a convention a later edit can drop.
+- `app.ts` sequences it — `append` → `commit()` (or `discard()` on failure) →
+  broadcast — in `publishDispatch`. A refused append is dropped and logged; the
+  table-facing recovery is issue #121's recording-paused state. A Room with no
+  open recording at all is a bug in this server rather than a disk failure, so
+  it is logged loudly and played on: refusing would strand the table.
+- `app.ts` owns **one operation queue per Room** (`enqueue`). Socket Commands,
+  clock-driven folds and Seat mutations run one at a time in arrival order;
+  other Rooms are unaffected. HTTP seat routes await their turn in it, so a
+  reply never races the broadcast it caused.
+- The Room holds a **monotonic `revision`**, bumped on every committed
+  transaction and by nothing else — a rejection or a Seat mutation changes no
+  engine state and must not invalidate a queued fold, or the hand would stall.
+  A queued clock-fold captures the revision when the clock is armed and is
+  discarded on dequeue if the Room has advanced at all. Actor-matching is not
+  enough: heads-up the non-button seat acts *last* preflop and *first* on the
+  flop (`initialToAct`), so a fold queued behind that seat's own check finds it
+  legitimately back on the clock a beat later. Every revision bump re-arms the
+  clock, so discarding a stale fold never leaves a Room without one.
 
 ## Seat lifecycle at the transport
 
@@ -95,10 +132,10 @@ seats. RNG draws are guarded so a seat that can't act never consumes a draw
 (keeping a deterministic RNG stable across the sequence). `unitRandom` clamps
 injected values into `[0, 1)` without rounding a valid `MAX_UNIT_RANDOM`.
 
-## Persistence (`packages/persistence`)
+## Recording (`packages/recording`)
 
-`HandLog` is an append-as-you-go JSONL logger: a seats manifest written once,
-then a command/event file pair per hand. Every write is a single synchronous
-`fs` call, so a killed process loses at most the one record it was mid-write on,
-never a batch. The game id is validated (it becomes a directory name). Records
-carry `ENGINE_LOG_VERSION` for replay/audit.
+One `RoomRecording` per live Room, opened by `POST /rooms` before the Room is
+joinable and closed when it ends or the app does. It takes whole operations, and
+owns ordering, retry, confirmed offsets and rollback itself; the server hands it
+`transaction.operation` and waits. Its filesystem is injected, so every failure
+path is testable and the shipped server has no way to make itself fail.

--- a/docs/design/server.md
+++ b/docs/design/server.md
@@ -59,14 +59,22 @@ Nothing is broadcast before it is recorded (Phase 2 spec #129 §3, issue #118).
   Settling a transaction twice throws: the obligation rides on the handle rather
   than on a convention a later edit can drop.
 - `app.ts` sequences it — `append` → `commit()` (or `discard()` on failure) →
-  broadcast — in `publishDispatch`. A refused append is dropped and logged; the
-  table-facing recovery is issue #121's recording-paused state. A Room with no
-  open recording at all is a bug in this server rather than a disk failure, so
-  it is logged loudly and played on: refusing would strand the table.
+  broadcast — in `publishDispatch`, which answers whether the operation was
+  published. A refused append is dropped and logged, and it **cancels the
+  Actor's clock**: the timer that fired is spent, and nothing may act on an
+  unrecorded Room. Eviction and leave hang on that answer too — a seat whose
+  fold could not be recorded is still holding its hand, so it is not taken from
+  its player and the route answers `503 recording-unavailable` rather than 204.
+  The table-facing recovery is issue #121's recording-paused state. A Room with
+  no open recording at all is a bug in this server rather than a disk failure,
+  so it is logged loudly and played on: refusing would strand the table.
 - `app.ts` owns **one operation queue per Room** (`enqueue`). Socket Commands,
-  clock-driven folds and Seat mutations run one at a time in arrival order;
-  other Rooms are unaffected. HTTP seat routes await their turn in it, so a
-  reply never races the broadcast it caused.
+  clock-driven folds, Seat mutations (claims, evictions, presence, sit-out/in,
+  seat count), Room settings, a joiner's catch-up and the Room's own teardown
+  run one at a time in arrival order; other Rooms are unaffected. HTTP routes
+  await their turn in it, so a reply never races the broadcast it caused.
+  Reads outside the queue are safe by construction: a staged transaction
+  mutates nothing, so anything read there is already committed.
 - The Room holds a **monotonic `revision`**, bumped on every committed
   transaction and by nothing else — a rejection or a Seat mutation changes no
   engine state and must not invalidate a queued fold, or the hand would stall.
@@ -95,8 +103,8 @@ Nothing is broadcast before it is recorded (Phase 2 spec #129 §3, issue #118).
   resync notice.
 - **Sit-out/in** (ADR-0002) is a seat-only room-store mutation that never
   reaches the engine.
-- **Room end**: `endRoom` handles both "End session" and the table's grace
-  window elapsing identically — notify, close, discard transport bookkeeping,
+- **Room end**: `endRoom` runs in the Room's queue and handles both "End
+  session" and the table's grace window elapsing identically — notify, close, discard transport bookkeeping,
   discard the room. Only in-memory state; hand logs on disk are untouched. The
   table socket closing arms a single `graceWindowMs` timer; a table reconnect
   clears it.

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -8,6 +8,7 @@ import {
   MIN_SEAT_COUNT,
   MIN_SHOT_CLOCK_SECONDS,
   type RoomView,
+  type SeatId,
   type ServerMessage,
 } from "@table-top-poker/protocol";
 import type { FastifyInstance } from "fastify";
@@ -23,7 +24,12 @@ import {
 import type { MemoryFileSystem } from "@table-top-poker/recording/testing";
 import { ActionClock } from "./action-clock.js";
 import { buildApp } from "./app.js";
-import { RoomStore, toRoomView } from "./rooms.js";
+import {
+  type DispatchResult,
+  RoomStore,
+  type SeatCommandType,
+  toRoomView,
+} from "./rooms.js";
 
 const RECORDINGS_ROOT = "/recordings";
 
@@ -66,6 +72,21 @@ interface SeatClaimBody {
   readonly displayName: string;
   readonly sittingOut: boolean;
   readonly sittingOutReason: "voluntary" | "waiting-for-next-hand" | null;
+}
+
+/**
+ * Drives the store directly for test setup, settling the transaction the way
+ * `app.ts` does once its append confirms.
+ */
+function commitDispatch(
+  rooms: RoomStore,
+  code: string,
+  identity: SeatId | "table",
+  type: SeatCommandType,
+): DispatchResult {
+  const result = rooms.dispatch(code, identity, type);
+  if ("commit" in result) result.commit();
+  return result;
 }
 
 function unclaimedSeats(): RoomView["seats"] {
@@ -563,7 +584,7 @@ describe("seat claim/evict routes", () => {
     const code = await createRoom();
     rooms.claimSeat(code, 0, "P0");
     rooms.claimSeat(code, 1, "P1");
-    rooms.dispatch(code, "table", "startHand");
+    commitDispatch(rooms, code, "table", "startHand");
 
     const response = await app.inject({
       method: "POST",
@@ -869,7 +890,7 @@ describe("seat-count settings route", () => {
     const room = rooms.create();
     rooms.claimSeat(room.code, 0, "P0");
     rooms.claimSeat(room.code, 1, "P1");
-    rooms.dispatch(room.code, "table", "startHand");
+    commitDispatch(rooms, room.code, "table", "startHand");
 
     const table = new WebSocket(
       `ws://127.0.0.1:${String(port)}/ws?room=${room.code}&role=table`,
@@ -941,7 +962,7 @@ describe("shot-clock settings route", () => {
     const room = rooms.create();
     rooms.claimSeat(room.code, 0, "P0");
     rooms.claimSeat(room.code, 1, "P1");
-    const started = rooms.dispatch(room.code, "table", "startHand");
+    const started = commitDispatch(rooms, room.code, "table", "startHand");
     if (!("steps" in started)) throw new Error("expected start-hand steps");
 
     const settings = { enabled: true, seconds: 30 };
@@ -958,9 +979,9 @@ describe("shot-clock settings route", () => {
 
     const actor = rooms.currentActor(room.code);
     if (actor === undefined) throw new Error("expected a current actor");
-    const folded = rooms.dispatch(room.code, actor, "fold");
+    const folded = commitDispatch(rooms, room.code, actor, "fold");
     if (!("steps" in folded)) throw new Error("expected fold steps");
-    const next = rooms.dispatch(room.code, "table", "nextHand");
+    const next = commitDispatch(rooms, room.code, "table", "nextHand");
     if (!("steps" in next)) throw new Error("expected next-hand steps");
 
     expect(room.shotClockSettings).toEqual(settings);
@@ -1042,12 +1063,12 @@ describe("seat-count movement over WebSocket", () => {
     const player = connect(room.code, 5, token);
     await opened(player.socket);
 
-    rooms.dispatch(room.code, "table", "startHand");
+    commitDispatch(rooms, room.code, "table", "startHand");
     for (let i = 0; i < MAX_SEAT_COUNT; i++) {
       if (room.engine?.hand?.status === "complete") break;
       const actor = rooms.currentActor(room.code);
       if (actor === undefined) throw new Error("expected a current actor");
-      rooms.dispatch(room.code, actor, "fold");
+      commitDispatch(rooms, room.code, actor, "fold");
     }
 
     const response = await app.inject({
@@ -3145,5 +3166,282 @@ describe("hand summaries over WebSocket", () => {
       type: "hand-list",
       summaries: [],
     });
+  });
+});
+
+describe("the commit seam", () => {
+  const SHOT_CLOCK_SECONDS = 5;
+
+  interface Connection {
+    readonly socket: WebSocket;
+    readonly messages: ServerMessage[];
+  }
+
+  interface ArmedTimer {
+    readonly timeoutMs: number;
+    readonly fire: () => void;
+  }
+
+  /**
+   * A filesystem whose appends can be held open. Real appends are
+   * single-digit milliseconds, which is far too fast to interleave anything
+   * against on purpose — and interleaving is exactly what the seam exists to
+   * survive.
+   */
+  function gateAppends(inner: MemoryFileSystem) {
+    let held: Promise<void> | null = null;
+    let release = (): void => undefined;
+    let announceArrival = (): void => undefined;
+    let arrival = Promise.resolve();
+
+    return {
+      fileSystem: {
+        ...inner,
+        async appendFile(filePath: string, contents: string): Promise<void> {
+          announceArrival();
+          if (held !== null) await held;
+          await inner.appendFile(filePath, contents);
+        },
+      },
+      hold(): void {
+        held = new Promise<void>((resolve) => {
+          release = () => {
+            resolve();
+          };
+        });
+        arrival = new Promise<void>((resolve) => {
+          announceArrival = () => {
+            resolve();
+          };
+        });
+      },
+      /** Resolves once an append has reached the held gate. */
+      arrived(): Promise<void> {
+        return arrival;
+      },
+      release(): void {
+        held = null;
+        release();
+      },
+    };
+  }
+
+  interface SeamRig {
+    readonly app: FastifyInstance;
+    readonly rooms: RoomStore;
+    readonly code: string;
+    readonly armed: ArmedTimer[];
+    readonly gate: ReturnType<typeof gateAppends>;
+    readonly table: Connection;
+    readonly seats: Connection[];
+  }
+
+  async function settle(ms = 20): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  async function waitFor(condition: () => boolean): Promise<void> {
+    for (let attempt = 0; attempt < 100; attempt++) {
+      if (condition()) return;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    throw new Error("timed out waiting for the room to catch up");
+  }
+
+  /**
+   * A heads-up room whose appends are gated and whose action timers are armed
+   * but never fired on their own, so a test fires them where it chooses.
+   */
+  async function headsUpRoom(shotClock = true): Promise<SeamRig> {
+    const gate = gateAppends(createMemoryFileSystem());
+    const armed: ArmedTimer[] = [];
+    const actionClock = new ActionClock(
+      90_000,
+      (callback, timeoutMs) => {
+        const handle = setTimeout(() => undefined, 60_000);
+        handle.unref();
+        armed.push({ timeoutMs, fire: callback });
+        return handle;
+      },
+      clearTimeout,
+    );
+    const rooms = new RoomStore();
+    const app = await buildApp({
+      rooms,
+      actionClock,
+      recordings: new DirectoryRecordings(RECORDINGS_ROOT, gate.fileSystem),
+    });
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected a bound TCP address");
+    }
+
+    const port = address.port;
+    const created = await app.inject({
+      method: "POST",
+      url: "/rooms",
+      payload: { seatCount: 2 },
+    });
+    const { code } = created.json<RoomCreatedBody>();
+    if (shotClock) {
+      rooms.changeShotClockSettings(code, {
+        enabled: true,
+        seconds: SHOT_CLOCK_SECONDS,
+      });
+    }
+
+    function connect(query: string): Connection {
+      const socket = new WebSocket(
+        `ws://127.0.0.1:${String(port)}/ws?${query}`,
+      );
+      const messages: ServerMessage[] = [];
+      socket.on("message", (data: Buffer) => {
+        messages.push(JSON.parse(data.toString()) as ServerMessage);
+      });
+      return { socket, messages };
+    }
+
+    const table = connect(`room=${code}&role=table`);
+    const seats = [0, 1].map((seatId) => {
+      const claim = rooms.claimSeat(code, seatId, `P${String(seatId)}`);
+      if (!("seat" in claim)) throw new Error("expected a claimed seat");
+      return connect(
+        `room=${code}&seat=${String(seatId)}&token=${claim.seat.token ?? ""}`,
+      );
+    });
+
+    await Promise.all(
+      [table, ...seats].map(
+        (conn) =>
+          new Promise<void>((resolve, reject) => {
+            if (conn.socket.readyState === WebSocket.OPEN) {
+              resolve();
+              return;
+            }
+            conn.socket.once("open", () => {
+              resolve();
+            });
+            conn.socket.once("error", reject);
+          }),
+      ),
+    );
+    await settle();
+    return { app, rooms, code, armed, gate, table, seats };
+  }
+
+  function actionsSeen(messages: ServerMessage[]) {
+    return messages
+      .filter((message) => message.type === "hand-update")
+      .map((message) => message.event)
+      .filter((event) => event.type === "ActionTaken");
+  }
+
+  it("discards a clock fold the room has moved past, even against the same seat", async () => {
+    // Heads-up, the non-button seat acts last preflop and first on the flop.
+    // Its own check is what moves the room on, so a fold queued behind that
+    // check finds the very seat it names back on the clock a beat later.
+    const rig = await headsUpRoom();
+    const { code, rooms, armed, gate, table, seats } = rig;
+    try {
+      table.socket.send(JSON.stringify({ type: "startHand" }));
+      await waitFor(() => rooms.currentActor(code) === 0);
+      seats[0]?.socket.send(JSON.stringify({ type: "call" }));
+      await waitFor(() => rooms.currentActor(code) === 1);
+      const staleFold = armed.at(-1);
+      if (staleFold === undefined) throw new Error("expected an armed timer");
+
+      gate.hold();
+      seats[1]?.socket.send(JSON.stringify({ type: "check" }));
+      await gate.arrived();
+      staleFold.fire();
+      gate.release();
+      await settle();
+
+      expect(
+        actionsSeen(table.messages).filter((event) => event.action === "fold"),
+      ).toEqual([]);
+      const hand = rooms.get(code)?.engine?.hand;
+      if (hand?.status !== "betting") {
+        throw new Error("expected the hand to still be live");
+      }
+      expect(hand.street).toBe("flop");
+      expect(rooms.currentActor(code)).toBe(1);
+    } finally {
+      for (const conn of [table, ...seats]) conn.socket.close();
+      await rig.app.close();
+    }
+  });
+
+  it("arms the action clock only once the append confirms", async () => {
+    const rig = await headsUpRoom();
+    const { code, rooms, armed, gate, table } = rig;
+    try {
+      gate.hold();
+      table.socket.send(JSON.stringify({ type: "startHand" }));
+      await gate.arrived();
+
+      expect(armed).toEqual([]);
+      const releasedAt = Date.now();
+      gate.release();
+      await waitFor(() => armed.length > 0);
+
+      expect(armed.at(-1)?.timeoutMs).toBe(SHOT_CLOCK_SECONDS * 1000);
+      expect(rooms.get(code)?.turnEndsAt).toBeGreaterThanOrEqual(
+        releasedAt + SHOT_CLOCK_SECONDS * 1000,
+      );
+    } finally {
+      for (const conn of [table, ...rig.seats]) conn.socket.close();
+      await rig.app.close();
+    }
+  });
+
+  it("broadcasts nothing a failed append refused to record", async () => {
+    const fileSystem = createMemoryFileSystem();
+    const rooms = new RoomStore();
+    const app = await buildApp({
+      rooms,
+      recordings: new DirectoryRecordings(RECORDINGS_ROOT, fileSystem),
+    });
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected a bound TCP address");
+    }
+    const created = await app.inject({
+      method: "POST",
+      url: "/rooms",
+      payload: { seatCount: 2 },
+    });
+    const { code } = created.json<RoomCreatedBody>();
+    for (const seatId of [0, 1]) {
+      rooms.claimSeat(code, seatId, `P${String(seatId)}`);
+    }
+    const table = new WebSocket(
+      `ws://127.0.0.1:${String(address.port)}/ws?room=${code}&role=table`,
+    );
+    const messages: ServerMessage[] = [];
+    table.on("message", (data: Buffer) => {
+      messages.push(JSON.parse(data.toString()) as ServerMessage);
+    });
+    try {
+      await new Promise<void>((resolve, reject) => {
+        table.once("open", () => {
+          resolve();
+        });
+        table.once("error", reject);
+      });
+      fileSystem.failAlways("appendFile");
+
+      table.send(JSON.stringify({ type: "startHand" }));
+      await settle(50);
+
+      expect(messages.filter((m) => m.type === "hand-update")).toEqual([]);
+      expect(rooms.get(code)?.engine).toBeNull();
+      expect(rooms.get(code)?.revision).toBe(0);
+    } finally {
+      table.close();
+      await app.close();
+    }
   });
 });

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -3232,6 +3232,8 @@ describe("the commit seam", () => {
     readonly code: string;
     readonly armed: ArmedTimer[];
     readonly gate: ReturnType<typeof gateAppends>;
+    /** The disk under the gate, for arming a failure. */
+    readonly disk: MemoryFileSystem;
     readonly table: Connection;
     readonly seats: Connection[];
   }
@@ -3253,7 +3255,8 @@ describe("the commit seam", () => {
    * but never fired on their own, so a test fires them where it chooses.
    */
   async function headsUpRoom(shotClock = true): Promise<SeamRig> {
-    const gate = gateAppends(createMemoryFileSystem());
+    const disk = createMemoryFileSystem();
+    const gate = gateAppends(disk);
     const armed: ArmedTimer[] = [];
     const actionClock = new ActionClock(
       90_000,
@@ -3327,7 +3330,7 @@ describe("the commit seam", () => {
       ),
     );
     await settle();
-    return { app, rooms, code, armed, gate, table, seats };
+    return { app, rooms, code, armed, gate, disk, table, seats };
   }
 
   function actionsSeen(messages: ServerMessage[]) {
@@ -3392,6 +3395,55 @@ describe("the commit seam", () => {
       );
     } finally {
       for (const conn of [table, ...rig.seats]) conn.socket.close();
+      await rig.app.close();
+    }
+  });
+
+  it("cancels the Actor's clock when the fold it fired could not be recorded", async () => {
+    const rig = await headsUpRoom();
+    const { code, rooms, armed, disk, table } = rig;
+    try {
+      table.socket.send(JSON.stringify({ type: "startHand" }));
+      await waitFor(() => rooms.currentActor(code) === 0);
+      const expired = armed.at(-1);
+      if (expired === undefined) throw new Error("expected an armed timer");
+
+      disk.failAlways("appendFile");
+      expired.fire();
+      await waitFor(() => rooms.get(code)?.turnEndsAt === null);
+
+      expect(
+        actionsSeen(table.messages).filter((event) => event.action === "fold"),
+      ).toEqual([]);
+      expect(rooms.currentActor(code)).toBe(0);
+    } finally {
+      for (const conn of [table, ...rig.seats]) conn.socket.close();
+      await rig.app.close();
+    }
+  });
+
+  it("keeps a seat whose fold could not be recorded, and says so", async () => {
+    const rig = await headsUpRoom();
+    const { app, code, rooms, disk, table, seats } = rig;
+    try {
+      table.socket.send(JSON.stringify({ type: "startHand" }));
+      await waitFor(() => rooms.currentActor(code) === 0);
+      disk.failAlways("appendFile");
+
+      const response = await app.inject({
+        method: "POST",
+        url: `/rooms/${code}/seats/0/evict`,
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.json()).toEqual({ error: "recording-unavailable" });
+      expect(rooms.get(code)?.seats[0]).toMatchObject({ claimed: true });
+      expect(seats[0]?.socket.readyState).toBe(WebSocket.OPEN);
+      expect(
+        actionsSeen(table.messages).filter((event) => event.action === "fold"),
+      ).toEqual([]);
+    } finally {
+      for (const conn of [table, ...seats]) conn.socket.close();
       await rig.app.close();
     }
   });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -280,13 +280,7 @@ export async function buildApp(
   const actionClock =
     options.actionClock ?? new ActionClock(options.actionClockMs);
   const socketRoomCode = new Map<WebSocket, string>();
-  /**
-   * One operation queue per Room. Socket Commands, clock-driven folds and Seat
-   * mutations enter their Room's queue in arrival order and run one at a time,
-   * so an awaited append can never be overtaken by the next operation; other
-   * Rooms are untouched by it (Phase 2 spec #129 §3). The tail is dropped once
-   * it drains, leaving nothing behind for an idle Room.
-   */
+  /** One operation queue per Room — see `docs/design/server.md`. Idle Rooms drop their tail. */
   const roomQueues = new Map<string, Promise<unknown>>();
   const pingMissed = new Map<WebSocket, number>();
   const evictedSockets = new WeakSet<WebSocket>();
@@ -313,11 +307,7 @@ export async function buildApp(
     return queued;
   }
 
-  /**
-   * Queues work nothing awaits — a socket Command, a fired timer. Their
-   * failures have nowhere to be returned to, so they land in the log rather
-   * than as an unhandled rejection.
-   */
+  /** Queues work nothing awaits, so its failures land in the log, not unhandled. */
   function enqueueDetached(
     code: string,
     operation: () => Promise<void> | void,
@@ -328,8 +318,8 @@ export async function buildApp(
   }
 
   function send(socket: WebSocket, message: ServerMessage): void {
-    // A queued operation outlives the message that started it, so its socket
-    // may have gone in between; `ws` treats a send after close as an error.
+    // A queued operation outlives the message that started it, and `ws` treats
+    // a send after close as an error.
     if (socket.readyState !== socket.OPEN) return;
     socket.send(JSON.stringify(message));
   }
@@ -429,7 +419,18 @@ export async function buildApp(
     const identity = socketIdentity.get(socket);
     const code = socketRoomCode.get(socket);
     if (!isSeat(identity) || code === undefined) return;
-    rooms.setSeatDisconnected(code, identity, disconnected);
+    enqueueDetached(code, () => {
+      setPresence(code, identity, disconnected);
+    });
+  }
+
+  /** Presence decides deal-in eligibility, so it takes its turn in the queue. */
+  function setPresence(
+    code: string,
+    seatId: SeatId,
+    disconnected: boolean,
+  ): void {
+    rooms.setSeatDisconnected(code, seatId, disconnected);
     broadcastRoomView(code);
   }
 
@@ -538,8 +539,7 @@ export async function buildApp(
   /**
    * Hands the room's recording one whole engine operation and waits for it to
    * be confirmed on disk. Answers whether the operation may now be applied and
-   * broadcast: nothing is published before its append confirms (Phase 2 spec
-   * #129 §3).
+   * broadcast.
    */
   async function appendOperation(
     code: string,
@@ -547,11 +547,8 @@ export async function buildApp(
   ): Promise<boolean> {
     const recording = roomRecordings.get(code);
     if (recording === undefined) {
-      // Every room created through `POST /rooms` has one. Reaching here means
-      // play is happening unrecorded, which the Room invariant forbids — so
-      // it is a loud bug, never a quiet skip (Phase 2 spec #129 §3). The Room
-      // is still played out: refusing the operation would strand the table on
-      // a bug of ours, and losing the transcript is the smaller harm.
+      // A bug of ours rather than a disk failure, so it is loud but not fatal
+      // to the table — see `docs/design/server.md`.
       app.log.error({ room: code }, "dispatch in a room with no recording");
       return true;
     }
@@ -560,16 +557,13 @@ export async function buildApp(
       await recording.append(operation);
       return true;
     } catch (error) {
-      // Filesystem detail belongs in operational logs, never on the wire.
-      // Telling the table and offering Retry / Continue without recording /
-      // End session is issue #121's recording-paused state; until then the
-      // operation is dropped, loudly here and nowhere else.
+      // Filesystem detail belongs in operational logs, never on the wire; the
+      // table-facing recovery is issue #121.
       app.log.error({ err: error, room: code }, "recording append failed");
       return false;
     }
   }
 
-  /** Records a refusal the engine ruled on. It changes nothing, so it commits nothing. */
   async function recordRejection(
     code: string,
     rejection: DispatchRejection,
@@ -747,23 +741,12 @@ export async function buildApp(
       options.actionClock === undefined && options.actionClockMs !== undefined
         ? options.actionClockMs
         : seconds * 1000;
-    // "preserve" keeps the Actor's existing deadline — another Seat's eviction
-    // must not hand them a fresh interval — but still re-arms the timer, so it
-    // carries the revision that eviction produced. Left alone, the fold it
-    // fires would dequeue stale and never be replaced.
     const preserved = policy === "preserve" ? room.turnEndsAt : null;
     const timeoutMs =
       preserved === null
         ? fullInterval
         : Math.max(preserved - now().getTime(), 0);
     room.turnEndsAt = preserved ?? now().getTime() + fullInterval;
-    // The revision this clock was armed against. A fired timer is no longer a
-    // timer — it is an operation queued behind whatever else arrived first,
-    // and clearing the timer cannot recall it. "Nothing has happened since I
-    // was scheduled" is the precondition for an auto-fold, and the Actor's
-    // identity cannot state it: heads-up, the non-button Seat acts last
-    // preflop and first on the flop, so a stale fold can find its Seat back on
-    // the clock a beat later, having just checked (Phase 2 spec #129 §3).
     const scheduledAt = room.revision;
     actionClock.schedule(code, timeoutMs, () => {
       enqueueDetached(code, async () => {
@@ -794,9 +777,9 @@ export async function buildApp(
   }
 
   /**
-   * Records an accepted dispatch, commits it, and only then tells the room.
-   * The order is the whole point of the seam: the append may fail, and an
-   * operation that failed to record is one the room must never have seen.
+   * Records an accepted dispatch, commits it, and only then tells the room —
+   * including arming the clock, so append latency costs nobody their thinking
+   * time. See the commit seam in `docs/design/server.md`.
    */
   async function publishDispatch(
     code: string,
@@ -804,18 +787,22 @@ export async function buildApp(
     options: {
       readonly actionClock?: ActionClockPolicy;
     } = {},
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (!(await appendOperation(code, transaction.operation))) {
       transaction.discard();
-      return;
+      // A refused operation cancels the Actor's clock rather than leaving a
+      // deadline nothing will honour: the timer that would have fired is
+      // spent, and no replacement may act on an unrecorded Room (§3).
+      actionClock.clear(code);
+      const room = rooms.get(code);
+      if (room !== undefined) room.turnEndsAt = null;
+      return false;
     }
     transaction.commit();
 
     if (transaction.seatMoves !== undefined) {
       applySeatMoves(code, transaction.seatMoves);
     }
-    // The clock arms only now, so a slow append is never deducted from the
-    // next player's thinking time.
     rescheduleActionClock(code, options.actionClock ?? "reschedule");
     for (const step of transaction.steps) {
       fanOutHandUpdate(code, step);
@@ -830,6 +817,7 @@ export async function buildApp(
       if (rollBotSitStates(code)) broadcastRoomView(code);
     }
     scheduleBotAction(code);
+    return true;
   }
 
   await app.register(fastifyStatic, { root: publicDir, index: false });
@@ -911,10 +899,14 @@ export async function buildApp(
     return { url, dataUrl };
   });
 
-  app.post<RoomCodeRoute>("/rooms/:code/end", (request, reply) => {
+  app.post<RoomCodeRoute>("/rooms/:code/end", async (request, reply) => {
     const room = findRoomOrReject(rooms, request.params.code, reply);
     if (!room) return;
-    endRoom(room.code);
+    // Behind the queue, so teardown never lands between an append and the
+    // commit it was going to confirm.
+    await enqueue(room.code, () => {
+      endRoom(room.code);
+    });
     return reply.code(204).send();
   });
 
@@ -954,35 +946,43 @@ export async function buildApp(
 
   app.post<RoomCodeRoute>("/rooms/:code/seats/count", changeSeatCount);
 
-  app.post<RoomCodeRoute>("/rooms/:code/sound", (request, reply) => {
+  app.post<RoomCodeRoute>("/rooms/:code/sound", async (request, reply) => {
     const body = ChangeSoundSettingsRequestSchema.safeParse(request.body);
     if (!body.success) {
       return reply.code(400).send({ error: "invalid-request-body" });
     }
     const room = findRoomOrReject(rooms, request.params.code, reply);
     if (!room) return;
-    const result = rooms.changeSoundSettings(room.code, body.data);
+    const result = await enqueue(room.code, () => {
+      const settings = rooms.changeSoundSettings(room.code, body.data);
+      if (!("error" in settings)) broadcastRoomView(room.code);
+      return settings;
+    });
     if ("error" in result) {
       return reply.code(404).send({ error: result.error });
     }
-    broadcastRoomView(room.code);
     return result;
   });
 
-  app.post<RoomCodeRoute>("/rooms/:code/shot-clock", (request, reply) => {
+  app.post<RoomCodeRoute>("/rooms/:code/shot-clock", async (request, reply) => {
     const body = ChangeShotClockRequestSchema.safeParse(request.body);
     if (!body.success) {
       return reply.code(400).send({ error: "invalid-request-body" });
     }
     const room = findRoomOrReject(rooms, request.params.code, reply);
     if (!room) return;
-    const result = rooms.changeShotClockSettings(room.code, body.data);
+    // Queued with everything else: a pending edit is taken up by the next
+    // committed deal-in, so it must not slip in beside one mid-append.
+    const result = await enqueue(room.code, () => {
+      const settings = rooms.changeShotClockSettings(room.code, body.data);
+      if (!("error" in settings)) broadcastRoomView(room.code);
+      return settings;
+    });
     if ("error" in result) {
       return reply
         .code(result.error === "room-not-found" ? 404 : 400)
         .send({ error: result.error });
     }
-    broadcastRoomView(room.code);
     return result;
   });
 
@@ -1033,25 +1033,27 @@ export async function buildApp(
 
   /**
    * Publishes the fold a freed seat owed, then broadcasts the seat itself.
-   * The seat is freed by the transaction, so it is never given up on a
-   * broadcast the recording refused. Runs inside the Room's queue.
+   * Answers false when that fold could not be recorded: the seat is still
+   * holding its hand, so it must not be taken from its player either.
    */
   async function publishSeatRelease(
     code: string,
     seatId: SeatId,
     released: EvictSeatResult,
     notify: boolean,
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (released.transaction !== undefined) {
-      await publishDispatch(code, released.transaction, {
+      const published = await publishDispatch(code, released.transaction, {
         actionClock:
           released.transaction.command.type === "evict"
             ? "preserve"
             : "reschedule",
       });
+      if (!published) return false;
     }
     broadcastRoomView(code);
     closeSeatSockets(code, seatId, notify);
+    return true;
   }
 
   app.post<RoomSeatRoute>(
@@ -1063,7 +1065,7 @@ export async function buildApp(
       }
       const room = findRoomOrReject(rooms, request.params.code, reply);
       if (!room) return;
-      await enqueue(room.code, () =>
+      const released = await enqueue(room.code, () =>
         publishSeatRelease(
           room.code,
           seatId,
@@ -1071,6 +1073,9 @@ export async function buildApp(
           true,
         ),
       );
+      if (!released) {
+        return reply.code(503).send({ error: "recording-unavailable" });
+      }
       return reply.code(204).send();
     },
   );
@@ -1090,9 +1095,13 @@ export async function buildApp(
       const refusal = await enqueue(code, async () => {
         const result = rooms.leaveSeat(code, seatId, body.data.token);
         if ("error" in result) return result.error;
-        await publishSeatRelease(code, seatId, result, false);
-        return undefined;
+        return (await publishSeatRelease(code, seatId, result, false))
+          ? undefined
+          : "recording-unavailable";
       });
+      if (refusal === "recording-unavailable") {
+        return reply.code(503).send({ error: refusal });
+      }
       if (refusal !== undefined) {
         return reply
           .code(refusal === "room-not-found" ? 404 : 403)
@@ -1158,40 +1167,42 @@ export async function buildApp(
             clearTimeout(timer);
             tableGraceTimers.delete(code);
           }
-        } else if (isSeat(identity)) {
-          rooms.setSeatDisconnected(code, identity, false);
         }
 
-        if (movedFrom !== undefined && isSeat(identity)) {
-          send(socket, { type: "seat-moved", from: movedFrom, to: identity });
-        }
+        // The catch-up takes its turn in the Room's queue, so a joiner is
+        // never caught up to a state the recording has yet to confirm.
+        const joined = identity;
+        enqueueDetached(code, () => {
+          if (isSeat(joined)) {
+            rooms.setSeatDisconnected(code, joined, false);
+          }
 
-        const room = rooms.get(code);
-        if (room) {
+          if (movedFrom !== undefined && isSeat(joined)) {
+            send(socket, { type: "seat-moved", from: movedFrom, to: joined });
+          }
+
+          const room = rooms.get(code);
+          if (!room) return;
           broadcastRoomView(code);
           // Incremental pushes alone would leave a reloaded table with an
           // empty picker for hands it had already seen — Phase 1's catch-up
           // is one view snapshot, which carries no summaries (§5). Sent even
           // when empty, so the picker has a definite starting state.
-          if (identity === "table") sendHandList(socket, code);
+          if (joined === "table") sendHandList(socket, code);
           // One fresh snapshot on connect, never event replay (§7, §9).
-          if (room.engine !== null) {
-            if (identity === "table") {
-              send(socket, {
-                type: "view-snapshot",
-                view: view(room.engine, "table", room.turnEndsAt),
-              });
-            } else if (
-              isSeat(identity) &&
-              room.engine.seats.includes(identity)
-            ) {
-              send(socket, {
-                type: "view-snapshot",
-                view: view(room.engine, identity, room.turnEndsAt),
-              });
-            }
+          if (room.engine === null) return;
+          if (joined === "table") {
+            send(socket, {
+              type: "view-snapshot",
+              view: view(room.engine, "table", room.turnEndsAt),
+            });
+          } else if (isSeat(joined) && room.engine.seats.includes(joined)) {
+            send(socket, {
+              type: "view-snapshot",
+              view: view(room.engine, joined, room.turnEndsAt),
+            });
           }
-        }
+        });
 
         socket.on("pong", () => {
           const missed = pingMissed.get(socket) ?? 0;
@@ -1302,13 +1313,16 @@ export async function buildApp(
                 code,
                 setTimeout(() => {
                   tableGraceTimers.delete(code);
-                  endRoom(code);
+                  enqueueDetached(code, () => {
+                    endRoom(code);
+                  });
                 }, graceWindowMs),
               );
             }
           } else if (isSeat(currentIdentity)) {
-            rooms.setSeatDisconnected(code, currentIdentity, true);
-            broadcastRoomView(code);
+            enqueueDetached(code, () => {
+              setPresence(code, currentIdentity, true);
+            });
           }
         });
       },

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -21,7 +21,6 @@ import {
   type SeatMove,
   type ServerMessage,
 } from "@table-top-poker/protocol";
-import { handStartContextFor } from "@table-top-poker/recording";
 import type {
   Recordings,
   RoomOperation,
@@ -48,7 +47,8 @@ import {
   type ClaimSeatError,
   type DispatchRejection,
   type DispatchStep,
-  type DispatchSuccess,
+  type DispatchTransaction,
+  type EvictSeatResult,
   type Room,
   RoomStore,
   toRoomView,
@@ -220,30 +220,6 @@ function authenticateSeat(
   };
 }
 
-/**
- * Turns an accepted dispatch into the whole operation the recording takes.
- * The state right after `HandStarted` is where a Hand's seats and button are
- * fixed; nothing later in the same operation moves them.
- */
-function toHandOperation(
-  result: DispatchSuccess,
-  now: () => Date,
-): RoomOperation {
-  const events = result.steps.map((step) => step.event);
-  const opening = result.steps.find(
-    (step) => step.event.type === "HandStarted",
-  );
-  const context =
-    opening === undefined
-      ? undefined
-      : handStartContextFor(events, opening.state, now);
-  return {
-    ...(context === undefined ? {} : { context }),
-    command: result.command,
-    outcome: events,
-  };
-}
-
 function seatCountBodyError(
   issues: readonly { readonly path: readonly PropertyKey[] }[],
 ): Extract<
@@ -304,13 +280,57 @@ export async function buildApp(
   const actionClock =
     options.actionClock ?? new ActionClock(options.actionClockMs);
   const socketRoomCode = new Map<WebSocket, string>();
+  /**
+   * One operation queue per Room. Socket Commands, clock-driven folds and Seat
+   * mutations enter their Room's queue in arrival order and run one at a time,
+   * so an awaited append can never be overtaken by the next operation; other
+   * Rooms are untouched by it (Phase 2 spec #129 §3). The tail is dropped once
+   * it drains, leaving nothing behind for an idle Room.
+   */
+  const roomQueues = new Map<string, Promise<unknown>>();
   const pingMissed = new Map<WebSocket, number>();
   const evictedSockets = new WeakSet<WebSocket>();
   const tableGraceTimers = new Map<string, NodeJS.Timeout>();
   const botActionTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const app = Fastify();
 
+  function enqueue<T>(
+    code: string,
+    operation: () => Promise<T> | T,
+  ): Promise<T> {
+    const queued = (roomQueues.get(code) ?? Promise.resolve()).then(
+      operation,
+      operation,
+    );
+    const tail = queued.then(
+      () => undefined,
+      () => undefined,
+    );
+    roomQueues.set(code, tail);
+    void tail.then(() => {
+      if (roomQueues.get(code) === tail) roomQueues.delete(code);
+    });
+    return queued;
+  }
+
+  /**
+   * Queues work nothing awaits — a socket Command, a fired timer. Their
+   * failures have nowhere to be returned to, so they land in the log rather
+   * than as an unhandled rejection.
+   */
+  function enqueueDetached(
+    code: string,
+    operation: () => Promise<void> | void,
+  ): void {
+    void enqueue(code, operation).catch((error: unknown) => {
+      app.log.error({ err: error, room: code }, "room operation failed");
+    });
+  }
+
   function send(socket: WebSocket, message: ServerMessage): void {
+    // A queued operation outlives the message that started it, so its socket
+    // may have gone in between; `ws` treats a send after close as an error.
+    if (socket.readyState !== socket.OPEN) return;
     socket.send(JSON.stringify(message));
   }
 
@@ -516,39 +536,46 @@ export async function buildApp(
   }
 
   /**
-   * Hands the room's recording one whole engine operation — the command, the
-   * events or rejection it produced, and the Hand context when it opens a
-   * Hand. The recording owns ordering, so this is not awaited here; issue
-   * #118 moves the await in front of the broadcast.
+   * Hands the room's recording one whole engine operation and waits for it to
+   * be confirmed on disk. Answers whether the operation may now be applied and
+   * broadcast: nothing is published before its append confirms (Phase 2 spec
+   * #129 §3).
    */
-  function recordDispatch(
+  async function appendOperation(
     code: string,
-    result: DispatchRejection | DispatchSuccess,
-  ): void {
-    if (result.command === undefined) return;
+    operation: RoomOperation,
+  ): Promise<boolean> {
     const recording = roomRecordings.get(code);
     if (recording === undefined) {
       // Every room created through `POST /rooms` has one. Reaching here means
       // play is happening unrecorded, which the Room invariant forbids — so
-      // it is a loud bug, never a quiet skip (Phase 2 spec #129 §3).
+      // it is a loud bug, never a quiet skip (Phase 2 spec #129 §3). The Room
+      // is still played out: refusing the operation would strand the table on
+      // a bug of ours, and losing the transcript is the smaller harm.
       app.log.error({ room: code }, "dispatch in a room with no recording");
-      return;
+      return true;
     }
 
-    const operation =
-      "steps" in result
-        ? toHandOperation(result, now)
-        : result.rejection === undefined
-          ? undefined
-          : { command: result.command, outcome: result.rejection };
-    if (operation === undefined) return;
-
-    void recording.append(operation).catch((error: unknown) => {
+    try {
+      await recording.append(operation);
+      return true;
+    } catch (error) {
       // Filesystem detail belongs in operational logs, never on the wire.
-      // Telling the table and blocking play is issue #121's recording-paused
-      // state; until then a failure is loud here and nowhere else.
+      // Telling the table and offering Retry / Continue without recording /
+      // End session is issue #121's recording-paused state; until then the
+      // operation is dropped, loudly here and nowhere else.
       app.log.error({ err: error, room: code }, "recording append failed");
-    });
+      return false;
+    }
+  }
+
+  /** Records a refusal the engine ruled on. It changes nothing, so it commits nothing. */
+  async function recordRejection(
+    code: string,
+    rejection: DispatchRejection,
+  ): Promise<void> {
+    if (rejection.operation === undefined) return;
+    await appendOperation(code, rejection.operation);
   }
 
   const pingTimer = setInterval(() => {
@@ -666,37 +693,41 @@ export async function buildApp(
     const timer = setTimeout(
       () => {
         botActionTimers.delete(code);
+        enqueueDetached(code, async () => {
+          const currentRoom = rooms.get(code);
+          if (!currentRoom || rooms.currentActor(code) !== actor) return;
+          const currentSeat = currentRoom.seats[actor];
+          if (!currentSeat?.claimed || currentSeat.bot !== true) return;
+          const engine = currentRoom.engine;
+          if (engine?.hand?.status !== "betting") return;
 
-        const currentRoom = rooms.get(code);
-        if (!currentRoom || rooms.currentActor(code) !== actor) return;
-        const currentSeat = currentRoom.seats[actor];
-        if (!currentSeat?.claimed || currentSeat.bot !== true) return;
-        const engine = currentRoom.engine;
-        if (engine?.hand?.status !== "betting") return;
+          const actorView = view(engine, actor);
+          if (
+            actorView.phase !== "betting" ||
+            actorView.legalActions.length === 0
+          ) {
+            return;
+          }
 
-        const actorView = view(engine, actor);
-        if (
-          actorView.phase !== "betting" ||
-          actorView.legalActions.length === 0
-        ) {
-          return;
-        }
-
-        const action = chooseBotAction(actorView.legalActions, botRng);
-        const result = rooms.dispatch(code, actor, action);
-        if (!("steps" in result)) {
-          rescheduleActionClock(code);
-          scheduleBotAction(code);
-          return;
-        }
-        publishDispatch(code, result);
+          const action = chooseBotAction(actorView.legalActions, botRng);
+          const result = rooms.dispatch(code, actor, action);
+          if (!("commit" in result)) {
+            rescheduleActionClock(code);
+            scheduleBotAction(code);
+            return;
+          }
+          await publishDispatch(code, result);
+        });
       },
       sampleBotActionDelay(botActionDelay, botRng),
     );
     botActionTimers.set(code, timer);
   }
 
-  function rescheduleActionClock(code: string): void {
+  function rescheduleActionClock(
+    code: string,
+    policy: ActionClockPolicy = "reschedule",
+  ): void {
     const room = rooms.get(code);
     const actor = rooms.currentActor(code);
     if (room === undefined || actor === undefined) {
@@ -712,65 +743,89 @@ export async function buildApp(
       return;
     }
 
-    const timeoutMs =
+    const fullInterval =
       options.actionClock === undefined && options.actionClockMs !== undefined
         ? options.actionClockMs
         : seconds * 1000;
-    room.turnEndsAt = now().getTime() + timeoutMs;
+    // "preserve" keeps the Actor's existing deadline — another Seat's eviction
+    // must not hand them a fresh interval — but still re-arms the timer, so it
+    // carries the revision that eviction produced. Left alone, the fold it
+    // fires would dequeue stale and never be replaced.
+    const preserved = policy === "preserve" ? room.turnEndsAt : null;
+    const timeoutMs =
+      preserved === null
+        ? fullInterval
+        : Math.max(preserved - now().getTime(), 0);
+    room.turnEndsAt = preserved ?? now().getTime() + fullInterval;
+    // The revision this clock was armed against. A fired timer is no longer a
+    // timer — it is an operation queued behind whatever else arrived first,
+    // and clearing the timer cannot recall it. "Nothing has happened since I
+    // was scheduled" is the precondition for an auto-fold, and the Actor's
+    // identity cannot state it: heads-up, the non-button Seat acts last
+    // preflop and first on the flop, so a stale fold can find its Seat back on
+    // the clock a beat later, having just checked (Phase 2 spec #129 §3).
+    const scheduledAt = room.revision;
     actionClock.schedule(code, timeoutMs, () => {
-      const currentRoom = rooms.get(code);
-      if (!currentRoom || rooms.currentActor(code) !== actor) {
-        rescheduleActionClock(code);
-        return;
-      }
+      enqueueDetached(code, async () => {
+        const currentRoom = rooms.get(code);
+        if (currentRoom?.revision !== scheduledAt) return;
+        if (rooms.currentActor(code) !== actor) {
+          rescheduleActionClock(code);
+          return;
+        }
 
-      const actorView =
-        currentRoom.engine === null
-          ? undefined
-          : view(currentRoom.engine, actor);
-      const action =
-        actorView?.phase === "betting" &&
-        actorView.legalActions.includes("check")
-          ? "check"
-          : "fold";
-      const result = rooms.dispatch(code, actor, action);
-      if ("steps" in result) {
-        publishDispatch(code, result);
-        return;
-      }
-      rescheduleActionClock(code);
+        const actorView =
+          currentRoom.engine === null
+            ? undefined
+            : view(currentRoom.engine, actor);
+        const action =
+          actorView?.phase === "betting" &&
+          actorView.legalActions.includes("check")
+            ? "check"
+            : "fold";
+        const result = rooms.dispatch(code, actor, action);
+        if ("commit" in result) {
+          await publishDispatch(code, result);
+          return;
+        }
+        rescheduleActionClock(code);
+      });
     });
   }
 
-  function publishDispatch(
+  /**
+   * Records an accepted dispatch, commits it, and only then tells the room.
+   * The order is the whole point of the seam: the append may fail, and an
+   * operation that failed to record is one the room must never have seen.
+   */
+  async function publishDispatch(
     code: string,
-    result: DispatchSuccess,
+    transaction: DispatchTransaction,
     options: {
       readonly actionClock?: ActionClockPolicy;
     } = {},
-  ): void {
-    if (result.seatMoves !== undefined) {
-      applySeatMoves(code, result.seatMoves);
+  ): Promise<void> {
+    if (!(await appendOperation(code, transaction.operation))) {
+      transaction.discard();
+      return;
     }
-    recordDispatch(code, result);
-    if (options.actionClock === "preserve") {
-      if (rooms.currentActor(code) === undefined) {
-        actionClock.clear(code);
-        const room = rooms.get(code);
-        if (room !== undefined) room.turnEndsAt = null;
-      }
-    } else {
-      rescheduleActionClock(code);
+    transaction.commit();
+
+    if (transaction.seatMoves !== undefined) {
+      applySeatMoves(code, transaction.seatMoves);
     }
-    for (const step of result.steps) {
+    // The clock arms only now, so a slow append is never deducted from the
+    // next player's thinking time.
+    rescheduleActionClock(code, options.actionClock ?? "reschedule");
+    for (const step of transaction.steps) {
       fanOutHandUpdate(code, step);
     }
     // After the fan-out: the summary describes a hand the room has already
     // seen, so no table learns of a completed hand before its last Event.
-    accumulateHandSummary(code, result.steps);
+    accumulateHandSummary(code, transaction.steps);
     if (
       testMode &&
-      result.steps.some((step) => step.event.type === "HandComplete")
+      transaction.steps.some((step) => step.event.type === "HandComplete")
     ) {
       if (rollBotSitStates(code)) broadcastRoomView(code);
     }
@@ -823,7 +878,7 @@ export async function buildApp(
   });
 
   if (testMode) {
-    app.post<RoomCodeRoute>("/rooms/:code/bots", (request, reply) => {
+    app.post<RoomCodeRoute>("/rooms/:code/bots", async (request, reply) => {
       const body = AddBotsRequestSchema.safeParse(request.body);
       if (!body.success) {
         return reply.code(400).send({ error: "invalid-request-body" });
@@ -831,12 +886,14 @@ export async function buildApp(
 
       const room = findRoomOrReject(rooms, request.params.code, reply);
       if (!room) return;
-      const result = rooms.addBots(room, body.data.count);
-
-      if (result.seats.length > 0) {
-        broadcastRoomView(room.code);
-      }
-      return { joined: result.seats.length };
+      const joined = await enqueue(room.code, () => {
+        const result = rooms.addBots(room, body.data.count);
+        if (result.seats.length > 0) {
+          broadcastRoomView(room.code);
+        }
+        return result.seats.length;
+      });
+      return { joined };
     });
   }
 
@@ -861,7 +918,7 @@ export async function buildApp(
     return reply.code(204).send();
   });
 
-  const changeSeatCount = (
+  const changeSeatCount = async (
     request: FastifyRequest<RoomCodeRoute>,
     reply: FastifyReply,
   ) => {
@@ -874,7 +931,15 @@ export async function buildApp(
 
     const room = findRoomOrReject(rooms, request.params.code, reply);
     if (!room) return;
-    const result = rooms.changeSeatCount(room.code, body.data.seatCount);
+    const result = await enqueue(room.code, () => {
+      const change = rooms.changeSeatCount(room.code, body.data.seatCount);
+      if ("error" in change) return change;
+
+      applySeatMoves(room.code, change.moves);
+      broadcastRoomView(room.code);
+      if (change.moves.length > 0) broadcastDisplayedHand(room.code);
+      return change;
+    });
     if ("error" in result) {
       if (result.error === "seat-count-below-floor") {
         return reply.code(400).send({
@@ -884,10 +949,6 @@ export async function buildApp(
       }
       return reply.code(400).send({ error: result.error });
     }
-
-    applySeatMoves(room.code, result.moves);
-    broadcastRoomView(room.code);
-    if (result.moves.length > 0) broadcastDisplayedHand(room.code);
     return result;
   };
 
@@ -940,7 +1001,7 @@ export async function buildApp(
 
   app.post<RoomSeatRoute>(
     "/rooms/:code/seats/:seatId/claim",
-    (request, reply) => {
+    async (request, reply) => {
       const seatId = parseSeatId(request.params.seatId);
       if (seatId === undefined) {
         return reply.code(400).send({ error: "invalid-seat-id" });
@@ -949,57 +1010,74 @@ export async function buildApp(
       if (!body.success) {
         return reply.code(400).send({ error: "invalid-display-name" });
       }
-      const result = rooms.claimSeat(
-        request.params.code,
-        seatId,
-        body.data.displayName,
-      );
+      const code = request.params.code;
+      const result = await enqueue(code, () => {
+        const claim = rooms.claimSeat(code, seatId, body.data.displayName);
+        if (!("error" in claim)) broadcastRoomView(code);
+        return claim;
+      });
       if ("error" in result) {
         return reply
           .code(CLAIM_ERROR_STATUS[result.error])
           .send({ error: result.error });
       }
-      broadcastRoomView(request.params.code);
       return {
         seatId: result.seat.id,
         token: result.seat.token,
         displayName: result.seat.displayName,
-        sittingOut: rooms.isSittingOut(request.params.code, result.seat.id),
-        sittingOutReason: rooms.sittingOutReason(
-          request.params.code,
-          result.seat.id,
-        ),
+        sittingOut: rooms.isSittingOut(code, result.seat.id),
+        sittingOutReason: rooms.sittingOutReason(code, result.seat.id),
       };
     },
   );
 
+  /**
+   * Publishes the fold a freed seat owed, then broadcasts the seat itself.
+   * The seat is freed by the transaction, so it is never given up on a
+   * broadcast the recording refused. Runs inside the Room's queue.
+   */
+  async function publishSeatRelease(
+    code: string,
+    seatId: SeatId,
+    released: EvictSeatResult,
+    notify: boolean,
+  ): Promise<void> {
+    if (released.transaction !== undefined) {
+      await publishDispatch(code, released.transaction, {
+        actionClock:
+          released.transaction.command.type === "evict"
+            ? "preserve"
+            : "reschedule",
+      });
+    }
+    broadcastRoomView(code);
+    closeSeatSockets(code, seatId, notify);
+  }
+
   app.post<RoomSeatRoute>(
     "/rooms/:code/seats/:seatId/evict",
-    (request, reply) => {
+    async (request, reply) => {
       const seatId = parseSeatId(request.params.seatId);
       if (seatId === undefined) {
         return reply.code(400).send({ error: "invalid-seat-id" });
       }
       const room = findRoomOrReject(rooms, request.params.code, reply);
       if (!room) return;
-      const eviction = rooms.evictSeat(request.params.code, seatId);
-      if (eviction.dispatch !== undefined) {
-        publishDispatch(request.params.code, eviction.dispatch, {
-          actionClock:
-            eviction.dispatch.command.type === "evict"
-              ? "preserve"
-              : "reschedule",
-        });
-      }
-      broadcastRoomView(request.params.code);
-      closeSeatSockets(request.params.code, seatId);
+      await enqueue(room.code, () =>
+        publishSeatRelease(
+          room.code,
+          seatId,
+          rooms.evictSeat(room.code, seatId),
+          true,
+        ),
+      );
       return reply.code(204).send();
     },
   );
 
   app.post<RoomSeatRoute>(
     "/rooms/:code/seats/:seatId/leave",
-    (request, reply) => {
+    async (request, reply) => {
       const seatId = parseSeatId(request.params.seatId);
       if (seatId === undefined) {
         return reply.code(400).send({ error: "invalid-seat-id" });
@@ -1008,26 +1086,18 @@ export async function buildApp(
       if (!body.success) {
         return reply.code(400).send({ error: "invalid-request-body" });
       }
-      const result = rooms.leaveSeat(
-        request.params.code,
-        seatId,
-        body.data.token,
-      );
-      if ("error" in result) {
+      const code = request.params.code;
+      const refusal = await enqueue(code, async () => {
+        const result = rooms.leaveSeat(code, seatId, body.data.token);
+        if ("error" in result) return result.error;
+        await publishSeatRelease(code, seatId, result, false);
+        return undefined;
+      });
+      if (refusal !== undefined) {
         return reply
-          .code(result.error === "room-not-found" ? 404 : 403)
-          .send({ error: result.error });
+          .code(refusal === "room-not-found" ? 404 : 403)
+          .send({ error: refusal });
       }
-      if (result.dispatch !== undefined) {
-        publishDispatch(request.params.code, result.dispatch, {
-          actionClock:
-            result.dispatch.command.type === "evict"
-              ? "preserve"
-              : "reschedule",
-        });
-      }
-      broadcastRoomView(request.params.code);
-      closeSeatSockets(request.params.code, seatId, false);
       return reply.code(204).send();
     },
   );
@@ -1176,12 +1246,11 @@ export async function buildApp(
               sendRejection(socket, "not-permitted");
               return;
             }
-            rooms.setSittingOut(
-              code,
-              currentIdentity,
-              parseResult.data.type === "sitOut",
-            );
-            broadcastRoomView(code);
+            const sittingOut = parseResult.data.type === "sitOut";
+            enqueueDetached(code, () => {
+              rooms.setSittingOut(code, currentIdentity, sittingOut);
+              broadcastRoomView(code);
+            });
             return;
           }
 
@@ -1194,28 +1263,28 @@ export async function buildApp(
             sendRejection(socket, "invalid-command");
             return;
           }
-          const dispatchResult = rooms.dispatch(
-            code,
-            currentIdentity,
-            parseResult.data.type,
-          );
-          if ("error" in dispatchResult) {
-            sendRejection(socket, dispatchResult.error);
-            return;
-          }
-          if ("reason" in dispatchResult) {
-            recordDispatch(code, dispatchResult);
-            sendRejection(socket, dispatchResult.reason);
-            return;
-          }
+          const commandType = parseResult.data.type;
+          enqueueDetached(code, async () => {
+            const dispatchResult = rooms.dispatch(
+              code,
+              currentIdentity,
+              commandType,
+            );
+            if ("error" in dispatchResult) {
+              sendRejection(socket, dispatchResult.error);
+              return;
+            }
+            if ("reason" in dispatchResult) {
+              await recordRejection(code, dispatchResult);
+              sendRejection(socket, dispatchResult.reason);
+              return;
+            }
 
-          publishDispatch(code, dispatchResult);
-          if (
-            parseResult.data.type === "startHand" ||
-            parseResult.data.type === "nextHand"
-          ) {
-            broadcastRoomView(code);
-          }
+            await publishDispatch(code, dispatchResult);
+            if (commandType === "startHand" || commandType === "nextHand") {
+              broadcastRoomView(code);
+            }
+          });
         });
 
         socket.on("close", () => {

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -5,14 +5,59 @@ import {
   MAX_DISPLAY_NAME_LENGTH,
   MAX_SEAT_COUNT,
   MIN_SEAT_COUNT,
+  type SeatId,
 } from "@table-top-poker/protocol";
 import { describe, expect, it } from "vitest";
-import { type Room, RoomStore, toRoomView } from "./rooms.js";
+import {
+  type DispatchResult,
+  type EvictSeatResult,
+  type Room,
+  RoomStore,
+  type SeatCommandType,
+  toRoomView,
+} from "./rooms.js";
 
 /** A deterministic `Math.random` stand-in, repeating its last value forever. */
 function sequenceOf(values: readonly number[]): () => number {
   let index = 0;
   return () => values[index++] ?? values.at(-1) ?? 0;
+}
+
+/**
+ * Dispatches and commits in one step, as `app.ts` does once the append
+ * confirms. Tests about the staging seam itself call `dispatch` directly and
+ * settle the transaction themselves.
+ */
+function commitDispatch(
+  store: RoomStore,
+  code: string,
+  identity: SeatId | "table",
+  type: SeatCommandType,
+): DispatchResult {
+  const result = store.dispatch(code, identity, type);
+  if ("commit" in result) result.commit();
+  return result;
+}
+
+function commitEviction(
+  store: RoomStore,
+  code: string,
+  seatId: SeatId,
+): EvictSeatResult {
+  const result = store.evictSeat(code, seatId);
+  result.transaction?.commit();
+  return result;
+}
+
+function commitLeave(
+  store: RoomStore,
+  code: string,
+  seatId: SeatId,
+  token: string,
+): EvictSeatResult | { readonly error: "room-not-found" | "not-permitted" } {
+  const result = store.leaveSeat(code, seatId, token);
+  if (!("error" in result)) result.transaction?.commit();
+  return result;
 }
 
 describe("RoomStore", () => {
@@ -228,7 +273,7 @@ describe("RoomStore", () => {
       });
       expect(room.seats[1]?.claimed).toBe(false);
 
-      store.evictSeat(room.code, 0);
+      commitEviction(store, room.code, 0);
       expect(store.claimSeat(room.code, 1, "Avery")).toHaveProperty("seat");
     });
 
@@ -275,7 +320,7 @@ describe("RoomStore", () => {
       const room = store.create();
       store.claimSeat(room.code, 0, "P0");
       store.claimSeat(room.code, 1, "P1");
-      store.dispatch(room.code, "table", "startHand");
+      commitDispatch(store, room.code, "table", "startHand");
 
       const result = store.claimSeat(room.code, 2, "P2");
 
@@ -294,7 +339,7 @@ describe("RoomStore", () => {
       const room = store.create();
       store.claimSeat(room.code, 0, "P0");
 
-      store.evictSeat(room.code, 0);
+      commitEviction(store, room.code, 0);
 
       expect(room.seats[0]).toEqual({
         id: 0,
@@ -318,7 +363,7 @@ describe("RoomStore", () => {
       const room = store.create();
       const added = store.addBots(room, 1);
 
-      store.evictSeat(room.code, added.seats[0]?.id ?? 0);
+      commitEviction(store, room.code, added.seats[0]?.id ?? 0);
 
       expect(room.seats[0]).not.toHaveProperty("bot");
       expect(toRoomView(room).seats[0]).not.toHaveProperty("bot");
@@ -335,7 +380,7 @@ describe("RoomStore", () => {
         displayName: "Blair",
       });
 
-      store.evictSeat(room.code, 0);
+      commitEviction(store, room.code, 0);
 
       expect(room.seats[0]).not.toHaveProperty("displayName");
     });
@@ -343,7 +388,7 @@ describe("RoomStore", () => {
     it("evicting a seat in an unknown room is a no-op", () => {
       const store = new RoomStore();
       expect(() => {
-        store.evictSeat("ZZZZ", 0);
+        commitEviction(store, "ZZZZ", 0);
       }).not.toThrow();
     });
   });
@@ -362,7 +407,7 @@ describe("RoomStore", () => {
       const room = store.create();
       const token = claimWithToken(store, room.code, 0);
 
-      const result = store.leaveSeat(room.code, 0, token);
+      const result = commitLeave(store, room.code, 0, token);
 
       expect(result).not.toHaveProperty("error");
       expect(room.seats[0]).toEqual({
@@ -379,7 +424,7 @@ describe("RoomStore", () => {
       const room = store.create();
       claimWithToken(store, room.code, 0);
 
-      const result = store.leaveSeat(room.code, 0, "not-the-token");
+      const result = commitLeave(store, room.code, 0, "not-the-token");
 
       expect(result).toEqual({ error: "not-permitted" });
       expect(room.seats[0]).toMatchObject({ claimed: true });
@@ -389,14 +434,14 @@ describe("RoomStore", () => {
       const store = new RoomStore();
       const room = store.create();
 
-      expect(store.leaveSeat(room.code, 0, "any")).toEqual({
+      expect(commitLeave(store, room.code, 0, "any")).toEqual({
         error: "not-permitted",
       });
     });
 
     it("reports room-not-found for an unknown room", () => {
       const store = new RoomStore();
-      expect(store.leaveSeat("ZZZZ", 0, "any")).toEqual({
+      expect(commitLeave(store, "ZZZZ", 0, "any")).toEqual({
         error: "room-not-found",
       });
     });
@@ -407,14 +452,14 @@ describe("RoomStore", () => {
       const tokens = [0, 1, 2].map((seatId) =>
         claimWithToken(store, room.code, seatId),
       );
-      store.dispatch(room.code, "table", "startHand");
+      commitDispatch(store, room.code, "table", "startHand");
       const actor = store.currentActor(room.code);
       if (actor === undefined) throw new Error("expected a current actor");
 
-      const result = store.leaveSeat(room.code, actor, tokens[actor] ?? "");
+      const result = commitLeave(store, room.code, actor, tokens[actor] ?? "");
 
       if ("error" in result) throw new Error("expected the leave to dispatch");
-      expect(result.dispatch?.steps.at(-1)?.event).toMatchObject({
+      expect(result.transaction?.steps.at(-1)?.event).toMatchObject({
         type: "ActionTaken",
         seatId: actor,
         action: "fold",
@@ -437,7 +482,7 @@ describe("RoomStore", () => {
         if (room.engine?.hand?.status === "complete") return;
         const actor = store.currentActor(room.code);
         if (actor === undefined) throw new Error("expected a current actor");
-        const result = store.dispatch(room.code, actor, "fold");
+        const result = commitDispatch(store, room.code, actor, "fold");
         if (!("steps" in result)) throw new Error("expected dispatch steps");
       }
       throw new Error("hand did not complete");
@@ -488,7 +533,7 @@ describe("RoomStore", () => {
       const store = new RoomStore();
       const room = store.create(2);
       claimSeats(store, room, [0, 1]);
-      const started = store.dispatch(room.code, "table", "startHand");
+      const started = commitDispatch(store, room.code, "table", "startHand");
       if (!("steps" in started)) throw new Error("expected dispatch steps");
 
       expect(store.changeSeatCount(room.code, 4)).toMatchObject({
@@ -499,7 +544,7 @@ describe("RoomStore", () => {
       claimSeats(store, room, [2]);
       completeHand(store, room);
 
-      const next = store.dispatch(room.code, "table", "nextHand");
+      const next = commitDispatch(store, room.code, "table", "nextHand");
 
       if (!("steps" in next)) throw new Error("expected dispatch steps");
       expect(room.engine?.seats).toEqual([0, 1, 2]);
@@ -546,7 +591,7 @@ describe("RoomStore", () => {
       const store = new RoomStore();
       const room = store.create();
       claimSeats(store, room, [2, 5, 7]);
-      const started = store.dispatch(room.code, "table", "startHand");
+      const started = commitDispatch(store, room.code, "table", "startHand");
       if (!("steps" in started)) throw new Error("expected dispatch steps");
       const liveEngine = room.engine;
 
@@ -562,7 +607,7 @@ describe("RoomStore", () => {
       expect(room.engine).toBe(liveEngine);
 
       completeHand(store, room);
-      const next = store.dispatch(room.code, "table", "nextHand");
+      const next = commitDispatch(store, room.code, "table", "nextHand");
 
       if (!("steps" in next)) throw new Error("expected dispatch steps");
       expect(next.seatMoves).toEqual([
@@ -581,10 +626,10 @@ describe("RoomStore", () => {
       const store = new RoomStore();
       const room = store.create();
       claimSeats(store, room, [2, 5, 7]);
-      const started = store.dispatch(room.code, "table", "startHand");
+      const started = commitDispatch(store, room.code, "table", "startHand");
       if (!("steps" in started)) throw new Error("expected dispatch steps");
       completeHand(store, room);
-      const second = store.dispatch(room.code, "table", "nextHand");
+      const second = commitDispatch(store, room.code, "table", "nextHand");
       if (!("steps" in second)) throw new Error("expected dispatch steps");
       completeHand(store, room);
 
@@ -610,7 +655,7 @@ describe("RoomStore", () => {
         false,
       ]);
 
-      const next = store.dispatch(room.code, "table", "nextHand");
+      const next = commitDispatch(store, room.code, "table", "nextHand");
 
       if (!("steps" in next)) throw new Error("expected dispatch steps");
       expect(next.seatMoves).toBeUndefined();
@@ -631,7 +676,7 @@ describe("RoomStore", () => {
 
     it("rejects a command for an unknown room", () => {
       const store = new RoomStore();
-      expect(store.dispatch("ZZZZ", "table", "startHand")).toEqual({
+      expect(commitDispatch(store, "ZZZZ", "table", "startHand")).toEqual({
         error: "room-not-found",
       });
     });
@@ -639,7 +684,7 @@ describe("RoomStore", () => {
     it("rejects a table-only command sent by a seat", () => {
       const store = new RoomStore();
       const room = roomWithClaimedSeats(store, 2);
-      expect(store.dispatch(room.code, 0, "startHand")).toEqual({
+      expect(commitDispatch(store, room.code, 0, "startHand")).toEqual({
         error: "not-permitted",
       });
     });
@@ -647,7 +692,7 @@ describe("RoomStore", () => {
     it("rejects a seat-only command sent by the table", () => {
       const store = new RoomStore();
       const room = roomWithClaimedSeats(store, 2);
-      expect(store.dispatch(room.code, "table", "fold")).toEqual({
+      expect(commitDispatch(store, room.code, "table", "fold")).toEqual({
         error: "not-permitted",
       });
     });
@@ -655,7 +700,7 @@ describe("RoomStore", () => {
     it("rejects starting a hand with fewer than 2 dealt-in seats", () => {
       const store = new RoomStore();
       const room = roomWithClaimedSeats(store, 1);
-      expect(store.dispatch(room.code, "table", "startHand")).toEqual({
+      expect(commitDispatch(store, room.code, "table", "startHand")).toEqual({
         reason: "not-enough-players",
       });
     });
@@ -663,7 +708,7 @@ describe("RoomStore", () => {
     it("rejects an action before any hand has started", () => {
       const store = new RoomStore();
       const room = roomWithClaimedSeats(store, 2);
-      expect(store.dispatch(room.code, 0, "fold")).toEqual({
+      expect(commitDispatch(store, room.code, 0, "fold")).toEqual({
         reason: "hand-not-in-progress",
       });
     });
@@ -676,7 +721,7 @@ describe("RoomStore", () => {
       });
       const room = roomWithClaimedSeats(store, 3);
 
-      const result = store.dispatch(room.code, "table", "startHand");
+      const result = commitDispatch(store, room.code, "table", "startHand");
 
       if (!("steps" in result)) throw new Error("expected dispatch steps");
       expect(result.steps.map((step) => step.event.type)).toEqual([
@@ -697,11 +742,11 @@ describe("RoomStore", () => {
     it("excludes a mid-hand joiner from the deal, showing it sitting out", () => {
       const store = new RoomStore();
       const room = roomWithClaimedSeats(store, 2);
-      store.dispatch(room.code, "table", "startHand");
+      commitDispatch(store, room.code, "table", "startHand");
       const midHandJoin = store.claimSeat(room.code, 2, "P2");
       if (!("seat" in midHandJoin)) throw new Error("expected a claim");
 
-      const foldResult = store.dispatch(room.code, 2, "fold");
+      const foldResult = commitDispatch(store, room.code, 2, "fold");
 
       expect(foldResult).toMatchObject({
         reason: "not-your-turn",
@@ -715,7 +760,7 @@ describe("RoomStore", () => {
       const store = new RoomStore();
       const room = roomWithClaimedSeats(store, 2);
 
-      store.dispatch(room.code, "table", "startHand");
+      commitDispatch(store, room.code, "table", "startHand");
 
       expect(room.seats[0]?.sittingOut).toBe(false);
       expect(room.seats[1]?.sittingOut).toBe(false);
@@ -724,9 +769,9 @@ describe("RoomStore", () => {
     it("rejects a second startHand once a hand is already in progress", () => {
       const store = new RoomStore();
       const room = roomWithClaimedSeats(store, 2);
-      store.dispatch(room.code, "table", "startHand");
+      commitDispatch(store, room.code, "table", "startHand");
 
-      const result = store.dispatch(room.code, "table", "startHand");
+      const result = commitDispatch(store, room.code, "table", "startHand");
       expect(result).toMatchObject({
         reason: "hand-already-in-progress",
         command: {
@@ -748,7 +793,7 @@ describe("RoomStore", () => {
     it("rejects an out-of-turn fold", () => {
       const store = new RoomStore();
       const room = roomWithClaimedSeats(store, 2);
-      const started = store.dispatch(room.code, "table", "startHand");
+      const started = commitDispatch(store, room.code, "table", "startHand");
       if (!("steps" in started)) throw new Error("expected dispatch steps");
       const streetStarted = started.steps.at(-1)?.event;
       if (streetStarted?.type !== "StreetStarted") {
@@ -759,13 +804,13 @@ describe("RoomStore", () => {
       );
       if (!outOfTurnSeat) throw new Error("expected an out-of-turn seat");
 
-      expect(store.dispatch(room.code, outOfTurnSeat.id, "fold")).toMatchObject(
-        {
-          reason: "not-your-turn",
-          command: { type: "fold", seatId: outOfTurnSeat.id },
-          rejection: { type: "Rejection", reason: "not-your-turn" },
-        },
-      );
+      expect(
+        commitDispatch(store, room.code, outOfTurnSeat.id, "fold"),
+      ).toMatchObject({
+        reason: "not-your-turn",
+        command: { type: "fold", seatId: outOfTurnSeat.id },
+        rejection: { type: "Rejection", reason: "not-your-turn" },
+      });
     });
 
     function completeHand(store: RoomStore, room: Room): void {
@@ -773,7 +818,7 @@ describe("RoomStore", () => {
         if (room.engine?.hand?.status === "complete") return;
         const actor = store.currentActor(room.code);
         if (actor === undefined) throw new Error("expected a current actor");
-        const result = store.dispatch(room.code, actor, "fold");
+        const result = commitDispatch(store, room.code, actor, "fold");
         if (!("steps" in result)) throw new Error("expected dispatch steps");
       }
       throw new Error("hand did not complete");
@@ -783,11 +828,11 @@ describe("RoomStore", () => {
       it("deals a mid-hand joiner into the next hand", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 2);
-        store.dispatch(room.code, "table", "startHand");
+        commitDispatch(store, room.code, "table", "startHand");
         store.claimSeat(room.code, 2, "P2");
         completeHand(store, room);
 
-        const result = store.dispatch(room.code, "table", "nextHand");
+        const result = commitDispatch(store, room.code, "table", "nextHand");
 
         if (!("steps" in result)) throw new Error("expected dispatch steps");
         const holeCardsDealt = result.steps.find(
@@ -805,13 +850,13 @@ describe("RoomStore", () => {
       it("keeps a between-hand joiner sitting out until the next deal-in", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 2);
-        store.dispatch(room.code, "table", "startHand");
+        commitDispatch(store, room.code, "table", "startHand");
         completeHand(store, room);
         store.claimSeat(room.code, 2, "P2");
 
         expect(toRoomView(room).seats[2]).toMatchObject({ sittingOut: true });
 
-        const result = store.dispatch(room.code, "table", "nextHand");
+        const result = commitDispatch(store, room.code, "table", "nextHand");
 
         if (!("steps" in result)) throw new Error("expected dispatch steps");
         expect(toRoomView(room).seats[2]).toMatchObject({ sittingOut: false });
@@ -820,11 +865,11 @@ describe("RoomStore", () => {
       it("excludes a disconnected seat from the next hand's deal-in", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 3);
-        store.dispatch(room.code, "table", "startHand");
+        commitDispatch(store, room.code, "table", "startHand");
         completeHand(store, room);
         store.setSeatDisconnected(room.code, 2, true);
 
-        const result = store.dispatch(room.code, "table", "nextHand");
+        const result = commitDispatch(store, room.code, "table", "nextHand");
 
         if (!("steps" in result)) throw new Error("expected dispatch steps");
         expect(room.engine?.seats).not.toContain(2);
@@ -833,11 +878,11 @@ describe("RoomStore", () => {
       it("rejects nextHand once too few seats remain eligible, without dealing anyone in", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 2);
-        store.dispatch(room.code, "table", "startHand");
+        commitDispatch(store, room.code, "table", "startHand");
         completeHand(store, room);
         store.setSeatDisconnected(room.code, 1, true);
 
-        expect(store.dispatch(room.code, "table", "nextHand")).toEqual({
+        expect(commitDispatch(store, room.code, "table", "nextHand")).toEqual({
           reason: "not-enough-players",
         });
       });
@@ -845,13 +890,13 @@ describe("RoomStore", () => {
       it("rejects nextHand as stale-next-hand while a hand is still live, leaving seats and button untouched", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 3);
-        store.dispatch(room.code, "table", "startHand");
+        commitDispatch(store, room.code, "table", "startHand");
         store.setSeatDisconnected(room.code, 2, true);
 
         const seatsBefore = room.engine?.seats;
         const buttonBefore = room.engine?.button;
 
-        const result = store.dispatch(room.code, "table", "nextHand");
+        const result = commitDispatch(store, room.code, "table", "nextHand");
 
         expect(result).toMatchObject({ reason: "stale-next-hand" });
         expect(room.engine?.seats).toBe(seatsBefore);
@@ -864,11 +909,11 @@ describe("RoomStore", () => {
       it("auto-folds the current actor before freeing the evicted seat", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 3);
-        store.dispatch(room.code, "table", "startHand");
+        commitDispatch(store, room.code, "table", "startHand");
         const actor = store.currentActor(room.code);
         if (actor === undefined) throw new Error("expected a current actor");
 
-        store.evictSeat(room.code, actor);
+        commitEviction(store, room.code, actor);
 
         expect(room.seats[actor]).toMatchObject({ claimed: false });
         expect(store.currentActor(room.code)).not.toBe(actor);
@@ -881,11 +926,11 @@ describe("RoomStore", () => {
       it("keeps a bot reclaimed into an evicted live seat out until the next hand", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 3);
-        store.dispatch(room.code, "table", "startHand");
+        commitDispatch(store, room.code, "table", "startHand");
         const actor = store.currentActor(room.code);
         if (actor === undefined) throw new Error("expected a current actor");
 
-        store.evictSeat(room.code, actor);
+        commitEviction(store, room.code, actor);
         const added = store.addBots(room, 1);
         const bot = added.seats[0];
         if (bot === undefined) throw new Error("expected a bot seat");
@@ -904,7 +949,7 @@ describe("RoomStore", () => {
         expect(room.engine.hand.players.get(actor)?.folded).toBe(true);
 
         completeHand(store, room);
-        const next = store.dispatch(room.code, "table", "nextHand");
+        const next = commitDispatch(store, room.code, "table", "nextHand");
         if (!("steps" in next)) throw new Error("expected next-hand steps");
         const holeCardsDealt = next.steps.find(
           (step) => step.event.type === "HoleCardsDealt",
@@ -927,7 +972,7 @@ describe("RoomStore", () => {
       it("auto-folds a later in-hand seat without moving the current actor", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 3);
-        store.dispatch(room.code, "table", "startHand");
+        commitDispatch(store, room.code, "table", "startHand");
         if (room.engine?.hand?.status !== "betting") {
           throw new Error("expected a betting hand");
         }
@@ -937,16 +982,16 @@ describe("RoomStore", () => {
           throw new Error("expected two seats to be awaiting action");
         }
 
-        const result = store.evictSeat(room.code, evicted);
+        const result = commitEviction(store, room.code, evicted);
 
-        if (result.dispatch === undefined) {
+        if (result.transaction === undefined) {
           throw new Error("expected the eviction fold to dispatch");
         }
-        expect(result.dispatch.command).toEqual({
+        expect(result.transaction.command).toEqual({
           type: "evict",
           seatId: evicted,
         });
-        expect(result.dispatch.steps.map((step) => step.event)).toEqual([
+        expect(result.transaction.steps.map((step) => step.event)).toEqual([
           { type: "ActionTaken", seatId: evicted, action: "fold" },
         ]);
         expect(room.seats[evicted]).toMatchObject({ claimed: false });
@@ -958,20 +1003,18 @@ describe("RoomStore", () => {
       it("completes a heads-up hand when evicting the current actor", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 2);
-        store.dispatch(room.code, "table", "startHand");
+        commitDispatch(store, room.code, "table", "startHand");
         const actor = store.currentActor(room.code);
         if (actor === undefined) throw new Error("expected a current actor");
 
-        const result = store.evictSeat(room.code, actor);
+        const result = commitEviction(store, room.code, actor);
 
-        if (result.dispatch === undefined) {
+        if (result.transaction === undefined) {
           throw new Error("expected the eviction fold to dispatch");
         }
-        expect(result.dispatch.steps.map((step) => step.event.type)).toEqual([
-          "ActionTaken",
-          "HandFoldedOut",
-          "HandComplete",
-        ]);
+        expect(result.transaction.steps.map((step) => step.event.type)).toEqual(
+          ["ActionTaken", "HandFoldedOut", "HandComplete"],
+        );
         expect(room.seats[actor]).toMatchObject({ claimed: false });
         expect(store.currentActor(room.code)).toBeUndefined();
         expect(room.engine?.hand?.status).toBe("complete");
@@ -980,11 +1023,11 @@ describe("RoomStore", () => {
       it("frees a claimed seat via evictSeat regardless of connection status", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 3);
-        store.dispatch(room.code, "table", "startHand");
+        commitDispatch(store, room.code, "table", "startHand");
         completeHand(store, room);
         store.setSeatDisconnected(room.code, 2, true);
 
-        store.evictSeat(room.code, 2);
+        commitEviction(store, room.code, 2);
 
         expect(room.seats[2]).toMatchObject({ claimed: false, token: null });
       });
@@ -992,12 +1035,12 @@ describe("RoomStore", () => {
       it("has no automatic eviction — a disconnected seat stays occupied across any number of hands", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 3);
-        store.dispatch(room.code, "table", "startHand");
+        commitDispatch(store, room.code, "table", "startHand");
         completeHand(store, room);
         store.setSeatDisconnected(room.code, 2, true);
 
         for (let i = 0; i < 5; i++) {
-          store.dispatch(room.code, "table", "nextHand");
+          commitDispatch(store, room.code, "table", "nextHand");
           completeHand(store, room);
         }
 
@@ -1008,7 +1051,7 @@ describe("RoomStore", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 2);
 
-        store.evictSeat(room.code, 1);
+        commitEviction(store, room.code, 1);
 
         expect(room.seats[1]).toMatchObject({ claimed: false });
       });
@@ -1020,7 +1063,7 @@ describe("RoomStore", () => {
         const room = roomWithClaimedSeats(store, 3);
         store.setSittingOut(room.code, 2, true);
 
-        const result = store.dispatch(room.code, "table", "startHand");
+        const result = commitDispatch(store, room.code, "table", "startHand");
 
         if (!("steps" in result)) throw new Error("expected dispatch steps");
         expect(room.engine?.seats).not.toContain(2);
@@ -1034,11 +1077,11 @@ describe("RoomStore", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 3);
         store.setSittingOut(room.code, 2, true);
-        store.dispatch(room.code, "table", "startHand");
+        commitDispatch(store, room.code, "table", "startHand");
         completeHand(store, room);
 
         store.setSittingOut(room.code, 2, false);
-        const result = store.dispatch(room.code, "table", "nextHand");
+        const result = commitDispatch(store, room.code, "table", "nextHand");
 
         if (!("steps" in result)) throw new Error("expected dispatch steps");
         expect(room.engine?.seats).toContain(2);
@@ -1051,6 +1094,201 @@ describe("RoomStore", () => {
         store.setSittingOut(room.code, 0, true);
 
         expect(room.seats[0]?.sittingOut).toBe(false);
+      });
+    });
+  });
+
+  describe("the commit seam", () => {
+    function roomWithClaimedSeats(
+      store: RoomStore,
+      seatIds: readonly SeatId[],
+    ) {
+      const room = store.create();
+      for (const seatId of seatIds) {
+        store.claimSeat(room.code, seatId, `P${String(seatId)}`);
+      }
+      return room;
+    }
+
+    function stagedDispatch(
+      store: RoomStore,
+      code: string,
+      identity: SeatId | "table",
+      type: SeatCommandType,
+    ) {
+      const result = store.dispatch(code, identity, type);
+      if (!("commit" in result)) throw new Error("expected a transaction");
+      return result;
+    }
+
+    it("changes nothing about the room until the transaction commits", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, [0, 1]);
+
+      const transaction = stagedDispatch(
+        store,
+        room.code,
+        "table",
+        "startHand",
+      );
+
+      expect(room.engine).toBeNull();
+      expect(room.revision).toBe(0);
+      expect(store.currentActor(room.code)).toBeUndefined();
+
+      transaction.commit();
+
+      expect(room.engine?.hand?.status).toBe("betting");
+      expect(room.revision).toBe(1);
+    });
+
+    it("leaves a discarded dispatch no trace, and takes the next one", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, [0, 1]);
+
+      stagedDispatch(store, room.code, "table", "startHand").discard();
+
+      expect(room.engine).toBeNull();
+      expect(room.revision).toBe(0);
+
+      const retried = stagedDispatch(store, room.code, "table", "startHand");
+      retried.commit();
+
+      expect(room.engine?.hand?.status).toBe("betting");
+      expect(room.revision).toBe(1);
+    });
+
+    it("refuses to settle a transaction twice", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, [0, 1]);
+      const transaction = stagedDispatch(
+        store,
+        room.code,
+        "table",
+        "startHand",
+      );
+
+      transaction.commit();
+
+      expect(() => {
+        transaction.commit();
+      }).toThrow(/already settled/);
+      expect(() => {
+        transaction.discard();
+      }).toThrow(/already settled/);
+      expect(room.revision).toBe(1);
+    });
+
+    it("leaves a rejected command's revision alone, so a queued clock fold survives it", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, [0, 1]);
+      commitDispatch(store, room.code, "table", "startHand");
+      const revision = room.revision;
+      const actor = store.currentActor(room.code);
+      if (actor === undefined) throw new Error("expected a current actor");
+
+      const rejected = store.dispatch(room.code, 1 - actor, "fold");
+
+      expect(rejected).toMatchObject({ reason: "not-your-turn" });
+      expect(room.revision).toBe(revision);
+    });
+
+    it("stages the seat shrink with the hand it belongs to, not before", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, [2, 5, 7]);
+      commitDispatch(store, room.code, "table", "startHand");
+      store.changeSeatCount(room.code, 3);
+      for (let fold = 0; fold < 2; fold++) {
+        const actor = store.currentActor(room.code);
+        if (actor === undefined) throw new Error("expected a current actor");
+        commitDispatch(store, room.code, actor, "fold");
+      }
+      const engineBefore = room.engine;
+
+      const transaction = stagedDispatch(store, room.code, "table", "nextHand");
+
+      expect(room.seats).toHaveLength(MAX_SEAT_COUNT);
+      expect(room.pendingSeatCount).toBe(3);
+      expect(room.engine).toBe(engineBefore);
+      expect(transaction.seatMoves).toEqual([
+        { from: 2, to: 0 },
+        { from: 5, to: 1 },
+        { from: 7, to: 2 },
+      ]);
+
+      transaction.commit();
+
+      expect(room.seats).toHaveLength(3);
+      expect(room.pendingSeatCount).toBeNull();
+      expect(room.engine?.seats).toEqual([0, 1, 2]);
+    });
+
+    it("frees an evicted seat only once its fold is committed", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, [0, 1, 2]);
+      commitDispatch(store, room.code, "table", "startHand");
+      const actor = store.currentActor(room.code);
+      if (actor === undefined) throw new Error("expected a current actor");
+
+      const eviction = store.evictSeat(room.code, actor);
+
+      if (eviction.transaction === undefined) {
+        throw new Error("expected the eviction fold to stage");
+      }
+      expect(room.seats[actor]).toMatchObject({ claimed: true });
+      expect(store.currentActor(room.code)).toBe(actor);
+
+      eviction.transaction.commit();
+
+      expect(room.seats[actor]).toMatchObject({ claimed: false });
+      expect(store.currentActor(room.code)).not.toBe(actor);
+    });
+
+    it("carries the whole operation the recording takes", () => {
+      const startedAt = "2026-08-17T19:30:00.000Z";
+      const store = new RoomStore(
+        Math.random,
+        undefined,
+        () => "seed-1",
+        undefined,
+        () => new Date(startedAt),
+      );
+      const room = roomWithClaimedSeats(store, [0, 1]);
+
+      const transaction = stagedDispatch(
+        store,
+        room.code,
+        "table",
+        "startHand",
+      );
+
+      expect(transaction.operation).toEqual({
+        context: { startedAt, seats: [0, 1], button: 0 },
+        command: { type: "startHand", seatId: 0, seed: "seed-1" },
+        outcome: transaction.steps.map((step) => step.event),
+      });
+    });
+
+    it("gives a rejection the operation that records it, and no hand context", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, [0, 1]);
+      commitDispatch(store, room.code, "table", "startHand");
+
+      const rejected = store.dispatch(room.code, "table", "startHand");
+
+      if (!("reason" in rejected)) throw new Error("expected a rejection");
+      expect(rejected.operation).toEqual({
+        command: rejected.command,
+        outcome: rejected.rejection,
+      });
+    });
+
+    it("has no operation for a refusal the engine never ruled on", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, [0]);
+
+      expect(store.dispatch(room.code, "table", "startHand")).toEqual({
+        reason: "not-enough-players",
       });
     });
   });
@@ -1078,7 +1316,7 @@ describe("RoomStore", () => {
     it("is the seat named by the hand's own StreetStarted event", () => {
       const store = new RoomStore();
       const room = roomWithClaimedSeats(store, 2);
-      const started = store.dispatch(room.code, "table", "startHand");
+      const started = commitDispatch(store, room.code, "table", "startHand");
       if (!("steps" in started)) throw new Error("expected dispatch steps");
       const streetStarted = started.steps.at(-1)?.event;
       if (streetStarted?.type !== "StreetStarted") {
@@ -1091,11 +1329,11 @@ describe("RoomStore", () => {
     it("advances to the next actor after a legal action", () => {
       const store = new RoomStore();
       const room = roomWithClaimedSeats(store, 2);
-      store.dispatch(room.code, "table", "startHand");
+      commitDispatch(store, room.code, "table", "startHand");
       const actor = store.currentActor(room.code);
       if (actor === undefined) throw new Error("expected a current actor");
 
-      store.dispatch(room.code, actor, "call");
+      commitDispatch(store, room.code, actor, "call");
 
       expect(store.currentActor(room.code)).not.toBe(actor);
     });
@@ -1176,7 +1414,7 @@ describe("changeShotClockSettings", () => {
     const room = store.create();
     store.claimSeat(room.code, 0, "P0");
     store.claimSeat(room.code, 1, "P1");
-    const started = store.dispatch(room.code, "table", "startHand");
+    const started = commitDispatch(store, room.code, "table", "startHand");
     if (!("steps" in started)) throw new Error("expected start-hand steps");
     const settings = { enabled: true, seconds: 30 };
 
@@ -1188,9 +1426,9 @@ describe("changeShotClockSettings", () => {
 
     const actor = store.currentActor(room.code);
     if (actor === undefined) throw new Error("expected a current actor");
-    const folded = store.dispatch(room.code, actor, "fold");
+    const folded = commitDispatch(store, room.code, actor, "fold");
     if (!("steps" in folded)) throw new Error("expected fold steps");
-    const next = store.dispatch(room.code, "table", "nextHand");
+    const next = commitDispatch(store, room.code, "table", "nextHand");
     if (!("steps" in next)) throw new Error("expected next-hand steps");
 
     expect(room.shotClockSettings).toEqual(settings);

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -53,12 +53,7 @@ export interface Room {
   readonly code: string;
   readonly seats: Seat[];
   engine: EngineState | null;
-  /**
-   * Counts committed engine operations. A caller that captured it earlier can
-   * ask the only question that makes a queued auto-fold safe — "has anything
-   * happened since?" — which the Actor's identity alone cannot answer (Phase 2
-   * spec #129 §3).
-   */
+  /** Committed engine operations, counted so a caller can ask what has happened since. */
   revision: number;
   pendingSeatCount: number | null;
   turnEndsAt: number | null;
@@ -119,18 +114,13 @@ export interface DispatchSuccess {
 }
 
 /**
- * An accepted dispatch that has changed nothing yet: the Room still holds the
- * engine state, the seats and the pending seat count it had before. The caller
- * records {@link operation}, then calls {@link commit} — or {@link discard} if
- * the append failed — so nothing is ever broadcast that was not recorded first
- * (Phase 2 spec #129 §3). The obligation rides on the handle rather than on a
- * convention a later edit can quietly drop, so settling twice throws.
+ * An accepted dispatch that has changed nothing yet. The caller records
+ * {@link operation}, then settles the handle exactly once — see the commit
+ * seam in `docs/design/server.md`.
  */
 export interface DispatchTransaction extends DispatchSuccess {
   readonly operation: RoomOperation;
-  /** Applies the staged changes to the Room and bumps its revision. */
   commit(): void;
-  /** Abandons them, leaving the Room exactly as the dispatch found it. */
   discard(): void;
 }
 
@@ -165,7 +155,6 @@ function makeSeats(seatCount: number): Seat[] {
 }
 
 interface SeatRepack {
-  /** The seat row the Room takes on, ready to replace `room.seats`. */
   readonly seats: readonly Seat[];
   readonly moves: readonly SeatMove[];
   readonly mapping: ReadonlyMap<SeatId, SeatId>;
@@ -369,11 +358,9 @@ function toRoomOperation(
 /** Everything a committed dispatch changes about its Room, and nothing else. */
 interface StagedTransition {
   readonly engine: EngineState;
-  /** A pending shrink this dispatch takes up, seat row and all. */
   readonly repack?: SeatRepack;
-  /** The seats this dispatch deals in, when it opens a Hand. */
+  /** The seats it deals in, when it opens a Hand. */
   readonly dealIn?: readonly SeatId[];
-  /** A seat whose eviction waits on the engine operation that covers it. */
   readonly freedSeat?: SeatId;
 }
 
@@ -543,9 +530,8 @@ export class RoomStore {
 
   /**
    * Frees a seat, folding the hand it is holding first. Where a fold is
-   * needed the seat is not freed here: it is freed by the returned
-   * transaction, so the seat and the engine operation that covers it land
-   * together or not at all.
+   * needed the returned transaction is what frees the seat — see the commit
+   * seam in `docs/design/server.md`.
    */
   evictSeat(code: string, seatId: SeatId): EvictSeatResult {
     const room = this.#rooms.get(code);
@@ -553,9 +539,8 @@ export class RoomStore {
     if (!seat) return {};
 
     if (this.currentActor(code) === seatId) {
-      const result = this.#dispatch(code, seatId, "fold", seatId);
-      if (!("commit" in result)) return {};
-      return { transaction: result };
+      const transaction = this.#stageSeatRelease(room, seatId, "fold");
+      return transaction === undefined ? {} : { transaction };
     }
 
     const hand = room.engine?.hand;
@@ -567,9 +552,8 @@ export class RoomStore {
       player !== undefined &&
       !player.folded
     ) {
-      const transaction = this.#stageEviction(room, seatId);
-      if (transaction === undefined) return {};
-      return { transaction };
+      const transaction = this.#stageSeatRelease(room, seatId, "evict");
+      return transaction === undefined ? {} : { transaction };
     }
 
     freeSeat(seat);
@@ -684,22 +668,13 @@ export class RoomStore {
 
   /**
    * Decides one Command against the Room and stages what it would change,
-   * without changing anything. Every filesystem-free, synchronous decision
-   * lives here; the caller sequences the append and the commit.
+   * without changing anything — see the commit seam in
+   * `docs/design/server.md`.
    */
   dispatch(
     code: string,
     identity: SeatId | "table",
     type: SeatCommandType,
-  ): DispatchResult {
-    return this.#dispatch(code, identity, type);
-  }
-
-  #dispatch(
-    code: string,
-    identity: SeatId | "table",
-    type: SeatCommandType,
-    freedSeat?: SeatId,
   ): DispatchResult {
     const room = this.#rooms.get(code);
     if (!room) return { error: "room-not-found" };
@@ -751,7 +726,6 @@ export class RoomStore {
         engine: decided.engine,
         ...(repack === undefined ? {} : { repack }),
         ...(opensHand ? { dealIn: candidateEngine.seats } : {}),
-        ...(freedSeat === undefined ? {} : { freedSeat }),
       },
       {
         command,
@@ -761,9 +735,14 @@ export class RoomStore {
     );
   }
 
-  #stageEviction(room: Room, seatId: SeatId): DispatchTransaction | undefined {
+  /** The fold or eviction that has to be recorded before a seat is freed. */
+  #stageSeatRelease(
+    room: Room,
+    seatId: SeatId,
+    type: "fold" | "evict",
+  ): DispatchTransaction | undefined {
     if (room.engine === null) return undefined;
-    const command: Command = { type: "evict", seatId };
+    const command: Command = { type, seatId };
     const decided = this.#decide(room.engine, command);
     if (!("steps" in decided)) return undefined;
     return this.#stage(
@@ -828,7 +807,9 @@ export class RoomStore {
         room.engine = transition.engine;
         room.revision += 1;
       },
-      discard: settle,
+      discard: () => {
+        settle();
+      },
     };
   }
 

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -1,4 +1,6 @@
 import { randomUUID } from "node:crypto";
+import { handStartContextFor } from "@table-top-poker/recording";
+import type { RoomOperation } from "@table-top-poker/recording";
 import {
   apply,
   createInitialState,
@@ -51,6 +53,13 @@ export interface Room {
   readonly code: string;
   readonly seats: Seat[];
   engine: EngineState | null;
+  /**
+   * Counts committed engine operations. A caller that captured it earlier can
+   * ask the only question that makes a queued auto-fold safe — "has anything
+   * happened since?" — which the Actor's identity alone cannot answer (Phase 2
+   * spec #129 §3).
+   */
+  revision: number;
   pendingSeatCount: number | null;
   turnEndsAt: number | null;
   pendingShotClock: ShotClockSettings | null;
@@ -83,7 +92,8 @@ export type ClaimSeatError =
 export type ClaimSeatResult = { seat: Seat } | { error: ClaimSeatError };
 
 export interface EvictSeatResult {
-  readonly dispatch?: DispatchSuccess;
+  /** Present when freeing the seat needs an engine operation recorded first. */
+  readonly transaction?: DispatchTransaction;
 }
 
 export type ChangeSeatCountError = Exclude<
@@ -108,14 +118,32 @@ export interface DispatchSuccess {
   readonly seatMoves?: readonly SeatMove[];
 }
 
+/**
+ * An accepted dispatch that has changed nothing yet: the Room still holds the
+ * engine state, the seats and the pending seat count it had before. The caller
+ * records {@link operation}, then calls {@link commit} — or {@link discard} if
+ * the append failed — so nothing is ever broadcast that was not recorded first
+ * (Phase 2 spec #129 §3). The obligation rides on the handle rather than on a
+ * convention a later edit can quietly drop, so settling twice throws.
+ */
+export interface DispatchTransaction extends DispatchSuccess {
+  readonly operation: RoomOperation;
+  /** Applies the staged changes to the Room and bumps its revision. */
+  commit(): void;
+  /** Abandons them, leaving the Room exactly as the dispatch found it. */
+  discard(): void;
+}
+
 export interface DispatchRejection {
   readonly reason: DispatchRejectionReason;
   readonly command?: Command;
   readonly rejection?: Rejection;
+  /** Absent for a refusal the engine never saw, which is not recordable. */
+  readonly operation?: RoomOperation;
 }
 
 export type DispatchResult =
-  | DispatchSuccess
+  | DispatchTransaction
   | { readonly error: "room-not-found" | "not-permitted" }
   | DispatchRejection;
 
@@ -137,11 +165,13 @@ function makeSeats(seatCount: number): Seat[] {
 }
 
 interface SeatRepack {
+  /** The seat row the Room takes on, ready to replace `room.seats`. */
+  readonly seats: readonly Seat[];
   readonly moves: readonly SeatMove[];
   readonly mapping: ReadonlyMap<SeatId, SeatId>;
 }
 
-function repackSeats(room: Room, seatCount: number): SeatRepack {
+function planRepack(room: Room, seatCount: number): SeatRepack {
   const claimed = room.seats.filter((seat) => seat.claimed);
   const replacement = makeSeats(seatCount);
   const mapping = new Map<SeatId, SeatId>();
@@ -170,8 +200,12 @@ function repackSeats(room: Room, seatCount: number): SeatRepack {
     };
   });
 
-  room.seats.splice(0, room.seats.length, ...replacement);
-  return { moves, mapping };
+  return { seats: replacement, moves, mapping };
+}
+
+function applyRepack(room: Room, repack: SeatRepack): void {
+  room.seats.splice(0, room.seats.length, ...repack.seats);
+  room.pendingSeatCount = null;
 }
 
 function remapSeatId(
@@ -218,18 +252,14 @@ function remapCompletedEngineState(
   };
 }
 
-function emptySeatRepack(): SeatRepack {
-  return { moves: [], mapping: new Map() };
-}
+const NO_SEAT_MAPPING: ReadonlyMap<SeatId, SeatId> = new Map();
 
-function applyPendingShrink(room: Room): SeatRepack {
-  if (room.pendingSeatCount === null) return emptySeatRepack();
-  const repack = repackSeats(
+function planPendingShrink(room: Room): SeatRepack | undefined {
+  if (room.pendingSeatCount === null) return undefined;
+  return planRepack(
     room,
     Math.max(room.pendingSeatCount, claimedSeatFloor(room)),
   );
-  room.pendingSeatCount = null;
-  return repack;
 }
 
 function applyPendingShotClock(room: Room): void {
@@ -250,8 +280,8 @@ function appliedSeatCountChange(
   };
 }
 
-function eligibleSeats(room: Room): SeatId[] {
-  return room.seats
+function eligibleSeats(seats: readonly Seat[]): SeatId[] {
+  return seats
     .filter((seat) => seat.claimed && !seat.disconnected && !seat.sittingOut)
     .map((seat) => seat.id);
 }
@@ -312,6 +342,41 @@ function resolveButtonFor(
   return ordered.find((id) => id > previousButton) ?? first;
 }
 
+/**
+ * Turns an accepted dispatch into the whole operation the recording takes.
+ * The state right after `HandStarted` is where a Hand's seats and button are
+ * fixed; nothing later in the same operation moves them.
+ */
+function toRoomOperation(
+  success: DispatchSuccess,
+  now: () => Date,
+): RoomOperation {
+  const events = success.steps.map((step) => step.event);
+  const opening = success.steps.find(
+    (step) => step.event.type === "HandStarted",
+  );
+  const context =
+    opening === undefined
+      ? undefined
+      : handStartContextFor(events, opening.state, now);
+  return {
+    ...(context === undefined ? {} : { context }),
+    command: success.command,
+    outcome: events,
+  };
+}
+
+/** Everything a committed dispatch changes about its Room, and nothing else. */
+interface StagedTransition {
+  readonly engine: EngineState;
+  /** A pending shrink this dispatch takes up, seat row and all. */
+  readonly repack?: SeatRepack;
+  /** The seats this dispatch deals in, when it opens a Hand. */
+  readonly dealIn?: readonly SeatId[];
+  /** A seat whose eviction waits on the engine operation that covers it. */
+  readonly freedSeat?: SeatId;
+}
+
 export class RoomStore {
   readonly #rooms = new Map<string, Room>();
   /** Codes reserved by staged-but-uncommitted rooms, so two never collide. */
@@ -320,17 +385,20 @@ export class RoomStore {
   readonly #generateToken: () => string;
   readonly #generateSeed: () => string;
   readonly #generateRoomId: () => string;
+  readonly #now: () => Date;
 
   constructor(
     random: () => number = Math.random,
     generateToken: () => string = randomUUID,
     generateSeed: () => string = randomUUID,
     generateRoomId: () => string = randomUUID,
+    now: () => Date = () => new Date(),
   ) {
     this.#random = random;
     this.#generateToken = generateToken;
     this.#generateSeed = generateSeed;
     this.#generateRoomId = generateRoomId;
+    this.#now = now;
   }
 
   /**
@@ -356,6 +424,7 @@ export class RoomStore {
       code,
       seats: makeSeats(seatCount),
       engine: null,
+      revision: 0,
       pendingSeatCount: null,
       turnEndsAt: null,
       pendingShotClock: null,
@@ -472,17 +541,21 @@ export class RoomStore {
     return `Bot ${String(number)}`;
   }
 
+  /**
+   * Frees a seat, folding the hand it is holding first. Where a fold is
+   * needed the seat is not freed here: it is freed by the returned
+   * transaction, so the seat and the engine operation that covers it land
+   * together or not at all.
+   */
   evictSeat(code: string, seatId: SeatId): EvictSeatResult {
     const room = this.#rooms.get(code);
     const seat = room?.seats[seatId];
     if (!seat) return {};
 
     if (this.currentActor(code) === seatId) {
-      const result = this.dispatch(code, seatId, "fold");
-      if (!("steps" in result)) return {};
-
-      freeSeat(seat);
-      return { dispatch: result };
+      const result = this.#dispatch(code, seatId, "fold", seatId);
+      if (!("commit" in result)) return {};
+      return { transaction: result };
     }
 
     const hand = room.engine?.hand;
@@ -494,11 +567,9 @@ export class RoomStore {
       player !== undefined &&
       !player.folded
     ) {
-      const result = this.#dispatchEviction(room, seatId);
-      if (result === undefined) return {};
-
-      freeSeat(seat);
-      return { dispatch: result };
+      const transaction = this.#stageEviction(room, seatId);
+      if (transaction === undefined) return {};
+      return { transaction };
     }
 
     freeSeat(seat);
@@ -551,11 +622,11 @@ export class RoomStore {
       };
     }
 
-    const repack = repackSeats(room, seatCount);
+    const repack = planRepack(room, seatCount);
+    applyRepack(room, repack);
     if (room.engine !== null && isHandComplete(room.engine)) {
       room.engine = remapCompletedEngineState(room.engine, repack.mapping);
     }
-    room.pendingSeatCount = null;
     return appliedSeatCountChange(room, repack.moves);
   }
 
@@ -611,10 +682,24 @@ export class RoomStore {
     seat.disconnected = disconnected;
   }
 
+  /**
+   * Decides one Command against the Room and stages what it would change,
+   * without changing anything. Every filesystem-free, synchronous decision
+   * lives here; the caller sequences the append and the commit.
+   */
   dispatch(
     code: string,
     identity: SeatId | "table",
     type: SeatCommandType,
+  ): DispatchResult {
+    return this.#dispatch(code, identity, type);
+  }
+
+  #dispatch(
+    code: string,
+    identity: SeatId | "table",
+    type: SeatCommandType,
+    freedSeat?: SeatId,
   ): DispatchResult {
     const room = this.#rooms.get(code);
     if (!room) return { error: "room-not-found" };
@@ -624,61 +709,84 @@ export class RoomStore {
       return { error: "not-permitted" };
     }
 
-    let seatMoves: readonly SeatMove[] = [];
+    let repack: SeatRepack | undefined;
     let candidateEngine = room.engine;
+    let opensHand = false;
     if (type === "startHand" && room.engine === null) {
-      const dealIn = eligibleSeats(room);
+      const dealIn = eligibleSeats(room.seats);
       if (dealIn.length < 2) return { reason: "not-enough-players" };
       candidateEngine = createInitialState(dealIn);
+      opensHand = true;
     } else if (type === "nextHand" && room.engine !== null) {
-      if (eligibleSeats(room).length < 2) {
+      if (eligibleSeats(room.seats).length < 2) {
         return { reason: "not-enough-players" };
       }
 
-      const repack = isHandComplete(room.engine)
-        ? applyPendingShrink(room)
-        : emptySeatRepack();
-      seatMoves = repack.moves;
-      const previousButton = remapSeatId(room.engine.button, repack.mapping);
-      const dealIn = eligibleSeats(room);
+      repack = isHandComplete(room.engine)
+        ? planPendingShrink(room)
+        : undefined;
+      const previousButton = remapSeatId(
+        room.engine.button,
+        repack?.mapping ?? NO_SEAT_MAPPING,
+      );
+      const dealIn = eligibleSeats(repack?.seats ?? room.seats);
       candidateEngine = {
         ...room.engine,
         seats: dealIn,
         button: resolveButtonFor(previousButton, dealIn),
       };
+      opensHand = true;
     }
 
     if (candidateEngine === null) return { reason: "hand-not-in-progress" };
 
     const command = this.#buildCommand(identity, type);
-    const result = this.#runEngineCommand(room, candidateEngine, command);
-    if (!("steps" in result)) return result;
+    const decided = this.#decide(candidateEngine, command);
+    if (!("steps" in decided)) return decided;
 
-    if (type === "startHand" || type === "nextHand") {
-      updateWaitingForNextHand(room, candidateEngine.seats);
-      applyPendingShotClock(room);
-    }
-
-    return seatMoves.length > 0 ? { ...result, seatMoves } : result;
+    const seatMoves = repack?.moves ?? [];
+    return this.#stage(
+      room,
+      {
+        engine: decided.engine,
+        ...(repack === undefined ? {} : { repack }),
+        ...(opensHand ? { dealIn: candidateEngine.seats } : {}),
+        ...(freedSeat === undefined ? {} : { freedSeat }),
+      },
+      {
+        command,
+        steps: decided.steps,
+        ...(seatMoves.length > 0 ? { seatMoves } : {}),
+      },
+    );
   }
 
-  #dispatchEviction(room: Room, seatId: SeatId): DispatchSuccess | undefined {
+  #stageEviction(room: Room, seatId: SeatId): DispatchTransaction | undefined {
     if (room.engine === null) return undefined;
-    const result = this.#runEngineCommand(room, room.engine, {
-      type: "evict",
-      seatId,
-    });
-    return "steps" in result ? result : undefined;
+    const command: Command = { type: "evict", seatId };
+    const decided = this.#decide(room.engine, command);
+    if (!("steps" in decided)) return undefined;
+    return this.#stage(
+      room,
+      { engine: decided.engine, freedSeat: seatId },
+      { command, steps: decided.steps },
+    );
   }
 
-  #runEngineCommand(
-    room: Room,
+  #decide(
     candidateEngine: EngineState,
     command: Command,
-  ): DispatchSuccess | DispatchRejection {
+  ):
+    | { readonly steps: readonly DispatchStep[]; readonly engine: EngineState }
+    | DispatchRejection {
     const result = decide(candidateEngine, command);
     if (!Array.isArray(result)) {
-      return { reason: result.reason, command, rejection: result };
+      return {
+        reason: result.reason,
+        command,
+        rejection: result,
+        operation: { command, outcome: result },
+      };
     }
 
     const steps: DispatchStep[] = [];
@@ -687,8 +795,41 @@ export class RoomStore {
       state = apply(state, event);
       steps.push({ event, state });
     }
-    room.engine = state;
-    return { command, steps };
+    return { steps, engine: state };
+  }
+
+  #stage(
+    room: Room,
+    transition: StagedTransition,
+    success: DispatchSuccess,
+  ): DispatchTransaction {
+    let settled = false;
+    const settle = () => {
+      if (settled) throw new Error("dispatch transaction already settled");
+      settled = true;
+    };
+
+    return {
+      ...success,
+      operation: toRoomOperation(success, this.#now),
+      commit: () => {
+        settle();
+        if (transition.repack !== undefined) {
+          applyRepack(room, transition.repack);
+        }
+        if (transition.dealIn !== undefined) {
+          updateWaitingForNextHand(room, transition.dealIn);
+          applyPendingShotClock(room);
+        }
+        if (transition.freedSeat !== undefined) {
+          const seat = room.seats[transition.freedSeat];
+          if (seat) freeSeat(seat);
+        }
+        room.engine = transition.engine;
+        room.revision += 1;
+      },
+      discard: settle,
+    };
   }
 
   #buildCommand(identity: SeatId | "table", type: SeatCommandType): Command {

--- a/packages/server/src/sitting-out-reason.test.ts
+++ b/packages/server/src/sitting-out-reason.test.ts
@@ -1,6 +1,12 @@
-import { DEFAULT_SEAT_COUNT } from "@table-top-poker/protocol";
+import { DEFAULT_SEAT_COUNT, type SeatId } from "@table-top-poker/protocol";
 import { describe, expect, it } from "vitest";
-import { type Room, RoomStore, toRoomView } from "./rooms.js";
+import {
+  type DispatchResult,
+  type Room,
+  RoomStore,
+  type SeatCommandType,
+  toRoomView,
+} from "./rooms.js";
 
 function claimSeats(store: RoomStore, room: Room, count: number): void {
   for (let seatId = 0; seatId < count; seatId++) {
@@ -10,12 +16,24 @@ function claimSeats(store: RoomStore, room: Room, count: number): void {
   }
 }
 
+/** Dispatches and commits in one step, as `app.ts` does once its append confirms. */
+function commitDispatch(
+  store: RoomStore,
+  code: string,
+  identity: SeatId | "table",
+  type: SeatCommandType,
+): DispatchResult {
+  const result = store.dispatch(code, identity, type);
+  if ("commit" in result) result.commit();
+  return result;
+}
+
 function completeHand(store: RoomStore, room: Room): void {
   for (let attempt = 0; attempt < DEFAULT_SEAT_COUNT; attempt++) {
     if (room.engine?.hand?.status === "complete") return;
     const actor = store.currentActor(room.code);
     if (actor === undefined) throw new Error("expected a current actor");
-    const result = store.dispatch(room.code, actor, "fold");
+    const result = commitDispatch(store, room.code, actor, "fold");
     if (!("steps" in result)) throw new Error("expected dispatch steps");
   }
   throw new Error("hand did not complete");
@@ -39,7 +57,7 @@ describe("sitting-out reason in the room view", () => {
     });
 
     store.setSittingOut(room.code, 0, false);
-    store.dispatch(room.code, "table", "startHand");
+    commitDispatch(store, room.code, "table", "startHand");
     const lateClaim = store.claimSeat(room.code, 2, "P2");
     expect(lateClaim).toHaveProperty("seat");
     expect(toRoomView(room).seats[2]).toMatchObject({
@@ -48,7 +66,7 @@ describe("sitting-out reason in the room view", () => {
     });
 
     completeHand(store, room);
-    const nextHand = store.dispatch(room.code, "table", "nextHand");
+    const nextHand = commitDispatch(store, room.code, "table", "nextHand");
     expect(nextHand).toHaveProperty("steps");
     expect(toRoomView(room).seats[2]).toMatchObject({
       sittingOut: false,


### PR DESCRIPTION
Closes #118. Built on `replay`, per the ticket's build-branch note.

## The seam

`RoomStore.dispatch` is now pure and synchronous: it decides the Command against the Room and returns a `DispatchTransaction` carrying the `RoomOperation` the recording takes, having changed nothing.

```ts
const tx = rooms.dispatch(code, identity, type); // pure, synchronous
await recording.append(tx.operation);            // may fail
tx.commit();                                     // or tx.discard()
```

Everything a dispatch changes moved behind `commit()` — the engine reassignment, the pending seat shrink, the `pendingSeatCount` clear, the `waitingForNextHand` recompute, the pending shot-clock take-up, and an evicted seat's release. That retires the class of bug #95 was an instance of: a rejected `nextHand` can no longer rewrite the live hand's seats and button on its way out. Settling a handle twice throws.

## The queue and the clock

`app.ts` owns one operation queue per Room. Socket Commands, clock folds, bot actions, Seat mutations, Room settings, a joiner's catch-up and the Room's teardown all run one at a time in arrival order; other Rooms are independent.

Because the append is awaited, a fired timer is no longer a timer — it is an operation queued behind whatever else arrived first. The Room carries a `revision` bumped only on commit; a queued fold captures it when the clock is armed and is discarded on dequeue if the Room advanced at all. Actor-matching alone is not enough: heads-up the non-button seat acts **last** preflop and **first** on the flop, so a fold queued behind that seat's own check would fold a hand its owner just checked. `"preserve"` (a non-actor eviction) now keeps the actor's deadline but re-arms the timer against the new revision, so a discarded fold is never left unreplaced. The clock arms after the commit, so append latency is never charged to thinking time.

## Failure

A refused append discards the operation, cancels the Actor's clock, and — for eviction and leave — leaves the seat with its player, answering `503 recording-unavailable` rather than a 204 it cannot mean. The table-facing recovery (Retry / Continue without recording / End session) is #121.

## Tests

Five new app-level tests, including the heads-up regression the ticket asks for (driven through a gated-append filesystem and a manually fired timer) plus clock-arms-after-append, nothing-broadcast-on-failure, clock-cancelled-on-failure and seat-kept-on-failure. Nine new `RoomStore` seam tests. Each new behaviour was verified red before green.

`npm run build`, `npm run lint` and the full `npm test` suite pass locally (1038 tests).

> [!NOTE]
> `bot-driver.test.ts` ("chains legal actions for an all-bot hand") is flaky on `replay` already — it failed 3 of 6 runs on the untouched base branch. Not introduced here; worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ep1hXHMzWTF1w9vBmuEhcr