### PR TITLE
feat(table,server,protocol): the chaptered replay scrub

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -222,6 +222,28 @@ stepper shows the prefix with a warning.
 _Avoid_: Calling either corruption — a disagreement between complete records
 is the corrupt case, and it is a hard failure.
 
+**Hand review**:
+The table device's two surfaces for a finished Hand: a picker that chooses
+one from the session, and a Scrub that plays it back on the felt. Reachable
+only between Hands, and force-dismissed the moment a Hand starts — a review
+left open can never swallow the Board.
+
+**Scrub**:
+The table's replay transport: a timeline the width of the felt, ticked once
+per Replay position and chaptered by Street, draggable to any position.
+Autoplay is a secondary toggle, not the primary mode.
+_Avoid_: Calling it playback — getting to a moment is the point, not
+watching the Hand through.
+
+**Chapter**:
+A Street's landmark on the Scrub, seeking to the position that Street opens
+on. For every Street after preflop that is its `BoardDealt`, not its
+`StreetStarted`: the engine's cascade emits `StreetClosed → BoardDealt →
+StreetStarted`, so anchoring on the Street start lands after the cards
+appeared and the viewer never sees them arrive. Chapters are the navigation
+contract; the per-position ticks beside them are a visual affordance that
+may collapse on an unusually long Hand.
+
 **Hand summary**:
 What one completed Hand looks like in a list of them — its ordinal and
 start time, the Button, the Seats dealt in and the Survivors, the public

--- a/packages/harness/src/replay-source.ts
+++ b/packages/harness/src/replay-source.ts
@@ -1,16 +1,13 @@
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
-import type {
-  ReplayAuditRecord,
-  ReplayCommandRecord,
-  ReplayInput,
-} from "@table-top-poker/engine";
+import type { ReplayInput } from "@table-top-poker/engine";
 import {
-  handRecordingPaths,
+  nodeFileSystem,
+  readHandRecording,
   RECORDING_LAYOUT_VERSION,
   roomManifestPath,
 } from "@table-top-poker/recording";
-import type { HandContext, RoomManifest } from "@table-top-poker/recording";
+import type { RoomManifest } from "@table-top-poker/recording";
 
 /** A hard failure: nothing is written to stdout and the CLI exits `1`. */
 export type ReplaySourceFailure =
@@ -188,49 +185,6 @@ export async function resolveRoomDirectory(
   return { roomDir: chosen.roomDir, manifest: chosen.manifest, note };
 }
 
-/** A validated final JSONL line the reader discarded because it was torn. */
-export interface TornRecord {
-  readonly file: string;
-  readonly line: number;
-}
-
-interface ParsedJsonl<T> {
-  readonly records: readonly T[];
-  readonly tornRecord: TornRecord | null;
-}
-
-/**
- * Parses a JSONL file, tolerating an unterminated final line as torn rather
- * than malformed: append-as-you-go persistence (`RoomRecording`) never
- * leaves a torn line anywhere but the last, since every earlier write already
- * completed with its trailing newline before the next one began.
- */
-function parseJsonl<T>(file: string, contents: string): ParsedJsonl<T> {
-  if (contents === "") return { records: [], tornRecord: null };
-
-  const endsWithNewline = contents.endsWith("\n");
-  const body = endsWithNewline ? contents.slice(0, -1) : contents;
-  const lines = body.split("\n");
-  const records: T[] = [];
-
-  for (const [index, line] of lines.entries()) {
-    try {
-      records.push(JSON.parse(line) as T);
-    } catch {
-      const isFinalLine = index === lines.length - 1;
-      if (isFinalLine && !endsWithNewline) {
-        return { records, tornRecord: { file, line: index + 1 } };
-      }
-      throw new ReplaySourceError({
-        kind: "malformed-record",
-        file,
-        line: index + 1,
-      });
-    }
-  }
-  return { records, tornRecord: null };
-}
-
 export interface LoadedHand {
   readonly roomDir: string;
   readonly resolutionNote: string | undefined;
@@ -238,11 +192,9 @@ export interface LoadedHand {
 }
 
 /**
- * Resolves `<room>`, reads Hand `handOrdinal`'s three files, and assembles
- * the `ReplayInput` the engine's `replayHand` takes. At most one of
- * `commands.jsonl`/`events.jsonl` can carry a torn final line — a crash can
- * only land mid-write of one file at a time — so `tornRecord` is whichever
- * one reports it.
+ * Resolves `<room>`, then reads Hand `handOrdinal` through the same reader
+ * the server's replay path uses — one parse of the durable format, so the
+ * stepper and the table can never disagree about what a torn tail is.
  */
 export async function loadHand(
   room: string,
@@ -251,62 +203,25 @@ export async function loadHand(
 ): Promise<LoadedHand> {
   const resolved = await resolveRoomDirectory(room, recordingsDir);
 
-  const paths = handRecordingPaths(resolved.roomDir, handOrdinal);
-  // Independent files, read concurrently — none depends on another's content.
-  const [contextText, commandsText, eventsText] = await Promise.all([
-    readFileOrUndefined(paths.contextPath),
-    // A missing commands/events file reads as empty — an empty Command log
-    // is the engine's own `invalid-command-log` failure, and a commands
-    // file with no matching events file is the orphaned-trailing-Command
-    // case §4 describes, not a harness-level "missing file".
-    readFileOrUndefined(paths.commandsPath).then((text) => text ?? ""),
-    readFileOrUndefined(paths.eventsPath).then((text) => text ?? ""),
-  ]);
-
-  if (contextText === undefined) {
-    throw new ReplaySourceError({
-      kind: "missing-file",
-      file: paths.contextPath,
-    });
+  const read = await readHandRecording({
+    fileSystem: nodeFileSystem,
+    roomDir: resolved.roomDir,
+    handOrdinal,
+  });
+  if (read.status === "missing-file") {
+    throw new ReplaySourceError({ kind: "missing-file", file: read.file });
   }
-  let context: HandContext;
-  try {
-    context = JSON.parse(contextText) as HandContext;
-  } catch {
+  if (read.status === "malformed-record") {
     throw new ReplaySourceError({
       kind: "malformed-record",
-      file: paths.contextPath,
-      line: 1,
+      file: read.file,
+      line: read.line,
     });
   }
-
-  const commands = parseJsonl<ReplayCommandRecord>(
-    paths.commandsPath,
-    commandsText,
-  );
-  const events = parseJsonl<ReplayAuditRecord>(paths.eventsPath, eventsText);
-
-  const tornRecord = commands.tornRecord ?? events.tornRecord ?? null;
-
-  const input: ReplayInput = {
-    sources: {
-      context: paths.contextPath,
-      commands: paths.commandsPath,
-      events: paths.eventsPath,
-    },
-    context: {
-      v: context.v,
-      seats: context.seats,
-      button: context.button,
-    },
-    commands: commands.records,
-    events: events.records,
-    tornRecord,
-  };
 
   return {
     roomDir: resolved.roomDir,
     resolutionNote: resolved.note,
-    input,
+    input: read.input,
   };
 }

--- a/packages/player-client/src/actions/rejectionCopy.ts
+++ b/packages/player-client/src/actions/rejectionCopy.ts
@@ -25,7 +25,7 @@ export function rejectionCopy(
       return "Not enough players to start.";
     case "not-permitted":
       return "That's not something you can do.";
-    case "replay-not-supported":
+    case "hand-unavailable":
       // Replay is a table-device surface; a phone never sends the request
       // this answers, so this exists only to keep the switch exhaustive.
       return "Hand review isn't available here.";

--- a/packages/player-client/src/ws/useWebSocket.ts
+++ b/packages/player-client/src/ws/useWebSocket.ts
@@ -162,6 +162,7 @@ export function useWebSocket(
             break;
           case "hand-list":
           case "hand-summary":
+          case "hand-replay":
             // Hand review is a table-device surface (#129 §6); the server
             // never sends these to a seat, and a phone has nothing to do
             // with one if it ever did.

--- a/packages/protocol/src/hand.ts
+++ b/packages/protocol/src/hand.ts
@@ -14,20 +14,21 @@ export interface HandUpdateMessage {
 /**
  * A server-rejected command, reason-coded, delivered to the sender only.
  *
- * `replay-not-supported` answers a well-formed replay request this server
- * cannot serve yet, so a client can tell "not built" from a dropped socket.
- * It retires when the Replay read path lands.
+ * `hand-unavailable` answers a `get-hand` for an ordinal this Room cannot
+ * serve — never recorded, incomplete, or disagreeing with its own audit
+ * stream. One reason covers all three: which it was is filesystem detail, and
+ * that stays in operational server logs (Phase 2 spec #129 §3).
  *
  * `recording-paused` answers a command a paused Room cannot record — a
  * recording failure, not a rule violation, so it lives here and never
- * reaches the engine's own `RejectionReason` (Phase 2 spec #129 §3).
+ * reaches the engine's own `RejectionReason` (§3).
  */
 export type ServerRejectionReason =
   | "invalid-command"
   | "room-not-found"
   | "not-enough-players"
   | "not-permitted"
-  | "replay-not-supported"
+  | "hand-unavailable"
   | "recording-paused";
 
 export interface CommandRejectedMessage {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -1,6 +1,7 @@
 export * from "@table-top-poker/engine";
 export * from "./command-schema.js";
 export * from "./hand.js";
+export * from "./replay.js";
 export * from "./replay-schema.js";
 export * from "./room.js";
 export * from "./summary.js";

--- a/packages/protocol/src/replay.ts
+++ b/packages/protocol/src/replay.ts
@@ -1,0 +1,28 @@
+import type { HandEvent, TableView } from "@table-top-poker/engine";
+
+/**
+ * One position of a replayed Hand as the table may see it: the Event that
+ * arrived and the table projection of the state after applying it. Position 0
+ * is the starting state and carries `event: null`, mirroring the live
+ * `HandUpdateMessage` pairing (Phase 2 spec #129 §5).
+ *
+ * The pairing is load-bearing rather than convenient: `FoldedOutView` has no
+ * board, so a fold-out hand's board is unreachable from a sequence of views
+ * alone.
+ *
+ * There is no `Rejection` variant, and adding one would be a visibility
+ * regression: rejections are sender-only and never broadcast (#17), so
+ * replaying them to the room would show what the room never saw live. The
+ * absence is enforced by this type, not by a runtime filter (§2).
+ */
+export interface TableReplayPosition {
+  readonly event: HandEvent | null;
+  readonly view: TableView;
+}
+
+/** One recorded Hand, whole — no chunking and no pagination (§5). */
+export interface HandReplayMessage {
+  readonly type: "hand-replay";
+  readonly handOrdinal: number;
+  readonly positions: readonly TableReplayPosition[];
+}

--- a/packages/protocol/src/replay.ts
+++ b/packages/protocol/src/replay.ts
@@ -1,19 +1,14 @@
 import type { HandEvent, TableView } from "@table-top-poker/engine";
 
 /**
- * One position of a replayed Hand as the table may see it: the Event that
- * arrived and the table projection of the state after applying it. Position 0
- * is the starting state and carries `event: null`, mirroring the live
- * `HandUpdateMessage` pairing (Phase 2 spec #129 §5).
+ * One Replay position as the table may see it, pairing the Event with the
+ * table projection of the state after applying it — `FoldedOutView` carries
+ * no board, so a fold-out Hand's board is unreachable from views alone
+ * (Phase 2 spec #129 §5). Position 0 carries `event: null`.
  *
- * The pairing is load-bearing rather than convenient: `FoldedOutView` has no
- * board, so a fold-out hand's board is unreachable from a sequence of views
- * alone.
- *
- * There is no `Rejection` variant, and adding one would be a visibility
- * regression: rejections are sender-only and never broadcast (#17), so
- * replaying them to the room would show what the room never saw live. The
- * absence is enforced by this type, not by a runtime filter (§2).
+ * There is deliberately no `Rejection` variant: rejections are sender-only
+ * and never broadcast (#17), and the absence is enforced by this type rather
+ * than by a runtime filter someone could forget.
  */
 export interface TableReplayPosition {
   readonly event: HandEvent | null;

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -6,6 +6,7 @@ import type {
 } from "@table-top-poker/engine";
 import { z } from "zod";
 import type { CommandRejectedMessage, HandUpdateMessage } from "./hand.js";
+import type { HandReplayMessage } from "./replay.js";
 import type { HandSummary } from "./summary.js";
 
 export const MIN_SEAT_COUNT = 2;
@@ -242,6 +243,7 @@ export type ServerMessage =
   | RoomEndedMessage
   | HandListMessage
   | HandSummaryMessage
+  | HandReplayMessage
   | RecordingPausedMessage
   | RecordingResumedMessage
   | RecordingStoppedMessage;

--- a/packages/recording/src/file-system.ts
+++ b/packages/recording/src/file-system.ts
@@ -2,6 +2,7 @@ import {
   access,
   appendFile,
   mkdir,
+  readFile,
   rename,
   rm,
   truncate,
@@ -27,6 +28,8 @@ import {
 export interface RecordingFileSystem {
   /** Whether a file or directory is already there. */
   exists(target: string): Promise<boolean>;
+  /** The whole contents of `filePath`, or undefined if it is not there. */
+  readFile(filePath: string): Promise<string | undefined>;
   /** Creates `dir` and any missing parents; succeeds if it already exists. */
   mkdir(dir: string): Promise<void>;
   /** Creates or replaces `filePath` wholesale. */
@@ -49,6 +52,14 @@ export const nodeFileSystem: RecordingFileSystem = {
       return true;
     } catch {
       return false;
+    }
+  },
+  async readFile(filePath) {
+    try {
+      return await readFile(filePath, { encoding: "utf8" });
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+      throw cause;
     }
   },
   async mkdir(dir) {

--- a/packages/recording/src/hand-reader.test.ts
+++ b/packages/recording/src/hand-reader.test.ts
@@ -1,0 +1,179 @@
+import { ENGINE_LOG_VERSION } from "@table-top-poker/engine";
+import { describe, expect, it } from "vitest";
+import { readHandRecording } from "./hand-reader.js";
+import { createMemoryFileSystem } from "./memory-file-system.js";
+import { handRecordingPaths } from "./paths.js";
+
+const roomDir = "/recordings/room-1";
+const paths = handRecordingPaths(roomDir, 1);
+
+const context = {
+  v: ENGINE_LOG_VERSION,
+  roomId: "room-1",
+  handOrdinal: 1,
+  startedAt: "2026-08-20T12:00:00.000Z",
+  seats: [0, 1, 2],
+  button: 1,
+};
+
+function jsonl(records: readonly unknown[]): string {
+  return records.map((record) => JSON.stringify(record) + "\n").join("");
+}
+
+const commands = [
+  { type: "startHand", seatId: 0, seed: "s", v: ENGINE_LOG_VERSION },
+  { type: "fold", seatId: 2, v: ENGINE_LOG_VERSION },
+];
+
+const events = [
+  { type: "HandStarted", seed: "s", button: 1, v: ENGINE_LOG_VERSION },
+  { type: "ActionTaken", seatId: 2, action: "fold", v: ENGINE_LOG_VERSION },
+];
+
+async function diskWith(
+  files: Readonly<Record<string, string>>,
+): Promise<ReturnType<typeof createMemoryFileSystem>> {
+  const fileSystem = createMemoryFileSystem();
+  await fileSystem.mkdir(roomDir);
+  for (const [filePath, contents] of Object.entries(files)) {
+    await fileSystem.writeFile(filePath, contents);
+  }
+  return fileSystem;
+}
+
+const wholeHand = {
+  [paths.contextPath]: JSON.stringify(context) + "\n",
+  [paths.commandsPath]: jsonl(commands),
+  [paths.eventsPath]: jsonl(events),
+};
+
+describe("readHandRecording", () => {
+  it("assembles the replay input a Hand's three files hold", async () => {
+    const fileSystem = await diskWith(wholeHand);
+
+    const read = await readHandRecording({
+      fileSystem,
+      roomDir,
+      handOrdinal: 1,
+    });
+
+    expect(read).toEqual({
+      status: "read",
+      input: {
+        sources: {
+          context: paths.contextPath,
+          commands: paths.commandsPath,
+          events: paths.eventsPath,
+        },
+        context: { v: ENGINE_LOG_VERSION, seats: [0, 1, 2], button: 1 },
+        commands,
+        events,
+        tornRecord: null,
+      },
+    });
+  });
+
+  it("reports a missing context file rather than replaying without one", async () => {
+    const fileSystem = await diskWith({
+      [paths.commandsPath]: jsonl(commands),
+      [paths.eventsPath]: jsonl(events),
+    });
+
+    expect(
+      await readHandRecording({ fileSystem, roomDir, handOrdinal: 1 }),
+    ).toEqual({ status: "missing-file", file: paths.contextPath });
+  });
+
+  it("reads a missing commands or events file as empty", async () => {
+    const fileSystem = await diskWith({
+      [paths.contextPath]: JSON.stringify(context) + "\n",
+    });
+
+    const read = await readHandRecording({
+      fileSystem,
+      roomDir,
+      handOrdinal: 1,
+    });
+
+    expect(read).toMatchObject({
+      status: "read",
+      input: { commands: [], events: [] },
+    });
+  });
+
+  it("tolerates an unterminated final line as torn, not malformed", async () => {
+    const fileSystem = await diskWith({
+      ...wholeHand,
+      [paths.eventsPath]: jsonl([events[0]]) + '{"type":"ActionTa',
+    });
+
+    const read = await readHandRecording({
+      fileSystem,
+      roomDir,
+      handOrdinal: 1,
+    });
+
+    expect(read).toMatchObject({
+      status: "read",
+      input: {
+        events: [events[0]],
+        tornRecord: { file: paths.eventsPath, line: 2 },
+      },
+    });
+  });
+
+  it("reports a malformed line that is not the last one", async () => {
+    const fileSystem = await diskWith({
+      ...wholeHand,
+      [paths.eventsPath]: "{oh no\n" + jsonl(events),
+    });
+
+    expect(
+      await readHandRecording({ fileSystem, roomDir, handOrdinal: 1 }),
+    ).toEqual({
+      status: "malformed-record",
+      file: paths.eventsPath,
+      line: 1,
+    });
+  });
+
+  it("reports a context document that does not parse", async () => {
+    const fileSystem = await diskWith({
+      ...wholeHand,
+      [paths.contextPath]: "{not json",
+    });
+
+    expect(
+      await readHandRecording({ fileSystem, roomDir, handOrdinal: 1 }),
+    ).toEqual({
+      status: "malformed-record",
+      file: paths.contextPath,
+      line: 1,
+    });
+  });
+
+  it("reads the hand the ordinal names, not whichever one is there", async () => {
+    const second = handRecordingPaths(roomDir, 2);
+    const fileSystem = await diskWith({
+      ...wholeHand,
+      [second.contextPath]:
+        JSON.stringify({ ...context, handOrdinal: 2, button: 2 }) + "\n",
+      [second.commandsPath]: jsonl(commands),
+      [second.eventsPath]: jsonl(events),
+    });
+
+    const read = await readHandRecording({
+      fileSystem,
+      roomDir,
+      handOrdinal: 2,
+    });
+
+    expect(read).toMatchObject({
+      status: "read",
+      input: {
+        context: { button: 2 },
+        sources: { context: second.contextPath },
+      },
+    });
+  });
+});

--- a/packages/recording/src/hand-reader.ts
+++ b/packages/recording/src/hand-reader.ts
@@ -1,0 +1,146 @@
+import type {
+  ReplayAuditRecord,
+  ReplayCommandRecord,
+  ReplayInput,
+} from "@table-top-poker/engine";
+import type { RecordingFileSystem } from "./file-system.js";
+import { handRecordingPaths } from "./paths.js";
+import type { HandContext } from "./records.js";
+
+/**
+ * What one Hand's three files hold, or why they could not be read. Nothing
+ * here is a replay verdict: the engine's `replayHand` decides whether the
+ * records agree, and this only reports the shapes it could not parse.
+ */
+export type HandRecordingRead =
+  | { readonly status: "read"; readonly input: ReplayInput }
+  | { readonly status: "missing-file"; readonly file: string }
+  | {
+      readonly status: "malformed-record";
+      readonly file: string;
+      readonly line: number;
+    };
+
+export interface ReadHandRecordingOptions {
+  readonly fileSystem: RecordingFileSystem;
+  readonly roomDir: string;
+  readonly handOrdinal: number;
+}
+
+interface ParsedJsonl<T> {
+  readonly records: readonly T[];
+  readonly tornRecord: { readonly file: string; readonly line: number } | null;
+}
+
+class MalformedRecordError extends Error {
+  readonly file: string;
+  readonly line: number;
+
+  constructor(file: string, line: number) {
+    super(`malformed record: ${file}:${String(line)}`);
+    this.file = file;
+    this.line = line;
+  }
+}
+
+/**
+ * Parses a JSONL file, tolerating an unterminated final line as torn rather
+ * than malformed: append-as-you-go persistence (`RoomRecording`) never leaves
+ * a torn line anywhere but the last, since every earlier write completed with
+ * its trailing newline before the next one began.
+ */
+function parseJsonl<T>(file: string, contents: string): ParsedJsonl<T> {
+  if (contents === "") return { records: [], tornRecord: null };
+
+  const endsWithNewline = contents.endsWith("\n");
+  const body = endsWithNewline ? contents.slice(0, -1) : contents;
+  const lines = body.split("\n");
+  const records: T[] = [];
+
+  for (const [index, line] of lines.entries()) {
+    try {
+      records.push(JSON.parse(line) as T);
+    } catch {
+      const isFinalLine = index === lines.length - 1;
+      if (isFinalLine && !endsWithNewline) {
+        return { records, tornRecord: { file, line: index + 1 } };
+      }
+      throw new MalformedRecordError(file, index + 1);
+    }
+  }
+  return { records, tornRecord: null };
+}
+
+/**
+ * Reads Hand `handOrdinal` of the Room recording at `roomDir` into the
+ * `ReplayInput` the engine's `replayHand` takes.
+ *
+ * The filesystem is injected rather than imported, so every caller reads
+ * through the same seam the writer uses — which is what lets the server's
+ * replay path be exercised against an in-memory disk (Phase 2 spec #129 §3).
+ *
+ * At most one of `commands.jsonl`/`events.jsonl` can carry a torn final line
+ * — a crash lands mid-write of one file at a time — so `tornRecord` is
+ * whichever one reports it.
+ */
+export async function readHandRecording({
+  fileSystem,
+  roomDir,
+  handOrdinal,
+}: ReadHandRecordingOptions): Promise<HandRecordingRead> {
+  const paths = handRecordingPaths(roomDir, handOrdinal);
+  // Independent files, read concurrently — none depends on another's content.
+  const [contextText, commandsText, eventsText] = await Promise.all([
+    fileSystem.readFile(paths.contextPath),
+    // A missing commands/events file reads as empty: an empty Command log is
+    // the engine's own `invalid-command-log` failure, and a commands file
+    // with no matching events file is the orphaned-trailing-Command case §4
+    // describes, not a missing file.
+    fileSystem.readFile(paths.commandsPath).then((text) => text ?? ""),
+    fileSystem.readFile(paths.eventsPath).then((text) => text ?? ""),
+  ]);
+
+  if (contextText === undefined) {
+    return { status: "missing-file", file: paths.contextPath };
+  }
+
+  let context: HandContext;
+  try {
+    context = JSON.parse(contextText) as HandContext;
+  } catch {
+    return { status: "malformed-record", file: paths.contextPath, line: 1 };
+  }
+
+  let commands: ParsedJsonl<ReplayCommandRecord>;
+  let events: ParsedJsonl<ReplayAuditRecord>;
+  try {
+    commands = parseJsonl(paths.commandsPath, commandsText);
+    events = parseJsonl(paths.eventsPath, eventsText);
+  } catch (error) {
+    if (!(error instanceof MalformedRecordError)) throw error;
+    return {
+      status: "malformed-record",
+      file: error.file,
+      line: error.line,
+    };
+  }
+
+  return {
+    status: "read",
+    input: {
+      sources: {
+        context: paths.contextPath,
+        commands: paths.commandsPath,
+        events: paths.eventsPath,
+      },
+      context: {
+        v: context.v,
+        seats: context.seats,
+        button: context.button,
+      },
+      commands: commands.records,
+      events: events.records,
+      tornRecord: commands.tornRecord ?? events.tornRecord,
+    },
+  };
+}

--- a/packages/recording/src/index.ts
+++ b/packages/recording/src/index.ts
@@ -1,5 +1,10 @@
 export { nodeFileSystem } from "./file-system.js";
 export type { RecordingFileSystem } from "./file-system.js";
+export { readHandRecording } from "./hand-reader.js";
+export type {
+  HandRecordingRead,
+  ReadHandRecordingOptions,
+} from "./hand-reader.js";
 export { handStartContextFor } from "./hand-start-context.js";
 export type { HandPositions } from "./hand-start-context.js";
 export {

--- a/packages/recording/src/memory-file-system.ts
+++ b/packages/recording/src/memory-file-system.ts
@@ -115,6 +115,11 @@ export function createMemoryFileSystem(): MemoryFileSystem {
     exists(target) {
       return Promise.resolve(files.has(target) || dirs.has(target));
     },
+    readFile(filePath) {
+      return settle(() => {
+        checkFailure("readFile", filePath);
+      }).then(() => files.get(filePath));
+    },
     mkdir(dir) {
       return settle(() => {
         checkFailure("mkdir", dir);

--- a/packages/recording/src/recordings.ts
+++ b/packages/recording/src/recordings.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
 import { nodeFileSystem } from "./file-system.js";
 import type { RecordingFileSystem } from "./file-system.js";
+import { readHandRecording } from "./hand-reader.js";
+import type { HandRecordingRead } from "./hand-reader.js";
 import { assertValidRoomId, roomManifestPath } from "./paths.js";
 import { RECORDING_LAYOUT_VERSION } from "./records.js";
 import type { RoomManifest } from "./records.js";
@@ -22,6 +24,15 @@ export interface CreateRoomRecordingOptions {
  */
 export interface Recordings {
   create(options: CreateRoomRecordingOptions): Promise<RoomRecording>;
+  /**
+   * Reads one Hand of an already-created Room recording back.
+   *
+   * On the root rather than on {@link RoomRecording} deliberately: a
+   * recording on disk outlives its writer. "Continue without recording"
+   * closes the writer and never reopens it, and the Hands recorded before
+   * that failure must stay replayable (Phase 2 spec #129 §3).
+   */
+  readHand(roomId: string, handOrdinal: number): Promise<HandRecordingRead>;
 }
 
 const WRITE_PROBE_FILENAME = ".recordings-write-probe";
@@ -114,6 +125,15 @@ export class DirectoryRecordings implements Recordings {
       roomDir,
       fileSystem: this.#fs,
       ...(this.#retries === undefined ? {} : { retries: this.#retries }),
+    });
+  }
+
+  readHand(roomId: string, handOrdinal: number): Promise<HandRecordingRead> {
+    assertValidRoomId(roomId);
+    return readHandRecording({
+      fileSystem: this.#fs,
+      roomDir: path.join(this.root, roomId),
+      handOrdinal,
     });
   }
 

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_SEAT_COUNT,
   DEFAULT_SHOT_CLOCK,
   ENGINE_LOG_VERSION,
+  legalActions,
   DEFAULT_SOUND_SETTINGS,
   MAX_SEAT_COUNT,
   MAX_SHOT_CLOCK_SECONDS,
@@ -3098,15 +3099,18 @@ describe("hand summaries over WebSocket", () => {
     });
   });
 
-  it("answers a well-formed get-hand rather than dropping it", async () => {
-    const { table } = await seatedRoom();
-    table.socket.send(JSON.stringify({ type: "get-hand", handOrdinal: 1 }));
+  it("refuses a get-hand from a player's socket", async () => {
+    const { seats } = await seatedRoom();
+    const seat = seats[0];
+    if (seat === undefined) throw new Error("expected a connected seat");
+    seat.socket.send(JSON.stringify({ type: "get-hand", handOrdinal: 1 }));
     await settle();
 
-    expect(table.messages).toContainEqual({
+    expect(seat.messages).toContainEqual({
       type: "command-rejected",
-      reason: "replay-not-supported",
+      reason: "not-permitted",
     });
+    expect(seat.messages.some((m) => m.type === "hand-replay")).toBe(false);
   });
 
   it("summarises nothing for a hand still in progress", async () => {
@@ -3166,6 +3170,274 @@ describe("hand summaries over WebSocket", () => {
       type: "hand-list",
       summaries: [],
     });
+  });
+});
+
+describe("hand replay over WebSocket", () => {
+  const SEAT_COUNT = 3;
+
+  let app: FastifyInstance;
+  let rooms: RoomStore;
+  let fileSystem: MemoryFileSystem;
+  let port: number;
+
+  beforeEach(async () => {
+    fileSystem = createMemoryFileSystem();
+    rooms = new RoomStore();
+    app = await buildApp({
+      rooms,
+      recordings: new DirectoryRecordings(RECORDINGS_ROOT, fileSystem),
+    });
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected a bound TCP address");
+    }
+    port = address.port;
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  function connect(query: string): {
+    socket: WebSocket;
+    messages: ServerMessage[];
+  } {
+    const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/ws?${query}`);
+    const messages: ServerMessage[] = [];
+    socket.on("message", (data: Buffer) => {
+      messages.push(JSON.parse(data.toString()) as ServerMessage);
+    });
+    return { socket, messages };
+  }
+
+  async function opened(socket: WebSocket): Promise<void> {
+    if (socket.readyState === WebSocket.OPEN) return;
+    await new Promise<void>((resolve, reject) => {
+      socket.on("open", resolve);
+      socket.on("error", reject);
+    });
+  }
+
+  async function settle(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+
+  /** A room created through the real route, so it has a real recording. */
+  async function recordedRoom(): Promise<{
+    code: string;
+    table: { socket: WebSocket; messages: ServerMessage[] };
+    seats: Record<number, { socket: WebSocket }>;
+  }> {
+    const response = await app.inject({
+      method: "POST",
+      url: "/rooms",
+      payload: { seatCount: SEAT_COUNT },
+    });
+    const code = response.json<RoomCreatedBody>().code;
+    const table = connect(`room=${code}&role=table`);
+    await opened(table.socket);
+
+    const seats: Record<number, { socket: WebSocket }> = {};
+    for (let seatId = 0; seatId < SEAT_COUNT; seatId += 1) {
+      const claim = rooms.claimSeat(code, seatId, `P${String(seatId)}`);
+      if (!("seat" in claim)) throw new Error("expected a claimed seat");
+      const seat = connect(
+        `room=${code}&seat=${String(seatId)}&token=${claim.seat.token ?? ""}`,
+      );
+      await opened(seat.socket);
+      seats[seatId] = seat;
+    }
+    await settle();
+    return { code, table, seats };
+  }
+
+  /** Folds whoever is on the clock until the hand is over. */
+  async function foldToTheEnd(
+    code: string,
+    seats: Record<number, { socket: WebSocket }>,
+  ): Promise<void> {
+    for (let i = 0; i < 8; i++) {
+      if (rooms.get(code)?.engine?.hand?.status === "complete") return;
+      const actor = rooms.currentActor(code);
+      if (actor === undefined) throw new Error("expected a current actor");
+      seats[actor]?.socket.send(JSON.stringify({ type: "fold" }));
+      await settle();
+    }
+    throw new Error("hand did not complete");
+  }
+
+  /** Checks or calls every seat around until the flop is out. */
+  async function passToTheFlop(
+    code: string,
+    seats: Record<number, { socket: WebSocket }>,
+  ): Promise<void> {
+    for (let i = 0; i < 12; i++) {
+      const hand = rooms.get(code)?.engine?.hand;
+      if (hand?.status !== "betting") throw new Error("hand is not betting");
+      if (hand.street !== "preflop") return;
+      const actor = rooms.currentActor(code);
+      if (actor === undefined) throw new Error("expected a current actor");
+      const legal = legalActions(hand, actor);
+      const action = legal.includes("check") ? "check" : "call";
+      seats[actor]?.socket.send(JSON.stringify({ type: action }));
+      await settle();
+    }
+    throw new Error("never reached the flop");
+  }
+
+  async function playOneHand(): Promise<{
+    code: string;
+    table: { socket: WebSocket; messages: ServerMessage[] };
+    seats: Record<number, { socket: WebSocket }>;
+  }> {
+    const room = await recordedRoom();
+    room.table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    await foldToTheEnd(room.code, room.seats);
+    return room;
+  }
+
+  it("serves a completed hand as one whole replay, position 0 first", async () => {
+    const { table } = await playOneHand();
+
+    table.messages.length = 0;
+    table.socket.send(JSON.stringify({ type: "get-hand", handOrdinal: 1 }));
+    await settle();
+
+    const replays = table.messages.filter((m) => m.type === "hand-replay");
+    expect(replays).toHaveLength(1);
+    const replay = replays[0];
+    expect(replay?.handOrdinal).toBe(1);
+    expect(replay?.positions[0]?.event).toBeNull();
+    expect(replay?.positions[0]?.view.phase).toBe("no-hand");
+    expect(replay?.positions.map((position) => position.event?.type)).toEqual([
+      undefined,
+      "HandStarted",
+      "HoleCardsDealt",
+      "StreetStarted",
+      "ActionTaken",
+      "ActionTaken",
+      "HandFoldedOut",
+      "HandComplete",
+    ]);
+    expect(table.messages.some((m) => m.type === "command-rejected")).toBe(
+      false,
+    );
+  });
+
+  it("projects every replayed position through the table view", async () => {
+    const { table } = await playOneHand();
+
+    table.socket.send(JSON.stringify({ type: "get-hand", handOrdinal: 1 }));
+    await settle();
+
+    const replay = table.messages.find((m) => m.type === "hand-replay");
+    const views = JSON.stringify(
+      replay?.positions.map((position) => position.view),
+    );
+    expect(views).not.toContain("holeCards");
+    expect(views).not.toContain("players");
+    expect(views).not.toContain("seed");
+  });
+
+  it("shows the table no seat's hole cards at any position", async () => {
+    const { table } = await playOneHand();
+
+    table.socket.send(JSON.stringify({ type: "get-hand", handOrdinal: 1 }));
+    await settle();
+
+    const replay = table.messages.find((m) => m.type === "hand-replay");
+    const dealt = replay?.positions.find(
+      (position) => position.event?.type === "HoleCardsDealt",
+    );
+    expect(dealt?.event).toEqual({ type: "HoleCardsDealt", deals: [] });
+  });
+
+  it("replays a fold-out hand with the board it died on", async () => {
+    const { code, table, seats } = await recordedRoom();
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    await passToTheFlop(code, seats);
+    await foldToTheEnd(code, seats);
+
+    table.socket.send(JSON.stringify({ type: "get-hand", handOrdinal: 1 }));
+    await settle();
+
+    const replay = table.messages.find((m) => m.type === "hand-replay");
+    // The terminal `folded-out` view carries no board, so the flop is only
+    // reachable from the positions before it.
+    expect(replay?.positions.at(-1)?.view.phase).toBe("folded-out");
+    const boards = (replay?.positions ?? []).flatMap((position) =>
+      "board" in position.view ? [position.view.board.length] : [],
+    );
+    expect(Math.max(...boards)).toBe(3);
+  });
+
+  it("refuses an ordinal the session has not completed", async () => {
+    const { table } = await playOneHand();
+
+    table.socket.send(JSON.stringify({ type: "get-hand", handOrdinal: 2 }));
+    await settle();
+
+    expect(table.messages).toContainEqual({
+      type: "command-rejected",
+      reason: "hand-unavailable",
+    });
+    expect(table.messages.some((m) => m.type === "hand-replay")).toBe(false);
+  });
+
+  it("refuses the hand still being dealt", async () => {
+    const { code, table } = await playOneHand();
+    table.socket.send(JSON.stringify({ type: "nextHand" }));
+    await settle();
+    expect(rooms.get(code)?.engine?.hand?.status).toBe("betting");
+
+    table.socket.send(JSON.stringify({ type: "get-hand", handOrdinal: 2 }));
+    await settle();
+
+    expect(table.messages).toContainEqual({
+      type: "command-rejected",
+      reason: "hand-unavailable",
+    });
+  });
+
+  it("refuses a hand whose recording has gone missing", async () => {
+    const { code, table } = await playOneHand();
+    const room = rooms.get(code);
+    if (!room) throw new Error("expected the room to be live");
+    await fileSystem.remove(
+      `${RECORDINGS_ROOT}/${room.id}/hand-0001.context.json`,
+    );
+
+    table.socket.send(JSON.stringify({ type: "get-hand", handOrdinal: 1 }));
+    await settle();
+
+    expect(table.messages).toContainEqual({
+      type: "command-rejected",
+      reason: "hand-unavailable",
+    });
+  });
+
+  it("still replays the hands recorded before Continue without recording", async () => {
+    const { code, table } = await playOneHand();
+    fileSystem.failAlways("appendFile");
+    table.socket.send(JSON.stringify({ type: "nextHand" }));
+    await settle();
+    expect(table.messages).toContainEqual({ type: "recording-paused" });
+    await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/recording/continue`,
+    });
+    await settle();
+
+    table.messages.length = 0;
+    table.socket.send(JSON.stringify({ type: "get-hand", handOrdinal: 1 }));
+    await settle();
+
+    const replay = table.messages.find((m) => m.type === "hand-replay");
+    expect(replay?.handOrdinal).toBe(1);
   });
 });
 

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -42,7 +42,9 @@ import {
   unitRandom,
   type BotRng,
 } from "./bot-policy.js";
+import { tableReplayOf } from "./hand-replay.js";
 import { joinUrl, roomQrCodeDataUrl } from "./qr.js";
+import { redactEventFor } from "./redact-event.js";
 import {
   type ClaimSeatError,
   type DispatchRejection,
@@ -179,20 +181,6 @@ function findRoomOrReject(
     return undefined;
   }
   return room;
-}
-
-function redactEventFor(
-  event: HandEvent,
-  identity: SeatId | "table",
-): HandEvent {
-  if (event.type !== "HoleCardsDealt") return event;
-  return {
-    ...event,
-    deals:
-      identity === "table"
-        ? []
-        : event.deals.filter((deal) => deal.seatId === identity),
-  };
 }
 
 function parseSeatId(raw: string): number | undefined {
@@ -507,6 +495,58 @@ export async function buildApp(
       type: "hand-list",
       summaries: handSummaries.get(code) ?? [],
     });
+  }
+
+  /**
+   * Answers a `get-hand` with the whole Hand — every position of it, in one
+   * message (Phase 2 spec #129 §5).
+   *
+   * The listing is the authority on which ordinals may be served: it holds
+   * exactly the Hands this Room saw complete, so an ordinal missing from it
+   * is one still being dealt, abandoned mid-deal, or never recorded at all.
+   * Checking it here keeps the "an incomplete Hand is never offered" rule
+   * (§4) from resting on the picker alone.
+   *
+   * Reading takes no turn in the Room's queue: a completed Hand's files are
+   * final, and every later operation writes to a different Hand's — so
+   * queueing would only make replay wait on a disk that is already stalling.
+   */
+  function sendHandReplay(
+    socket: WebSocket,
+    code: string,
+    handOrdinal: number,
+  ): void {
+    const room = rooms.get(code);
+    const listed = handSummaries
+      .get(code)
+      ?.some((summary) => summary.handOrdinal === handOrdinal);
+    if (room === undefined || listed !== true) {
+      sendRejection(socket, "hand-unavailable");
+      return;
+    }
+
+    void options.recordings
+      .readHand(room.id, handOrdinal)
+      .then((read) => tableReplayOf(read))
+      .catch((error: unknown) => ({
+        status: "unavailable" as const,
+        diagnostic: `read failed: ${String(error)}`,
+      }))
+      .then((replay) => {
+        if (replay.status === "unavailable") {
+          app.log.error(
+            { room: code, hand: handOrdinal, replay: replay.diagnostic },
+            "could not replay hand",
+          );
+          sendRejection(socket, "hand-unavailable");
+          return;
+        }
+        send(socket, {
+          type: "hand-replay",
+          handOrdinal,
+          positions: replay.positions,
+        });
+      });
   }
 
   /**
@@ -1493,12 +1533,7 @@ export async function buildApp(
             if (replay.data.type === "list-hands") {
               sendHandList(socket, code);
             } else {
-              // `get-hand` is served by the Replay capability, which lands
-              // with the recording read path; the request shape is validated
-              // here so that ticket adds a response, not a boundary. Answer
-              // rather than drop it, so a client can tell an unbuilt feature
-              // from a dead socket.
-              sendRejection(socket, "replay-not-supported");
+              sendHandReplay(socket, code, replay.data.handOrdinal);
             }
             return;
           }

--- a/packages/server/src/hand-replay.test.ts
+++ b/packages/server/src/hand-replay.test.ts
@@ -1,0 +1,214 @@
+import {
+  apply,
+  decide,
+  ENGINE_LOG_VERSION,
+  legalActions,
+} from "@table-top-poker/protocol";
+import type {
+  ActionType,
+  Command,
+  EngineState,
+  HandEvent,
+  Street,
+} from "@table-top-poker/protocol";
+import {
+  handRecordingPaths,
+  readHandRecording,
+  type HandRecordingRead,
+} from "@table-top-poker/recording";
+import { createMemoryFileSystem } from "@table-top-poker/recording/testing";
+import { describe, expect, it } from "vitest";
+import { tableReplayOf } from "./hand-replay.js";
+
+const roomDir = "/recordings/room-1";
+const paths = handRecordingPaths(roomDir, 1);
+const seats = [0, 1, 2];
+const button = 0;
+
+/**
+ * Runs Commands through the engine exactly as a live Room would, keeping the
+ * generated records. Fixtures are *recorded*, never hand-authored: the
+ * adapter's whole job is to agree with the engine, so a fixture that
+ * disagreed with it would prove nothing.
+ */
+function play(commands: readonly Command[]): {
+  readonly state: EngineState;
+  readonly records: readonly (HandEvent | { type: "Rejection" })[];
+} {
+  let state: EngineState = { seats: [...seats], button, hand: null };
+  const records: (HandEvent | { type: "Rejection" })[] = [];
+  for (const command of commands) {
+    const outcome = decide(state, command);
+    for (const record of Array.isArray(outcome) ? outcome : [outcome]) {
+      records.push(record);
+      if (record.type !== "Rejection") state = apply(state, record);
+    }
+  }
+  return { state, records };
+}
+
+async function record(
+  commands: readonly Command[],
+): Promise<HandRecordingRead> {
+  const { records } = play(commands);
+  const fileSystem = createMemoryFileSystem();
+  await fileSystem.mkdir(roomDir);
+  await fileSystem.writeFile(
+    paths.contextPath,
+    JSON.stringify({
+      v: ENGINE_LOG_VERSION,
+      roomId: "room-1",
+      handOrdinal: 1,
+      startedAt: "2026-08-20T12:00:00.000Z",
+      seats,
+      button,
+    }) + "\n",
+  );
+  const lines = (items: readonly object[]) =>
+    items
+      .map((item) => JSON.stringify({ ...item, v: ENGINE_LOG_VERSION }) + "\n")
+      .join("");
+  await fileSystem.writeFile(paths.commandsPath, lines(commands));
+  await fileSystem.writeFile(paths.eventsPath, lines(records));
+  return readHandRecording({ fileSystem, roomDir, handOrdinal: 1 });
+}
+
+/**
+ * Drives a whole hand from a seat-blind policy, so a fixture is always a
+ * sequence the engine actually accepted — action order is button-relative and
+ * hand-authoring it invites a fixture full of `not-your-turn`.
+ */
+function drive(
+  seed: string,
+  choose: (street: Street, legal: readonly ActionType[]) => ActionType,
+): readonly Command[] {
+  const commands: Command[] = [{ type: "startHand", seatId: 0, seed }];
+  for (let guard = 0; guard < 60; guard += 1) {
+    const hand = play(commands).state.hand;
+    if (hand?.status !== "betting") break;
+    const actor = hand.toAct[0];
+    if (actor === undefined) break;
+    commands.push({
+      type: choose(hand.street, legalActions(hand, actor)),
+      seatId: actor,
+    });
+  }
+  return commands;
+}
+
+const passively = (legal: readonly ActionType[]): ActionType =>
+  legal.includes("check") ? "check" : "call";
+
+const foldOut = drive("seed-1", () => "fold");
+const checkedDown = drive("seed-2", (_street, legal) => passively(legal));
+const foldOutOnTheTurn = drive("seed-3", (street, legal) =>
+  street === "turn" ? "fold" : passively(legal),
+);
+
+function eventTypesOf(
+  positions: readonly { readonly event: HandEvent | null }[],
+): (string | null)[] {
+  return positions.map((position) => position.event?.type ?? null);
+}
+
+describe("tableReplayOf", () => {
+  it("projects every position through the table view boundary", async () => {
+    const replay = tableReplayOf(await record(foldOut));
+
+    if (replay.status !== "replayed") throw new Error(replay.diagnostic);
+    expect(replay.positions[0]).toEqual({
+      event: null,
+      view: { phase: "no-hand", button },
+    });
+    expect(eventTypesOf(replay.positions)).toEqual([
+      null,
+      "HandStarted",
+      "HoleCardsDealt",
+      "StreetStarted",
+      "ActionTaken",
+      "ActionTaken",
+      "HandFoldedOut",
+      "HandComplete",
+    ]);
+  });
+
+  it("carries no EngineState and no seat's hole cards in any view", async () => {
+    const replay = tableReplayOf(await record(foldOut));
+
+    if (replay.status !== "replayed") throw new Error(replay.diagnostic);
+    const views = JSON.stringify(replay.positions.map((p) => p.view));
+    expect(views).not.toContain("holeCards");
+    expect(views).not.toContain("players");
+    expect(views).not.toContain("ring");
+    expect(views).not.toContain("seed");
+  });
+
+  it("hands the table an empty deal, never a seat's two cards", async () => {
+    const replay = tableReplayOf(await record(foldOut));
+
+    if (replay.status !== "replayed") throw new Error(replay.diagnostic);
+    const dealt = replay.positions.find(
+      (position) => position.event?.type === "HoleCardsDealt",
+    );
+    expect(dealt?.event).toEqual({ type: "HoleCardsDealt", deals: [] });
+    expect(JSON.stringify(replay.positions)).not.toContain("rank");
+  });
+
+  it("replays a hand that reached showdown", async () => {
+    const replay = tableReplayOf(await record(checkedDown));
+
+    if (replay.status !== "replayed") throw new Error(replay.diagnostic);
+    expect(replay.positions.at(-1)?.event).toEqual({ type: "HandComplete" });
+    expect(replay.positions.some((p) => p.view.phase === "showdown")).toBe(
+      true,
+    );
+  });
+
+  it("keeps a fold-out hand's board, which its terminal view cannot express", async () => {
+    const replay = tableReplayOf(await record(foldOutOnTheTurn));
+
+    if (replay.status !== "replayed") throw new Error(replay.diagnostic);
+    expect(replay.positions.at(-1)?.view.phase).toBe("folded-out");
+    // The final view has no board at all, so the four cards the table
+    // watched land are only reachable from the positions before it.
+    const boards = replay.positions.flatMap((p) =>
+      "board" in p.view ? [p.view.board.length] : [],
+    );
+    expect(Math.max(...boards)).toBe(4);
+  });
+
+  it("refuses a hand whose recording could not be read", () => {
+    const replay = tableReplayOf({
+      status: "missing-file",
+      file: paths.contextPath,
+    });
+
+    expect(replay.status).toBe("unavailable");
+  });
+
+  it("refuses an incomplete hand rather than serving its prefix", async () => {
+    const read = await record(foldOut);
+    if (read.status !== "read") throw new Error("expected a read");
+
+    const replay = tableReplayOf({
+      status: "read",
+      input: { ...read.input, events: read.input.events.slice(0, -1) },
+    });
+
+    expect(replay.status).toBe("unavailable");
+  });
+
+  it("refuses a hand whose persisted events disagree with the replay", async () => {
+    const read = await record(foldOut);
+    if (read.status !== "read") throw new Error("expected a read");
+    const events = [...read.input.events];
+    events[1] = { type: "HandComplete", v: ENGINE_LOG_VERSION };
+
+    const replay = tableReplayOf({
+      status: "read",
+      input: { ...read.input, events },
+    });
+
+    expect(replay.status).toBe("unavailable");
+  });
+});

--- a/packages/server/src/hand-replay.ts
+++ b/packages/server/src/hand-replay.ts
@@ -1,0 +1,74 @@
+import { replayHand, view } from "@table-top-poker/protocol";
+import type { TableReplayPosition } from "@table-top-poker/protocol";
+import type { HandRecordingRead } from "@table-top-poker/recording";
+import { redactEventFor } from "./redact-event.js";
+
+/**
+ * A replayed Hand, or the reason it cannot be served. The reason never
+ * reaches the table — a `hand-unavailable` rejection says only that much —
+ * so `diagnostic` exists for the operational log, where filesystem and
+ * corruption detail belongs (Phase 2 spec #129 §3).
+ */
+export type TableHandReplay =
+  | {
+      readonly status: "replayed";
+      readonly positions: readonly TableReplayPosition[];
+    }
+  | { readonly status: "unavailable"; readonly diagnostic: string };
+
+/**
+ * Turns one read Hand recording into the positions the table may see.
+ *
+ * This is the server's whole replay adapter, and the boundary the visibility
+ * guarantee rests on: the engine's flipbook carries complete `EngineState`,
+ * and every position leaves here projected through `view(state, "table")`
+ * into a protocol type that cannot hold one (§7). It takes no audience,
+ * redaction option or `revealEverything` flag, and there is no other way out
+ * of the engine's replay on this side of the wire. Each position's Event goes
+ * through the same `redactEventFor` the live fan-out uses, so the table is
+ * shown exactly what it was shown live and no more.
+ *
+ * Only a `complete` replay is served. An incomplete one — a torn tail, or a
+ * Command with no recorded outcome — is refused rather than truncated: the
+ * picker must not offer such a Hand at all (§4), so one arriving here means
+ * the listing and the recording have already disagreed.
+ */
+export function tableReplayOf(read: HandRecordingRead): TableHandReplay {
+  if (read.status === "missing-file") {
+    return { status: "unavailable", diagnostic: `missing ${read.file}` };
+  }
+  if (read.status === "malformed-record") {
+    return {
+      status: "unavailable",
+      diagnostic: `malformed record at ${read.file}:${String(read.line)}`,
+    };
+  }
+
+  const outcome = replayHand(read.input);
+  if (outcome.status === "failed") {
+    return {
+      status: "unavailable",
+      diagnostic: `replay failed: ${JSON.stringify(outcome.failure)}`,
+    };
+  }
+  if (outcome.status === "incomplete") {
+    return {
+      status: "unavailable",
+      diagnostic: `replay incomplete: ${JSON.stringify({
+        tornRecord: outcome.tornRecord,
+        orphanedCommand: outcome.orphanedCommand,
+      })}`,
+    };
+  }
+
+  return {
+    status: "replayed",
+    positions: outcome.positions.map((position) => ({
+      event:
+        position.event === null
+          ? null
+          : redactEventFor(position.event, "table"),
+      view: view(position.state, "table"),
+    })),
+  };
+}

--- a/packages/server/src/redact-event.ts
+++ b/packages/server/src/redact-event.ts
@@ -1,0 +1,24 @@
+import type { HandEvent, SeatId } from "@table-top-poker/protocol";
+
+/**
+ * The Event as one identity may see it. Only `HoleCardsDealt` carries
+ * anything private: the table is told the deal happened and to whom nothing,
+ * and a seat is told only its own two cards (Phase 1 spec #130 §4).
+ *
+ * Shared by the live fan-out and the replay adapter so the visibility
+ * boundary is one function — a replay that re-derived it could drift into
+ * showing the room cards it never saw live.
+ */
+export function redactEventFor(
+  event: HandEvent,
+  identity: SeatId | "table",
+): HandEvent {
+  if (event.type !== "HoleCardsDealt") return event;
+  return {
+    ...event,
+    deals:
+      identity === "table"
+        ? []
+        : event.deals.filter((deal) => deal.seatId === identity),
+  };
+}

--- a/packages/table-client/src/App.review.test.tsx
+++ b/packages/table-client/src/App.review.test.tsx
@@ -1,0 +1,217 @@
+import type { SeatView, TableView } from "@table-top-poker/protocol";
+import React from "react";
+/* eslint-disable @typescript-eslint/no-deprecated -- React 19's DOM-free component test renderer is deprecated but remains the available interaction harness here. */
+import { act, create } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { App } from "./App.js";
+import type { HandPickerProps } from "./HandPicker.js";
+import type { TableControlsProps } from "./TableControls.js";
+import { useTableStore } from "./store/store.js";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const picker = vi.hoisted((): { props: HandPickerProps | null } => ({
+  props: null,
+}));
+const socket = vi.hoisted(() => ({ send: vi.fn() }));
+
+vi.mock("./ws/useWebSocket.js", () => ({ useWebSocket: () => socket }));
+
+vi.mock("./HandPicker.js", () => ({
+  HandPicker: (props: HandPickerProps) => {
+    picker.props = props;
+    return React.createElement("div", { "data-testid": "hand-picker" });
+  },
+}));
+
+vi.mock("./TableControls.js", () => ({
+  TableControls: (props: TableControlsProps) =>
+    props.onReviewHands === undefined
+      ? null
+      : React.createElement("button", {
+          "data-testid": "review-hands-button",
+          onClick: props.onReviewHands,
+        }),
+}));
+
+// A live hand puts a seat on the clock, which animates on a frame callback.
+vi.stubGlobal("requestAnimationFrame", () => 0);
+vi.stubGlobal("cancelAnimationFrame", () => undefined);
+
+vi.stubGlobal("window", {
+  localStorage: { getItem: () => null, setItem: () => undefined },
+  setTimeout: (handler: () => void, ms: number) => setTimeout(handler, ms),
+  clearTimeout: (id: number) => {
+    clearTimeout(id);
+  },
+  addEventListener: () => undefined,
+  removeEventListener: () => undefined,
+});
+
+function seat(id: number): SeatView {
+  return {
+    id,
+    claimed: true,
+    sittingOut: false,
+    sittingOutReason: null,
+    disconnected: false,
+  };
+}
+
+const completeHand: TableView = {
+  phase: "folded-out",
+  button: 0,
+  smallBlind: 1,
+  bigBlind: 2,
+  dealtSeatCount: 2,
+  winner: 0,
+};
+
+const liveHand: TableView = {
+  phase: "betting",
+  turnEndsAt: null,
+  button: 0,
+  smallBlind: 1,
+  bigBlind: 2,
+  dealtSeatCount: 2,
+  street: "preflop",
+  board: [],
+  toAct: [1],
+  seats: [
+    { seatId: 0, folded: false },
+    { seatId: 1, folded: false },
+  ],
+};
+
+interface Node {
+  readonly props: { readonly onClick?: () => void };
+}
+
+interface Renderer {
+  readonly root: {
+    findByProps(props: Record<string, unknown>): Node;
+    findAllByProps(props: Record<string, unknown>): readonly Node[];
+  };
+  readonly unmount: () => void;
+}
+
+function inRoom(handView: TableView): void {
+  useTableStore.setState({
+    roomCode: "ABCD",
+    joinUrl: "http://localhost:3000/join/ABCD",
+    qrCodeDataUrl: "data:image/png;base64,xyz",
+    seats: [seat(0), seat(1)],
+    connectionStatus: "connected",
+    handView,
+  });
+}
+
+let mounted: Renderer | null = null;
+
+function render(): Renderer {
+  let renderer!: Renderer;
+  act(() => {
+    renderer = create(<App />);
+  });
+  mounted = renderer;
+  return renderer;
+}
+
+function click(renderer: Renderer, testId: string): void {
+  act(() => {
+    renderer.root.findByProps({ "data-testid": testId }).props.onClick?.();
+  });
+}
+
+describe("App hand review", () => {
+  beforeEach(() => {
+    useTableStore.setState(useTableStore.getInitialState());
+    socket.send.mockReset();
+    picker.props = null;
+  });
+
+  afterEach(() => {
+    act(() => {
+      mounted?.unmount();
+    });
+    mounted = null;
+  });
+
+  it("asks for the tapped hand over the room socket, then hands the felt to the scrub", () => {
+    inRoom(completeHand);
+    const renderer = render();
+
+    click(renderer, "review-hands-button");
+    act(() => {
+      picker.props?.onSelectHand(3);
+    });
+
+    expect(socket.send).toHaveBeenCalledWith({
+      type: "get-hand",
+      handOrdinal: 3,
+    });
+    expect(useTableStore.getState().review).toEqual({
+      status: "loading",
+      handOrdinal: 3,
+    });
+    expect(() =>
+      renderer.root.findByProps({ "data-testid": "hand-picker" }),
+    ).toThrow();
+  });
+
+  it("returns to the picker from Back to hands", () => {
+    inRoom(completeHand);
+    const renderer = render();
+    click(renderer, "review-hands-button");
+    act(() => {
+      picker.props?.onSelectHand(3);
+    });
+
+    click(renderer, "back-to-hands-button");
+
+    expect(useTableStore.getState().review).toBeNull();
+    expect(
+      renderer.root.findByProps({ "data-testid": "hand-picker" }),
+    ).toBeDefined();
+  });
+
+  it("force-dismisses an open review the moment a hand starts", () => {
+    inRoom(completeHand);
+    const renderer = render();
+    click(renderer, "review-hands-button");
+    act(() => {
+      picker.props?.onSelectHand(3);
+    });
+
+    act(() => {
+      useTableStore.setState({ handView: liveHand });
+    });
+
+    expect(useTableStore.getState().review).toBeNull();
+    expect(() =>
+      renderer.root.findByProps({ "data-testid": "hand-picker" }),
+    ).toThrow();
+  });
+
+  it("gives the felt to the scrub, so the live board is not also on screen", () => {
+    inRoom(completeHand);
+    useTableStore.setState({
+      review: {
+        status: "ready",
+        handOrdinal: 3,
+        positions: [{ event: null, view: { phase: "no-hand", button: 0 } }],
+      },
+    });
+
+    const renderer = render();
+
+    const found = (testId: string) =>
+      renderer.root.findAllByProps({ "data-testid": testId });
+    expect(found("replay-stage")).toHaveLength(1);
+    expect(found("replay-transport")).toHaveLength(1);
+    expect(found("seats")).toHaveLength(1);
+    expect(found("join-panel")).toHaveLength(0);
+  });
+});

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -112,7 +112,7 @@ export function App() {
     setMenuSeatId(null);
   }, [roomCode, menuSeatId]);
 
-  const handleRoomEnded = useCallback(() => {
+  const forgetSession = useCallback(() => {
     clearHostedRoom(window.localStorage);
     setSettingsOpen(false);
     setHandPickerOpen(false);
@@ -122,9 +122,7 @@ export function App() {
     clearHandHistory();
   }, [clearRoom, clearHand, clearHandHistory, closeReview]);
 
-  const { send } = useWebSocket(roomCode, {
-    onRoomEnded: handleRoomEnded,
-  });
+  const { send } = useWebSocket(roomCode, { onRoomEnded: forgetSession });
 
   const [seatCount, setSeatCount] = useState(DEFAULT_SEAT_COUNT);
   const handleCreateRoom = useCallback(() => {
@@ -142,19 +140,11 @@ export function App() {
   const handleEndSession = useCallback(() => {
     if (!roomCode) return;
     endSession(roomCode)
-      .then(() => {
-        clearHostedRoom(window.localStorage);
-        setSettingsOpen(false);
-        setHandPickerOpen(false);
-        closeReview();
-        clearRoom();
-        clearHand();
-        clearHandHistory();
-      })
+      .then(forgetSession)
       .catch((error: unknown) => {
         console.error(error);
       });
-  }, [roomCode, clearRoom, clearHand, clearHandHistory, closeReview]);
+  }, [roomCode, forgetSession]);
 
   const handleAddBot = useCallback(() => {
     if (roomCode === null || !testMode) return;

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -8,7 +8,7 @@ import {
   type SoundSettings,
 } from "@table-top-poker/protocol";
 import { color, unlockAudio } from "@table-top-poker/ui-shared";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type CSSProperties } from "react";
 import {
   changeSeatCount,
   changeShotClockSettings,
@@ -21,6 +21,7 @@ import {
 } from "./api/rooms.js";
 import { Board } from "./Board.js";
 import { HandPicker } from "./HandPicker.js";
+import { HandReview } from "./replay/HandReview.js";
 import { HouseRulesSheet } from "./HouseRulesSheet.js";
 import { NotRecordingBanner } from "./NotRecordingBanner.js";
 import { SeatCountPicker } from "./SeatCountPicker.js";
@@ -38,6 +39,15 @@ import {
 } from "./storage/hostedRoom.js";
 import { useTableStore } from "./store/store.js";
 import { useWebSocket } from "./ws/useWebSocket.js";
+
+const feltSurfaceStyle: CSSProperties = {
+  position: "absolute",
+  inset: "1em",
+  borderRadius: "0.7em",
+  background: color.felt,
+  boxShadow:
+    "inset 0 0 12em 4em rgba(0,0,0,.62), inset 0 2px 0 rgba(255,255,255,.08)",
+};
 
 export function App() {
   const roomCode = useTableStore((state) => state.roomCode);
@@ -57,6 +67,9 @@ export function App() {
   const clearHand = useTableStore((state) => state.clearHand);
   const handSummaries = useTableStore((state) => state.handSummaries);
   const clearHandHistory = useTableStore((state) => state.clearHandHistory);
+  const review = useTableStore((state) => state.review);
+  const openReview = useTableStore((state) => state.openReview);
+  const closeReview = useTableStore((state) => state.closeReview);
 
   useEffect(() => {
     const stored = loadHostedRoom(window.localStorage);
@@ -103,10 +116,11 @@ export function App() {
     clearHostedRoom(window.localStorage);
     setSettingsOpen(false);
     setHandPickerOpen(false);
+    closeReview();
     clearRoom();
     clearHand();
     clearHandHistory();
-  }, [clearRoom, clearHand, clearHandHistory]);
+  }, [clearRoom, clearHand, clearHandHistory, closeReview]);
 
   const { send } = useWebSocket(roomCode, {
     onRoomEnded: handleRoomEnded,
@@ -132,6 +146,7 @@ export function App() {
         clearHostedRoom(window.localStorage);
         setSettingsOpen(false);
         setHandPickerOpen(false);
+        closeReview();
         clearRoom();
         clearHand();
         clearHandHistory();
@@ -139,7 +154,7 @@ export function App() {
       .catch((error: unknown) => {
         console.error(error);
       });
-  }, [roomCode, clearRoom, clearHand, clearHandHistory]);
+  }, [roomCode, clearRoom, clearHand, clearHandHistory, closeReview]);
 
   const handleAddBot = useCallback(() => {
     if (roomCode === null || !testMode) return;
@@ -184,6 +199,29 @@ export function App() {
     send({ type: "nextHand" });
   }, [send]);
 
+  const handleSelectHand = useCallback(
+    (handOrdinal: number) => {
+      openReview(handOrdinal);
+      setHandPickerOpen(false);
+      send({ type: "get-hand", handOrdinal });
+    },
+    [openReview, send],
+  );
+
+  const handleBackToHands = useCallback(() => {
+    closeReview();
+    setHandPickerOpen(true);
+  }, [closeReview]);
+
+  // A review left open can never swallow the board, so a hand starting takes
+  // the felt back with no confirmation (Phase 2 spec #129 §6).
+  const handLive = isHandLive(handView);
+  useEffect(() => {
+    if (!handLive) return;
+    closeReview();
+    setHandPickerOpen(false);
+  }, [handLive, closeReview]);
+
   const claimedSeatCount = seats.filter((seat) => seat.claimed).length;
   const handInProgress = handView !== null;
   const enoughPlayers = countDealInSeats(seats) >= MIN_SEAT_COUNT;
@@ -212,17 +250,16 @@ export function App() {
             onSeatCountChange={setSeatCount}
             onCreateRoom={handleCreateRoom}
           />
+        ) : review !== null ? (
+          <div style={feltSurfaceStyle}>
+            <HandReview
+              review={review}
+              seats={seats}
+              onClose={handleBackToHands}
+            />
+          </div>
         ) : (
-          <div
-            style={{
-              position: "absolute",
-              inset: "1em",
-              borderRadius: "0.7em",
-              background: color.felt,
-              boxShadow:
-                "inset 0 0 12em 4em rgba(0,0,0,.62), inset 0 2px 0 rgba(255,255,255,.08)",
-            }}
-          >
+          <div style={feltSurfaceStyle}>
             <Seats
               seats={seats}
               view={handView}
@@ -326,6 +363,7 @@ export function App() {
               <HandPicker
                 summaries={handSummaries}
                 seats={seats}
+                onSelectHand={handleSelectHand}
                 onClose={() => {
                   setHandPickerOpen(false);
                 }}

--- a/packages/table-client/src/HandPicker.test.tsx
+++ b/packages/table-client/src/HandPicker.test.tsx
@@ -1,8 +1,21 @@
 import type { Card, HandSummary, SeatView } from "@table-top-poker/protocol";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+/* eslint-disable @typescript-eslint/no-deprecated -- React 19's DOM-free component test renderer is deprecated but remains the available interaction harness here. */
+import { act, create } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
 import { HandPicker } from "./HandPicker.js";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// The relative start-time label re-ticks on an interval; these tests render
+// in Node, which has no `window` to hang it off.
+vi.stubGlobal("window", {
+  setInterval: () => 0,
+  clearInterval: () => undefined,
+});
 
 const noop = () => undefined;
 
@@ -96,6 +109,7 @@ describe("HandPicker", () => {
       <HandPicker
         summaries={[foldedOutWalk, raiseWarToTurn]}
         seats={[seat(0), seat(1), seat(2)]}
+        onSelectHand={noop}
         onClose={noop}
       />,
     );
@@ -114,6 +128,7 @@ describe("HandPicker", () => {
       <HandPicker
         summaries={[foldedOutWalk]}
         seats={[seat(0), seat(1)]}
+        onSelectHand={noop}
         onClose={noop}
       />,
     );
@@ -126,6 +141,7 @@ describe("HandPicker", () => {
       <HandPicker
         summaries={[foldedOutWalk]}
         seats={[seat(0), seat(1)]}
+        onSelectHand={noop}
         onClose={noop}
       />,
     );
@@ -137,6 +153,7 @@ describe("HandPicker", () => {
       <HandPicker
         summaries={[showdown]}
         seats={[seat(0), seat(1)]}
+        onSelectHand={noop}
         onClose={noop}
       />,
     );
@@ -145,14 +162,53 @@ describe("HandPicker", () => {
 
   it("shows an empty state when no hands have completed", () => {
     const html = renderToStaticMarkup(
-      <HandPicker summaries={[]} seats={[]} onClose={noop} />,
+      <HandPicker
+        summaries={[]}
+        seats={[]}
+        onSelectHand={noop}
+        onClose={noop}
+      />,
     );
     expect(html).toContain("No hands played yet");
   });
 
+  it("hands the tapped hand's ordinal to the scrub", () => {
+    const onSelectHand = vi.fn();
+    let renderer!: {
+      root: {
+        findByProps(props: Record<string, unknown>): {
+          props: { onClick?: () => void };
+        };
+      };
+    };
+
+    act(() => {
+      renderer = create(
+        <HandPicker
+          summaries={[foldedOutWalk, raiseWarToTurn]}
+          seats={[seat(0), seat(1), seat(2)]}
+          onSelectHand={onSelectHand}
+          onClose={noop}
+        />,
+      );
+    });
+    act(() => {
+      renderer.root
+        .findByProps({ "data-testid": "hand-row-2" })
+        .props.onClick?.();
+    });
+
+    expect(onSelectHand).toHaveBeenCalledWith(2);
+  });
+
   it("exposes a close control", () => {
     const html = renderToStaticMarkup(
-      <HandPicker summaries={[]} seats={[]} onClose={noop} />,
+      <HandPicker
+        summaries={[]}
+        seats={[]}
+        onSelectHand={noop}
+        onClose={noop}
+      />,
     );
     expect(html).toContain('data-testid="close-hand-picker-button"');
   });

--- a/packages/table-client/src/HandPicker.tsx
+++ b/packages/table-client/src/HandPicker.tsx
@@ -19,6 +19,7 @@ import { seatLabel } from "./seatLabel.js";
 export interface HandPickerProps {
   readonly summaries: readonly HandSummary[];
   readonly seats: readonly SeatView[];
+  readonly onSelectHand: (handOrdinal: number) => void;
   readonly onClose: () => void;
 }
 
@@ -117,6 +118,10 @@ function BoardStrip({ board }: { readonly board: readonly CardType[] }) {
 }
 
 const rowStyle: CSSProperties = {
+  font: "inherit",
+  color: "inherit",
+  textAlign: "left",
+  cursor: "pointer",
   display: "grid",
   gridTemplateColumns: "3em 1fr 15em",
   alignItems: "center",
@@ -132,14 +137,22 @@ function HandRow({
   hand,
   seats,
   now,
+  onSelect,
 }: {
   readonly hand: HandSummary;
   readonly seats: readonly SeatView[];
   readonly now: number;
+  readonly onSelect: () => void;
 }) {
   const outcome = outcomeText(hand, seats);
   return (
-    <div data-testid={`hand-row-${String(hand.handOrdinal)}`} style={rowStyle}>
+    <button
+      type="button"
+      data-testid={`hand-row-${String(hand.handOrdinal)}`}
+      aria-label={`Review hand ${String(hand.handOrdinal)}`}
+      onClick={onSelect}
+      style={rowStyle}
+    >
       <span
         style={{
           fontFamily: font.display,
@@ -180,7 +193,7 @@ function HandRow({
           {formatRelative(hand.startedAt, now)}
         </span>
       </span>
-    </div>
+    </button>
   );
 }
 
@@ -192,7 +205,12 @@ const kickerStyle: CSSProperties = {
   color: color.textDim,
 };
 
-export function HandPicker({ summaries, seats, onClose }: HandPickerProps) {
+export function HandPicker({
+  summaries,
+  seats,
+  onSelectHand,
+  onClose,
+}: HandPickerProps) {
   const now = useNow();
   const ordered = useMemo(
     () => [...summaries].sort((a, b) => b.handOrdinal - a.handOrdinal),
@@ -298,6 +316,9 @@ export function HandPicker({ summaries, seats, onClose }: HandPickerProps) {
                 hand={hand}
                 seats={seats}
                 now={now}
+                onSelect={() => {
+                  onSelectHand(hand.handOrdinal);
+                }}
               />
             ))
           )}

--- a/packages/table-client/src/replay/HandReview.test.tsx
+++ b/packages/table-client/src/replay/HandReview.test.tsx
@@ -10,7 +10,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 /* eslint-disable @typescript-eslint/no-deprecated -- React 19's DOM-free component test renderer is deprecated but remains the available interaction harness here. */
 import { act, create } from "react-test-renderer";
 import { describe, expect, it, vi } from "vitest";
-import type { HandReview as Review } from "../store/replaySlice.js";
+import type { HandReviewState } from "../store/replaySlice.js";
 import { HandReview } from "./HandReview.js";
 import type { ReplayStageProps } from "./ReplayStage.js";
 
@@ -113,7 +113,7 @@ const positions: readonly TableReplayPosition[] = [
   })),
 ];
 
-const ready: Review = { status: "ready", handOrdinal: 7, positions };
+const ready: HandReviewState = { status: "ready", handOrdinal: 7, positions };
 
 interface Node {
   readonly props: {
@@ -128,7 +128,7 @@ interface Renderer {
   };
 }
 
-function render(review: Review = ready): Renderer {
+function render(review: HandReviewState = ready): Renderer {
   let renderer!: Renderer;
   act(() => {
     renderer = create(
@@ -262,7 +262,7 @@ describe("HandReview", () => {
       />,
     );
 
-    expect(loading).toContain("Loading hand 7");
+    expect(loading).toContain("Loading the hand");
     expect(unavailable).toContain("can&#x27;t be replayed");
     expect(unavailable).toContain('data-testid="back-to-hands-button"');
   });

--- a/packages/table-client/src/replay/HandReview.test.tsx
+++ b/packages/table-client/src/replay/HandReview.test.tsx
@@ -1,0 +1,269 @@
+import type {
+  Card,
+  HandEvent,
+  SeatView,
+  TableReplayPosition,
+  TableView,
+} from "@table-top-poker/protocol";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+/* eslint-disable @typescript-eslint/no-deprecated -- React 19's DOM-free component test renderer is deprecated but remains the available interaction harness here. */
+import { act, create } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
+import type { HandReview as Review } from "../store/replaySlice.js";
+import { HandReview } from "./HandReview.js";
+import type { ReplayStageProps } from "./ReplayStage.js";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const stagedView = vi.hoisted((): { current: TableView | null } => ({
+  current: null,
+}));
+
+/**
+ * The felt is the live `Seats` and `Board`; what matters here is *which*
+ * projected view they are handed at a position, so the stage is stood in for
+ * and the view it received is read back.
+ */
+vi.mock("./ReplayStage.js", () => ({
+  ReplayStage: (props: ReplayStageProps) => {
+    stagedView.current = props.view;
+    return React.createElement("div", { "data-testid": "replay-stage" });
+  },
+}));
+
+vi.stubGlobal("window", {
+  setTimeout: (handler: () => void, ms: number) => setTimeout(handler, ms),
+  clearTimeout: (id: number) => {
+    clearTimeout(id);
+  },
+  addEventListener: () => undefined,
+  removeEventListener: () => undefined,
+});
+
+const seats: readonly SeatView[] = [0, 1, 2].map((id) => ({
+  id,
+  claimed: true,
+  sittingOut: false,
+  sittingOutReason: null,
+  disconnected: false,
+}));
+
+const card = (rank: Card["rank"]): Card => ({ rank, suit: "clubs" });
+
+function bettingView(board: readonly Card[]): TableView {
+  return {
+    phase: "betting",
+    turnEndsAt: null,
+    button: 0,
+    smallBlind: 1,
+    bigBlind: 2,
+    dealtSeatCount: 3,
+    street: board.length === 0 ? "preflop" : "flop",
+    board,
+    toAct: [1],
+    seats: [
+      { seatId: 0, folded: false },
+      { seatId: 1, folded: false },
+      { seatId: 2, folded: false },
+    ],
+  };
+}
+
+/**
+ * A hand that reaches the flop and folds out, paired with the boards the
+ * table saw — the cascade order (`StreetClosed → BoardDealt → StreetStarted`)
+ * is what the chapter anchoring turns on.
+ */
+const events: readonly HandEvent[] = [
+  { type: "HandStarted", seed: "s", button: 0 },
+  { type: "HoleCardsDealt", deals: [] },
+  { type: "StreetStarted", street: "preflop", actor: 1 },
+  { type: "ActionTaken", seatId: 1, action: "check" },
+  { type: "StreetClosed", street: "preflop" },
+  {
+    type: "BoardDealt",
+    street: "flop",
+    cards: [card("A"), card("K"), card("Q")],
+  },
+  { type: "StreetStarted", street: "flop", actor: 1 },
+  { type: "ActionTaken", seatId: 1, action: "fold" },
+  { type: "HandFoldedOut", winner: 2 },
+  { type: "HandComplete" },
+];
+
+const flop = [card("A"), card("K"), card("Q")];
+
+const foldedOut: TableView = {
+  phase: "folded-out",
+  button: 0,
+  smallBlind: 1,
+  bigBlind: 2,
+  dealtSeatCount: 3,
+  winner: 2,
+};
+
+const positions: readonly TableReplayPosition[] = [
+  { event: null, view: { phase: "no-hand", button: 0 } },
+  ...events.map((event, index) => ({
+    event,
+    view: index >= 8 ? foldedOut : bettingView(index >= 5 ? flop : []),
+  })),
+];
+
+const ready: Review = { status: "ready", handOrdinal: 7, positions };
+
+interface Node {
+  readonly props: {
+    readonly onClick?: () => void;
+    readonly onPointerDown?: (event: { readonly clientX: number }) => void;
+  };
+}
+
+interface Renderer {
+  readonly root: {
+    findByProps(props: Record<string, unknown>): Node;
+  };
+}
+
+function render(review: Review = ready): Renderer {
+  let renderer!: Renderer;
+  act(() => {
+    renderer = create(
+      <HandReview review={review} seats={seats} onClose={() => undefined} />,
+    );
+  });
+  return renderer;
+}
+
+function click(renderer: Renderer, testId: string): void {
+  act(() => {
+    renderer.root.findByProps({ "data-testid": testId }).props.onClick?.();
+  });
+}
+
+describe("HandReview", () => {
+  it("ticks the track once per event ordinal, heavier at street boundaries", () => {
+    const html = renderToStaticMarkup(
+      <HandReview review={ready} seats={seats} onClose={() => undefined} />,
+    );
+
+    for (const position of events.map((_unused, index) => index + 1)) {
+      expect(html).toContain(`data-testid="replay-tick-${String(position)}"`);
+    }
+    expect(html).not.toContain(
+      `data-testid="replay-tick-${String(events.length + 1)}"`,
+    );
+    expect(html.match(/data-street-boundary="true"/g)).toHaveLength(2);
+  });
+
+  it("offers a chapter for each street the hand reached, and no others", () => {
+    const html = renderToStaticMarkup(
+      <HandReview review={ready} seats={seats} onClose={() => undefined} />,
+    );
+
+    expect(html).toContain('data-testid="replay-chapter-preflop"');
+    expect(html).toContain('data-testid="replay-chapter-flop"');
+    expect(html).not.toContain('data-testid="replay-chapter-turn"');
+  });
+
+  it("seeks a chapter to the street's BoardDealt, so the cards are seen arriving", () => {
+    const renderer = render();
+
+    click(renderer, "replay-chapter-flop");
+
+    expect(positions[6]?.event?.type).toBe("BoardDealt");
+    expect(stagedView.current).toBe(positions[6]?.view);
+    const view = stagedView.current;
+    expect(view?.phase === "betting" ? view.board : []).toHaveLength(3);
+    // The position before it has a bare felt, which is what makes this a
+    // *deal* rather than cards that were suddenly always there.
+    const before = positions[5]?.view;
+    expect(before?.phase === "betting" ? before.board : ["x"]).toHaveLength(0);
+  });
+
+  it("opens at position 0, not mid-hand and not playing", () => {
+    render();
+
+    expect(stagedView.current?.phase).toBe("no-hand");
+  });
+
+  it("keeps autoplay off until it is asked for, then advances the felt", async () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = render();
+      expect(stagedView.current?.phase).toBe("no-hand");
+
+      click(renderer, "replay-play");
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5_000);
+      });
+
+      expect(stagedView.current?.phase).not.toBe("no-hand");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops autoplay when the track is pressed", async () => {
+    vi.useFakeTimers();
+    try {
+      const renderer = render();
+      click(renderer, "replay-play");
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2_000);
+      });
+      const held = stagedView.current;
+
+      act(() => {
+        renderer.root
+          .findByProps({ "data-testid": "replay-track" })
+          .props.onClick?.();
+      });
+      act(() => {
+        renderer.root
+          .findByProps({ "data-testid": "replay-track" })
+          .props.onPointerDown?.({ clientX: 0 });
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10_000);
+      });
+
+      expect(stagedView.current).toBe(held);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("offers a way back to the picker", () => {
+    const html = renderToStaticMarkup(
+      <HandReview review={ready} seats={seats} onClose={() => undefined} />,
+    );
+
+    expect(html).toContain('data-testid="back-to-hands-button"');
+    expect(html).toContain("Back to hands");
+  });
+
+  it("says so while the hand is on its way, and if it never arrives", () => {
+    const loading = renderToStaticMarkup(
+      <HandReview
+        review={{ status: "loading", handOrdinal: 7 }}
+        seats={seats}
+        onClose={() => undefined}
+      />,
+    );
+    const unavailable = renderToStaticMarkup(
+      <HandReview
+        review={{ status: "unavailable", handOrdinal: 7 }}
+        seats={seats}
+        onClose={() => undefined}
+      />,
+    );
+
+    expect(loading).toContain("Loading hand 7");
+    expect(unavailable).toContain("can&#x27;t be replayed");
+    expect(unavailable).toContain('data-testid="back-to-hands-button"');
+  });
+});

--- a/packages/table-client/src/replay/HandReview.tsx
+++ b/packages/table-client/src/replay/HandReview.tsx
@@ -1,13 +1,13 @@
 import type { SeatView } from "@table-top-poker/protocol";
 import { color, font, fontSize } from "@table-top-poker/ui-shared";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { HandReview as Review } from "../store/replaySlice.js";
+import type { HandReviewState } from "../store/replaySlice.js";
 import { beatAt, chaptersOf, holdAt, toBeats } from "./beats.js";
 import { ReplayStage } from "./ReplayStage.js";
 import { ReplayTransport, TRANSPORT_HEIGHT } from "./ReplayTransport.js";
 
 export interface HandReviewProps {
-  readonly review: Review;
+  readonly review: HandReviewState;
   readonly seats: readonly SeatView[];
   readonly onClose: () => void;
 }
@@ -46,11 +46,11 @@ export function HandReview({ review, seats, onClose }: HandReviewProps) {
     };
   }, [playing, position, scrubbing, atEnd, beats]);
 
-  const startScrubbing = useCallback((next: boolean) => {
-    setScrubbing(next);
-    // Pressing the track stops autoplay: the scrub is the primary mode and
-    // a clock fighting a finger is the worst of both.
-    if (next) setPlaying(false);
+  // Pressing the track stops autoplay: the scrub is the primary mode, and a
+  // clock fighting a finger is the worst of both.
+  const changeScrubbing = useCallback((scrubbing: boolean) => {
+    setScrubbing(scrubbing);
+    if (scrubbing) setPlaying(false);
   }, []);
 
   const togglePlay = useCallback(() => {
@@ -78,8 +78,8 @@ export function HandReview({ review, seats, onClose }: HandReviewProps) {
           }}
         >
           {review.status === "loading"
-            ? `Loading hand ${String(review.handOrdinal)}`
-            : `Hand ${String(review.handOrdinal)} can't be replayed`}
+            ? "Loading the hand"
+            : "That hand can't be replayed"}
         </div>
       </>
     );
@@ -104,7 +104,7 @@ export function HandReview({ review, seats, onClose }: HandReviewProps) {
         playing={playing}
         scrubbing={scrubbing}
         onSeek={setPosition}
-        onScrubbingChange={startScrubbing}
+        onScrubbingChange={changeScrubbing}
         onTogglePlay={togglePlay}
         currentStreet={beatAt(beats, position)?.street ?? null}
       />

--- a/packages/table-client/src/replay/HandReview.tsx
+++ b/packages/table-client/src/replay/HandReview.tsx
@@ -1,0 +1,149 @@
+import type { SeatView } from "@table-top-poker/protocol";
+import { color, font, fontSize } from "@table-top-poker/ui-shared";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { HandReview as Review } from "../store/replaySlice.js";
+import { beatAt, chaptersOf, holdAt, toBeats } from "./beats.js";
+import { ReplayStage } from "./ReplayStage.js";
+import { ReplayTransport, TRANSPORT_HEIGHT } from "./ReplayTransport.js";
+
+export interface HandReviewProps {
+  readonly review: Review;
+  readonly seats: readonly SeatView[];
+  readonly onClose: () => void;
+}
+
+/**
+ * One recorded hand, scrubbable. The whole hand is already in hand — the
+ * server sends every position in one message — so the track can lay out its
+ * ticks and street chapters before anything is touched (Phase 2 spec #129 §5).
+ */
+export function HandReview({ review, seats, onClose }: HandReviewProps) {
+  const positions = review.status === "ready" ? review.positions : [];
+  const beats = useMemo(() => toBeats(positions), [positions]);
+  const chapters = useMemo(() => chaptersOf(beats), [beats]);
+
+  const [position, setPosition] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [scrubbing, setScrubbing] = useState(false);
+
+  useEffect(() => {
+    setPosition(0);
+    setPlaying(false);
+  }, [review.handOrdinal]);
+
+  const atEnd = position >= beats.length;
+
+  useEffect(() => {
+    if (!playing || atEnd || scrubbing) return;
+    const timer = window.setTimeout(
+      () => {
+        setPosition((current) => current + 1);
+      },
+      holdAt(beats, position),
+    );
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [playing, position, scrubbing, atEnd, beats]);
+
+  const startScrubbing = useCallback((next: boolean) => {
+    setScrubbing(next);
+    // Pressing the track stops autoplay: the scrub is the primary mode and
+    // a clock fighting a finger is the worst of both.
+    if (next) setPlaying(false);
+  }, []);
+
+  const togglePlay = useCallback(() => {
+    setPosition((current) => (current >= beats.length ? 0 : current));
+    setPlaying((current) => !current);
+  }, [beats.length]);
+
+  if (review.status !== "ready") {
+    return (
+      <>
+        <BackToHands onClose={onClose} />
+        <div
+          data-testid="replay-notice"
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontFamily: font.mono,
+            fontSize: fontSize.md,
+            letterSpacing: "0.14em",
+            textTransform: "uppercase",
+            color: color.textDim,
+          }}
+        >
+          {review.status === "loading"
+            ? `Loading hand ${String(review.handOrdinal)}`
+            : `Hand ${String(review.handOrdinal)} can't be replayed`}
+        </div>
+      </>
+    );
+  }
+
+  const view = positions[position]?.view ?? positions[0]?.view;
+
+  return (
+    <>
+      {view !== undefined && (
+        <ReplayStage
+          view={view}
+          seats={seats}
+          transportHeight={TRANSPORT_HEIGHT}
+        />
+      )}
+      <BackToHands onClose={onClose} />
+      <ReplayTransport
+        beats={beats}
+        chapters={chapters}
+        position={position}
+        playing={playing}
+        scrubbing={scrubbing}
+        onSeek={setPosition}
+        onScrubbingChange={startScrubbing}
+        onTogglePlay={togglePlay}
+        currentStreet={beatAt(beats, position)?.street ?? null}
+      />
+    </>
+  );
+}
+
+function BackToHands({ onClose }: { readonly onClose: () => void }) {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: "1.4em",
+        left: "1.8em",
+        right: "1.8em",
+        display: "flex",
+        justifyContent: "flex-end",
+        zIndex: 3,
+      }}
+    >
+      <button
+        type="button"
+        data-testid="back-to-hands-button"
+        onClick={onClose}
+        style={{
+          fontFamily: font.mono,
+          fontSize: "0.62em",
+          letterSpacing: "0.16em",
+          textTransform: "uppercase",
+          color: color.textDim,
+          background: "transparent",
+          border: `1px solid ${color.border}`,
+          borderRadius: "999px",
+          padding: "0.7em 1.3em",
+          cursor: "pointer",
+        }}
+      >
+        Back to hands
+      </button>
+    </div>
+  );
+}

