### PR TITLE
feat(server): continue without recording

### DIFF
--- a/docs/design/server.md
+++ b/docs/design/server.md
@@ -180,9 +180,24 @@ Only the table has an exit to choose:
   `RoomRecording.discardLatched` — a best-effort restore of the confirmed
   tail, safe to call unconditionally since it no-ops when nothing latched —
   before closing.
-
-**Continue without recording** is a later ticket's third exit; nothing here
-should be read as ruling it out.
+- **Continue without recording**
+  (`POST /rooms/:code/recording/continue`) is for a failure Retry cannot fix
+  — a worn SD card flips read-only and stays there. `continueWithoutRecording`
+  commits the retained transaction exactly as `retryRecording` does, but
+  appends nothing: the repairs Retry performs are themselves writes, and
+  cannot run on the disk that just refused one, so the Hand in flight is left
+  exactly as the failed append's own rollback left it. `RoomRecording.close`
+  is called and the Room's entry in `roomRecordings` is dropped — `close`
+  touches no file, it only stops the recording accepting further operations.
+  `recordingStopped` then latches the choice for the Room's life: `isRecordingPaused`
+  can go on to answer false forever after (gameplay is never blocked again),
+  but `appendOperation` treats the Room as already recorded without touching
+  disk, and `accumulateHandSummary` stops entering completed hands into the
+  picker's listing — including the Hand that was in flight, which finishes
+  live but was never recorded whole. Hands recorded before the failure are
+  unaffected and stay in the listing. Broadcasts `recording-stopped`, a
+  persistent notice with no corresponding "resumed" — a socket that joins
+  afterward is caught up on connect, the same way a still-paused Room is.
 
 ## Shutdown
 

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -168,9 +168,10 @@ export function useWebSocket(
             break;
           case "recording-paused":
           case "recording-resumed":
-            // Recording-paused's not-recording banner is a table-device
-            // surface (#122); a rejected command already tells a phone
-            // recording-paused through `command-rejected`.
+          case "recording-stopped":
+            // The not-recording banner is a table-device surface (#122); a
+            // rejected command already tells a phone recording-paused
+            // through `command-rejected`.
             break;
         }
       });

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -222,6 +222,16 @@ export interface RecordingResumedMessage {
   readonly type: "recording-resumed";
 }
 
+/**
+ * Sent once "Continue without recording" resumes a paused Room without its
+ * recording. A persistent notice, not a toggle: it is never followed by a
+ * `recording-resumed` for the same Room, and a socket that joins afterward
+ * gets it on connect (Phase 2 spec #129 §3, issue #122).
+ */
+export interface RecordingStoppedMessage {
+  readonly type: "recording-stopped";
+}
+
 export type ServerMessage =
   | RoomViewMessage
   | PlayerEvictedMessage
@@ -233,4 +243,5 @@ export type ServerMessage =
   | HandListMessage
   | HandSummaryMessage
   | RecordingPausedMessage
-  | RecordingResumedMessage;
+  | RecordingResumedMessage
+  | RecordingStoppedMessage;

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -3930,4 +3930,233 @@ describe("the commit seam", () => {
       }
     });
   });
