### PR TITLE
fix(server): close recordings only after every queued command lands

### DIFF
--- a/packages/recording/src/room-recording.test.ts
+++ b/packages/recording/src/room-recording.test.ts
@@ -670,4 +670,36 @@ describe("RoomRecording.close", () => {
       }),
     ).rejects.toThrow(/closed/);
   });
+
+  it("refuses a retry arriving after the close", async () => {
+    const fs = createMemoryFileSystem();
+    const recording = await openRecording(fs);
+    const operation = {
+      context: context(),
+      command: startHand,
+      outcome: [handStarted],
+    };
+    fs.failAlways("appendFile");
+    await expect(recording.append(operation)).rejects.toThrow(/append failed/);
+    fs.healAll();
+    await recording.close();
+
+    await expect(recording.retry(operation)).rejects.toThrow(/closed/);
+  });
+
+  it("refuses a discardLatched arriving after the close", async () => {
+    const fs = createMemoryFileSystem();
+    const recording = await openRecording(fs);
+    const operation = {
+      context: context(),
+      command: startHand,
+      outcome: [handStarted],
+    };
+    fs.failAlways("appendFile");
+    await expect(recording.append(operation)).rejects.toThrow(/append failed/);
+    fs.healAll();
+    await recording.close();
+
+    await expect(recording.discardLatched(operation)).rejects.toThrow(/closed/);
+  });
 });