--- a/packages/table-client/src/replay/ReplayStage.test.tsx
+++ b/packages/table-client/src/replay/ReplayStage.test.tsx
@@ -1,0 +1,53 @@
+import type { SeatView, TableView } from "@table-top-poker/protocol";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { CAPTION_BAND, ReplayStage, TOP_BAND } from "./ReplayStage.js";
+
+const seats: readonly SeatView[] = [0, 1, 2, 3].map((id) => ({
+  id,
+  claimed: true,
+  sittingOut: false,
+  sittingOutReason: null,
+  disconnected: false,
+}));
+
+const view: TableView = {
+  phase: "betting",
+  turnEndsAt: null,
+  button: 0,
+  smallBlind: 1,
+  bigBlind: 2,
+  dealtSeatCount: 4,
+  street: "flop",
+  board: [
+    { rank: "A", suit: "spades" },
+    { rank: "K", suit: "hearts" },
+    { rank: "2", suit: "clubs" },
+  ],
+  toAct: [1],
+  seats: seats.map((seat) => ({ seatId: seat.id, folded: false })),
+};
+
+const TRANSPORT = 10.2;
+
+describe("ReplayStage", () => {
+  it("lays the table out between reserved bands, clear of the transport", () => {
+    const html = renderToStaticMarkup(
+      <ReplayStage view={view} seats={seats} transportHeight={TRANSPORT} />,
+    );
+
+    expect(html).toContain(`top:${String(TOP_BAND)}em`);
+    expect(html).toContain(`bottom:${String(TRANSPORT + CAPTION_BAND)}em`);
+  });
+
+  it("renders the felt through the live Seats and Board, projected", () => {
+    const html = renderToStaticMarkup(
+      <ReplayStage view={view} seats={seats} transportHeight={TRANSPORT} />,
+    );
+
+    expect(html).toContain('data-testid="seats"');
+    expect(html).toContain('data-testid="community-cards"');
+    expect(html).toContain('data-phase="betting"');
+  });
+});

