### PR TITLE
test(server): prove shutdown drains the recording cleanly

### DIFF
--- a/docs/design/server.md
+++ b/docs/design/server.md
@@ -183,3 +183,32 @@ Only the table has an exit to choose:
 
 **Continue without recording** is a later ticket's third exit; nothing here
 should be read as ruling it out.
+
+## Shutdown
+
+`SIGINT`/`SIGTERM` (`server.ts`) and "End session" close a Room's recording
+the same way — draining rather than dropping whatever was still in flight —
+they just differ in what triggers it and what happens after.
+
+- **A single Room ending** (`endRoom`, "End session" or the table's grace
+  window elapsing) runs in that Room's own operation queue, so it is already
+  ordered after anything already dispatched to it. It discards a paused
+  Room's retained transaction, then `drainRecording` restores a paused
+  recording's confirmed tail (`discardLatched`, a no-op unless the recording
+  latched) and closes the writer, before the Room itself is discarded.
+- **Process shutdown** (`onClose`, run from the `SIGINT`/`SIGTERM` handlers
+  in `server.ts` via `app.close()`) closes every Room's recording instead of
+  one. A command already dispatched but not yet appended when the signal
+  lands must still land: `onClose` first awaits every Room's operation queue
+  (`roomQueues`), *then* drains and closes each open `RoomRecording` the same
+  way `endRoom` does, restoring any paused Room's confirmed tail first. Only
+  once every recording is closed does the handler call `process.exit(0)` (or
+  `1` if closing itself throws) — a deploy is `systemctl restart poker`, so
+  this is the normal way the process ends, not an edge case.
+
+Either path leaves every Hand file a clean prefix of confirmed operations, so
+a recording closed this way always replays with no `incomplete-hand`. Only a
+`SIGKILL` — which gives the process no chance to run `onClose` at all — can
+still leave one torn final record; that is accepted and handled by the
+incomplete-Hand rule (`packages/engine`'s Replay capability) rather than
+defended against here.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4159,6 +4159,7 @@
         "qrcode": "^1.5.4"
       },
       "devDependencies": {
+        "@table-top-poker/engine": "*",
         "@types/qrcode": "^1.5.6",
         "@types/ws": "^8.18.1",
         "ws": "^8.21.1"

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -19,6 +19,7 @@
     "qrcode": "^1.5.4"
   },
   "devDependencies": {
+    "@table-top-poker/engine": "*",
     "@types/qrcode": "^1.5.6",
     "@types/ws": "^8.18.1",
     "ws": "^8.21.1"

--- a/packages/server/src/shutdown-drain.test.ts
+++ b/packages/server/src/shutdown-drain.test.ts
@@ -1,0 +1,311 @@
+import { execFileSync, spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+import { createServer } from "node:net";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import type { PlayerView, ActionType } from "@table-top-poker/engine";
+import type { ServerMessage } from "@table-top-poker/protocol";
+
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const serverEntry = path.join(repoRoot, "packages/server/dist/server.js");
+const harnessCli = path.join(repoRoot, "packages/harness/dist/cli.js");
+
+interface RoomCreatedBody {
+  readonly code: string;
+}
+
+interface SeatClaimedBody {
+  readonly seatId: number;
+  readonly token: string;
+}
+
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.listen(0, "127.0.0.1", () => {
+      const address = probe.address();
+      if (address === null || typeof address === "string") {
+        reject(new Error("expected a bound TCP address"));
+        return;
+      }
+      const port = address.port;
+      probe.close((error) => {
+        if (error) reject(error);
+        else resolve(port);
+      });
+    });
+    probe.on("error", reject);
+  });
+}
+
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error("timed out waiting for the condition");
+}
+
+async function waitUntilServing(baseUrl: string): Promise<void> {
+  const start = Date.now();
+  for (;;) {
+    try {
+      const response = await fetch(`${baseUrl}/config`);
+      if (response.ok) return;
+    } catch {
+      // server not accepting connections yet
+    }
+    if (Date.now() - start > 10_000) {
+      throw new Error("server never became ready");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+interface Connection {
+  readonly socket: WebSocket;
+  readonly messages: ServerMessage[];
+}
+
+function connect(baseUrl: string, query: string): Connection {
+  const socket = new WebSocket(`${baseUrl.replace("http", "ws")}/ws?${query}`);
+  const messages: ServerMessage[] = [];
+  socket.on("message", (data: Buffer) => {
+    messages.push(JSON.parse(data.toString()) as ServerMessage);
+  });
+  return { socket, messages };
+}
+
+async function waitForOpen(connection: Connection): Promise<void> {
+  if (connection.socket.readyState === WebSocket.OPEN) return;
+  await new Promise<void>((resolve, reject) => {
+    connection.socket.once("open", () => {
+      resolve();
+    });
+    connection.socket.once("error", reject);
+  });
+}
+
+/** The one seat whose own view currently carries a non-empty legal-action list. */
+function actingSeat(
+  seats: readonly Connection[],
+): { seat: Connection; action: ActionType } | undefined {
+  for (const seat of seats) {
+    const view = [...seat.messages]
+      .reverse()
+      .map((message) =>
+        message.type === "hand-update" ? message.view : undefined,
+      )
+      .find((candidate): candidate is PlayerView => candidate !== undefined);
+    if (view?.phase !== "betting") continue;
+    const legal = view.legalActions;
+    if (legal.length === 0) continue;
+    const action = legal.includes("call")
+      ? "call"
+      : legal.includes("check")
+        ? "check"
+        : legal[0];
+    if (action === undefined) continue;
+    return { seat, action };
+  }
+  return undefined;
+}
+
+function actionsTaken(table: Connection): number {
+  return table.messages.filter(
+    (message) =>
+      message.type === "hand-update" && message.event.type === "ActionTaken",
+  ).length;
+}
+
+/**
+ * Plays two actions, resolving once the table has broadcast confirmation of
+ * both — `actingSeat` reads each seat's own last-known view, which lags the
+ * server by a network round trip, so picking the next actor before that
+ * catches up finds the seat that *just* acted rather than the one now on
+ * the clock.
+ */
+async function playOneRound(
+  table: Connection,
+  seats: readonly Connection[],
+): Promise<void> {
+  table.socket.send(JSON.stringify({ type: "startHand" }));
+  for (let round = 0; round < 2; round += 1) {
+    let found: { seat: Connection; action: ActionType } | undefined;
+    await waitFor(() => {
+      found = actingSeat(seats);
+      return found !== undefined;
+    });
+    if (found === undefined) throw new Error("expected an acting seat");
+    const confirmedBefore = actionsTaken(table);
+    found.seat.socket.send(JSON.stringify({ type: found.action }));
+    await waitFor(() => actionsTaken(table) > confirmedBefore);
+  }
+}
+
+describe("server shutdown drains the recording", () => {
+  beforeAll(() => {
+    execFileSync(
+      "npm",
+      [
+        "run",
+        "build",
+        "-w",
+        "@table-top-poker/harness",
+        "-w",
+        "@table-top-poker/server",
+      ],
+      { cwd: repoRoot, stdio: "pipe" },
+    );
+  }, 120_000);
+
+  const dirs: string[] = [];
+  const children: ChildProcess[] = [];
+
+  afterEach(() => {
+    for (const child of children.splice(0)) {
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill("SIGKILL");
+      }
+    }
+    for (const dir of dirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it.each(["SIGINT", "SIGTERM"] as const)(
+    "exits 0 on %s, leaving a recording that replays cleanly",
+    async (signal) => {
+      const recordingsDir = mkdtempSync(path.join(tmpdir(), "shutdown-"));
+      dirs.push(recordingsDir);
+      const port = await getFreePort();
+      const baseUrl = `http://127.0.0.1:${String(port)}`;
+
+      const child = spawn(process.execPath, [serverEntry], {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          PORT: String(port),
+          HOST: "127.0.0.1",
+          RECORDINGS_DIR: recordingsDir,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      children.push(child);
+      let stderr = "";
+      child.stderr.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString("utf8");
+      });
+
+      await waitUntilServing(baseUrl);
+
+      const created = await fetch(`${baseUrl}/rooms`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ seatCount: 2 }),
+      });
+      const { code } = (await created.json()) as RoomCreatedBody;
+
+      const claims = await Promise.all(
+        [0, 1].map(async (seatId) => {
+          const response = await fetch(
+            `${baseUrl}/rooms/${code}/seats/${String(seatId)}/claim`,
+            {
+              method: "POST",
+              headers: { "content-type": "application/json" },
+              body: JSON.stringify({ displayName: `P${String(seatId)}` }),
+            },
+          );
+          return (await response.json()) as SeatClaimedBody;
+        }),
+      );
+
+      const table = connect(baseUrl, `room=${code}&role=table`);
+      const seats = claims.map((claim) =>
+        connect(
+          baseUrl,
+          `room=${code}&seat=${String(claim.seatId)}&token=${claim.token}`,
+        ),
+      );
+      await Promise.all([table, ...seats].map(waitForOpen));
+
+      await playOneRound(table, seats);
+
+      for (const connection of [table, ...seats]) connection.socket.close();
+
+      const exit = new Promise<{
+        code: number | null;
+        signal: NodeJS.Signals | null;
+      }>((resolve) => {
+        child.once("exit", (exitCode, exitSignal) => {
+          resolve({ code: exitCode, signal: exitSignal });
+        });
+      });
+      child.kill(signal);
+      const result = await exit;
+
+      expect(result.code, stderr).toBe(0);
+
+      const roomDirs = readdirSync(recordingsDir);
+      expect(roomDirs).toHaveLength(1);
+      const roomId = roomDirs[0];
+      if (roomId === undefined) throw new Error("expected a recorded room");
+
+      const commandsPath = path.join(
+        recordingsDir,
+        roomId,
+        "hand-0001.commands.jsonl",
+      );
+      const commandLines = readFileSync(commandsPath, "utf8")
+        .split("\n")
+        .filter((line) => line !== "");
+      expect(commandLines.length).toBeGreaterThanOrEqual(3);
+      for (const line of commandLines) {
+        expect(() => {
+          JSON.parse(line);
+        }).not.toThrow();
+      }
+
+      const replay = spawn(
+        process.execPath,
+        [
+          harnessCli,
+          "replay",
+          roomId,
+          "--hand",
+          "1",
+          "--recordings-dir",
+          recordingsDir,
+        ],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      );
+      children.push(replay);
+      let replayStdout = "";
+      let replayStderr = "";
+      replay.stdout.on("data", (chunk: Buffer) => {
+        replayStdout += chunk.toString("utf8");
+      });
+      replay.stderr.on("data", (chunk: Buffer) => {
+        replayStderr += chunk.toString("utf8");
+      });
+      const replayExit = await new Promise<number | null>((resolve) => {
+        replay.once("exit", (replayExitCode) => {
+          resolve(replayExitCode);
+        });
+      });
+
+      expect(replayExit, replayStderr).toBe(0);
+      expect(replayStderr).not.toContain("incomplete-hand");
+      expect(replayStdout.trim().split("\n").length).toBeGreaterThan(0);
+    },
+    30_000,
+  );
+});

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -5,5 +5,9 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "references": [{ "path": "../recording" }, { "path": "../protocol" }]
+  "references": [
+    { "path": "../engine" },
+    { "path": "../recording" },
+    { "path": "../protocol" }
+  ]
 }


### PR DESCRIPTION
## Summary

Closes #123. The write-path work this ticket asks for turned out to already be shipped: `endRoom` and the `onClose` hook (added as part of #121's follow-up, PR #239) already stop new operations, drain the active operation, restore a paused Room's confirmed tail, close the recording, and only then remove the Room / exit — for both "End session" and `SIGINT`/`SIGTERM` (`server.ts` already wires the signal handlers into `app.close()`).

What was missing:

- An end-to-end proof that this actually works: a real spawned server, driven over real HTTP/WS, signaled with `SIGINT`/`SIGTERM`, whose recording then replays cleanly through the harness CLI with exit `0` and no `incomplete-hand`. The existing coverage (`app.test.ts`) proves the fs-seam behaviour (queue draining, paused-tail restore) but never proves the resulting file is actually replayable.
- Documentation: `docs/design/server.md` covered "End session" under recording-paused but never described process shutdown at all.

## Changes

- `packages/server/src/shutdown-drain.test.ts` (new): builds `@table-top-poker/harness` and `@table-top-poker/server`, spawns the real server against a temp `RECORDINGS_DIR`, plays a heads-up round over real WebSocket connections, sends `SIGINT`/`SIGTERM`, asserts exit code `0`, then runs `harness replay` against the resulting recording and asserts exit `0` with no `incomplete-hand` diagnostic.
- `docs/design/server.md`: adds a "Shutdown" section describing how a single Room ending and process shutdown both drain recordings, and why only `SIGKILL` can still leave a torn tail.
- `packages/server/package.json` / `tsconfig.json`: add `@table-top-poker/engine` as a dev-only reference for the test's view/action types (the harness CLI itself is spawned as a subprocess, not imported, to keep the server package boundary as-is).

## Test plan

- [x] `npx vitest run packages/server/src/shutdown-drain.test.ts` — 2 passed (SIGINT, SIGTERM), run 5x to rule out timing flakiness
- [x] `npx vitest run packages/server/src/app.test.ts packages/recording/src/room-recording.test.ts packages/harness/src/recording.durability.test.ts` — 157 passed
- [x] `npm run build`, `npm run lint` clean
- [x] `/code-review` — 3 findings (a race in the test's own round-2 action selection, an untracked child process in cleanup, an over-long inline comment), all fixed and re-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K79ZLfTzkKZDXT6xxMLNNy