--- a/packages/recording/src/room-recording.ts
+++ b/packages/recording/src/room-recording.ts
@@ -109,6 +109,11 @@ export class RoomRecording {
    * leaving the recording latched, if the retry fails too.
    */
   retry(operation: RoomOperation): Promise<void> {
+    if (this.#closing) {
+      return Promise.reject(
+        new Error(`recording for room ${this.roomId} is closed`),
+      );
+    }
     const settled = this.#queue.then(() => this.#retryNow(operation));
     this.#queue = settled.then(
       () => undefined,
@@ -133,6 +138,9 @@ export class RoomRecording {
    * to end rather than retry. A no-op when the recording never latched.
    */
   async discardLatched(operation: RoomOperation | undefined): Promise<void> {
+    if (this.#closing) {
+      throw new Error(`recording for room ${this.roomId} is closed`);
+    }
     const settled = this.#queue.then(() => this.#discardLatchedNow(operation));
     this.#queue = settled.then(
       () => undefined,

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -3254,7 +3254,10 @@ describe("the commit seam", () => {
    * A heads-up room whose appends are gated and whose action timers are armed
    * but never fired on their own, so a test fires them where it chooses.
    */
-  async function headsUpRoom(shotClock = true): Promise<SeamRig> {
+  async function headsUpRoom(
+    shotClock = true,
+    testMode = false,
+  ): Promise<SeamRig> {
     const disk = createMemoryFileSystem();
     const gate = gateAppends(disk);
     const armed: ArmedTimer[] = [];
@@ -3272,6 +3275,7 @@ describe("the commit seam", () => {
     const app = await buildApp({
       rooms,
       actionClock,
+      testMode,
       recordings: new DirectoryRecordings(RECORDINGS_ROOT, gate.fileSystem),
     });
     await app.listen({ port: 0, host: "127.0.0.1" });
@@ -3623,6 +3627,62 @@ describe("the commit seam", () => {
       } finally {
         for (const conn of [table, ...seats]) conn.socket.close();
         await rig.app.close();
+      }
+    });
+
+    it("rejects the test-mode add-bots seat claim while paused", async () => {
+      const rig = await headsUpRoom(true, true);
+      const { app: rigApp, code, rooms, disk, table, seats } = rig;
+      try {
+        table.socket.send(JSON.stringify({ type: "startHand" }));
+        await waitFor(() => rooms.currentActor(code) === 0);
+        disk.failAlways("appendFile");
+        seats[0]?.socket.send(JSON.stringify({ type: "call" }));
+        await waitFor(() => rooms.get(code)?.turnEndsAt === null);
+
+        const addBots = await rigApp.inject({
+          method: "POST",
+          url: `/rooms/${code}/bots`,
+          payload: { count: 1 },
+        });
+        expect(addBots.statusCode).toBe(503);
+        expect(addBots.json()).toEqual({ error: "recording-paused" });
+      } finally {
+        for (const conn of [table, ...seats]) conn.socket.close();
+        await rig.app.close();
+      }
+    });
+
+    it("does not drop a command still queued when the app closes", async () => {
+      const rig = await headsUpRoom();
+      const { code, rooms, disk, gate, table, seats } = rig;
+      try {
+        table.socket.send(JSON.stringify({ type: "startHand" }));
+        await waitFor(() => rooms.currentActor(code) === 0);
+
+        // Hold the first action's append open, then queue a second action
+        // behind it — still waiting on the room's own queue, not yet at the
+        // recording — before the app starts closing.
+        gate.hold();
+        seats[0]?.socket.send(JSON.stringify({ type: "call" }));
+        await gate.arrived();
+        seats[1]?.socket.send(JSON.stringify({ type: "check" }));
+
+        const closed = rig.app.close();
+        await settle();
+        gate.release();
+        await closed;
+
+        const commands = parseRecordedLines(
+          disk.read(commandsPath(rooms, code)),
+        ) as { type: string }[];
+        expect(commands.map((command) => command.type)).toEqual([
+          "startHand",
+          "call",
+          "check",
+        ]);
+      } finally {
+        for (const conn of [table, ...seats]) conn.socket.close();
       }
     });
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -649,6 +649,10 @@ export async function buildApp(
     clearInterval(pingTimer);
     for (const timer of tableGraceTimers.values()) clearTimeout(timer);
     for (const code of botActionTimers.keys()) clearBotActionTimer(code);
+    // A command already queued for a Room — dispatched but not yet appended —
+    // must land before that Room's recording closes, or it is dropped rather
+    // than lost loudly.
+    await Promise.all([...roomQueues.values()]);
     const draining = [...roomRecordings.keys()].map((code) =>
       drainRecording(code, pausedRooms.get(code)?.operation),
     );
@@ -986,14 +990,20 @@ export async function buildApp(
 
       const room = findRoomOrReject(rooms, request.params.code, reply);
       if (!room) return;
-      const joined = await enqueue(room.code, () => {
-        const result = rooms.addBots(room, body.data.count);
-        if (result.seats.length > 0) {
+      const result = await enqueue(room.code, () => {
+        if (isRecordingPaused(room.code)) {
+          return { error: "recording-paused" as const };
+        }
+        const added = rooms.addBots(room, body.data.count);
+        if (added.seats.length > 0) {
           broadcastRoomView(room.code);
         }
-        return result.seats.length;
+        return { joined: added.seats.length };
       });
-      return { joined };
+      if ("error" in result) {
+        return reply.code(503).send(result);
+      }
+      return result;
     });
   }
 


### PR DESCRIPTION
## Summary

Follow-up from an Opus-5-high code review of #121's merged `recording-paused` implementation (PR #238). All findings verified against the actual diff; only issues reachable through code that PR touched are included here — everything else the review flagged was pre-existing and out of scope.

- `onClose` drained every open `RoomRecording` without first waiting for commands already queued behind an in-flight append. A command dispatched but not yet appended could reach `RoomRecording.append` after `#closing` was set and be silently dropped on shutdown — the exact failure mode `recording-paused` exists to prevent. `onClose` now awaits every room's queue (`roomQueues`) before draining recordings.
- `RoomRecording.retry`/`discardLatched` lacked the closed-recording guard `append` already had, so a future caller invoking them concurrently with `close()` could write after the recording was meant to be final. Added the same guard.
- The test-mode `/rooms/:code/bots` route claimed seats via `rooms.addBots` without checking `isRecordingPaused`, unlike the production seat-claim route — brought it in line.

## Test plan

- [x] `npx vitest run packages/server/src/app.test.ts packages/recording/src/room-recording.test.ts` — 154 passed
- [x] New regression test for the shutdown race verified to fail without the fix, pass with it
- [x] New tests for `retry`/`discardLatched` refusing after `close()`
- [x] New test for the paused `/bots` route rejection
- [x] `npm run build`, `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ep1hXHMzWTF1w9vBmuEhcr