--- a/packages/table-client/src/replay/ReplayStage.tsx
+++ b/packages/table-client/src/replay/ReplayStage.tsx
@@ -1,0 +1,66 @@
+import type { SeatView, TableView } from "@table-top-poker/protocol";
+import { Board } from "../Board.js";
+import { Seats } from "../Seats.js";
+
+export interface ReplayStageProps {
+  readonly view: TableView;
+  readonly seats: readonly SeatView[];
+  /** Height in `em` of the transport chrome drawn along the bottom. */
+  readonly transportHeight: number;
+}
+
+/**
+ * The strip below the felt the caption claims (#127). Reserved here because
+ * the band is what keeps the bottom seat row clear of the transport, not
+ * because this component draws anything in it.
+ */
+export const CAPTION_BAND = 2.4;
+
+/**
+ * A seat pod is anchored by its avatar and grows *around* that anchor, so a
+ * top-row pod carrying a showdown description reaches further up than
+ * `posFor`'s 10% and clips the felt's edge. The bottom row overlaps the
+ * transport for the mirror reason (Phase 2 spec #129 §6).
+ */
+export const TOP_BAND = 4.5;
+
+/**
+ * The felt at one position of a replayed hand: the live `Seats` and `Board`,
+ * fed the position's `view(state, "table")`. No `replay` flag and no parallel
+ * rendering path — the visibility guarantee is inherited, not re-implemented.
+ *
+ * `Board` is deliberately not keyed on the position: it decides for itself
+ * which cards have just arrived, so scrubbing does not re-deal all five.
+ */
+export function ReplayStage({
+  view,
+  seats,
+  transportHeight,
+}: ReplayStageProps) {
+  return (
+    <div
+      data-testid="replay-stage"
+      style={{
+        position: "absolute",
+        top: `${String(TOP_BAND)}em`,
+        left: 0,
+        right: 0,
+        bottom: `${String(transportHeight + CAPTION_BAND)}em`,
+      }}
+    >
+      <Seats seats={seats} view={view} />
+      <div
+        style={{
+          position: "absolute",
+          inset: 0,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          pointerEvents: "none",
+        }}
+      >
+        <Board view={view} seats={seats} />
+      </div>
+    </div>
+  );
+}

