### PR TITLE
test(server): drive the bot-driver hand-complete test on real timers

### DIFF
--- a/packages/server/src/bot-driver.test.ts
+++ b/packages/server/src/bot-driver.test.ts
@@ -1,6 +1,6 @@
 import type { ServerMessage } from "@table-top-poker/protocol";
 import type { FastifyInstance } from "fastify";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import WebSocket from "ws";
 import { buildApp } from "./app.js";
 import { RoomStore } from "./rooms.js";
@@ -79,13 +79,11 @@ describe("bot driver", () => {
   afterEach(async () => {
     if (socket) await closeTable(socket);
     if (app) await app.close();
-    vi.useRealTimers();
     socket = undefined;
     app = undefined;
   });
 
   it("chains legal actions for an all-bot hand started by the table", async () => {
-    vi.useFakeTimers();
     const rooms = new RoomStore();
     const room = rooms.create(3);
     const added = rooms.addBots(room, 3);
@@ -102,10 +100,6 @@ describe("bot driver", () => {
     socket = running.socket;
 
     socket.send(JSON.stringify({ type: "startHand" }));
-    for (let attempt = 0; attempt < 30; attempt++) {
-      if (room.engine?.hand?.status === "complete") break;
-      await vi.advanceTimersByTimeAsync(1);
-    }
     await waitForMessage(
       running,
       (message) =>


### PR DESCRIPTION
## Summary
- Fixes #235: the "chains legal actions for an all-bot hand started by the table" test intermittently timed out because it mixed `vi.useFakeTimers()` with the test's real WebSocket/HTTP I/O — the fake-timer advance loop raced the live socket and, on the failure path, stalled the whole pipeline before any message arrived.
- Confirmed pre-existing on `main` per the issue's follow-up investigation, unrelated to #114/#118.
- Drops the fake timers and the manual 30-attempt `advanceTimersByTimeAsync` loop; the test now relies purely on the existing event-driven `waitForMessage` helper, same as its two sibling tests in the file which already drive bots over real timers at `botActionDelayMs: 1`.

## Test plan
- [x] `npx vitest run packages/server/src/bot-driver.test.ts` — 10/10 runs green (previously flaked ~1-in-3)
- [x] `npx tsc --build --force` in `packages/server` — clean
- [x] `npx eslint` / `npx prettier --check` on the changed file — clean
- [x] `npx vitest run packages/server` — full package suite, 187/187 passing
- [x] `/code-review` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ep1hXHMzWTF1w9vBmuEhcr