+
+  describe("continue without recording", () => {
+    function commandsPath(rooms: RoomStore, code: string): string {
+      const roomId = rooms.get(code)?.id;
+      return `${RECORDINGS_ROOT}/${String(roomId)}/hand-0001.commands.jsonl`;
+    }
+
+    async function foldHandToCompletion(
+      code: string,
+      rooms: RoomStore,
+      seats: Connection[],
+    ): Promise<void> {
+      for (let i = 0; i < 8; i++) {
+        if (rooms.get(code)?.engine?.hand?.status === "complete") return;
+        const actor = rooms.currentActor(code);
+        if (actor === undefined) throw new Error("expected a current actor");
+        seats[actor]?.socket.send(JSON.stringify({ type: "fold" }));
+        await settle();
+      }
+      throw new Error("hand did not complete");
+    }
+
+    it("resumes play immediately with write access still revoked, and never repairs or writes to the recording again", async () => {
+      const rig = await headsUpRoom();
+      const { app: rigApp, code, rooms, disk, table, seats } = rig;
+      try {
+        table.socket.send(JSON.stringify({ type: "startHand" }));
+        await waitFor(() => rooms.currentActor(code) === 0);
+        disk.failAlways("appendFile");
+        seats[0]?.socket.send(JSON.stringify({ type: "call" }));
+        await waitFor(() => rooms.get(code)?.turnEndsAt === null);
+
+        const path = commandsPath(rooms, code);
+        const tailAfterFailure = disk.read(path);
+        // The repairs Retry performs are themselves writes — arm those to
+        // fail too, so a stray repair attempt here would leave a trace.
+        disk.failAlways("truncate");
+        disk.failAlways("remove");
+
+        const resumed = await rigApp.inject({
+          method: "POST",
+          url: `/rooms/${code}/recording/continue`,
+        });
+        expect(resumed.statusCode).toBe(204);
+        await waitFor(() => rooms.currentActor(code) === 1);
+        await settle();
+
+        expect(disk.read(path)).toBe(tailAfterFailure);
+        expect(table.messages.some((m) => m.type === "recording-stopped")).toBe(
+          true,
+        );
+
+        // Play goes on live on the same still-broken disk: no per-hand
+        // retry, no re-pause, and the recording never grows again.
+        seats[1]?.socket.send(JSON.stringify({ type: "check" }));
+        await waitFor(
+          () =>
+            actionsSeen(table.messages).filter((e) => e.action === "check")
+              .length > 0,
+        );
+        await settle();
+
+        expect(disk.read(path)).toBe(tailAfterFailure);
+        expect(
+          table.messages.filter((m) => m.type === "recording-paused"),
+        ).toHaveLength(1);
+      } finally {
+        for (const conn of [table, ...seats]) conn.socket.close();
+        await rig.app.close();
+      }
+    });
+
+    it("answers not-paused when continue is called on a Room that is not paused", async () => {
+      const rig = await headsUpRoom();
+      const { app: rigApp, code, table, seats } = rig;
+      try {
+        const resumed = await rigApp.inject({
+          method: "POST",
+          url: `/rooms/${code}/recording/continue`,
+        });
+        expect(resumed.statusCode).toBe(409);
+      } finally {
+        for (const conn of [table, ...seats]) conn.socket.close();
+        await rig.app.close();
+      }
+    });
+
+    it("tells a socket that joins afterward that recording has stopped", async () => {
+      const rig = await headsUpRoom();
+      const { app: rigApp, code, rooms, disk, table, seats } = rig;
+      try {
+        table.socket.send(JSON.stringify({ type: "startHand" }));
+        await waitFor(() => rooms.currentActor(code) === 0);
+        disk.failAlways("appendFile");
+        seats[0]?.socket.send(JSON.stringify({ type: "call" }));
+        await waitFor(() => rooms.get(code)?.turnEndsAt === null);
+        await rigApp.inject({
+          method: "POST",
+          url: `/rooms/${code}/recording/continue`,
+        });
+
+        const address = rigApp.server.address();
+        if (address === null || typeof address === "string") {
+          throw new Error("expected a bound TCP address");
+        }
+        const joinerMessages: ServerMessage[] = [];
+        const joiner = new WebSocket(
+          `ws://127.0.0.1:${String(address.port)}/ws?room=${code}&role=table`,
+        );
+        joiner.on("message", (data: Buffer) => {
+          joinerMessages.push(JSON.parse(data.toString()) as ServerMessage);
+        });
+        await new Promise<void>((resolve, reject) => {
+          joiner.once("open", () => {
+            resolve();
+          });
+          joiner.once("error", reject);
+        });
+        await settle();
+
+        expect(joinerMessages.some((m) => m.type === "recording-stopped")).toBe(
+          true,
+        );
+        expect(joinerMessages.some((m) => m.type === "recording-paused")).toBe(
+          false,
+        );
+        joiner.close();
+      } finally {
+        for (const conn of [table, ...seats]) conn.socket.close();
+        await rig.app.close();
+      }
+    });
+
+    it("keeps hands recorded before the failure in the picker, but never offers the abandoned Hand", async () => {
+      const rig = await headsUpRoom();
+      const { app: rigApp, code, rooms, disk, table, seats } = rig;
+      try {
+        table.socket.send(JSON.stringify({ type: "startHand" }));
+        await waitFor(() => rooms.currentActor(code) !== undefined);
+        await foldHandToCompletion(code, rooms, seats);
+        await settle();
+        expect(
+          table.messages
+            .filter((m) => m.type === "hand-summary")
+            .map((m) => m.summary.handOrdinal),
+        ).toEqual([1]);
+
+        table.socket.send(JSON.stringify({ type: "nextHand" }));
+        await waitFor(
+          () => rooms.get(code)?.engine?.hand?.status === "betting",
+        );
+        disk.failAlways("appendFile");
+        const actor = rooms.currentActor(code);
+        if (actor === undefined) throw new Error("expected a current actor");
+        // Heads-up, this fold both fails to record and ends hand 2 outright.
+        seats[actor]?.socket.send(JSON.stringify({ type: "fold" }));
+        await waitFor(() =>
+          table.messages.some((m) => m.type === "recording-paused"),
+        );
+
+        const resumed = await rigApp.inject({
+          method: "POST",
+          url: `/rooms/${code}/recording/continue`,
+        });
+        expect(resumed.statusCode).toBe(204);
+        await settle();
+
+        expect(
+          table.messages
+            .filter((m) => m.type === "hand-summary")
+            .map((m) => m.summary.handOrdinal),
+        ).toEqual([1]);
+
+        const address = rigApp.server.address();
+        if (address === null || typeof address === "string") {
+          throw new Error("expected a bound TCP address");
+        }
+        const joinerMessages: ServerMessage[] = [];
+        const joiner = new WebSocket(
+          `ws://127.0.0.1:${String(address.port)}/ws?room=${code}&role=table`,
+        );
+        joiner.on("message", (data: Buffer) => {
+          joinerMessages.push(JSON.parse(data.toString()) as ServerMessage);
+        });
+        await new Promise<void>((resolve, reject) => {
+          joiner.once("open", () => {
+            resolve();
+          });
+          joiner.once("error", reject);
+        });
+        await settle();
+
+        const handList = joinerMessages.find((m) => m.type === "hand-list");
+        expect(handList?.summaries.map((s) => s.handOrdinal)).toEqual([1]);
+        joiner.close();
+      } finally {
+        for (const conn of [table, ...seats]) conn.socket.close();
+        await rig.app.close();
+      }
+    });
+
+    it("still ends cleanly, with nothing left to drain, after Continue without recording", async () => {
+      const rig = await headsUpRoom();
+      const { app: rigApp, code, rooms, disk, table, seats } = rig;
+      try {
+        table.socket.send(JSON.stringify({ type: "startHand" }));
+        await waitFor(() => rooms.currentActor(code) === 0);
+        disk.failAlways("appendFile");
+        seats[0]?.socket.send(JSON.stringify({ type: "call" }));
+        await waitFor(() => rooms.get(code)?.turnEndsAt === null);
+
+        const resumed = await rigApp.inject({
+          method: "POST",
+          url: `/rooms/${code}/recording/continue`,
+        });
+        expect(resumed.statusCode).toBe(204);
+
+        const ended = await rigApp.inject({
+          method: "POST",
+          url: `/rooms/${code}/end`,
+        });
+        expect(ended.statusCode).toBe(204);
+        expect(rooms.get(code)).toBeUndefined();
+      } finally {
+        for (const conn of [table, ...seats]) conn.socket.close();
+        await rig.app.close();
+      }
+    });
+  });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -253,6 +253,12 @@ export async function buildApp(
   }
   const pausedRooms = new Map<string, PausedRoom>();
   /**
+   * A Room enters here once "Continue without recording" resumes it — see
+   * recording-paused in `docs/design/server.md`. Latched for the Room's
+   * life: nothing ever removes a code from this set.
+   */
+  const recordingStopped = new Set<string>();
+  /**
    * Every completed hand of a room, oldest first, held for the Room's life —
    * no disk read is involved (Phase 2 spec #129 §5). A server restart
    * destroys the Room outright, so there is no session whose listing would
@@ -477,6 +483,9 @@ export async function buildApp(
     pausedRooms.delete(code);
     paused?.transaction?.discard();
     await drainRecording(code, paused?.operation);
+    // A future Room may collide on this join code once it is re-rolled —
+    // leaving this set would start it already believing it has no recording.
+    recordingStopped.delete(code);
     rooms.end(code);
   }
 
@@ -505,7 +514,10 @@ export async function buildApp(
    * and summarises that hand the moment it completes — the same moment
    * "Review hands" becomes reachable (§6). Only a hand seen whole, from its
    * `HandStarted` to its `HandComplete`, is ever summarised, so a listing
-   * can't be built from a partial recording (§4).
+   * can't be built from a partial recording (§4). Once "Continue without
+   * recording" has latched, no hand completing from here has a recording to
+   * replay — including the one already in flight — so none of them enter
+   * the listing either (§3, issue #122).
    */
   function accumulateHandSummary(
     code: string,
@@ -527,6 +539,7 @@ export async function buildApp(
       if (step.event.type !== "HandComplete") continue;
 
       handsInProgress.delete(code);
+      if (recordingStopped.has(code)) continue;
       let summary: HandSummary;
       try {
         summary = summarise(inProgress.events, {
@@ -558,6 +571,10 @@ export async function buildApp(
     code: string,
     operation: RoomOperation,
   ): Promise<boolean> {
+    // "Continue without recording" latches this — no later operation is
+    // ever offered to the recording again, so nothing here re-pauses the
+    // Room on the very disk it just chose to stop trusting (§3, issue #122).
+    if (recordingStopped.has(code)) return true;
     const recording = roomRecordings.get(code);
     if (recording === undefined) {
       // A bug of ours rather than a disk failure, so it is loud but not fatal
@@ -899,6 +916,24 @@ export async function buildApp(
   }
 
   /**
+   * Settles a paused Room's retained operation exactly as a live dispatch
+   * would, once the reason it couldn't be applied has been resolved one way
+   * or another (recorded via Retry, or waved through by Continue without
+   * recording) — the one place Retry and Continue share for resuming play,
+   * so they cannot drift apart on it. A retained Rejection has no
+   * transaction to settle: only the clock restarts.
+   */
+  function resumePausedTransaction(code: string, paused: PausedRoom): void {
+    if (paused.transaction !== undefined) {
+      settleDispatch(code, paused.transaction, "reschedule");
+      paused.onSettled?.();
+    } else {
+      rescheduleActionClock(code, "reschedule");
+      scheduleBotAction(code);
+    }
+  }
+
+  /**
    * Resumes a paused Room: retries the operation it retained and, once
    * confirmed, settles it exactly as a live dispatch would. The Actor's
    * clock always restarts at a fresh full interval — a player who lost
@@ -925,14 +960,43 @@ export async function buildApp(
     }
 
     pausedRooms.delete(code);
-    if (paused.transaction !== undefined) {
-      settleDispatch(code, paused.transaction, "reschedule");
-      paused.onSettled?.();
-    } else {
-      rescheduleActionClock(code, "reschedule");
-      scheduleBotAction(code);
-    }
+    resumePausedTransaction(code, paused);
     broadcastRecordingResumed(code);
+    return "resumed";
+  }
+
+  /**
+   * Resumes a paused Room without repairing or ever writing to its
+   * recording again — the exit for a disk that will not accept a write a
+   * second time (§3, issue #122). The retained operation commits live
+   * exactly as `retryRecording` would, but nothing is appended for it: the
+   * repairs Retry performs (truncating to confirmed offsets, restoring a
+   * parseable tail) are themselves writes, and cannot run on the filesystem
+   * that just refused one. The recording is closed as it stands —
+   * `RoomRecording.close` touches no file — and `recordingStopped` latches
+   * the choice so no later operation, in this Hand or any after it, is ever
+   * offered to a recording again.
+   */
+  async function continueWithoutRecording(
+    code: string,
+  ): Promise<"resumed" | "not-paused"> {
+    const paused = pausedRooms.get(code);
+    if (paused === undefined) return "not-paused";
+    pausedRooms.delete(code);
+    recordingStopped.add(code);
+
+    const recording = roomRecordings.get(code);
+    roomRecordings.delete(code);
+    if (recording !== undefined) {
+      try {
+        await recording.close();
+      } catch (error) {
+        app.log.error({ err: error, room: code }, "recording close failed");
+      }
+    }
+
+    resumePausedTransaction(code, paused);
+    broadcastToRoom(code, { type: "recording-stopped" });
     return "resumed";
   }
 
@@ -1278,6 +1342,21 @@ export async function buildApp(
     },
   );
 
+  app.post<RoomCodeRoute>(
+    "/rooms/:code/recording/continue",
+    async (request, reply) => {
+      const room = findRoomOrReject(rooms, request.params.code, reply);
+      if (!room) return;
+      const result = await enqueue(room.code, () =>
+        continueWithoutRecording(room.code),
+      );
+      if (result === "not-paused") {
+        return reply.code(409).send({ error: "not-paused" });
+      }
+      return reply.code(204).send();
+    },
+  );
+
   app.register((wsApp, _opts, done) => {
     wsApp.get<WsRoute>(
       "/ws",
@@ -1351,11 +1430,14 @@ export async function buildApp(
           const room = rooms.get(code);
           if (!room) return;
           broadcastRoomView(code);
-          // A joiner's own catch-up, not a broadcast: recording-paused is
-          // told once at the moment it starts, and a socket that connects
-          // after that moment would otherwise never learn play has stopped.
+          // A joiner's own catch-up, not a broadcast: recording-paused and
+          // recording-stopped are each told once at the moment they start,
+          // and a socket that connects after that moment would otherwise
+          // never learn play has stopped, or that it is no longer recorded.
           if (isRecordingPaused(code)) {
             send(socket, { type: "recording-paused" });
+          } else if (recordingStopped.has(code)) {
+            send(socket, { type: "recording-stopped" });
           }
           // Incremental pushes alone would leave a reloaded table with an
           // empty picker for hands it had already seen — Phase 1's catch-up

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -253,4 +253,17 @@ describe("App", () => {
       'data-testid="add-bot-button"',
     );
   });
+
+  it("shows the not-recording banner once recording has stopped, and hides it otherwise", () => {
+    enterRoom(2, liveHand);
+    expect(renderToStaticMarkup(<App />)).not.toContain(
+      'data-testid="not-recording-banner"',
+    );
+
+    enterRoom(2, liveHand);
+    store.overrides = { ...store.overrides, recordingStopped: true };
+    expect(renderToStaticMarkup(<App />)).toContain(
+      'data-testid="not-recording-banner"',
+    );
+  });
 });

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -21,6 +21,7 @@ import {
 } from "./api/rooms.js";
 import { Board } from "./Board.js";
 import { HouseRulesSheet } from "./HouseRulesSheet.js";
+import { NotRecordingBanner } from "./NotRecordingBanner.js";
 import { SeatCountPicker } from "./SeatCountPicker.js";
 import { JoinPanel } from "./JoinPanel.js";
 import { SeatMenu } from "./SeatMenu.js";
@@ -49,6 +50,7 @@ export function App() {
   const testMode = useTableStore((state) => state.testMode);
   const connectionStatus = useTableStore((state) => state.connectionStatus);
   const handView = useTableStore((state) => state.handView);
+  const recordingStopped = useTableStore((state) => state.recordingStopped);
   const setRoomCreated = useTableStore((state) => state.setRoomCreated);
   const clearRoom = useTableStore((state) => state.clearRoom);
   const clearHand = useTableStore((state) => state.clearHand);
@@ -193,6 +195,7 @@ export function App() {
         showRoomCode={handInProgress && !joinOpen}
         onOpenJoin={toggleJoin}
       />
+      {recordingStopped && <NotRecordingBanner />}
       <main className="felt">
         {roomCode === null ? (
           <SeatCountPicker

--- a/packages/table-client/src/NotRecordingBanner.test.tsx
+++ b/packages/table-client/src/NotRecordingBanner.test.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { NotRecordingBanner } from "./NotRecordingBanner.js";
+
+describe("NotRecordingBanner", () => {
+  it("names itself as a status region and states hands are not being saved", () => {
+    const html = renderToStaticMarkup(<NotRecordingBanner />);
+    expect(html).toContain('data-testid="not-recording-banner"');
+    expect(html).toContain('role="status"');
+    expect(html).toContain("Not recording");
+  });
+});

--- a/packages/table-client/src/NotRecordingBanner.tsx
+++ b/packages/table-client/src/NotRecordingBanner.tsx
@@ -1,0 +1,35 @@
+import { color, font, fontSize } from "@table-top-poker/ui-shared";
+
+/**
+ * Persistent notice for the remainder of a Room's life once "Continue
+ * without recording" has resumed it (Phase 2 spec #129 §3). Never
+ * dismissable and never paired with a "recording resumed" counterpart —
+ * recording does not come back.
+ */
+export function NotRecordingBanner() {
+  return (
+    <div
+      data-testid="not-recording-banner"
+      role="status"
+      style={{
+        flex: "none",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "0.5em",
+        width: "100%",
+        padding: "0.5em 1em",
+        background: color.lossBackground,
+        borderBottom: `1px solid ${color.lossBorder}`,
+        fontFamily: font.mono,
+        fontSize: fontSize.xs,
+        fontWeight: 600,
+        letterSpacing: "0.08em",
+        textTransform: "uppercase",
+        color: color.textBright,
+      }}
+    >
+      Not recording — hands from here on will not be saved
+    </div>
+  );
+}

--- a/packages/table-client/src/store/roomSlice.ts
+++ b/packages/table-client/src/store/roomSlice.ts
@@ -17,12 +17,19 @@ export interface RoomSlice {
   readonly pendingShotClock: ShotClockSettings | null;
   readonly soundSettings: SoundSettings;
   readonly shotClockSettings: ShotClockSettings;
+  /**
+   * Latched true once "Continue without recording" resumes the Room —
+   * never cleared while the Room lives, since recording never comes back
+   * (Phase 2 spec #129 §3).
+   */
+  readonly recordingStopped: boolean;
   readonly setRoomCreated: (room: {
     code: string;
     joinUrl: string;
     qrCodeDataUrl: string;
   }) => void;
   readonly setRoomView: (view: RoomView) => void;
+  readonly setRecordingStopped: () => void;
   readonly clearRoom: () => void;
 }
 
@@ -35,6 +42,7 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
   pendingShotClock: null,
   soundSettings: DEFAULT_SOUND_SETTINGS,
   shotClockSettings: DEFAULT_SHOT_CLOCK,
+  recordingStopped: false,
   setRoomCreated: ({ code, joinUrl, qrCodeDataUrl }) => {
     set({
       roomCode: code,
@@ -54,6 +62,9 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
       shotClockSettings: view.shotClockSettings,
     });
   },
+  setRecordingStopped: () => {
+    set({ recordingStopped: true });
+  },
   clearRoom: () => {
     set({
       roomCode: null,
@@ -64,6 +75,7 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      recordingStopped: false,
     });
   },
 });

--- a/packages/table-client/src/store/store.test.ts
+++ b/packages/table-client/src/store/store.test.ts
@@ -98,6 +98,21 @@ describe("useTableStore", () => {
     expect(useTableStore.getState().handView).toBeNull();
   });
 
+  it("latches recording-stopped true and keeps it through a room-view update", () => {
+    useTableStore.getState().setRecordingStopped();
+    expect(useTableStore.getState().recordingStopped).toBe(true);
+
+    useTableStore.getState().setRoomView({
+      code: "ABCD",
+      pendingSeatCount: null,
+      pendingShotClock: null,
+      soundSettings: DEFAULT_SOUND_SETTINGS,
+      shotClockSettings: DEFAULT_SHOT_CLOCK,
+      seats: [],
+    });
+    expect(useTableStore.getState().recordingStopped).toBe(true);
+  });
+
   it("clears the room slice back to its initial state", () => {
     useTableStore.getState().setRoomView({
       code: "ABCD",
@@ -115,8 +130,10 @@ describe("useTableStore", () => {
         },
       ],
     });
+    useTableStore.getState().setRecordingStopped();
     useTableStore.getState().clearRoom();
     expect(useTableStore.getState().roomCode).toBeNull();
     expect(useTableStore.getState().seats).toEqual([]);
+    expect(useTableStore.getState().recordingStopped).toBe(false);
   });
 });

--- a/packages/table-client/src/ws/useWebSocket.ts
+++ b/packages/table-client/src/ws/useWebSocket.ts
@@ -26,6 +26,9 @@ export function useWebSocket(
   );
   const setRoomView = useTableStore((state) => state.setRoomView);
   const setHandView = useTableStore((state) => state.setHandView);
+  const setRecordingStopped = useTableStore(
+    (state) => state.setRecordingStopped,
+  );
   const socketRef = useRef<WebSocket | null>(null);
   const optionsRef = useRef(options);
   optionsRef.current = options;
@@ -73,6 +76,8 @@ export function useWebSocket(
           setHandView(message.view);
         } else if (message.type === "room-ended") {
           optionsRef.current.onRoomEnded?.();
+        } else if (message.type === "recording-stopped") {
+          setRecordingStopped();
         }
       });
     }
@@ -85,7 +90,13 @@ export function useWebSocket(
       socketRef.current?.close();
       socketRef.current = null;
     };
-  }, [roomCode, setConnectionStatus, setRoomView, setHandView]);
+  }, [
+    roomCode,
+    setConnectionStatus,
+    setRoomView,
+    setHandView,
+    setRecordingStopped,
+  ]);
 
   const send = useCallback((command: ClientCommand) => {
     socketRef.current?.send(JSON.stringify(command));


### PR DESCRIPTION
## Summary
- Adds `continueWithoutRecording` and `POST /rooms/:code/recording/continue`, the third exit from recording-paused for a failure Retry cannot fix (a worn SD card that stays read-only). It commits the retained operation live but never appends it, and never repairs the file tail — those repairs are themselves writes.
- `recordingStopped` latches the choice for the Room's life: no later operation is ever offered to the recording again, and no hand completing afterward (including the one in flight when the append failed) enters the hand picker's listing. Hands recorded before the failure are unaffected.
- Broadcasts a new `recording-stopped` protocol message; a socket joining afterward is caught up on connect, mirroring `recording-paused`. `table-client` renders a persistent not-recording banner once it lands.
- Refactored `retryRecording`/`continueWithoutRecording`'s shared "settle the retained transaction" logic into `resumePausedTransaction` per code review.

Closes #122.

## Test plan
- [x] `npx vitest run src/app.test.ts` (server, 121 tests)
- [x] `npx vitest run --project server --project table-client --project protocol` (429 tests)
- [x] `npx vitest run --project player-client` (379 tests, exhaustive-switch fix)
- [x] `npm run build` (full monorepo typecheck)
- [x] `npm run lint` (eslint + prettier)
- [x] `/code-review medium` — one finding (duplicated resume logic), applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jp7uJVJAo5MQDTeqEswV5r