--- a/packages/table-client/src/replay/ReplayTransport.tsx
+++ b/packages/table-client/src/replay/ReplayTransport.tsx
@@ -16,10 +16,18 @@ export interface ReplayTransportProps {
 }
 
 /**
- * Chapter chips (3.4em) + gap (0.8em) + track (4.6em) + bottom margin (1.4em),
- * in `em`. `ReplayStage` reserves this band so the seat ring rides clear of it.
+ * Comfortably past the ~44px touch-target floor at the table device's root
+ * size, and wide enough to hit without aiming.
  */
-export const TRANSPORT_HEIGHT = 10.2;
+const CHIP_HEIGHT = 3.4;
+const ROW_GAP = 0.8;
+/** The grab zone, deliberately far taller than the 6px rail it draws. */
+const TRACK_HEIGHT = 4.6;
+const BOTTOM_MARGIN = 1.4;
+
+/** The band `ReplayStage` reserves, so the seat ring rides clear of it. */
+export const TRANSPORT_HEIGHT =
+  CHIP_HEIGHT + ROW_GAP + TRACK_HEIGHT + BOTTOM_MARGIN;
 
 /**
  * The scrub: a ticked track the width of the felt, chaptered by street, with
@@ -80,10 +88,10 @@ export function ReplayTransport({
         position: "absolute",
         left: "1.8em",
         right: "1.8em",
-        bottom: "1.4em",
+        bottom: `${String(BOTTOM_MARGIN)}em`,
         display: "flex",
         flexDirection: "column",
-        gap: "0.8em",
+        gap: `${String(ROW_GAP)}em`,
         zIndex: 3,
       }}
     >
@@ -121,7 +129,7 @@ export function ReplayTransport({
         }}
         style={{
           position: "relative",
-          height: "4.6em",
+          height: `${String(TRACK_HEIGHT)}em`,
           display: "flex",
           alignItems: "center",
           cursor: "pointer",
@@ -152,15 +160,15 @@ export function ReplayTransport({
           <span
             key={beat.position}
             data-testid={`replay-tick-${String(beat.position)}`}
-            data-street-boundary={beat.isStreetStart}
+            data-street-boundary={beat.isStreetBoundary}
             style={{
               position: "absolute",
               left: `${String((beat.position / total) * 100)}%`,
               transform: "translateX(-50%)",
-              width: beat.isStreetStart ? "3px" : "2px",
-              height: beat.isStreetStart ? "2.2em" : "1.1em",
+              width: beat.isStreetBoundary ? "3px" : "2px",
+              height: beat.isStreetBoundary ? "2.2em" : "1.1em",
               borderRadius: "999px",
-              background: beat.isStreetStart
+              background: beat.isStreetBoundary
                 ? color.textMuted
                 : "rgba(255,255,255,.34)",
             }}
@@ -209,7 +217,7 @@ function Chip({
         fontSize: "0.78em",
         letterSpacing: "0.12em",
         textTransform: "uppercase",
-        minHeight: "3.4em",
+        minHeight: `${String(CHIP_HEIGHT)}em`,
         minWidth: "6em",
         padding: "0.9em 1.6em",
         borderRadius: "999px",

--- a/packages/table-client/src/replay/ReplayTransport.tsx
+++ b/packages/table-client/src/replay/ReplayTransport.tsx
@@ -1,0 +1,225 @@
+import { color, font } from "@table-top-poker/ui-shared";
+import { useCallback, useEffect, useRef, type ReactNode } from "react";
+import type { Beat, Chapter } from "./beats.js";
+import { positionAtRatio, ticksFor } from "./track.js";
+
+export interface ReplayTransportProps {
+  readonly beats: readonly Beat[];
+  readonly chapters: readonly Chapter[];
+  readonly position: number;
+  readonly playing: boolean;
+  readonly scrubbing: boolean;
+  readonly onSeek: (position: number) => void;
+  readonly onScrubbingChange: (scrubbing: boolean) => void;
+  readonly onTogglePlay: () => void;
+  readonly currentStreet: Chapter["street"] | null;
+}
+
+/**
+ * Chapter chips (3.4em) + gap (0.8em) + track (4.6em) + bottom margin (1.4em),
+ * in `em`. `ReplayStage` reserves this band so the seat ring rides clear of it.
+ */
+export const TRANSPORT_HEIGHT = 10.2;
+
+/**
+ * The scrub: a ticked track the width of the felt, chaptered by street, with
+ * autoplay demoted to a chip beside the chapters.
+ *
+ * Sized for a finger rather than a cursor — the grab zone is the full height
+ * of the track row, well past the visible rail, and the chips clear the touch
+ * target floor (Phase 2 spec #129 §6).
+ */
+export function ReplayTransport({
+  beats,
+  chapters,
+  position,
+  playing,
+  scrubbing,
+  onSeek,
+  onScrubbingChange,
+  onTogglePlay,
+  currentStreet,
+}: ReplayTransportProps) {
+  const total = beats.length;
+  const trackRef = useRef<HTMLDivElement | null>(null);
+
+  const seekToClientX = useCallback(
+    (clientX: number) => {
+      const track = trackRef.current;
+      if (!track) return;
+      const rect = track.getBoundingClientRect();
+      onSeek(positionAtRatio((clientX - rect.left) / rect.width, total));
+    },
+    [onSeek, total],
+  );
+
+  // The drag continues wherever the finger goes, including off the track and
+  // off the element entirely, so the listeners live on the window.
+  useEffect(() => {
+    if (!scrubbing) return;
+    const onMove = (event: PointerEvent) => {
+      seekToClientX(event.clientX);
+    };
+    const onUp = () => {
+      onScrubbingChange(false);
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+  }, [scrubbing, seekToClientX, onScrubbingChange]);
+
+  const progress = total === 0 ? 0 : (position / total) * 100;
+
+  return (
+    <div
+      data-testid="replay-transport"
+      style={{
+        position: "absolute",
+        left: "1.8em",
+        right: "1.8em",
+        bottom: "1.4em",
+        display: "flex",
+        flexDirection: "column",
+        gap: "0.8em",
+        zIndex: 3,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "0.7em" }}>
+        <Chip
+          active={playing}
+          label={playing ? "Pause replay" : "Play replay"}
+          testId="replay-play"
+          onClick={onTogglePlay}
+        >
+          {playing ? "❚❚ pause" : "▶ play"}
+        </Chip>
+        <span style={{ flex: 1 }} />
+        {chapters.map((chapter) => (
+          <Chip
+            key={chapter.street}
+            active={currentStreet === chapter.street}
+            label={`Seek to the ${chapter.label.toLowerCase()}`}
+            testId={`replay-chapter-${chapter.street}`}
+            onClick={() => {
+              onSeek(chapter.position);
+            }}
+          >
+            {chapter.label}
+          </Chip>
+        ))}
+      </div>
+
+      <div
+        ref={trackRef}
+        data-testid="replay-track"
+        onPointerDown={(event) => {
+          onScrubbingChange(true);
+          seekToClientX(event.clientX);
+        }}
+        style={{
+          position: "relative",
+          height: "4.6em",
+          display: "flex",
+          alignItems: "center",
+          cursor: "pointer",
+          touchAction: "none",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            right: 0,
+            height: "6px",
+            borderRadius: "999px",
+            background: "rgba(255,255,255,.14)",
+          }}
+        />
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            width: `${String(progress)}%`,
+            height: "6px",
+            borderRadius: "999px",
+            background: color.accent,
+          }}
+        />
+        {ticksFor(beats).map((beat) => (
+          <span
+            key={beat.position}
+            data-testid={`replay-tick-${String(beat.position)}`}
+            data-street-boundary={beat.isStreetStart}
+            style={{
+              position: "absolute",
+              left: `${String((beat.position / total) * 100)}%`,
+              transform: "translateX(-50%)",
+              width: beat.isStreetStart ? "3px" : "2px",
+              height: beat.isStreetStart ? "2.2em" : "1.1em",
+              borderRadius: "999px",
+              background: beat.isStreetStart
+                ? color.textMuted
+                : "rgba(255,255,255,.34)",
+            }}
+          />
+        ))}
+        <span
+          data-testid="replay-thumb"
+          style={{
+            position: "absolute",
+            left: `${String(progress)}%`,
+            transform: "translate(-50%, 0)",
+            width: "1.9em",
+            height: "1.9em",
+            borderRadius: "50%",
+            background: color.text,
+            border: `3px solid ${color.accent}`,
+            boxShadow: "0 6px 20px rgba(0,0,0,.8)",
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function Chip({
+  active,
+  label,
+  testId,
+  onClick,
+  children,
+}: {
+  readonly active: boolean;
+  readonly label: string;
+  readonly testId: string;
+  readonly onClick: () => void;
+  readonly children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      data-testid={testId}
+      onClick={onClick}
+      style={{
+        fontFamily: font.mono,
+        fontSize: "0.78em",
+        letterSpacing: "0.12em",
+        textTransform: "uppercase",
+        minHeight: "3.4em",
+        minWidth: "6em",
+        padding: "0.9em 1.6em",
+        borderRadius: "999px",
+        cursor: "pointer",
+        background: active ? color.controlFill : "rgba(6,9,8,.5)",
+        border: `1px solid ${active ? color.borderStrong : color.border}`,
+        color: active ? color.text : color.textMuted,
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/packages/table-client/src/replay/beats.test.ts
+++ b/packages/table-client/src/replay/beats.test.ts
@@ -55,12 +55,14 @@ describe("toBeats", () => {
     );
   });
 
-  it("marks street starts, which the track draws heavier", () => {
+  it("marks each street's first beat, which the track draws heavier", () => {
     const beats = toBeats(positionsFor(toTheTurn));
 
     expect(
-      beats.filter((beat) => beat.isStreetStart).map((beat) => beat.position),
-    ).toEqual([3, 7, 11]);
+      beats
+        .filter((beat) => beat.isStreetBoundary)
+        .map((beat) => beat.position),
+    ).toEqual([3, 6, 10]);
   });
 
   it("stamps a BoardDealt with the street it opens, not the one it ends", () => {
@@ -113,6 +115,16 @@ describe("chaptersOf", () => {
 
     expect(new Set(chapters.map((chapter) => chapter.street)).size).toBe(
       chapters.length,
+    );
+  });
+
+  it("seeks each chapter to the beat the track draws heaviest", () => {
+    const beats = toBeats(positionsFor(toTheTurn));
+
+    expect(chaptersOf(beats).map((chapter) => chapter.position)).toEqual(
+      beats
+        .filter((beat) => beat.isStreetBoundary)
+        .map((beat) => beat.position),
     );
   });
 });

--- a/packages/table-client/src/replay/beats.test.ts
+++ b/packages/table-client/src/replay/beats.test.ts
@@ -1,0 +1,118 @@
+import type {
+  Card,
+  HandEvent,
+  TableReplayPosition,
+} from "@table-top-poker/protocol";
+import { describe, expect, it } from "vitest";
+import { beatAt, chaptersOf, toBeats } from "./beats.js";
+
+const noHand = { phase: "no-hand", button: 0 } as const;
+
+/**
+ * Positions carry a view the beat model never reads, so every fixture here
+ * pairs its events with the same placeholder — what a beat is made of is the
+ * question under test.
+ */
+function positionsFor(
+  events: readonly HandEvent[],
+): readonly TableReplayPosition[] {
+  return [
+    { event: null, view: noHand },
+    ...events.map((event) => ({ event, view: noHand })),
+  ];
+}
+
+const card = (rank: Card["rank"]): Card => ({ rank, suit: "clubs" });
+
+/** The engine's own cascade order: close, deal, start. */
+function streetCascade(street: "flop" | "turn" | "river"): HandEvent[] {
+  const previous = { flop: "preflop", turn: "flop", river: "turn" } as const;
+  return [
+    { type: "StreetClosed", street: previous[street] },
+    { type: "BoardDealt", street, cards: [card("2")] },
+    { type: "StreetStarted", street, actor: 1 },
+  ];
+}
+
+const toTheTurn: readonly HandEvent[] = [
+  { type: "HandStarted", seed: "s", button: 0 },
+  { type: "HoleCardsDealt", deals: [] },
+  { type: "StreetStarted", street: "preflop", actor: 1 },
+  { type: "ActionTaken", seatId: 1, action: "call" },
+  ...streetCascade("flop"),
+  { type: "ActionTaken", seatId: 1, action: "check" },
+  ...streetCascade("turn"),
+  { type: "ActionTaken", seatId: 1, action: "raise" },
+];
+
+describe("toBeats", () => {
+  it("gives every event ordinal a beat, and position 0 none", () => {
+    const beats = toBeats(positionsFor(toTheTurn));
+
+    expect(beats).toHaveLength(toTheTurn.length);
+    expect(beats.map((beat) => beat.position)).toEqual(
+      toTheTurn.map((_event, index) => index + 1),
+    );
+  });
+
+  it("marks street starts, which the track draws heavier", () => {
+    const beats = toBeats(positionsFor(toTheTurn));
+
+    expect(
+      beats.filter((beat) => beat.isStreetStart).map((beat) => beat.position),
+    ).toEqual([3, 7, 11]);
+  });
+
+  it("stamps a BoardDealt with the street it opens, not the one it ends", () => {
+    const beats = toBeats(positionsFor(toTheTurn));
+
+    // ordinal 5 is `StreetClosed preflop`, 6 is the flop's `BoardDealt`.
+    expect(beatAt(beats, 5)?.street).toBe("preflop");
+    expect(beatAt(beats, 6)?.street).toBe("flop");
+  });
+
+  it("holds the beats that change the felt longer than the bookkeeping", () => {
+    const beats = toBeats(positionsFor(toTheTurn));
+    const weightOf = (position: number) => beatAt(beats, position)?.weight ?? 0;
+
+    expect(weightOf(6)).toBeGreaterThan(weightOf(5));
+  });
+
+  it("has no beat before the hand starts", () => {
+    expect(beatAt(toBeats(positionsFor(toTheTurn)), 0)).toBeNull();
+  });
+});
+
+describe("chaptersOf", () => {
+  it("anchors a street on its BoardDealt, so its cards are seen arriving", () => {
+    const chapters = chaptersOf(toBeats(positionsFor(toTheTurn)));
+
+    expect(chapters).toEqual([
+      { street: "preflop", label: "Preflop", position: 3 },
+      { street: "flop", label: "Flop", position: 6 },
+      { street: "turn", label: "Turn", position: 10 },
+    ]);
+  });
+
+  it("offers only the streets the hand reached", () => {
+    const walk: HandEvent[] = [
+      { type: "HandStarted", seed: "s", button: 0 },
+      { type: "StreetStarted", street: "preflop", actor: 1 },
+      { type: "ActionTaken", seatId: 1, action: "fold" },
+      { type: "HandFoldedOut", winner: 0 },
+      { type: "HandComplete" },
+    ];
+
+    expect(chaptersOf(toBeats(positionsFor(walk)))).toEqual([
+      { street: "preflop", label: "Preflop", position: 2 },
+    ]);
+  });
+
+  it("names each street once, however many beats it holds", () => {
+    const chapters = chaptersOf(toBeats(positionsFor(toTheTurn)));
+
+    expect(new Set(chapters.map((chapter) => chapter.street)).size).toBe(
+      chapters.length,
+    );
+  });
+});

--- a/packages/table-client/src/replay/beats.ts
+++ b/packages/table-client/src/replay/beats.ts
@@ -1,0 +1,130 @@
+import type {
+  HandEvent,
+  Street,
+  TableReplayPosition,
+} from "@table-top-poker/protocol";
+
+/**
+ * One Event ordinal, dressed for the transport: the street it belongs to, how
+ * long autoplay holds on it, and whether it opens a street.
+ *
+ * Position is the Event ordinal throughout (Phase 2 spec #129 §2) — beat *n*
+ * is the state after applying *n* Events, so position 0 has no beat.
+ */
+export interface Beat {
+  readonly position: number;
+  readonly street: Street | null;
+  /** How long autoplay holds here, in ms. */
+  readonly weight: number;
+  readonly isStreetStart: boolean;
+}
+
+const streetLabel: Record<Street, string> = {
+  preflop: "Preflop",
+  flop: "Flop",
+  turn: "Turn",
+  river: "River",
+};
+
+/**
+ * Autoplay's per-event pacing. The shape is the claim: beats that *change
+ * what is on the felt* (a deal, a board, a showdown) are held, and beats that
+ * only advance the bookkeeping go past quickly — `StreetClosed` is
+ * near-instant, being a real ordinal with nothing to show.
+ *
+ * Weighting redistributes attention rather than saving time: measured against
+ * a 33-event fixture it ran 27.7s to uniform's 28.1s, which is why autoplay
+ * is the secondary control and the scrub is the primary one (§6).
+ */
+const WEIGHTS: Record<HandEvent["type"], number> = {
+  HandStarted: 900,
+  HoleCardsDealt: 1400,
+  StreetStarted: 500,
+  ActionTaken: 700,
+  StreetClosed: 200,
+  BoardDealt: 1600,
+  HandFoldedOut: 2400,
+  ShowdownReached: 3200,
+  HandComplete: 2000,
+};
+
+/**
+ * A beat belongs to the street it *shows*, which for a `BoardDealt` is the
+ * street it opens rather than the one still in progress when it lands. That
+ * stamping is what puts each street's first beat on its `BoardDealt`, and
+ * `chaptersOf` needs no special case for the cascade.
+ */
+function streetOf(event: HandEvent, current: Street | null): Street | null {
+  if (event.type === "StreetStarted" || event.type === "BoardDealt") {
+    return event.street;
+  }
+  return current;
+}
+
+export function toBeats(
+  positions: readonly TableReplayPosition[],
+): readonly Beat[] {
+  let street: Street | null = null;
+  const beats: Beat[] = [];
+
+  for (const [index, position] of positions.entries()) {
+    const event = position.event;
+    if (event === null) continue;
+    street = streetOf(event, street);
+    beats.push({
+      position: index,
+      street,
+      weight: WEIGHTS[event.type],
+      isStreetStart: event.type === "StreetStarted",
+    });
+  }
+  return beats;
+}
+
+export interface Chapter {
+  readonly street: Street;
+  readonly label: string;
+  /** The ordinal the chip seeks to. */
+  readonly position: number;
+}
+
+/**
+ * The named landmarks people navigate by — "on the turn, when Seat 4 raised".
+ * Each street's first beat is its anchor, which for every street after
+ * preflop is its `BoardDealt`: the engine's cascade emits `StreetClosed →
+ * BoardDealt → StreetStarted`, so anchoring on the street start would land
+ * *after* the cards appeared and a viewer tapping "Turn" would never see the
+ * turn card arrive (§6).
+ */
+export function chaptersOf(beats: readonly Beat[]): readonly Chapter[] {
+  const chapters: Chapter[] = [];
+  const seen = new Set<Street>();
+
+  for (const beat of beats) {
+    if (beat.street === null || seen.has(beat.street)) continue;
+    seen.add(beat.street);
+    chapters.push({
+      street: beat.street,
+      label: streetLabel[beat.street],
+      position: beat.position,
+    });
+  }
+  return chapters;
+}
+
+export function beatAt(beats: readonly Beat[], position: number): Beat | null {
+  if (position <= 0) return null;
+  return beats[position - 1] ?? null;
+}
+
+/** A hand opens on an empty felt, where there is nothing to hold on. */
+const LEAD_IN = 400;
+
+/**
+ * How long autoplay stays at `position`: the weight of the Event that put the
+ * felt in the state now on screen, so a board deal is held and a
+ * `StreetClosed` is passed straight through.
+ */
+export function holdAt(beats: readonly Beat[], position: number): number {
+  return beatAt(beats, position)?.weight ?? LEAD_IN;
+}

--- a/packages/table-client/src/replay/beats.ts
+++ b/packages/table-client/src/replay/beats.ts
@@ -5,18 +5,21 @@ import type {
 } from "@table-top-poker/protocol";
 
 /**
- * One Event ordinal, dressed for the transport: the street it belongs to, how
- * long autoplay holds on it, and whether it opens a street.
- *
- * Position is the Event ordinal throughout (Phase 2 spec #129 §2) — beat *n*
- * is the state after applying *n* Events, so position 0 has no beat.
+ * One Event ordinal, dressed for the transport. Position is the Event ordinal
+ * throughout (Phase 2 spec #129 §2) — beat *n* is the state after applying
+ * *n* Events, so position 0 has no beat.
  */
 export interface Beat {
   readonly position: number;
   readonly street: Street | null;
   /** How long autoplay holds here, in ms. */
   readonly weight: number;
-  readonly isStreetStart: boolean;
+  /**
+   * The first beat of its street: the track draws it heavier and a Chapter
+   * seeks to it. One flag for both, so a chip can never land beside the tick
+   * marking the boundary it names.
+   */
+  readonly isStreetBoundary: boolean;
 }
 
 const streetLabel: Record<Street, string> = {
@@ -27,14 +30,8 @@ const streetLabel: Record<Street, string> = {
 };
 
 /**
- * Autoplay's per-event pacing. The shape is the claim: beats that *change
- * what is on the felt* (a deal, a board, a showdown) are held, and beats that
- * only advance the bookkeeping go past quickly — `StreetClosed` is
- * near-instant, being a real ordinal with nothing to show.
- *
- * Weighting redistributes attention rather than saving time: measured against
- * a 33-event fixture it ran 27.7s to uniform's 28.1s, which is why autoplay
- * is the secondary control and the scrub is the primary one (§6).
+ * Autoplay's per-event pacing: beats that *change what is on the felt* are
+ * held, and beats that only advance the bookkeeping go past quickly (§6).
  */
 const WEIGHTS: Record<HandEvent["type"], number> = {
   HandStarted: 900,
@@ -48,12 +45,7 @@ const WEIGHTS: Record<HandEvent["type"], number> = {
   HandComplete: 2000,
 };
 
-/**
- * A beat belongs to the street it *shows*, which for a `BoardDealt` is the
- * street it opens rather than the one still in progress when it lands. That
- * stamping is what puts each street's first beat on its `BoardDealt`, and
- * `chaptersOf` needs no special case for the cascade.
- */
+/** A beat belongs to the street it *shows* — see Chapter in `CONTEXT.md`. */
 function streetOf(event: HandEvent, current: Street | null): Street | null {
   if (event.type === "StreetStarted" || event.type === "BoardDealt") {
     return event.street;
@@ -70,12 +62,13 @@ export function toBeats(
   for (const [index, position] of positions.entries()) {
     const event = position.event;
     if (event === null) continue;
+    const previous = street;
     street = streetOf(event, street);
     beats.push({
       position: index,
       street,
       weight: WEIGHTS[event.type],
-      isStreetStart: event.type === "StreetStarted",
+      isStreetBoundary: street !== null && street !== previous,
     });
   }
   return beats;
@@ -88,28 +81,13 @@ export interface Chapter {
   readonly position: number;
 }
 
-/**
- * The named landmarks people navigate by — "on the turn, when Seat 4 raised".
- * Each street's first beat is its anchor, which for every street after
- * preflop is its `BoardDealt`: the engine's cascade emits `StreetClosed →
- * BoardDealt → StreetStarted`, so anchoring on the street start would land
- * *after* the cards appeared and a viewer tapping "Turn" would never see the
- * turn card arrive (§6).
- */
+/** The Scrub's street landmarks — see Chapter in `CONTEXT.md`. */
 export function chaptersOf(beats: readonly Beat[]): readonly Chapter[] {
-  const chapters: Chapter[] = [];
-  const seen = new Set<Street>();
-
-  for (const beat of beats) {
-    if (beat.street === null || seen.has(beat.street)) continue;
-    seen.add(beat.street);
-    chapters.push({
-      street: beat.street,
-      label: streetLabel[beat.street],
-      position: beat.position,
-    });
-  }
-  return chapters;
+  return beats.flatMap((beat) => {
+    const street = beat.street;
+    if (!beat.isStreetBoundary || street === null) return [];
+    return [{ street, label: streetLabel[street], position: beat.position }];
+  });
 }
 
 export function beatAt(beats: readonly Beat[], position: number): Beat | null {

--- a/packages/table-client/src/replay/track.test.ts
+++ b/packages/table-client/src/replay/track.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 import type { Beat } from "./beats.js";
 import { MAX_TICKS, positionAtRatio, ticksFor } from "./track.js";
 
-function beats(count: number, streetStarts: readonly number[] = []): Beat[] {
+function beats(count: number, boundaries: readonly number[] = []): Beat[] {
   return Array.from({ length: count }, (_unused, index) => ({
     position: index + 1,
     street: "preflop" as const,
     weight: 100,
-    isStreetStart: streetStarts.includes(index + 1),
+    isStreetBoundary: boundaries.includes(index + 1),
   }));
 }
 
@@ -52,7 +52,9 @@ describe("ticksFor", () => {
       expect(drawn.map((tick) => tick.position)).toContain(boundary);
     }
     expect(
-      drawn.filter((tick) => tick.isStreetStart).map((tick) => tick.position),
+      drawn
+        .filter((tick) => tick.isStreetBoundary)
+        .map((tick) => tick.position),
     ).toEqual(boundaries);
   });
 });

--- a/packages/table-client/src/replay/track.test.ts
+++ b/packages/table-client/src/replay/track.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { Beat } from "./beats.js";
+import { MAX_TICKS, positionAtRatio, ticksFor } from "./track.js";
+
+function beats(count: number, streetStarts: readonly number[] = []): Beat[] {
+  return Array.from({ length: count }, (_unused, index) => ({
+    position: index + 1,
+    street: "preflop" as const,
+    weight: 100,
+    isStreetStart: streetStarts.includes(index + 1),
+  }));
+}
+
+describe("positionAtRatio", () => {
+  it("lands on the nearest ordinal", () => {
+    expect(positionAtRatio(0, 10)).toBe(0);
+    expect(positionAtRatio(0.5, 10)).toBe(5);
+    expect(positionAtRatio(0.44, 10)).toBe(4);
+    expect(positionAtRatio(1, 10)).toBe(10);
+  });
+
+  it("clamps a finger that has left the track", () => {
+    expect(positionAtRatio(-0.3, 10)).toBe(0);
+    expect(positionAtRatio(1.8, 10)).toBe(10);
+  });
+
+  it("stays at 0 for a hand with no positions to seek", () => {
+    expect(positionAtRatio(0.5, 0)).toBe(0);
+  });
+});
+
+describe("ticksFor", () => {
+  it("draws one tick per ordinal for an ordinary hand", () => {
+    const drawn = ticksFor(beats(33, [3, 7]));
+
+    expect(drawn.map((tick) => tick.position)).toEqual(
+      beats(33).map((beat) => beat.position),
+    );
+  });
+
+  it("collapses the ticks of an unusually long hand", () => {
+    const drawn = ticksFor(beats(MAX_TICKS * 4, [5]));
+
+    expect(drawn.length).toBeLessThanOrEqual(MAX_TICKS);
+  });
+
+  it("keeps every street boundary when it collapses — chapters are the contract", () => {
+    const boundaries = [5, 400, 900];
+    const drawn = ticksFor(beats(MAX_TICKS * 4, boundaries));
+
+    for (const boundary of boundaries) {
+      expect(drawn.map((tick) => tick.position)).toContain(boundary);
+    }
+    expect(
+      drawn.filter((tick) => tick.isStreetStart).map((tick) => tick.position),
+    ).toEqual(boundaries);
+  });
+});

--- a/packages/table-client/src/replay/track.ts
+++ b/packages/table-client/src/replay/track.ts
@@ -1,11 +1,6 @@
 import type { Beat } from "./beats.js";
 
-/**
- * Where one-tick-per-ordinal stops being legible: past a few hundred ticks
- * they are sub-pixel on a table device and the thumb covers dozens of them.
- * Hand length is unbounded — `raise` is always legal and uncapped — so this
- * is reached by a real hand, not only by an exotic one (Phase 2 spec #129 §5).
- */
+/** Where one-tick-per-ordinal stops being legible on a table device (§6). */
 export const MAX_TICKS = 240;
 
 /** Maps a fraction along the track to the ordinal it names. */
@@ -15,15 +10,14 @@ export function positionAtRatio(ratio: number, total: number): number {
 }
 
 /**
- * The ticks the track draws. Ticks are a visual affordance — the hand's
- * *shape*, where the action clustered — and may collapse on a long hand;
- * street boundaries never do, because chapters are the navigation contract
- * (§6).
+ * The ticks the track draws. Ticks are a visual affordance and may collapse on
+ * a long hand; street boundaries never do, because chapters are the
+ * navigation contract (§6).
  */
 export function ticksFor(beats: readonly Beat[]): readonly Beat[] {
   if (beats.length <= MAX_TICKS) return beats;
   const stride = Math.ceil(beats.length / MAX_TICKS);
   return beats.filter(
-    (beat, index) => beat.isStreetStart || index % stride === 0,
+    (beat, index) => beat.isStreetBoundary || index % stride === 0,
   );
 }

--- a/packages/table-client/src/replay/track.ts
+++ b/packages/table-client/src/replay/track.ts
@@ -1,0 +1,29 @@
+import type { Beat } from "./beats.js";
+
+/**
+ * Where one-tick-per-ordinal stops being legible: past a few hundred ticks
+ * they are sub-pixel on a table device and the thumb covers dozens of them.
+ * Hand length is unbounded — `raise` is always legal and uncapped — so this
+ * is reached by a real hand, not only by an exotic one (Phase 2 spec #129 §5).
+ */
+export const MAX_TICKS = 240;
+
+/** Maps a fraction along the track to the ordinal it names. */
+export function positionAtRatio(ratio: number, total: number): number {
+  if (total <= 0) return 0;
+  return Math.round(Math.max(0, Math.min(1, ratio)) * total);
+}
+
+/**
+ * The ticks the track draws. Ticks are a visual affordance — the hand's
+ * *shape*, where the action clustered — and may collapse on a long hand;
+ * street boundaries never do, because chapters are the navigation contract
+ * (§6).
+ */
+export function ticksFor(beats: readonly Beat[]): readonly Beat[] {
+  if (beats.length <= MAX_TICKS) return beats;
+  const stride = Math.ceil(beats.length / MAX_TICKS);
+  return beats.filter(
+    (beat, index) => beat.isStreetStart || index % stride === 0,
+  );
+}

--- a/packages/table-client/src/store/replaySlice.ts
+++ b/packages/table-client/src/store/replaySlice.ts
@@ -1,0 +1,56 @@
+import type { TableReplayPosition } from "@table-top-poker/protocol";
+import type { StateCreator } from "zustand";
+
+/**
+ * The hand under review. `loading` is its own state rather than a null
+ * `positions`, so a reply that arrives after the table has backed out — or
+ * moved on to another hand — can be recognised as stale and dropped.
+ */
+export type HandReview =
+  | { readonly status: "loading"; readonly handOrdinal: number }
+  | {
+      readonly status: "ready";
+      readonly handOrdinal: number;
+      readonly positions: readonly TableReplayPosition[];
+    }
+  | { readonly status: "unavailable"; readonly handOrdinal: number };
+
+export interface ReplaySlice {
+  readonly review: HandReview | null;
+  readonly openReview: (handOrdinal: number) => void;
+  readonly receiveReplay: (
+    handOrdinal: number,
+    positions: readonly TableReplayPosition[],
+  ) => void;
+  readonly failReview: () => void;
+  readonly closeReview: () => void;
+}
+
+export const createReplaySlice: StateCreator<ReplaySlice> = (set) => ({
+  review: null,
+  openReview: (handOrdinal) => {
+    set({ review: { status: "loading", handOrdinal } });
+  },
+  receiveReplay: (handOrdinal, positions) => {
+    set((state) =>
+      state.review?.handOrdinal === handOrdinal
+        ? { review: { status: "ready", handOrdinal, positions } }
+        : state,
+    );
+  },
+  failReview: () => {
+    set((state) =>
+      state.review?.status === "loading"
+        ? {
+            review: {
+              status: "unavailable",
+              handOrdinal: state.review.handOrdinal,
+            },
+          }
+        : state,
+    );
+  },
+  closeReview: () => {
+    set({ review: null });
+  },
+});

--- a/packages/table-client/src/store/replaySlice.ts
+++ b/packages/table-client/src/store/replaySlice.ts
@@ -6,7 +6,7 @@ import type { StateCreator } from "zustand";
  * `positions`, so a reply that arrives after the table has backed out — or
  * moved on to another hand — can be recognised as stale and dropped.
  */
-export type HandReview =
+export type HandReviewState =
   | { readonly status: "loading"; readonly handOrdinal: number }
   | {
       readonly status: "ready";
@@ -16,7 +16,7 @@ export type HandReview =
   | { readonly status: "unavailable"; readonly handOrdinal: number };
 
 export interface ReplaySlice {
-  readonly review: HandReview | null;
+  readonly review: HandReviewState | null;
   readonly openReview: (handOrdinal: number) => void;
   readonly receiveReplay: (
     handOrdinal: number,

--- a/packages/table-client/src/store/store.test.ts
+++ b/packages/table-client/src/store/store.test.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_SHOT_CLOCK,
   DEFAULT_SOUND_SETTINGS,
   type HandSummary,
+  type TableReplayPosition,
 } from "@table-top-poker/protocol";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useTableStore } from "./store.js";
@@ -19,6 +20,10 @@ function summary(handOrdinal: number): HandSummary {
     outcome: { kind: "folded-out", winner: 0 },
   };
 }
+
+const positions: readonly TableReplayPosition[] = [
+  { event: null, view: { phase: "no-hand", button: 0 } },
+];
 
 describe("useTableStore", () => {
   beforeEach(() => {
@@ -173,5 +178,43 @@ describe("useTableStore", () => {
     useTableStore.getState().setHandList([summary(1)]);
     useTableStore.getState().clearHandHistory();
     expect(useTableStore.getState().handSummaries).toEqual([]);
+  });
+
+  it("holds a requested hand as loading until its positions arrive", () => {
+    useTableStore.getState().openReview(2);
+    expect(useTableStore.getState().review).toEqual({
+      status: "loading",
+      handOrdinal: 2,
+    });
+
+    useTableStore.getState().receiveReplay(2, positions);
+    expect(useTableStore.getState().review).toEqual({
+      status: "ready",
+      handOrdinal: 2,
+      positions,
+    });
+  });
+
+  it("drops a replay for a hand no longer under review", () => {
+    useTableStore.getState().openReview(2);
+    useTableStore.getState().receiveReplay(1, positions);
+    expect(useTableStore.getState().review?.status).toBe("loading");
+
+    useTableStore.getState().closeReview();
+    useTableStore.getState().receiveReplay(2, positions);
+    expect(useTableStore.getState().review).toBeNull();
+  });
+
+  it("marks a hand the server refused unavailable, and only while loading", () => {
+    useTableStore.getState().openReview(2);
+    useTableStore.getState().failReview();
+    expect(useTableStore.getState().review).toEqual({
+      status: "unavailable",
+      handOrdinal: 2,
+    });
+
+    useTableStore.getState().receiveReplay(2, positions);
+    useTableStore.getState().failReview();
+    expect(useTableStore.getState().review?.status).toBe("ready");
   });
 });

--- a/packages/table-client/src/store/store.ts
+++ b/packages/table-client/src/store/store.ts
@@ -9,13 +9,15 @@ import {
   type HandHistorySlice,
 } from "./handHistorySlice.js";
 import { createHandSlice, type HandSlice } from "./handSlice.js";
+import { createReplaySlice, type ReplaySlice } from "./replaySlice.js";
 import { createRoomSlice, type RoomSlice } from "./roomSlice.js";
 
 export type TableStore = ConnectionSlice &
   ConfigSlice &
   RoomSlice &
   HandSlice &
-  HandHistorySlice;
+  HandHistorySlice &
+  ReplaySlice;
 
 export const useTableStore = create<TableStore>()((...args) => ({
   ...createConnectionSlice(...args),
@@ -23,4 +25,5 @@ export const useTableStore = create<TableStore>()((...args) => ({
   ...createRoomSlice(...args),
   ...createHandSlice(...args),
   ...createHandHistorySlice(...args),
+  ...createReplaySlice(...args),
 }));

--- a/packages/table-client/src/ws/useWebSocket.ts
+++ b/packages/table-client/src/ws/useWebSocket.ts
@@ -1,4 +1,8 @@
-import type { ClientCommand, ServerMessage } from "@table-top-poker/protocol";
+import type {
+  ClientCommand,
+  ReplayRequest,
+  ServerMessage,
+} from "@table-top-poker/protocol";
 import {
   applyRoomSoundSettings,
   onHandUpdate,
@@ -12,7 +16,12 @@ export interface UseWebSocketOptions {
 }
 
 export interface TableSocket {
-  readonly send: (command: ClientCommand) => void;
+  /**
+   * A replay request rides the same socket as a command — the socket already
+   * carries room identity from connect time (Phase 2 spec #129 §5) — though
+   * the server parses the two at separate schemas.
+   */
+  readonly send: (message: ClientCommand | ReplayRequest) => void;
 }
 
 const RETRY_DELAY_MS = 1500;
@@ -31,6 +40,8 @@ export function useWebSocket(
   );
   const setHandList = useTableStore((state) => state.setHandList);
   const addHandSummary = useTableStore((state) => state.addHandSummary);
+  const receiveReplay = useTableStore((state) => state.receiveReplay);
+  const failReview = useTableStore((state) => state.failReview);
   const socketRef = useRef<WebSocket | null>(null);
   const optionsRef = useRef(options);
   optionsRef.current = options;
@@ -80,6 +91,13 @@ export function useWebSocket(
           setHandList(message.summaries);
         } else if (message.type === "hand-summary") {
           addHandSummary(message.summary);
+        } else if (message.type === "hand-replay") {
+          receiveReplay(message.handOrdinal, message.positions);
+        } else if (
+          message.type === "command-rejected" &&
+          message.reason === "hand-unavailable"
+        ) {
+          failReview();
         } else if (message.type === "room-ended") {
           optionsRef.current.onRoomEnded?.();
         } else if (message.type === "recording-stopped") {
@@ -104,10 +122,12 @@ export function useWebSocket(
     setRecordingStopped,
     setHandList,
     addHandSummary,
+    receiveReplay,
+    failReview,
   ]);
 
-  const send = useCallback((command: ClientCommand) => {
-    socketRef.current?.send(JSON.stringify(command));
+  const send = useCallback((message: ClientCommand | ReplayRequest) => {
+    socketRef.current?.send(JSON.stringify(message));
   }, []);
 
   return { send };


### PR DESCRIPTION
Closes #126. Tap a hand in the picker and watch it back on the felt — the tracer bullet through the whole read path.

Built against `replay`, per the ticket's build-branch note. Per-seat action labels, the caption strip's content and the status-bar hand label are #127; this reserves the band they fill.

## The read seam

`RecordingFileSystem` gains `readFile`, and one `readHandRecording` assembles a Hand's three files into the engine's `ReplayInput`. The harness's dev stepper now goes through it too, so the stepper and the table can never disagree about what a torn tail is. `Recordings.readHand` sits on the root rather than on `RoomRecording`, because a recording on disk outlives its writer — the hands recorded before **Continue without recording** stay replayable, and there's a test for exactly that.

## The server adapter

Reads that recording, runs the engine Replay capability, and projects every position through `view(state, "table")` into a protocol type that cannot hold an `EngineState`. Each position's Event goes through the same `redactEventFor` the live fan-out uses — lifted out of `app.ts` so there is one visibility boundary, not two — so the table gets an empty deal and never a seat's hole cards.

Only a `complete` replay is served, and the in-memory listing is checked first, so an ordinal the Room never saw complete is refused with `hand-unavailable`. `replay-not-supported` retires.

## The transport

The chaptered scrub settled on `prototype/replay-transport`: a track ticked once per Event ordinal with heavier street boundaries, street chapters anchored on each street's `BoardDealt` so the cards are *seen arriving*, a thumb draggable anywhere with the full track row as its grab zone, and autoplay demoted to a chip that stops the moment the track is pressed. Ticks collapse past a few hundred positions; chapters never do.

The felt is the live `Seats` and `Board` with no `replay` flag, laid out between reserved bands top and bottom so no pod clips the felt edge or overlaps the transport. Starting a hand force-dismisses the review with no confirmation.

## Review pass

A second commit takes the code-review findings: the heavy boundary tick and the chapter chip now share one `isStreetBoundary` flag (they were one ordinal apart), `Chapter`/`Scrub`/`Hand review` enter `CONTEXT.md`, and a few naming and duplication cleanups.

## Checks

Typecheck, `npm run lint`, and the full suite (115 files, 1214 tests) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HgMHcSE8Syimmso4FR4R2