### PR TITLE
feat(table): review hands entry and the hand picker

### DIFF
--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -20,6 +20,7 @@ import {
   fetchRoom,
 } from "./api/rooms.js";
 import { Board } from "./Board.js";
+import { HandPicker } from "./HandPicker.js";
 import { HouseRulesSheet } from "./HouseRulesSheet.js";
 import { NotRecordingBanner } from "./NotRecordingBanner.js";
 import { SeatCountPicker } from "./SeatCountPicker.js";
@@ -54,6 +55,8 @@ export function App() {
   const setRoomCreated = useTableStore((state) => state.setRoomCreated);
   const clearRoom = useTableStore((state) => state.clearRoom);
   const clearHand = useTableStore((state) => state.clearHand);
+  const handSummaries = useTableStore((state) => state.handSummaries);
+  const clearHandHistory = useTableStore((state) => state.clearHandHistory);
 
   useEffect(() => {
     const stored = loadHostedRoom(window.localStorage);
@@ -74,6 +77,8 @@ export function App() {
 
   const [menuSeatId, setMenuSeatId] = useState<number | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
+
+  const [handPickerOpen, setHandPickerOpen] = useState(false);
 
   const [showdownCollapsed, setShowdownCollapsed] = useState(false);
   const atShowdown = handView?.phase === "showdown";
@@ -97,9 +102,11 @@ export function App() {
   const handleRoomEnded = useCallback(() => {
     clearHostedRoom(window.localStorage);
     setSettingsOpen(false);
+    setHandPickerOpen(false);
     clearRoom();
     clearHand();
-  }, [clearRoom, clearHand]);
+    clearHandHistory();
+  }, [clearRoom, clearHand, clearHandHistory]);
 
   const { send } = useWebSocket(roomCode, {
     onRoomEnded: handleRoomEnded,
@@ -124,13 +131,15 @@ export function App() {
       .then(() => {
         clearHostedRoom(window.localStorage);
         setSettingsOpen(false);
+        setHandPickerOpen(false);
         clearRoom();
         clearHand();
+        clearHandHistory();
       })
       .catch((error: unknown) => {
         console.error(error);
       });
-  }, [roomCode, clearRoom, clearHand]);
+  }, [roomCode, clearRoom, clearHand, clearHandHistory]);
 
   const handleAddBot = useCallback(() => {
     if (roomCode === null || !testMode) return;
@@ -307,6 +316,18 @@ export function App() {
                 onAddBot={handleAddBot}
                 onViewShowdown={() => {
                   setShowdownCollapsed(false);
+                }}
+                onReviewHands={() => {
+                  setHandPickerOpen(true);
+                }}
+              />
+            )}
+            {handPickerOpen && (
+              <HandPicker
+                summaries={handSummaries}
+                seats={seats}
+                onClose={() => {
+                  setHandPickerOpen(false);
                 }}
               />
             )}

--- a/packages/table-client/src/HandPicker.test.tsx
+++ b/packages/table-client/src/HandPicker.test.tsx
@@ -1,0 +1,159 @@
+import type { Card, HandSummary, SeatView } from "@table-top-poker/protocol";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { HandPicker } from "./HandPicker.js";
+
+const noop = () => undefined;
+
+function card(rank: Card["rank"], suit: Card["suit"]): Card {
+  return { rank, suit };
+}
+
+function seat(id: number, displayName: string | null = null): SeatView {
+  return {
+    id,
+    claimed: true,
+    sittingOut: false,
+    sittingOutReason: null,
+    disconnected: false,
+    ...(displayName !== null && { displayName }),
+  };
+}
+
+const foldedOutWalk: HandSummary = {
+  handOrdinal: 1,
+  startedAt: new Date(Date.now() - 90_000).toISOString(),
+  button: 0,
+  seatsDealtIn: [0, 1],
+  survivors: [1],
+  board: [],
+  streetReached: "preflop",
+  bettingShape: { kind: "walk" },
+  outcome: { kind: "folded-out", winner: 1 },
+};
+
+const raiseWarToTurn: HandSummary = {
+  handOrdinal: 2,
+  startedAt: new Date(Date.now() - 5_000).toISOString(),
+  button: 1,
+  seatsDealtIn: [0, 1, 2],
+  survivors: [0, 2],
+  board: [card("2", "clubs"), card("7", "hearts"), card("K", "spades")],
+  streetReached: "turn",
+  bettingShape: { kind: "raise-war", raises: 4 },
+  outcome: { kind: "folded-out", winner: 2 },
+};
+
+const showdown: HandSummary = {
+  handOrdinal: 3,
+  startedAt: new Date(Date.now() - 10_000).toISOString(),
+  button: 0,
+  seatsDealtIn: [0, 1],
+  survivors: [0, 1],
+  board: [
+    card("2", "clubs"),
+    card("7", "hearts"),
+    card("K", "spades"),
+    card("9", "diamonds"),
+    card("A", "clubs"),
+  ],
+  streetReached: "river",
+  bettingShape: { kind: "one-raise" },
+  outcome: {
+    kind: "showdown",
+    winners: [0],
+    reveals: [
+      {
+        seatId: 0,
+        bestHand: [
+          card("A", "clubs"),
+          card("A", "spades"),
+          card("K", "spades"),
+          card("9", "diamonds"),
+          card("7", "hearts"),
+        ],
+        description: "Pair of aces",
+      },
+      {
+        seatId: 1,
+        bestHand: [
+          card("2", "hearts"),
+          card("2", "diamonds"),
+          card("K", "spades"),
+          card("9", "diamonds"),
+          card("7", "hearts"),
+        ],
+        description: "Pair of twos",
+      },
+    ],
+  },
+};
+
+describe("HandPicker", () => {
+  it("lists hands newest-first with ordinal, betting shape, and outcome", () => {
+    const html = renderToStaticMarkup(
+      <HandPicker
+        summaries={[foldedOutWalk, raiseWarToTurn]}
+        seats={[seat(0), seat(1), seat(2)]}
+        onClose={noop}
+      />,
+    );
+    const firstRow = html.indexOf('data-testid="hand-row-2"');
+    const secondRow = html.indexOf('data-testid="hand-row-1"');
+    expect(firstRow).toBeGreaterThan(-1);
+    expect(secondRow).toBeGreaterThan(firstRow);
+    expect(html).toContain("raise war — 4 raises");
+    expect(html).toContain("walk — folded round");
+    expect(html).toContain("2 to the turn");
+    expect(html).toContain("1 to preflop");
+  });
+
+  it("shows dashed empty slots for undealt streets", () => {
+    const html = renderToStaticMarkup(
+      <HandPicker
+        summaries={[foldedOutWalk]}
+        seats={[seat(0), seat(1)]}
+        onClose={noop}
+      />,
+    );
+    const dashedSlots = html.match(/border:1px dashed/g) ?? [];
+    expect(dashedSlots).toHaveLength(5);
+  });
+
+  it("shows the fold-out winner by seat and hides the showdown wording", () => {
+    const html = renderToStaticMarkup(
+      <HandPicker
+        summaries={[foldedOutWalk]}
+        seats={[seat(0), seat(1)]}
+        onClose={noop}
+      />,
+    );
+    expect(html).toContain("Seat 2 wins — everyone folded");
+  });
+
+  it("shows the showdown winner's hand description", () => {
+    const html = renderToStaticMarkup(
+      <HandPicker
+        summaries={[showdown]}
+        seats={[seat(0), seat(1)]}
+        onClose={noop}
+      />,
+    );
+    expect(html).toContain("Seat 1 wins — Pair of aces");
+  });
+
+  it("shows an empty state when no hands have completed", () => {
+    const html = renderToStaticMarkup(
+      <HandPicker summaries={[]} seats={[]} onClose={noop} />,
+    );
+    expect(html).toContain("No hands played yet");
+  });
+
+  it("exposes a close control", () => {
+    const html = renderToStaticMarkup(
+      <HandPicker summaries={[]} seats={[]} onClose={noop} />,
+    );
+    expect(html).toContain('data-testid="close-hand-picker-button"');
+  });
+});

--- a/packages/table-client/src/HandPicker.tsx
+++ b/packages/table-client/src/HandPicker.tsx
@@ -1,0 +1,308 @@
+import type {
+  BettingShape,
+  Card as CardType,
+  HandSummary,
+  SeatView,
+  Street,
+} from "@table-top-poker/protocol";
+import {
+  Card,
+  Panel,
+  color,
+  font,
+  fontSize,
+  radius,
+} from "@table-top-poker/ui-shared";
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
+import { seatLabel } from "./seatLabel.js";
+
+export interface HandPickerProps {
+  readonly summaries: readonly HandSummary[];
+  readonly seats: readonly SeatView[];
+  readonly onClose: () => void;
+}
+
+/**
+ * Polls `Date.now()` on an interval rather than computing the relative
+ * label once at mount, so it visibly goes stale ("just now" -> "1m ago")
+ * while the picker stays open (§6).
+ */
+function useNow(): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+    return () => {
+      window.clearInterval(id);
+    };
+  }, []);
+  return now;
+}
+
+function formatRelative(startedAt: string, now: number): string {
+  const seconds = Math.max(
+    0,
+    Math.round((now - new Date(startedAt).getTime()) / 1000),
+  );
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${String(minutes)}m ago`;
+  const hours = Math.floor(minutes / 60);
+  const remainderMinutes = minutes % 60;
+  return remainderMinutes === 0
+    ? `${String(hours)}h ago`
+    : `${String(hours)}h ${String(remainderMinutes)}m ago`;
+}
+
+/** This client's copy for the wire's structured descriptor — see `BettingShape`. */
+function bettingShapeText(shape: BettingShape): string {
+  switch (shape.kind) {
+    case "walk":
+      return "walk — folded round";
+    case "preflop-raise":
+      return "preflop raise took it";
+    case "checked-down":
+      return "checked down";
+    case "one-raise":
+      return "one raise";
+    case "raise-war":
+      return `raise war — ${String(shape.raises)} raises`;
+  }
+}
+
+const streetPhrase: Record<Street, string> = {
+  preflop: "preflop",
+  flop: "the flop",
+  turn: "the turn",
+  river: "the river",
+};
+
+function outcomeText(hand: HandSummary, seats: readonly SeatView[]): string {
+  const { outcome } = hand;
+  if (outcome.kind === "folded-out") {
+    return `${seatLabel(outcome.winner, seats)} wins — everyone folded`;
+  }
+  const names = outcome.winners.map((seatId) => seatLabel(seatId, seats));
+  const verb = outcome.winners.length > 1 ? "split" : "wins";
+  const description = outcome.reveals.find((reveal) =>
+    outcome.winners.includes(reveal.seatId),
+  )?.description;
+  const headline = `${names.join(" & ")} ${verb}`;
+  return description ? `${headline} — ${description}` : headline;
+}
+
+function BoardStrip({ board }: { readonly board: readonly CardType[] }) {
+  const slots = Array.from({ length: 5 }, (_, i) => board[i] ?? null);
+  return (
+    <div style={{ display: "flex", gap: "0.35em", fontSize: "1.3em" }}>
+      {slots.map((card, i) =>
+        card ? (
+          <Card key={i} rank={card.rank} suit={card.suit} />
+        ) : (
+          <div
+            key={i}
+            style={{
+              width: "3.5em",
+              height: "5em",
+              borderRadius: "0.2em",
+              border: `1px dashed ${color.border}`,
+              background: color.mutedSurface,
+            }}
+          />
+        ),
+      )}
+    </div>
+  );
+}
+
+const rowStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "3em 1fr 15em",
+  alignItems: "center",
+  gap: "1.2em",
+  width: "100%",
+  padding: "0.7em 1.1em",
+  borderRadius: radius.control,
+  border: `1px solid ${color.border}`,
+  background: color.surfaceGradient,
+};
+
+function HandRow({
+  hand,
+  seats,
+  now,
+}: {
+  readonly hand: HandSummary;
+  readonly seats: readonly SeatView[];
+  readonly now: number;
+}) {
+  const outcome = outcomeText(hand, seats);
+  return (
+    <div data-testid={`hand-row-${String(hand.handOrdinal)}`} style={rowStyle}>
+      <span
+        style={{
+          fontFamily: font.display,
+          fontSize: "1.7em",
+          color: color.textBright,
+          lineHeight: 1,
+        }}
+      >
+        {hand.handOrdinal}
+      </span>
+
+      <BoardStrip board={hand.board} />
+
+      <span style={{ display: "flex", flexDirection: "column", gap: "0.3em" }}>
+        <span
+          style={{
+            fontFamily: font.mono,
+            fontSize: "0.62em",
+            letterSpacing: "0.15em",
+            textTransform: "uppercase",
+            color: color.textDim,
+          }}
+        >
+          {String(hand.survivors.length)} to {streetPhrase[hand.streetReached]}{" "}
+          · {bettingShapeText(hand.bettingShape)}
+        </span>
+        <span
+          style={{
+            fontSize: "0.9em",
+            fontWeight: 600,
+            color: color.winText,
+          }}
+        >
+          {outcome}
+        </span>
+        <span style={{ fontSize: "0.72em", color: color.textFaint }}>
+          Button {seatLabel(hand.button, seats)} ·{" "}
+          {formatRelative(hand.startedAt, now)}
+        </span>
+      </span>
+    </div>
+  );
+}
+
+const kickerStyle: CSSProperties = {
+  fontFamily: font.mono,
+  fontSize: fontSize.xs,
+  letterSpacing: "0.24em",
+  textTransform: "uppercase",
+  color: color.textDim,
+};
+
+export function HandPicker({ summaries, seats, onClose }: HandPickerProps) {
+  const now = useNow();
+  const ordered = useMemo(
+    () => [...summaries].sort((a, b) => b.handOrdinal - a.handOrdinal),
+    [summaries],
+  );
+
+  return (
+    <div
+      data-testid="hand-picker"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="hand-picker-title"
+      style={{
+        position: "absolute",
+        inset: 0,
+        zIndex: 14,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "rgba(6,4,4,.66)",
+        backdropFilter: "blur(5px)",
+      }}
+    >
+      <Panel
+        style={{
+          width: "min(640px, calc(100% - 32px))",
+          maxHeight: "min(720px, calc(100% - 64px))",
+          borderRadius: radius.panel,
+          background: color.surfaceGradient,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <div
+          style={{
+            padding: "26px 30px 20px",
+            display: "flex",
+            justifyContent: "space-between",
+            gap: 20,
+            borderBottom: `1px solid ${color.border}`,
+          }}
+        >
+          <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            <span style={kickerStyle}>This session</span>
+            <span
+              id="hand-picker-title"
+              style={{
+                fontFamily: font.display,
+                fontWeight: 800,
+                letterSpacing: "-.03em",
+                fontSize: fontSize.display,
+                color: color.text,
+              }}
+            >
+              Review hands
+            </span>
+          </div>
+          <button
+            type="button"
+            aria-label="Close review hands"
+            data-testid="close-hand-picker-button"
+            onClick={onClose}
+            style={{
+              width: 42,
+              height: 42,
+              borderRadius: 13,
+              border: `1px solid ${color.border}`,
+              background: "transparent",
+              color: color.textMuted,
+              fontSize: 17,
+              cursor: "pointer",
+              flexShrink: 0,
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "0.55em",
+            overflowY: "auto",
+            padding: "1em 1.2em 1.4em",
+          }}
+        >
+          {ordered.length === 0 ? (
+            <span
+              style={{
+                padding: "1.2em 0.4em",
+                textAlign: "center",
+                color: color.textDim,
+                fontSize: fontSize.md,
+              }}
+            >
+              No hands played yet this session.
+            </span>
+          ) : (
+            ordered.map((hand) => (
+              <HandRow
+                key={hand.handOrdinal}
+                hand={hand}
+                seats={seats}
+                now={now}
+              />
+            ))
+          )}
+        </div>
+      </Panel>
+    </div>
+  );
+}

--- a/packages/table-client/src/HandPicker.tsx
+++ b/packages/table-client/src/HandPicker.tsx
@@ -218,7 +218,7 @@ export function HandPicker({ summaries, seats, onClose }: HandPickerProps) {
     >
       <Panel
         style={{
-          width: "min(640px, calc(100% - 32px))",
+          width: "min(820px, calc(100% - 32px))",
           maxHeight: "min(720px, calc(100% - 64px))",
           borderRadius: radius.panel,
           background: color.surfaceGradient,

--- a/packages/table-client/src/TableControls.test.tsx
+++ b/packages/table-client/src/TableControls.test.tsx
@@ -172,4 +172,63 @@ describe("TableControls", () => {
     expect(on).toContain('data-testid="add-bot-button"');
     expect(on).toContain("Add bot");
   });
+
+  it("hides Review hands before any hand has been played, even though Deal hand can start", () => {
+    const html = renderToStaticMarkup(
+      <TableControls
+        canStartHand
+        handComplete={false}
+        canDealNextHand
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+        onReviewHands={noop}
+      />,
+    );
+    expect(html).not.toContain('data-testid="review-hands-button"');
+  });
+
+  it("shows Review hands once the hand is complete", () => {
+    const html = renderToStaticMarkup(
+      <TableControls
+        canStartHand={false}
+        handComplete
+        canDealNextHand
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+        onReviewHands={noop}
+      />,
+    );
+    expect(html).toContain('data-testid="review-hands-button"');
+  });
+
+  it("hides Review hands while a hand is live and not yet complete", () => {
+    const html = renderToStaticMarkup(
+      <TableControls
+        canStartHand={false}
+        handComplete={false}
+        canDealNextHand
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+        onReviewHands={noop}
+      />,
+    );
+    expect(html).not.toContain('data-testid="review-hands-button"');
+  });
+
+  it("hides Review hands entirely when no handler is supplied", () => {
+    const html = renderToStaticMarkup(
+      <TableControls
+        canStartHand
+        handComplete={false}
+        canDealNextHand
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+      />,
+    );
+    expect(html).not.toContain('data-testid="review-hands-button"');
+  });
 });

--- a/packages/table-client/src/TableControls.tsx
+++ b/packages/table-client/src/TableControls.tsx
@@ -107,7 +107,7 @@ export function TableControls({
           </div>
         )
       )}
-      {onReviewHands && (
+      {onReviewHands && handComplete && (
         <PillButton
           tone="outline"
           data-testid="review-hands-button"

--- a/packages/table-client/src/store/handHistorySlice.ts
+++ b/packages/table-client/src/store/handHistorySlice.ts
@@ -1,0 +1,24 @@
+import type { HandSummary } from "@table-top-poker/protocol";
+import type { StateCreator } from "zustand";
+
+export interface HandHistorySlice {
+  readonly handSummaries: readonly HandSummary[];
+  readonly setHandList: (summaries: readonly HandSummary[]) => void;
+  readonly addHandSummary: (summary: HandSummary) => void;
+  readonly clearHandHistory: () => void;
+}
+
+export const createHandHistorySlice: StateCreator<HandHistorySlice> = (
+  set,
+) => ({
+  handSummaries: [],
+  setHandList: (summaries) => {
+    set({ handSummaries: summaries });
+  },
+  addHandSummary: (summary) => {
+    set((state) => ({ handSummaries: [...state.handSummaries, summary] }));
+  },
+  clearHandHistory: () => {
+    set({ handSummaries: [] });
+  },
+});

--- a/packages/table-client/src/store/store.test.ts
+++ b/packages/table-client/src/store/store.test.ts
@@ -1,9 +1,24 @@
 import {
   DEFAULT_SHOT_CLOCK,
   DEFAULT_SOUND_SETTINGS,
+  type HandSummary,
 } from "@table-top-poker/protocol";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useTableStore } from "./store.js";
+
+function summary(handOrdinal: number): HandSummary {
+  return {
+    handOrdinal,
+    startedAt: "2026-08-13T19:04:00.000Z",
+    button: 0,
+    seatsDealtIn: [0, 1],
+    survivors: [0],
+    board: [],
+    streetReached: "preflop",
+    bettingShape: { kind: "walk" },
+    outcome: { kind: "folded-out", winner: 0 },
+  };
+}
 
 describe("useTableStore", () => {
   beforeEach(() => {
@@ -135,5 +150,28 @@ describe("useTableStore", () => {
     expect(useTableStore.getState().roomCode).toBeNull();
     expect(useTableStore.getState().seats).toEqual([]);
     expect(useTableStore.getState().recordingStopped).toBe(false);
+  });
+
+  it("replaces the hand list wholesale on a hand-list message", () => {
+    useTableStore.getState().setHandList([summary(1), summary(2)]);
+    expect(useTableStore.getState().handSummaries).toHaveLength(2);
+
+    useTableStore.getState().setHandList([summary(1)]);
+    expect(useTableStore.getState().handSummaries).toEqual([summary(1)]);
+  });
+
+  it("appends a hand summary without disturbing the existing list", () => {
+    useTableStore.getState().setHandList([summary(1)]);
+    useTableStore.getState().addHandSummary(summary(2));
+    expect(useTableStore.getState().handSummaries).toEqual([
+      summary(1),
+      summary(2),
+    ]);
+  });
+
+  it("clears the accumulated hand history", () => {
+    useTableStore.getState().setHandList([summary(1)]);
+    useTableStore.getState().clearHandHistory();
+    expect(useTableStore.getState().handSummaries).toEqual([]);
   });
 });

--- a/packages/table-client/src/store/store.ts
+++ b/packages/table-client/src/store/store.ts
@@ -4,14 +4,23 @@ import {
   createConnectionSlice,
 } from "./connectionSlice.js";
 import { createConfigSlice, type ConfigSlice } from "./configSlice.js";
+import {
+  createHandHistorySlice,
+  type HandHistorySlice,
+} from "./handHistorySlice.js";
 import { createHandSlice, type HandSlice } from "./handSlice.js";
 import { createRoomSlice, type RoomSlice } from "./roomSlice.js";
 
-export type TableStore = ConnectionSlice & ConfigSlice & RoomSlice & HandSlice;
+export type TableStore = ConnectionSlice &
+  ConfigSlice &
+  RoomSlice &
+  HandSlice &
+  HandHistorySlice;
 
 export const useTableStore = create<TableStore>()((...args) => ({
   ...createConnectionSlice(...args),
   ...createConfigSlice(...args),
   ...createRoomSlice(...args),
   ...createHandSlice(...args),
+  ...createHandHistorySlice(...args),
 }));

--- a/packages/table-client/src/ws/useWebSocket.ts
+++ b/packages/table-client/src/ws/useWebSocket.ts
@@ -29,6 +29,8 @@ export function useWebSocket(
   const setRecordingStopped = useTableStore(
     (state) => state.setRecordingStopped,
   );
+  const setHandList = useTableStore((state) => state.setHandList);
+  const addHandSummary = useTableStore((state) => state.addHandSummary);
   const socketRef = useRef<WebSocket | null>(null);
   const optionsRef = useRef(options);
   optionsRef.current = options;
@@ -74,6 +76,10 @@ export function useWebSocket(
           });
         } else if (message.type === "view-snapshot") {
           setHandView(message.view);
+        } else if (message.type === "hand-list") {
+          setHandList(message.summaries);
+        } else if (message.type === "hand-summary") {
+          addHandSummary(message.summary);
         } else if (message.type === "room-ended") {
           optionsRef.current.onRoomEnded?.();
         } else if (message.type === "recording-stopped") {
@@ -96,6 +102,8 @@ export function useWebSocket(
     setRoomView,
     setHandView,
     setRecordingStopped,
+    setHandList,
+    addHandSummary,
   ]);
 
   const send = useCallback((command: ClientCommand) => {


### PR DESCRIPTION
## Summary
- Adds a **Review hands** control to the felt's control rail, reachable only between hands (when Next hand / View showdown would show) — never mid-betting.
- Adds the `HandPicker` filmstrip overlay: newest-first rows keyed on `HandSummary` from #116's wire contract, each showing ordinal, board (dashed empties for undealt streets), survivors/street, this client's own betting-shape wording, outcome, and a button-seat line with a relative start time that re-ticks on the picker's own interval clock.
- Wires the `hand-list` / `hand-summary` socket messages into a new `handHistorySlice`, so a reload mid-session still lists every hand played so far.

Closes #125.

## Test plan
- [x] `npx vitest run packages/table-client` — 21 files, 148 tests passing
- [x] `npx tsc --build tsconfig.json` — clean
- [x] `npm run lint` — clean
- [ ] Manual verification in a running table client (not done in this pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GscEcUQNgMPGnNcjmcBvHX