### PR TITLE
test(harness): cover join-code and latest resolution at the replay CLI seam

### DIFF
--- a/packages/harness/src/replay-cli.test.ts
+++ b/packages/harness/src/replay-cli.test.ts
@@ -129,6 +129,71 @@ describe("runReplayCli", () => {
     expect(stdout.text()).not.toMatch(/resolved/);
   });
 
+  it("resolves a join code and prints the chosen directory to stderr, never stdout", async () => {
+    const recordingsDir = tempDir();
+    await seedRoom(recordingsDir, "room-a", HAPPY_COMMANDS, { code: "AB12" });
+    const stdout = collectingWritable();
+    const stderr = collectingWritable();
+
+    const exitCode = await runReplayCli(
+      ["AB12", "--hand", "1", "--recordings-dir", recordingsDir],
+      { stdout: stdout.writable, stderr: stderr.writable },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stderr.text()).toMatch(/resolved join code "AB12"/);
+    expect(stdout.text()).not.toMatch(/resolved/);
+  });
+
+  it("stdout is byte-identical whether the room is addressed by path, join code, or 'latest'", async () => {
+    const recordingsDir = tempDir();
+    await seedRoom(recordingsDir, "room-a", HAPPY_COMMANDS, { code: "AB12" });
+
+    async function run(room: string): Promise<string> {
+      const stdout = collectingWritable();
+      await runReplayCli(
+        [room, "--hand", "1", "--recordings-dir", recordingsDir],
+        { stdout: stdout.writable, stderr: collectingWritable().writable },
+      );
+      return stdout.text();
+    }
+
+    const byPath = await run(path.join(recordingsDir, "room-a"));
+    expect(await run("AB12")).toBe(byPath);
+    expect(await run("latest")).toBe(byPath);
+  });
+
+  it("a join code matching no recording fails with exit 1 and a diagnostic on stderr, nothing on stdout", async () => {
+    const recordingsDir = tempDir();
+    await seedRoom(recordingsDir, "room-a", HAPPY_COMMANDS, { code: "AB12" });
+    const stdout = collectingWritable();
+    const stderr = collectingWritable();
+
+    const exitCode = await runReplayCli(
+      ["ZZ99", "--hand", "1", "--recordings-dir", recordingsDir],
+      { stdout: stdout.writable, stderr: stderr.writable },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stdout.text()).toBe("");
+    expect(stderr.text()).toMatch(/missing-file/);
+  });
+
+  it("'latest' against an empty recordings directory fails with exit 1 and a diagnostic on stderr, nothing on stdout", async () => {
+    const recordingsDir = tempDir();
+    const stdout = collectingWritable();
+    const stderr = collectingWritable();
+
+    const exitCode = await runReplayCli(
+      ["latest", "--hand", "1", "--recordings-dir", recordingsDir],
+      { stdout: stdout.writable, stderr: stderr.writable },
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stdout.text()).toBe("");
+    expect(stderr.text()).toMatch(/missing-file/);
+  });
+
   it("interleaves a Rejection with the position it occurred at", async () => {
     const recordingsDir = tempDir();
     await seedRoom(recordingsDir, "room-a", [


### PR DESCRIPTION
## Summary
- Closes #124.
- The `latest`/join-code resolution described in #124 was already implemented and unit-tested in `packages/harness/src/replay-source.ts` (`resolveRoomDirectory`) as a side effect of the dev-stepper CLI work (#120) — no production code change here.
- Adds CLI-seam tests (`packages/harness/src/replay-cli.test.ts`) that pin down the remaining acceptance criteria at the public interface: join-code resolution note on stderr only, stdout byte-identical whether the room is addressed by path, join code, or `latest`, and exit 1 with a `missing-file` diagnostic when a code or `latest` resolves to nothing.

## Test plan
- [x] `npx vitest run packages/harness/src/replay-cli.test.ts` — 16/16 pass (12 existing + 4 new)
- [x] `npx vitest run packages/harness/src` — 71/71 pass
- [x] `npx tsc --build packages/harness` — clean
- [x] `npm run lint` — eslint + prettier clean
- [x] `/code-review` — no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1txbbHbvajLwnBxA9N13G