### PR TITLE
feat(table): per-seat action labels and the caption strip

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -244,6 +244,23 @@ appeared and the viewer never sees them arrive. Chapters are the navigation
 contract; the per-position ticks beside them are a visual affordance that
 may collapse on an unusually long Hand.
 
+**Action label**:
+What a Seat has done on the Street now on the felt, carried in the same slot
+the live "To act" pill uses. Folded back out of the Event stream: the table
+view's Seats carry only `folded`, so the view at a position cannot supply
+them. Cleared at each new Street, on the same boundary a Chapter anchors to —
+once the Turn is out, "Seat 4 called" is about a Street nobody is looking at.
+Raise is orange rather than accent red, which belongs to the clock, and Call
+is the one cool fill on an otherwise warm felt.
+
+**Caption**:
+The beat the Scrub has landed on, named in a band of its own below the felt
+so it can never sit on a Seat pod. The Caption says what happened and the
+Scrub's track shows progress; between them no Event ordinal is ever on
+screen. Position-as-ordinal stays the addressing scheme, but `11 / 33` means
+nothing to someone at a poker table. Which Hand is under review belongs in
+the status bar instead, not to a second title floating over the felt.
+
 **Hand summary**:
 What one completed Hand looks like in a list of them — its ordinal and
 start time, the Button, the Seats dealt in and the Survivors, the public

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -252,10 +252,16 @@ them. Cleared at each new Street, on the same boundary a Chapter anchors to —
 once the Turn is out, "Seat 4 called" is about a Street nobody is looking at.
 Raise is orange rather than accent red, which belongs to the clock, and Call
 is the one cool fill on an otherwise warm felt.
+_Avoid_: Showing one beside a "To act" pill. They share a slot, and the
+clock wins it: a Seat facing a re-raise is on the clock, which is the more
+urgent of the two things to say about it.
 
 **Caption**:
 The beat the Scrub has landed on, named in a band of its own below the felt
-so it can never sit on a Seat pod. The Caption says what happened and the
+so it can never sit on a Seat pod. A bottom-row pod grows below its anchor
+and, on a felt short enough, reaches into that band anyway — the Caption is
+drawn under the felt, so what gives is the Caption and never the table. The
+Caption says what happened and the
 Scrub's track shows progress; between them no Event ordinal is ever on
 screen. Position-as-ordinal stays the addressing scheme, but `11 / 33` means
 nothing to someone at a poker table. Which Hand is under review belongs in

--- a/packages/table-client/src/App.review.test.tsx
+++ b/packages/table-client/src/App.review.test.tsx
@@ -86,7 +86,10 @@ const liveHand: TableView = {
 };
 
 interface Node {
-  readonly props: { readonly onClick?: () => void };
+  readonly props: {
+    readonly onClick?: () => void;
+    readonly children?: string;
+  };
 }
 
 interface Renderer {
@@ -213,5 +216,33 @@ describe("App hand review", () => {
     expect(found("replay-transport")).toHaveLength(1);
     expect(found("seats")).toHaveLength(1);
     expect(found("join-panel")).toHaveLength(0);
+  });
+
+  it("names the hand under review in the status bar, not over the felt", () => {
+    inRoom(completeHand);
+    useTableStore.setState({
+      review: {
+        status: "ready",
+        handOrdinal: 3,
+        positions: [{ event: null, view: { phase: "no-hand", button: 0 } }],
+      },
+    });
+
+    const renderer = render();
+    const badge = renderer.root.findByProps({
+      "data-testid": "reviewing-hand",
+    });
+
+    expect(badge.props.children).toContain("hand 3");
+  });
+
+  it("takes the name back down when the review closes", () => {
+    inRoom(completeHand);
+
+    const renderer = render();
+
+    expect(
+      renderer.root.findAllByProps({ "data-testid": "reviewing-hand" }),
+    ).toHaveLength(0);
   });
 });

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -7,7 +7,13 @@ import {
   type ShotClockSettings,
   type SoundSettings,
 } from "@table-top-poker/protocol";
-import { color, unlockAudio } from "@table-top-poker/ui-shared";
+import {
+  color,
+  font,
+  fontSize,
+  radius,
+  unlockAudio,
+} from "@table-top-poker/ui-shared";
 import { useCallback, useEffect, useState, type CSSProperties } from "react";
 import {
   changeSeatCount,
@@ -48,6 +54,37 @@ const feltSurfaceStyle: CSSProperties = {
   boxShadow:
     "inset 0 0 12em 4em rgba(0,0,0,.62), inset 0 2px 0 rgba(255,255,255,.08)",
 };
+
+/**
+ * Which hand is under review, in the bar the connection badge sits in. It
+ * belongs here rather than over the felt: a second title floating on the
+ * table is one more thing between a reader and the board (§6).
+ */
+function ReviewingHand({ handOrdinal }: { readonly handOrdinal: number }) {
+  return (
+    <span
+      data-testid="reviewing-hand"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "0.5em",
+        padding: "0.45em 0.9em",
+        borderRadius: radius.pill,
+        background: color.control,
+        border: `1px solid ${color.border}`,
+        fontFamily: font.mono,
+        fontSize: fontSize.xs,
+        fontWeight: 600,
+        letterSpacing: "0.16em",
+        textTransform: "uppercase",
+        color: color.textMuted,
+        whiteSpace: "nowrap",
+      }}
+    >
+      {`Reviewing hand ${String(handOrdinal)}`}
+    </span>
+  );
+}
 
 export function App() {
   const roomCode = useTableStore((state) => state.roomCode);
@@ -231,6 +268,11 @@ export function App() {
         connectionStatus={connectionStatus}
         showRoomCode={handInProgress && !joinOpen}
         onOpenJoin={toggleJoin}
+        leading={
+          review === null ? undefined : (
+            <ReviewingHand handOrdinal={review.handOrdinal} />
+          )
+        }
       />
       {recordingStopped && <NotRecordingBanner />}
       <main className="felt">

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -55,11 +55,7 @@ const feltSurfaceStyle: CSSProperties = {
     "inset 0 0 12em 4em rgba(0,0,0,.62), inset 0 2px 0 rgba(255,255,255,.08)",
 };
 
-/**
- * Which hand is under review, in the bar the connection badge sits in. It
- * belongs here rather than over the felt: a second title floating on the
- * table is one more thing between a reader and the board (§6).
- */
+/** Which hand is under review — see Caption in `CONTEXT.md`. */
 function ReviewingHand({ handOrdinal }: { readonly handOrdinal: number }) {
   return (
     <span

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -776,11 +776,11 @@ describe("Seats: action labels", () => {
     expect(html).toMatch(
       /data-testid="seat-pod-3-action"[^>]*data-action="raise"/,
     );
-    expect(html).toContain("Raised");
+    expect(html).toContain("raised");
     expect(html).toMatch(
       /data-testid="seat-pod-1-action"[^>]*data-action="call"/,
     );
-    expect(html).toContain("Called");
+    expect(html).toContain("called");
   });
 
   it("leaves the seats that have not acted bare", () => {

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -1,4 +1,5 @@
 import type { SeatView, TableView } from "@table-top-poker/protocol";
+import { color } from "@table-top-poker/ui-shared";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
@@ -758,5 +759,81 @@ describe("Seats: position markers", () => {
 
     const fontSizes = html.match(/font-size:0\.62em/g);
     expect(fontSizes).toHaveLength(3);
+  });
+});
+
+describe("Seats: action labels", () => {
+  const labels = new Map<number, "fold" | "check" | "call" | "raise">([
+    [3, "raise"],
+    [1, "call"],
+  ]);
+
+  it("shows a pill for each seat that has acted", () => {
+    const html = renderToStaticMarkup(
+      <Seats seats={seats} view={threeHanded} actionLabels={labels} />,
+    );
+
+    expect(html).toMatch(
+      /data-testid="seat-pod-3-action"[^>]*data-action="raise"/,
+    );
+    expect(html).toContain("Raised");
+    expect(html).toMatch(
+      /data-testid="seat-pod-1-action"[^>]*data-action="call"/,
+    );
+    expect(html).toContain("Called");
+  });
+
+  it("leaves the seats that have not acted bare", () => {
+    const html = renderToStaticMarkup(
+      <Seats seats={seats} view={threeHanded} actionLabels={labels} />,
+    );
+
+    expect(html).not.toContain('data-testid="seat-pod-2-action"');
+  });
+
+  it("yields the slot to the seat on the clock", () => {
+    const html = renderToStaticMarkup(
+      <Seats
+        seats={seats}
+        view={threeHanded}
+        actionLabels={new Map([[0, "call" as const]])}
+      />,
+    );
+
+    expect(html).toContain('data-testid="seat-pod-0-to-act"');
+    expect(html).not.toContain('data-testid="seat-pod-0-action"');
+  });
+
+  it("keeps accent red for the clock alone, and paints raise orange", () => {
+    const html = renderToStaticMarkup(
+      <Seats seats={seats} view={threeHanded} actionLabels={labels} />,
+    );
+
+    const raise = styleOf(html, "seat-pod-3-action") ?? "";
+    const toAct = styleOf(html, "seat-pod-0-to-act") ?? "";
+
+    expect(raise).not.toBe("");
+    expect(toAct).toContain(color.accent);
+    expect(raise).not.toContain(color.accent);
+    expect(raise).toContain(color.actionRaise);
+  });
+
+  it("gives call the one cool fill on a warm felt", () => {
+    const html = renderToStaticMarkup(
+      <Seats seats={seats} view={threeHanded} actionLabels={labels} />,
+    );
+
+    const call = styleOf(html, "seat-pod-1-action") ?? "";
+
+    expect(call).toContain(color.actionCall);
+    expect(call).not.toContain(color.actionRaise);
+  });
+
+  it("flips a top-row pill with its pod", () => {
+    const html = renderToStaticMarkup(
+      <Seats seats={seats} view={threeHanded} actionLabels={labels} />,
+    );
+
+    expect(styleOf(html, "seat-pod-3-action")).toContain("rotate(180deg)");
   });
 });

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -1,4 +1,8 @@
-import type { SeatView, TableView } from "@table-top-poker/protocol";
+import type {
+  ActionType,
+  SeatView,
+  TableView,
+} from "@table-top-poker/protocol";
 import {
   color,
   font,
@@ -17,7 +21,56 @@ export interface SeatsProps {
   readonly view: TableView | null;
   readonly shotClockSeconds?: number;
   readonly onSeatClick?: (seatId: number) => void;
+  /**
+   * What each seat has done this street, for the seats that have acted. The
+   * view carries only `folded`, so this is folded back out of the Event
+   * stream by whoever has one (#127).
+   */
+  readonly actionLabels?: ReadonlyMap<number, ActionType>;
 }
+
+/** The slot below a pod that the clock and the action label share. */
+const slotPillStyle = {
+  padding: "0.35em 0.9em",
+  borderRadius: "999px",
+  fontFamily: font.mono,
+  fontSize: "0.7em",
+  fontWeight: 700,
+  letterSpacing: "0.2em",
+  textTransform: "uppercase",
+  whiteSpace: "nowrap",
+};
+
+function slotMotion(flipDegrees: number) {
+  return {
+    initial: { opacity: 0, y: 6, scale: 0.9, rotate: flipDegrees },
+    animate: { opacity: 1, y: 0, scale: 1, rotate: flipDegrees },
+    exit: { opacity: 0, y: 6, scale: 0.9, rotate: flipDegrees },
+    transition: { duration: 0.2 },
+  };
+}
+
+const actionText: Record<ActionType, string> = {
+  fold: "Folded",
+  check: "Checked",
+  call: "Called",
+  raise: "Raised",
+};
+
+/**
+ * Accent red is the clock's — the "To act" pill and the seat-pod glow — so
+ * raise takes orange instead, and call is the one cool fill on a warm felt
+ * (Phase 2 spec #129 §6).
+ */
+const actionTone: Record<
+  ActionType,
+  { readonly background: string; readonly ink: string }
+> = {
+  fold: { background: color.actionPassive, ink: color.textDim },
+  check: { background: color.actionPassive, ink: color.textMuted },
+  call: { background: color.actionCall, ink: "#fff" },
+  raise: { background: color.actionRaise, ink: color.pillInk },
+};
 
 type SeatStatus =
   "open" | "sitting-out" | "disconnected" | "folded" | "in-hand";
@@ -106,11 +159,13 @@ export function Seats({
   view,
   shotClockSeconds = 90,
   onSeatClick,
+  actionLabels,
 }: SeatsProps) {
   return (
     <div data-testid="seats" style={{ position: "absolute", inset: 0 }}>
       {seats.map((seat) => {
         const visual = deriveSeat(seat, view);
+        const acted = visual.isActor ? undefined : actionLabels?.get(seat.id);
         const pos = posFor(seat.id, seats.length);
         const isTopRow = pos.top < 50;
         const flipDegrees = isTopRow ? 180 : 0;
@@ -385,35 +440,36 @@ export function Seats({
               {podContent}
             </motion.div>
             <AnimatePresence>
-              {visual.isActor && (
+              {visual.isActor ? (
                 <motion.div
+                  key="to-act"
                   data-testid={`seat-pod-${String(seat.id)}-to-act`}
                   data-flipped={isTopRow}
-                  initial={{
-                    opacity: 0,
-                    y: 6,
-                    scale: 0.9,
-                    rotate: flipDegrees,
-                  }}
-                  animate={{ opacity: 1, y: 0, scale: 1, rotate: flipDegrees }}
-                  exit={{ opacity: 0, y: 6, scale: 0.9, rotate: flipDegrees }}
-                  transition={{ duration: 0.2 }}
+                  {...slotMotion(flipDegrees)}
                   style={{
-                    padding: "0.35em 0.9em",
-                    borderRadius: "999px",
+                    ...slotPillStyle,
                     background: color.accent,
                     color: "#fff",
-                    fontFamily: font.mono,
-                    fontSize: "0.7em",
-                    fontWeight: 700,
-                    letterSpacing: "0.2em",
-                    textTransform: "uppercase",
-                    whiteSpace: "nowrap",
                   }}
                 >
                   To act
                 </motion.div>
-              )}
+              ) : acted !== undefined ? (
+                <motion.div
+                  key="acted"
+                  data-testid={`seat-pod-${String(seat.id)}-action`}
+                  data-action={acted}
+                  data-flipped={isTopRow}
+                  {...slotMotion(flipDegrees)}
+                  style={{
+                    ...slotPillStyle,
+                    background: actionTone[acted].background,
+                    color: actionTone[acted].ink,
+                  }}
+                >
+                  {actionText[acted]}
+                </motion.div>
+              ) : null}
             </AnimatePresence>
             {seat.disconnected && (
               <span

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -14,6 +14,7 @@ import {
   type PositionMarker,
 } from "@table-top-poker/ui-shared";
 import { AnimatePresence, motion } from "motion/react";
+import { actionVerb, type SeatActionLabels } from "./actionWords.js";
 import { posFor } from "./table/posFor.js";
 
 export interface SeatsProps {
@@ -21,15 +22,9 @@ export interface SeatsProps {
   readonly view: TableView | null;
   readonly shotClockSeconds?: number;
   readonly onSeatClick?: (seatId: number) => void;
-  /**
-   * What each seat has done this street, for the seats that have acted. The
-   * view carries only `folded`, so this is folded back out of the Event
-   * stream by whoever has one (#127).
-   */
-  readonly actionLabels?: ReadonlyMap<number, ActionType>;
+  readonly actionLabels?: SeatActionLabels;
 }
 
-/** The slot below a pod that the clock and the action label share. */
 const slotPillStyle = {
   padding: "0.35em 0.9em",
   borderRadius: "999px",
@@ -50,18 +45,7 @@ function slotMotion(flipDegrees: number) {
   };
 }
 
-const actionText: Record<ActionType, string> = {
-  fold: "Folded",
-  check: "Checked",
-  call: "Called",
-  raise: "Raised",
-};
-
-/**
- * Accent red is the clock's — the "To act" pill and the seat-pod glow — so
- * raise takes orange instead, and call is the one cool fill on a warm felt
- * (Phase 2 spec #129 §6).
- */
+/** See Action label in `CONTEXT.md` for why raise is not accent red. */
 const actionTone: Record<
   ActionType,
   { readonly background: string; readonly ink: string }
@@ -467,7 +451,7 @@ export function Seats({
                     color: actionTone[acted].ink,
                   }}
                 >
-                  {actionText[acted]}
+                  {actionVerb[acted]}
                 </motion.div>
               ) : null}
             </AnimatePresence>

--- a/packages/table-client/src/actionWords.ts
+++ b/packages/table-client/src/actionWords.ts
@@ -1,0 +1,12 @@
+import type { ActionType, SeatId } from "@table-top-poker/protocol";
+
+/** See Action label in `CONTEXT.md`. */
+export type SeatActionLabels = ReadonlyMap<SeatId, ActionType>;
+
+/** Past tense, so one word serves both a seat's pill and the Caption. */
+export const actionVerb: Record<ActionType, string> = {
+  fold: "folded",
+  check: "checked",
+  call: "called",
+  raise: "raised",
+};

--- a/packages/table-client/src/replay/CaptionStrip.test.tsx
+++ b/packages/table-client/src/replay/CaptionStrip.test.tsx
@@ -1,0 +1,41 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import {
+  CAPTION_BAND,
+  CAPTION_LAYER,
+  CaptionStrip,
+  FELT_LAYER,
+} from "./CaptionStrip.js";
+
+const TRANSPORT = 10.2;
+
+describe("CaptionStrip", () => {
+  it("names the beat in a band of its own, above the transport", () => {
+    const html = renderToStaticMarkup(
+      <CaptionStrip caption="The turn" transportHeight={TRANSPORT} />,
+    );
+    const style =
+      /data-testid="replay-caption"[^>]*style="([^"]*)"/.exec(html)?.[1] ?? "";
+
+    expect(html).toContain("The turn");
+    expect(style).toContain(`bottom:${String(TRANSPORT)}em`);
+    expect(style).toContain(`height:${String(CAPTION_BAND)}em`);
+  });
+
+  it("renders an empty band when there is no beat to name", () => {
+    const html = renderToStaticMarkup(
+      <CaptionStrip caption={null} transportHeight={TRANSPORT} />,
+    );
+
+    expect(html).toContain('data-testid="replay-caption"');
+  });
+
+  it("gives way to a pod that reaches into its band, never over it", () => {
+    const html = renderToStaticMarkup(
+      <CaptionStrip caption="The turn" transportHeight={TRANSPORT} />,
+    );
+
+    expect(html).toContain(`z-index:${String(CAPTION_LAYER)}`);
+    expect(CAPTION_LAYER).toBeLessThan(FELT_LAYER);
+  });
+});

--- a/packages/table-client/src/replay/CaptionStrip.tsx
+++ b/packages/table-client/src/replay/CaptionStrip.tsx
@@ -6,13 +6,17 @@ export interface CaptionStripProps {
   readonly transportHeight: number;
 }
 
-/**
- * The band the caption owns. The strip has a band of its own so it can never
- * sit on a seat pod, and `ReplayStage` lays the felt out above it (§6).
- */
+/** The band the Caption owns, which `ReplayStage` lays the felt out above. */
 export const CAPTION_BAND = 2.4;
 
-/** What just happened, in the language of a poker table rather than ordinals. */
+/**
+ * A bottom-row pod grows below its anchor, so on a short felt it can reach
+ * into this band. The strip stays under the felt layer, so what gives is the
+ * caption rather than the table. See Caption in `CONTEXT.md`.
+ */
+export const CAPTION_LAYER = 0;
+export const FELT_LAYER = 1;
+
 export function CaptionStrip({ caption, transportHeight }: CaptionStripProps) {
   return (
     <div
@@ -23,6 +27,7 @@ export function CaptionStrip({ caption, transportHeight }: CaptionStripProps) {
         right: "1.8em",
         bottom: `${String(transportHeight)}em`,
         height: `${String(CAPTION_BAND)}em`,
+        zIndex: CAPTION_LAYER,
         display: "flex",
         alignItems: "center",
         justifyContent: "center",

--- a/packages/table-client/src/replay/CaptionStrip.tsx
+++ b/packages/table-client/src/replay/CaptionStrip.tsx
@@ -1,0 +1,42 @@
+import { color, font, fontSize } from "@table-top-poker/ui-shared";
+
+export interface CaptionStripProps {
+  readonly caption: string | null;
+  /** Height in `em` of the transport chrome the strip sits above. */
+  readonly transportHeight: number;
+}
+
+/**
+ * The band the caption owns. The strip has a band of its own so it can never
+ * sit on a seat pod, and `ReplayStage` lays the felt out above it (§6).
+ */
+export const CAPTION_BAND = 2.4;
+
+/** What just happened, in the language of a poker table rather than ordinals. */
+export function CaptionStrip({ caption, transportHeight }: CaptionStripProps) {
+  return (
+    <div
+      data-testid="replay-caption"
+      style={{
+        position: "absolute",
+        left: "1.8em",
+        right: "1.8em",
+        bottom: `${String(transportHeight)}em`,
+        height: `${String(CAPTION_BAND)}em`,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontFamily: font.mono,
+        fontSize: fontSize.sm,
+        letterSpacing: "0.08em",
+        color: color.textMuted,
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+        pointerEvents: "none",
+      }}
+    >
+      {caption}
+    </div>
+  );
+}

--- a/packages/table-client/src/replay/HandReview.test.tsx
+++ b/packages/table-client/src/replay/HandReview.test.tsx
@@ -11,8 +11,10 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { act, create } from "react-test-renderer";
 import { describe, expect, it, vi } from "vitest";
 import type { HandReviewState } from "../store/replaySlice.js";
+import { CAPTION_BAND } from "./CaptionStrip.js";
 import { HandReview } from "./HandReview.js";
 import type { ReplayStageProps } from "./ReplayStage.js";
+import { TRANSPORT_HEIGHT } from "./ReplayTransport.js";
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -22,14 +24,19 @@ const stagedView = vi.hoisted((): { current: TableView | null } => ({
   current: null,
 }));
 
+const stagedLabels = vi.hoisted(
+  (): { current: ReadonlyMap<number, string> | null } => ({ current: null }),
+);
+
 /**
  * The felt is the live `Seats` and `Board`; what matters here is *which*
- * projected view they are handed at a position, so the stage is stood in for
- * and the view it received is read back.
+ * projected view and labels they are handed at a position, so the stage is
+ * stood in for and what it received is read back.
  */
 vi.mock("./ReplayStage.js", () => ({
   ReplayStage: (props: ReplayStageProps) => {
     stagedView.current = props.view;
+    stagedLabels.current = props.actionLabels;
     return React.createElement("div", { "data-testid": "replay-stage" });
   },
 }));
@@ -119,6 +126,7 @@ interface Node {
   readonly props: {
     readonly onClick?: () => void;
     readonly onPointerDown?: (event: { readonly clientX: number }) => void;
+    readonly children?: string;
   };
 }
 
@@ -136,6 +144,43 @@ function render(review: HandReviewState = ready): Renderer {
     );
   });
   return renderer;
+}
+
+const TRACK_WIDTH = 100;
+
+/**
+ * A review whose track has been given a width, so a press lands on the
+ * ordinal under it rather than being ignored for want of a layout.
+ */
+function renderScrubbable(): Renderer {
+  let renderer!: Renderer;
+  act(() => {
+    renderer = create(
+      <HandReview review={ready} seats={seats} onClose={() => undefined} />,
+      {
+        createNodeMock: () => ({
+          getBoundingClientRect: () => ({ left: 0, width: TRACK_WIDTH }),
+        }),
+      },
+    );
+  });
+  return renderer;
+}
+
+/** Drags the thumb to one ordinal, the way a finger on the track would. */
+function seek(renderer: Renderer, position: number): void {
+  act(() => {
+    renderer.root
+      .findByProps({ "data-testid": "replay-track" })
+      .props.onPointerDown?.({
+        clientX: (position / events.length) * TRACK_WIDTH,
+      });
+  });
+}
+
+function captionOf(renderer: Renderer): string | undefined {
+  return renderer.root.findByProps({ "data-testid": "replay-caption" }).props
+    .children;
 }
 
 function click(renderer: Renderer, testId: string): void {
@@ -265,5 +310,64 @@ describe("HandReview", () => {
     expect(loading).toContain("Loading the hand");
     expect(unavailable).toContain("can&#x27;t be replayed");
     expect(unavailable).toContain('data-testid="back-to-hands-button"');
+  });
+});
+
+describe("HandReview: the caption strip", () => {
+  it("names the beat the scrub has landed on", () => {
+    const renderer = render();
+
+    click(renderer, "replay-chapter-flop");
+
+    expect(captionOf(renderer)).toBe("The flop");
+  });
+
+  it("has nothing to name before the first event", () => {
+    const html = renderToStaticMarkup(
+      <HandReview review={ready} seats={seats} onClose={() => undefined} />,
+    );
+
+    expect(html).toContain('data-testid="replay-caption"');
+    expect(html).not.toContain("Hand begins");
+  });
+
+  it("keeps its own band, clear of the transport below it", () => {
+    const html = renderToStaticMarkup(
+      <HandReview review={ready} seats={seats} onClose={() => undefined} />,
+    );
+    const style =
+      /data-testid="replay-caption"[^>]*style="([^"]*)"/.exec(html)?.[1] ?? "";
+
+    expect(style).toContain(`bottom:${String(TRANSPORT_HEIGHT)}em`);
+    expect(style).toContain(`height:${String(CAPTION_BAND)}em`);
+  });
+
+  it("shows no Event ordinal anywhere on screen", () => {
+    const html = renderToStaticMarkup(
+      <HandReview review={ready} seats={seats} onClose={() => undefined} />,
+    );
+    const onScreen = html.replaceAll(/<[^>]*>/g, " ");
+
+    expect(onScreen).not.toMatch(/\d+\s*\/\s*\d+/);
+  });
+});
+
+describe("HandReview: per-seat action labels", () => {
+  it("hands the felt what each seat has done this street", () => {
+    const renderer = renderScrubbable();
+
+    seek(renderer, 4);
+
+    expect([...(stagedLabels.current?.entries() ?? [])]).toEqual([
+      [1, "check"],
+    ]);
+  });
+
+  it("clears them once the next street's cards are out", () => {
+    const renderer = render();
+
+    click(renderer, "replay-chapter-flop");
+
+    expect(stagedLabels.current?.size).toBe(0);
   });
 });

--- a/packages/table-client/src/replay/HandReview.tsx
+++ b/packages/table-client/src/replay/HandReview.tsx
@@ -29,6 +29,11 @@ export function HandReview({ review, seats, onClose }: HandReviewProps) {
   const [playing, setPlaying] = useState(false);
   const [scrubbing, setScrubbing] = useState(false);
 
+  const labels = useMemo(
+    () => actionLabelsAt(positions, position),
+    [positions, position],
+  );
+
   useEffect(() => {
     setPosition(0);
     setPlaying(false);
@@ -89,6 +94,7 @@ export function HandReview({ review, seats, onClose }: HandReviewProps) {
   }
 
   const view = positions[position]?.view ?? positions[0]?.view;
+  const event = positions[position]?.event ?? null;
 
   return (
     <>
@@ -97,12 +103,12 @@ export function HandReview({ review, seats, onClose }: HandReviewProps) {
           view={view}
           seats={seats}
           transportHeight={TRANSPORT_HEIGHT}
-          actionLabels={actionLabelsAt(positions, position)}
+          actionLabels={labels}
         />
       )}
       <BackToHands onClose={onClose} />
       <CaptionStrip
-        caption={captionFor(positions[position]?.event ?? null, seats)}
+        caption={captionFor(event, seats)}
         transportHeight={TRANSPORT_HEIGHT}
       />
       <ReplayTransport

--- a/packages/table-client/src/replay/HandReview.tsx
+++ b/packages/table-client/src/replay/HandReview.tsx
@@ -2,7 +2,10 @@ import type { SeatView } from "@table-top-poker/protocol";
 import { color, font, fontSize } from "@table-top-poker/ui-shared";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { HandReviewState } from "../store/replaySlice.js";
+import { actionLabelsAt } from "./actionLabels.js";
 import { beatAt, chaptersOf, holdAt, toBeats } from "./beats.js";
+import { captionFor } from "./caption.js";
+import { CaptionStrip } from "./CaptionStrip.js";
 import { ReplayStage } from "./ReplayStage.js";
 import { ReplayTransport, TRANSPORT_HEIGHT } from "./ReplayTransport.js";
 
@@ -94,9 +97,14 @@ export function HandReview({ review, seats, onClose }: HandReviewProps) {
           view={view}
           seats={seats}
           transportHeight={TRANSPORT_HEIGHT}
+          actionLabels={actionLabelsAt(positions, position)}
         />
       )}
       <BackToHands onClose={onClose} />
+      <CaptionStrip
+        caption={captionFor(positions[position]?.event ?? null, seats)}
+        transportHeight={TRANSPORT_HEIGHT}
+      />
       <ReplayTransport
         beats={beats}
         chapters={chapters}

--- a/packages/table-client/src/replay/ReplayStage.test.tsx
+++ b/packages/table-client/src/replay/ReplayStage.test.tsx
@@ -2,7 +2,7 @@ import type { SeatView, TableView } from "@table-top-poker/protocol";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { CAPTION_BAND } from "./CaptionStrip.js";
+import { CAPTION_BAND, FELT_LAYER } from "./CaptionStrip.js";
 import { ReplayStage, TOP_BAND } from "./ReplayStage.js";
 
 const seats: readonly SeatView[] = [0, 1, 2, 3].map((id) => ({
@@ -45,6 +45,7 @@ describe("ReplayStage", () => {
 
     expect(html).toContain(`top:${String(TOP_BAND)}em`);
     expect(html).toContain(`bottom:${String(TRANSPORT + CAPTION_BAND)}em`);
+    expect(html).toContain(`z-index:${String(FELT_LAYER)}`);
   });
 
   it("renders the felt through the live Seats and Board, projected", () => {

--- a/packages/table-client/src/replay/ReplayStage.test.tsx
+++ b/packages/table-client/src/replay/ReplayStage.test.tsx
@@ -2,7 +2,8 @@ import type { SeatView, TableView } from "@table-top-poker/protocol";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { CAPTION_BAND, ReplayStage, TOP_BAND } from "./ReplayStage.js";
+import { CAPTION_BAND } from "./CaptionStrip.js";
+import { ReplayStage, TOP_BAND } from "./ReplayStage.js";
 
 const seats: readonly SeatView[] = [0, 1, 2, 3].map((id) => ({
   id,
@@ -34,7 +35,12 @@ const TRANSPORT = 10.2;
 describe("ReplayStage", () => {
   it("lays the table out between reserved bands, clear of the transport", () => {
     const html = renderToStaticMarkup(
-      <ReplayStage view={view} seats={seats} transportHeight={TRANSPORT} />,
+      <ReplayStage
+        view={view}
+        seats={seats}
+        transportHeight={TRANSPORT}
+        actionLabels={new Map()}
+      />,
     );
 
     expect(html).toContain(`top:${String(TOP_BAND)}em`);
@@ -43,7 +49,12 @@ describe("ReplayStage", () => {
 
   it("renders the felt through the live Seats and Board, projected", () => {
     const html = renderToStaticMarkup(
-      <ReplayStage view={view} seats={seats} transportHeight={TRANSPORT} />,
+      <ReplayStage
+        view={view}
+        seats={seats}
+        transportHeight={TRANSPORT}
+        actionLabels={new Map()}
+      />,
     );
 
     expect(html).toContain('data-testid="seats"');

--- a/packages/table-client/src/replay/ReplayStage.tsx
+++ b/packages/table-client/src/replay/ReplayStage.tsx
@@ -1,8 +1,8 @@
 import type { SeatView, TableView } from "@table-top-poker/protocol";
 import { Board } from "../Board.js";
 import { Seats } from "../Seats.js";
-import type { SeatActionLabels } from "./actionLabels.js";
-import { CAPTION_BAND } from "./CaptionStrip.js";
+import type { SeatActionLabels } from "../actionWords.js";
+import { CAPTION_BAND, FELT_LAYER } from "./CaptionStrip.js";
 
 export interface ReplayStageProps {
   readonly view: TableView;
@@ -43,6 +43,7 @@ export function ReplayStage({
         left: 0,
         right: 0,
         bottom: `${String(transportHeight + CAPTION_BAND)}em`,
+        zIndex: FELT_LAYER,
       }}
     >
       <Seats seats={seats} view={view} actionLabels={actionLabels} />

--- a/packages/table-client/src/replay/ReplayStage.tsx
+++ b/packages/table-client/src/replay/ReplayStage.tsx
@@ -1,20 +1,16 @@
 import type { SeatView, TableView } from "@table-top-poker/protocol";
 import { Board } from "../Board.js";
 import { Seats } from "../Seats.js";
+import type { SeatActionLabels } from "./actionLabels.js";
+import { CAPTION_BAND } from "./CaptionStrip.js";
 
 export interface ReplayStageProps {
   readonly view: TableView;
   readonly seats: readonly SeatView[];
   /** Height in `em` of the transport chrome drawn along the bottom. */
   readonly transportHeight: number;
+  readonly actionLabels: SeatActionLabels;
 }
-
-/**
- * The strip below the felt the caption claims (#127). Reserved here because
- * the band is what keeps the bottom seat row clear of the transport, not
- * because this component draws anything in it.
- */
-export const CAPTION_BAND = 2.4;
 
 /**
  * A seat pod is anchored by its avatar and grows *around* that anchor, so a
@@ -36,6 +32,7 @@ export function ReplayStage({
   view,
   seats,
   transportHeight,
+  actionLabels,
 }: ReplayStageProps) {
   return (
     <div
@@ -48,7 +45,7 @@ export function ReplayStage({
         bottom: `${String(transportHeight + CAPTION_BAND)}em`,
       }}
     >
-      <Seats seats={seats} view={view} />
+      <Seats seats={seats} view={view} actionLabels={actionLabels} />
       <div
         style={{
           position: "absolute",

--- a/packages/table-client/src/replay/actionLabels.test.ts
+++ b/packages/table-client/src/replay/actionLabels.test.ts
@@ -1,0 +1,97 @@
+import type {
+  Card,
+  HandEvent,
+  TableReplayPosition,
+} from "@table-top-poker/protocol";
+import { describe, expect, it } from "vitest";
+import { actionLabelsAt } from "./actionLabels.js";
+
+const noHand = { phase: "no-hand", button: 0 } as const;
+
+function positionsFor(
+  events: readonly HandEvent[],
+): readonly TableReplayPosition[] {
+  return [
+    { event: null, view: noHand },
+    ...events.map((event) => ({ event, view: noHand })),
+  ];
+}
+
+const card = (rank: Card["rank"]): Card => ({ rank, suit: "clubs" });
+
+/** The engine's own cascade order: close, deal, start. */
+function streetCascade(street: "flop" | "turn" | "river"): HandEvent[] {
+  const previous = { flop: "preflop", turn: "flop", river: "turn" } as const;
+  return [
+    { type: "StreetClosed", street: previous[street] },
+    { type: "BoardDealt", street, cards: [card("2")] },
+    { type: "StreetStarted", street, actor: 1 },
+  ];
+}
+
+const preflop: readonly HandEvent[] = [
+  { type: "HandStarted", seed: "s", button: 0 },
+  { type: "HoleCardsDealt", deals: [] },
+  { type: "StreetStarted", street: "preflop", actor: 1 },
+  { type: "ActionTaken", seatId: 1, action: "call" },
+  { type: "ActionTaken", seatId: 2, action: "raise" },
+  { type: "ActionTaken", seatId: 0, action: "fold" },
+];
+
+const intoTheFlop: readonly HandEvent[] = [
+  ...preflop,
+  ...streetCascade("flop"),
+  { type: "ActionTaken", seatId: 1, action: "check" },
+];
+
+describe("actionLabelsAt", () => {
+  it("has nothing to say before the first event", () => {
+    expect(actionLabelsAt(positionsFor(preflop), 0).size).toBe(0);
+  });
+
+  it("labels every seat that has acted this street", () => {
+    const labels = actionLabelsAt(positionsFor(preflop), preflop.length);
+
+    expect(labels.get(1)).toBe("call");
+    expect(labels.get(2)).toBe("raise");
+    expect(labels.get(0)).toBe("fold");
+  });
+
+  it("labels only the seats that have acted by this position", () => {
+    const labels = actionLabelsAt(positionsFor(preflop), 4);
+
+    expect(labels.get(1)).toBe("call");
+    expect(labels.has(2)).toBe(false);
+  });
+
+  it("carries a seat's latest action, not its first", () => {
+    const reraised = positionsFor([
+      ...preflop,
+      { type: "ActionTaken", seatId: 1, action: "raise" },
+    ]);
+
+    expect(actionLabelsAt(reraised, preflop.length + 1).get(1)).toBe("raise");
+  });
+
+  it("clears every label once the next street's cards are out", () => {
+    const positions = positionsFor(intoTheFlop);
+    const boardDealt = preflop.length + 2;
+
+    expect(actionLabelsAt(positions, boardDealt).size).toBe(0);
+  });
+
+  it("starts the new street's labels from the seats acting on it", () => {
+    const labels = actionLabelsAt(
+      positionsFor(intoTheFlop),
+      intoTheFlop.length,
+    );
+
+    expect([...labels.entries()]).toEqual([[1, "check"]]);
+  });
+
+  it("survives a position past the end of the hand", () => {
+    const labels = actionLabelsAt(positionsFor(preflop), 99);
+
+    expect(labels.get(1)).toBe("call");
+  });
+});

--- a/packages/table-client/src/replay/actionLabels.ts
+++ b/packages/table-client/src/replay/actionLabels.ts
@@ -1,0 +1,34 @@
+import type {
+  ActionType,
+  SeatId,
+  Street,
+  TableReplayPosition,
+} from "@table-top-poker/protocol";
+import { streetOf } from "./beats.js";
+
+/** What each seat has done on the street now on the felt. */
+export type SeatActionLabels = ReadonlyMap<SeatId, ActionType>;
+
+/**
+ * The seats' actions folded back out of the Event stream: `TableViewBetting`
+ * carries only `folded`, so the view at a position cannot say who called
+ * (Phase 2 spec #129 §6). Labels clear on the same street change the Chapters
+ * anchor to, which is the street's `BoardDealt` — once the turn is out, "Seat
+ * 4 called" is about a street nobody is looking at.
+ */
+export function actionLabelsAt(
+  positions: readonly TableReplayPosition[],
+  position: number,
+): SeatActionLabels {
+  const labels = new Map<SeatId, ActionType>();
+  let street: Street | null = null;
+
+  for (const { event } of positions.slice(1, position + 1)) {
+    if (event === null) continue;
+    const next = streetOf(event, street);
+    if (next !== street) labels.clear();
+    street = next;
+    if (event.type === "ActionTaken") labels.set(event.seatId, event.action);
+  }
+  return labels;
+}

--- a/packages/table-client/src/replay/actionLabels.ts
+++ b/packages/table-client/src/replay/actionLabels.ts
@@ -4,18 +4,10 @@ import type {
   Street,
   TableReplayPosition,
 } from "@table-top-poker/protocol";
+import type { SeatActionLabels } from "../actionWords.js";
 import { streetOf } from "./beats.js";
 
-/** What each seat has done on the street now on the felt. */
-export type SeatActionLabels = ReadonlyMap<SeatId, ActionType>;
-
-/**
- * The seats' actions folded back out of the Event stream: `TableViewBetting`
- * carries only `folded`, so the view at a position cannot say who called
- * (Phase 2 spec #129 §6). Labels clear on the same street change the Chapters
- * anchor to, which is the street's `BoardDealt` — once the turn is out, "Seat
- * 4 called" is about a street nobody is looking at.
- */
+/** The Action labels at one position — see Action label in `CONTEXT.md`. */
 export function actionLabelsAt(
   positions: readonly TableReplayPosition[],
   position: number,

--- a/packages/table-client/src/replay/beats.ts
+++ b/packages/table-client/src/replay/beats.ts
@@ -22,7 +22,7 @@ export interface Beat {
   readonly isStreetBoundary: boolean;
 }
 
-const streetLabel: Record<Street, string> = {
+export const streetLabel: Record<Street, string> = {
   preflop: "Preflop",
   flop: "Flop",
   turn: "Turn",
@@ -46,7 +46,10 @@ const WEIGHTS: Record<HandEvent["type"], number> = {
 };
 
 /** A beat belongs to the street it *shows* — see Chapter in `CONTEXT.md`. */
-function streetOf(event: HandEvent, current: Street | null): Street | null {
+export function streetOf(
+  event: HandEvent,
+  current: Street | null,
+): Street | null {
   if (event.type === "StreetStarted" || event.type === "BoardDealt") {
     return event.street;
   }

--- a/packages/table-client/src/replay/caption.test.ts
+++ b/packages/table-client/src/replay/caption.test.ts
@@ -1,0 +1,113 @@
+import type { Card, HandEvent, SeatView } from "@table-top-poker/protocol";
+import { describe, expect, it } from "vitest";
+import { captionFor } from "./caption.js";
+
+const seats: readonly SeatView[] = [0, 1, 2].map((id) => ({
+  id,
+  claimed: true,
+  sittingOut: false,
+  sittingOutReason: null,
+  disconnected: false,
+}));
+
+const named: readonly SeatView[] = seats.map((seat) =>
+  seat.id === 1 ? { ...seat, displayName: "Ada" } : seat,
+);
+
+const card = (rank: Card["rank"]): Card => ({ rank, suit: "clubs" });
+
+const showdown = (winners: number[]): HandEvent => ({
+  type: "ShowdownReached",
+  winners,
+  results: [0, 1].map((seatId) => ({
+    seatId,
+    rank: 1,
+    bestHand: [card("2"), card("3"), card("4"), card("5"), card("6")],
+    description: "a straight",
+  })),
+});
+
+describe("captionFor", () => {
+  it("says nothing at the position before the first event", () => {
+    expect(captionFor(null, seats)).toBeNull();
+  });
+
+  it("names the seat and what it did", () => {
+    expect(
+      captionFor({ type: "ActionTaken", seatId: 2, action: "raise" }, seats),
+    ).toBe("Seat 3 raised");
+    expect(
+      captionFor({ type: "ActionTaken", seatId: 0, action: "check" }, seats),
+    ).toBe("Seat 1 checked");
+  });
+
+  it("prefers a seat's display name", () => {
+    expect(
+      captionFor({ type: "ActionTaken", seatId: 1, action: "call" }, named),
+    ).toBe("Ada called");
+  });
+
+  it("names the board that just landed", () => {
+    expect(
+      captionFor(
+        { type: "BoardDealt", street: "turn", cards: [card("9")] },
+        seats,
+      ),
+    ).toBe("The turn");
+  });
+
+  it("names the street whose betting just opened", () => {
+    expect(
+      captionFor({ type: "StreetStarted", street: "flop", actor: 1 }, seats),
+    ).toBe("Flop betting");
+  });
+
+  it("names the winner of a hand nobody contested", () => {
+    expect(captionFor({ type: "HandFoldedOut", winner: 1 }, named)).toBe(
+      "Ada wins, everyone else folded",
+    );
+  });
+
+  it("names a showdown's winner and their hand", () => {
+    expect(captionFor(showdown([1]), named)).toBe(
+      "Showdown — Ada wins with a straight",
+    );
+  });
+
+  it("names both halves of a split pot", () => {
+    expect(captionFor(showdown([0, 1]), named)).toBe(
+      "Showdown — Seat 1 and Ada split with a straight",
+    );
+  });
+
+  it("has a caption for every beat the scrub can land on", () => {
+    const everyEvent: readonly HandEvent[] = [
+      { type: "HandStarted", seed: "s", button: 0 },
+      { type: "HoleCardsDealt", deals: [] },
+      { type: "StreetStarted", street: "preflop", actor: 1 },
+      { type: "ActionTaken", seatId: 1, action: "fold" },
+      { type: "StreetClosed", street: "preflop" },
+      { type: "BoardDealt", street: "flop", cards: [card("2")] },
+      { type: "HandFoldedOut", winner: 1 },
+      showdown([1]),
+      { type: "HandComplete" },
+    ];
+
+    for (const event of everyEvent) {
+      expect(captionFor(event, seats)).not.toBe("");
+      expect(captionFor(event, seats)).not.toBeNull();
+    }
+  });
+
+  it("never shows an Event ordinal", () => {
+    const captions = [
+      captionFor({ type: "HandStarted", seed: "s", button: 0 }, seats),
+      captionFor({ type: "HandComplete" }, seats),
+      captionFor({ type: "StreetClosed", street: "river" }, seats),
+    ];
+
+    for (const caption of captions) {
+      expect(caption).not.toMatch(/\d+\s*\/\s*\d+/);
+    }
+  });
+});

--- a/packages/table-client/src/replay/caption.ts
+++ b/packages/table-client/src/replay/caption.ts
@@ -1,0 +1,73 @@
+import type {
+  ActionType,
+  HandEvent,
+  SeatView,
+} from "@table-top-poker/protocol";
+import { seatLabel } from "../seatLabel.js";
+import { streetLabel } from "./beats.js";
+
+const actionVerb: Record<ActionType, string> = {
+  fold: "folded",
+  check: "checked",
+  call: "called",
+  raise: "raised",
+};
+
+const boardName = {
+  flop: "The flop",
+  turn: "The turn",
+  river: "The river",
+} as const;
+
+function listOf(names: readonly string[]): string {
+  if (names.length <= 1) return names[0] ?? "";
+  return `${names.slice(0, -1).join(", ")} and ${String(names.at(-1))}`;
+}
+
+function showdownCaption(
+  event: Extract<HandEvent, { type: "ShowdownReached" }>,
+  seats: readonly SeatView[],
+): string {
+  const winners = listOf(
+    event.winners.map((seatId) => seatLabel(seatId, seats)),
+  );
+  const description = event.results.find((result) =>
+    event.winners.includes(result.seatId),
+  )?.description;
+  const verb = event.winners.length > 1 ? "split" : "wins";
+  const hand = description === undefined ? "" : ` with ${description}`;
+  return `Showdown — ${winners} ${verb}${hand}`;
+}
+
+/**
+ * The beat just landed on, in the language of a poker table. The Event
+ * ordinal is the model's addressing scheme and never appears here: the track
+ * shows progress, the caption says what happened (Phase 2 spec #129 §6).
+ */
+export function captionFor(
+  event: HandEvent | null,
+  seats: readonly SeatView[],
+): string | null {
+  if (event === null) return null;
+
+  switch (event.type) {
+    case "HandStarted":
+      return "Hand begins";
+    case "HoleCardsDealt":
+      return "Hole cards dealt";
+    case "StreetStarted":
+      return `${streetLabel[event.street]} betting`;
+    case "ActionTaken":
+      return `${seatLabel(event.seatId, seats)} ${actionVerb[event.action]}`;
+    case "StreetClosed":
+      return `${streetLabel[event.street]} betting complete`;
+    case "BoardDealt":
+      return boardName[event.street];
+    case "HandFoldedOut":
+      return `${seatLabel(event.winner, seats)} wins, everyone else folded`;
+    case "ShowdownReached":
+      return showdownCaption(event, seats);
+    case "HandComplete":
+      return "Hand complete";
+  }
+}

--- a/packages/table-client/src/replay/caption.ts
+++ b/packages/table-client/src/replay/caption.ts
@@ -1,17 +1,7 @@
-import type {
-  ActionType,
-  HandEvent,
-  SeatView,
-} from "@table-top-poker/protocol";
+import type { HandEvent, SeatView } from "@table-top-poker/protocol";
+import { actionVerb } from "../actionWords.js";
 import { seatLabel } from "../seatLabel.js";
 import { streetLabel } from "./beats.js";
-
-const actionVerb: Record<ActionType, string> = {
-  fold: "folded",
-  check: "checked",
-  call: "called",
-  raise: "raised",
-};
 
 const boardName = {
   flop: "The flop",
@@ -19,7 +9,7 @@ const boardName = {
   river: "The river",
 } as const;
 
-function listOf(names: readonly string[]): string {
+function joinNames(names: readonly string[]): string {
   if (names.length <= 1) return names[0] ?? "";
   return `${names.slice(0, -1).join(", ")} and ${String(names.at(-1))}`;
 }
@@ -28,7 +18,7 @@ function showdownCaption(
   event: Extract<HandEvent, { type: "ShowdownReached" }>,
   seats: readonly SeatView[],
 ): string {
-  const winners = listOf(
+  const winners = joinNames(
     event.winners.map((seatId) => seatLabel(seatId, seats)),
   );
   const description = event.results.find((result) =>
@@ -39,11 +29,7 @@ function showdownCaption(
   return `Showdown — ${winners} ${verb}${hand}`;
 }
 
-/**
- * The beat just landed on, in the language of a poker table. The Event
- * ordinal is the model's addressing scheme and never appears here: the track
- * shows progress, the caption says what happened (Phase 2 spec #129 §6).
- */
+/** The beat just landed on — see Caption in `CONTEXT.md`. */
 export function captionFor(
   event: HandEvent | null,
   seats: readonly SeatView[],

--- a/packages/ui-shared/src/theme.ts
+++ b/packages/ui-shared/src/theme.ts
@@ -29,6 +29,10 @@ export const color = {
   accent: "#e5443c",
   accentBright: "#ef6259",
   accentDeep: "#a81d1c",
+
+  actionRaise: "#e08a34",
+  actionCall: "#3f83bd",
+  actionPassive: "rgba(255,255,255,.12)",
   disabledText: "rgba(243,236,225,.35)",
 
   avatarGradient: "linear-gradient(160deg,#e9a89f,#a13a2e)",


### PR DESCRIPTION
Closes #127. Builds on the `replay` branch, on top of #126's scrub.

At any position in the scrub you can read what just happened and what each seat has done this street, without counting ordinals.

## What's here

- **Per-seat action labels** — folded back out of the Event stream, because they have to be: `TableViewBetting.seats` carries only `folded`, so the view at a position cannot say who called. They clear on the same street change a Chapter anchors to (the street's `BoardDealt`), sharing `streetOf` with the beats rather than re-deriving a rule the two could drift apart on.
- **Colour** — accent red stays the clock's, both the "To act" pill and the seat-pod glow, so raise takes orange and call is the one cool fill on an otherwise warm felt. A label sits in the slot the clock uses and yields it whenever the seat is on the clock, so a pod never carries both.
- **The caption strip** fills the band #126 reserved.
- **No Event ordinal on screen** — the track shows progress, the caption says what happened, and the hand under review goes to the status bar's `leading` slot rather than a second title over the felt.

New domain terms **Action label** and **Caption** are recorded in `CONTEXT.md`.

## Two judgement calls worth a look

- **A seat on the clock loses its label.** One slot, so something has to yield, and the clock wins it — a seat facing a re-raise being on the clock is the more urgent thing to say. That reads against the letter of "every seat that has acted shows a pill", so flagging it; it's recorded as an `_Avoid_` under Action label.
- **The caption band was also #126's clearance for the bottom seat row's overhang.** Pods are anchored by their avatar and grow around it, so that clearance is a ratio of the felt's height (roughly, the felt must be ~5x a pod tall) and more reserved space cannot buy it — reserving more shrinks the felt and the 10% margin with it. The strip is drawn under the felt, so on a short felt what gives is the caption and never the table.

## Verification

`npm run build` typechecks clean, `npm run lint` (eslint + prettier) is clean, and 259 tests pass across `table-client` and `ui-shared`. Per CLAUDE.md I ran the targeted suites rather than the full local run — CI is the source of truth for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEEhH9EhgGHgHPuGZBpGZu