### PR TITLE
Resolve the final review on the replay branch

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -283,6 +283,14 @@ count. It is what makes otherwise identical fold-outs distinguishable in a
 list. Structured, never prose: the wording belongs to whichever client
 renders it.
 
+Two boundary calls fix the partition. Two or more raises read as a raise war
+wherever they happened, so a preflop 3-bet that ends preflop is a raise war,
+not a preflop raise — the count is the more informative fact, and a preflop
+raise is *one* raise winning uncontested. Checked down is the residual, so it
+also covers an unraised Hand that saw a flop and then folded out; a walk is
+reserved for the Hand that died preflop, which is the distinction the picker
+needs. A client's copy for checked down must therefore not promise a Showdown.
+
 **Survivor**:
 A Seat that was dealt into a Hand and never folded. One Survivor means the
 Hand folded out; two or more mean it reached Showdown. Distinct from the

--- a/docs/design/engine.md
+++ b/docs/design/engine.md
@@ -88,3 +88,17 @@ starts at `numSeats * 2 + boardLenSoFar`.
   or set to sit out).
 - A seat's `yourHoleCards` is null once folded; `legalActions` is populated only
   when it is that seat's turn (`toAct[0] === seatId`).
+
+## Replay
+
+A Hand's Command log opens with the operation that started it, which for every
+Hand after the first is a `nextHand`. `decide` only accepts that against a
+completed Hand, and Replay is scoped to one Hand starting from no Hand at all —
+so the opening Command is run as the `startHand` it behaved as. Both take the
+same path through `beginHand`, on the same seed and recorded Button, so the
+generated Events match the ones the live run recorded.
+
+Because `decide` echoes back whatever Command it was handed, a generated
+Rejection has the substituted Command on it. Replay restores the Command as
+*recorded* before comparing, or the substitution would leak into the audit
+comparison and report a faithful recording as corrupt.

--- a/docs/design/server.md
+++ b/docs/design/server.md
@@ -20,6 +20,16 @@ seat's socket gets nothing, never another seat's cards. `isSeat` is the single
 guard that excludes the `table`/`lobby` identities from any per-seat path, so
 those never reach `view(state, seatId)` or presence tracking.
 
+`hand-replay.ts` is the server's whole replay adapter, and the same guarantee
+rests on it. The engine's flipbook carries complete `EngineState`; every
+position leaves the adapter projected through `view(state, "table")` into a
+protocol type that cannot hold one, and each position's Event goes through the
+same `redactEventFor` the live fan-out uses. There is no audience option and no
+other way out of the engine's replay on this side of the wire, so the table is
+shown exactly what it was shown live and no more. Only a `complete` replay is
+served: an incomplete one is refused rather than truncated, and one arriving
+here means the listing and the recording have already disagreed.
+
 ## Presence is cosmetic; the clock is connection-independent
 
 - `markPresence`/`setSeatDisconnected` toggle a **cosmetic** badge only — never
@@ -147,6 +157,28 @@ joinable and closed when it ends or the app does. It takes whole operations, and
 owns ordering, retry, confirmed offsets and rollback itself; the server hands it
 `transaction.operation` and waits. Its filesystem is injected, so every failure
 path is testable and the shipped server has no way to make itself fail.
+
+`RecordingFileSystem` is a narrow set of simple primitives; atomicity is not
+one of them. An atomic replace is composed as `writeFile` + `rename`, which
+keeps the in-memory fake faithful without it having to model atomicity.
+
+`RECORDING_LAYOUT_VERSION` versions the recording *directory* — `room.json`,
+the Hand context sidecar, the Room ID keying — and appears on `room.json` and
+nowhere else. It is not `ENGINE_LOG_VERSION`, which versions the engine records
+inside those files. A pre-Phase-2 directory is recognised by having no
+`room.json` at all, never by comparing this number.
+
+`handOrdinal` counts hands *started*, not hands completed — it is what a Hand
+recording numbers its `hand-NNNN` partitions by, and a summary's ordinal is the
+address `get-hand` resolves against a recording. Counting completions would
+desynchronise the two the first time a hand was abandoned mid-deal.
+
+Serving a `get-hand` takes no turn in the Room's operation queue: a completed
+Hand's files are final and every later operation writes to a different Hand's,
+so queueing would only make replay wait on a disk that is already stalling. The
+hand listing is the authority on which ordinals may be served — it holds exactly
+the Hands this Room saw complete, so an ordinal missing from it is one still
+being dealt, abandoned mid-deal, or never recorded at all.
 
 ## Recording-paused
 

--- a/packages/engine/src/replay.ts
+++ b/packages/engine/src/replay.ts
@@ -10,15 +10,7 @@ import type {
 import { must } from "./util.js";
 import { ENGINE_LOG_VERSION } from "./version.js";
 
-/**
- * The Hand context (CONTEXT.md), narrowed to the two facts Replay bootstraps
- * from: the participating Seats and the Button the Hand was dealt on. Not a
- * state snapshot — it carries no cards.
- *
- * The recording's own context document also carries the Hand ordinal and
- * `startedAt`; neither enters the engine. The ordinal addresses a file in a
- * layout the engine knows nothing about, and `startedAt` is a clock.
- */
+/** Hand context (`CONTEXT.md`), narrowed to what the engine bootstraps from. */
 export interface ReplayHandContext {
   readonly v: number;
   readonly seats: readonly SeatId[];
@@ -33,11 +25,7 @@ export type ReplayAuditRecord = (HandEvent | Rejection) & {
   readonly v: number;
 };
 
-/**
- * Where each stream came from, for diagnostics. Replay never opens these —
- * the I/O-owning caller reads the files and names them here so a failure can
- * say which one it is about.
- */
+/** Stream names for diagnostics; Replay never opens them. */
 export interface ReplaySources {
   readonly context: string;
   readonly commands: string;
@@ -60,13 +48,8 @@ export interface ReplayInput {
 }
 
 /**
- * One notch of the flipbook: its generated Event and the complete
- * `EngineState` after applying it. Position 0 is the starting state and has
- * no Event.
- *
- * The state is carried whole, never as a projected view: `FoldedOutView`
- * has no board, so a fold-out hand's board would be unreachable from a
- * sequence of views alone.
+ * See Replay position in `CONTEXT.md`. State is carried whole, never as a
+ * view: `FoldedOutView` has no board, so a fold-out's board would be lost.
  */
 export interface ReplayPosition {
   readonly position: number;
@@ -74,11 +57,7 @@ export interface ReplayPosition {
   readonly state: EngineState;
 }
 
-/**
- * A validated Rejection. It changes no state and creates no position:
- * `position` is the unchanged position it occurred at, and `record` is its
- * ordinal in the persisted audit stream.
- */
+/** A validated Rejection: it creates no position, only names the one it hit. */
 export interface ReplayRejection {
   readonly position: number;
   readonly record: number;
@@ -124,27 +103,15 @@ export type ReplayOutcome =
   | ({
       readonly status: "incomplete";
       readonly tornRecord: ReplayTornRecord | null;
-      /**
-       * The zero-based ordinal, in the Command log, of the first Command with
-       * no complete audit evidence — where replay stopped. Null when only a
-       * torn record made the replay incomplete.
-       */
+      /** Where replay stopped; null when only a torn record ended it. */
       readonly orphanedCommand: number | null;
     } & ReplayFlipbook)
   | { readonly status: "failed"; readonly failure: ReplayFailure };
 
 /**
- * Replays one recorded Hand into an addressable flipbook of positions.
- *
- * The Command log is the source of truth: Commands are re-run through
- * `decide`, the Events they generate are folded through `apply`, and the
- * complete generated Event/`Rejection` sequence is *compared* against the
- * persisted audit stream. Persisted records are never trusted, repaired or
- * substituted — a disagreement between complete records is a hard failure.
- *
- * Pure by construction: no filesystem, no clock, no ambient randomness. It
- * takes no audience, redaction or `revealEverything` option — the visibility
- * split is by surface, and callers project the returned state themselves.
+ * Replays one recorded Hand into an addressable flipbook — see Replay in
+ * `CONTEXT.md`. The Command log is the source of truth; persisted records are
+ * compared against, never trusted, repaired or substituted.
  */
 export function replayHand(input: ReplayInput): ReplayOutcome {
   const versionFailure = firstVersionMismatch(input);
@@ -266,15 +233,7 @@ export function replayHand(input: ReplayInput): ReplayOutcome {
   return { status: "complete", positions, rejections };
 }
 
-/**
- * A Hand's Command log opens with the operation that started it, which for
- * every Hand after the first is a `nextHand`. `decide` only accepts that
- * against a *completed* Hand, and Replay is scoped to one Hand starting from
- * no Hand at all — so the opening Command is run as the `startHand` it
- * behaved as. Both take the same path through `beginHand`, on the same seed
- * and the same recorded Button, so the generated Events are identical to the
- * ones the live run recorded.
- */
+/** See Replay in `docs/design/engine.md`. */
 function openingCommand(record: ReplayCommandRecord): Command {
   const command = bareCommand(record);
   if (command.type === "nextHand") {
@@ -283,12 +242,7 @@ function openingCommand(record: ReplayCommandRecord): Command {
   return command;
 }
 
-/**
- * Restores the Command as *recorded* onto a generated Rejection. `decide`
- * echoes back whatever Command it was handed, so without this the opening
- * `nextHand`-as-`startHand` substitution above would leak into the comparison
- * and report a faithful recording as corrupt.
- */
+/** See Replay in `docs/design/engine.md`. */
 function asRecorded(
   rejection: Rejection,
   record: ReplayCommandRecord,
@@ -337,12 +291,7 @@ function firstVersionMismatch(input: ReplayInput): ReplayFailure | null {
   return null;
 }
 
-/**
- * The same 2-to-8 bound `createInitialState` enforces, plus the Button being
- * a seated player. Checked here so a context naming a Button that was never
- * dealt in fails as an invalid context, not somewhere inside
- * `rotateFromButton`.
- */
+/** Checked here so a bad Button fails as an invalid context, not inside `rotateFromButton`. */
 function validateContext(
   context: ReplayHandContext,
   file: string,
@@ -374,11 +323,7 @@ function validateCommandLog(
   return null;
 }
 
-/**
- * Structural equality over parsed JSON records. Key order survives a JSONL
- * round trip, so `JSON.stringify` would usually agree — but "usually" is not
- * what an audit comparison is for.
- */
+/** Structural, not `JSON.stringify`: key order is not what an audit rests on. */
 function equal(a: unknown, b: unknown): boolean {
   if (a === b) return true;
   if (Array.isArray(a) || Array.isArray(b)) {

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -109,6 +109,22 @@ passing the same `--seats` it was originally run with. Each hand's
 for a human or later replay tooling to read back; the harness CLI itself
 doesn't consume it.
 
+## Resolving `<room>` in the dev stepper
+
+The `<room>` positional resolves in this order: a literal path; a Room ID
+directly under `--recordings-dir`; then a four-character join code scanned
+across `--recordings-dir`, most recent `createdAt` winning a collision because
+codes are recycled; and finally the literal `latest`. A directory that exists
+always wins over a code scan, so a directory that happens to share a code's
+shape is never misread as one. The Room ID check is what makes the ID a
+harness run just printed usable as-is, without spelling out the path.
+
+The scan is deliberately unfiltered by layout version: `latest` and a join code
+pick the directory the timestamp actually names first and validate it second.
+Silently preferring an older, version-compatible directory would be the
+partial-replay-for-a-version-mismatch that the spec rules out, moved a step
+earlier.
+
 ## Failure modes
 
 The harness fails fast on malformed input rather than risk writing a
@@ -116,3 +132,16 @@ corrupt record into the output stream: invalid JSON on a line, a command
 `type` the engine doesn't recognize, or a malformed `--seats` value all
 print a message to stderr and exit non-zero, with nothing further written
 to stdout.
+
+### An all-torn first Command line
+
+`harness replay` treats any torn final JSONL record as incomplete, never as
+corrupt, and that carries no carve-out for the record being the Hand's first.
+When the first Command line is torn, `replayHand` has nothing to replay and
+reports `invalid-command-log: empty` — correct when the log really is empty,
+but indistinguishable there from a crash mid-write of the first line. The CLI
+reclassifies that one failure shape and emits the single position the Hand
+context alone still supports: position 0, the starting state, with the usual
+incomplete-Hand warning on stderr. It is the only failure the harness
+reclassifies rather than passing straight through, and reaching it means
+`replayHand` already validated the context and version.

--- a/packages/harness/src/replay-cli.ts
+++ b/packages/harness/src/replay-cli.ts
@@ -32,13 +32,7 @@ function incompleteHandDiagnostic(
   };
 }
 
-/**
- * The one flipbook position an all-torn Command log still supports: the
- * starting state, built from the Hand context alone. Mirrors the object
- * literal `replayHand` itself constructs (engine/src/replay.ts) — no public
- * engine constructor exists for "state at an arbitrary Button" (§4), and
- * this is the one caller-side place that legitimately needs the same shape.
- */
+/** See "An all-torn first Command line" in `packages/harness/README.md`. */
 function startingPositionOnly(loaded: LoadedHand): ReplayOutcome & {
   status: "complete";
 } {
@@ -54,15 +48,7 @@ function startingPositionOnly(loaded: LoadedHand): ReplayOutcome & {
   };
 }
 
-/**
- * Runs `harness replay`, returning the process exit code rather than setting
- * it, so callers — the real CLI and tests alike — decide what to do with it.
- *
- * Loads and validates the complete requested Hand before writing anything to
- * `stdout` (§7): every failure — bad arguments, a source-read failure, an
- * out-of-range selector, or the engine's own validation — writes only to
- * `stderr` and produces no stdout output at all.
- */
+/** Validates the whole Hand before any stdout: every failure writes only to stderr. */
 export async function runReplayCli(
   argv: readonly string[],
   streams: ReplayCliStreams,
@@ -77,16 +63,7 @@ export async function runReplayCli(
 
     const outcome = replayHand(loaded.input);
 
-    // A torn line on the Hand's very first Command line leaves `decide`
-    // nothing to replay, and the engine's own validation reports that as
-    // `invalid-command-log: empty` — correct when the log really is empty,
-    // but indistinguishable there from a crash mid-write of its first line.
-    // §4/§7 treat *any* torn final JSONL record as incomplete, not corrupt,
-    // with no carve-out for it being the first — so this is the one failure
-    // shape the harness reclassifies rather than passing straight through.
-    // Reaching it means `replayHand` already validated context and version
-    // (both run before the empty-log check), so position 0 is safe to
-    // synthesize without re-checking either.
+    // See "An all-torn first Command line" in `packages/harness/README.md`.
     if (
       outcome.status === "failed" &&
       outcome.failure.kind === "invalid-command-log" &&

--- a/packages/harness/src/replay-format.ts
+++ b/packages/harness/src/replay-format.ts
@@ -50,14 +50,7 @@ function includesPosition(selector: ReplaySelector, position: number): boolean {
   }
 }
 
-/**
- * Renders a flipbook into the JSONL records §7 specifies, in transcript
- * order: each selected position, immediately followed by every Rejection
- * that occurred while the Hand stayed at that position. Both lists already
- * carry that relative order — positions ascend by construction, and a
- * Rejection's `position` never precedes the position it was pushed after —
- * so grouping by position reconstructs it without re-deriving an ordinal.
- */
+/** Transcript order: each position, then the Rejections that occurred at it. */
 export function renderFlipbook(
   hand: number,
   flipbook: ReplayFlipbook,

--- a/packages/harness/src/replay-source.ts
+++ b/packages/harness/src/replay-source.ts
@@ -84,14 +84,7 @@ async function listRoomDirs(recordingsDir: string): Promise<string[]> {
     .map((entry) => path.join(recordingsDir, entry.name));
 }
 
-/**
- * The manifest of every directory under `recordingsDir` that parses as a
- * Room recording — deliberately unfiltered by layout version, so a `latest`
- * or join-code scan picks the directory the timestamp actually names first
- * and validates it second. Silently preferring an older, version-compatible
- * directory instead would be the "partial replay for a version mismatch"
- * §7 rules out, just moved a step earlier.
- */
+/** Unfiltered by layout version — see Resolving `<room>` in `packages/harness/README.md`. */
 async function candidateManifests(
   recordingsDir: string,
 ): Promise<{ roomDir: string; manifest: RoomManifest }[]> {
@@ -124,18 +117,7 @@ function byCreatedAtDescending(
   return a.manifest.createdAt < b.manifest.createdAt ? 1 : -1;
 }
 
-/**
- * Resolves the `<room>` positional to a directory: a literal path, a
- * four-character join code (scanned across `recordingsDir`, most recent
- * `createdAt` wins on a collision — codes are recycled), or the literal
- * `latest` (Phase 2 spec #129 §7). A directory that exists — either `room`
- * taken literally, or `room` as a Room ID directly under `recordingsDir` —
- * is always taken over a code scan, so a directory happening to share a
- * code's shape is never misread as one. The second check is what makes the
- * Room ID a harness run just printed (`--room-id`, or the default sortable
- * timestamp) usable as-is, without spelling out the path to `recordingsDir`
- * by hand.
- */
+/** See Resolving `<room>` in `packages/harness/README.md`. */
 export async function resolveRoomDirectory(
   room: string,
   recordingsDir: string,
@@ -191,11 +173,7 @@ export interface LoadedHand {
   readonly input: ReplayInput;
 }
 
-/**
- * Resolves `<room>`, then reads Hand `handOrdinal` through the same reader
- * the server's replay path uses — one parse of the durable format, so the
- * stepper and the table can never disagree about what a torn tail is.
- */
+/** Reads through the same reader the server uses, so neither can disagree on a torn tail. */
 export async function loadHand(
   room: string,
   handOrdinal: number,

--- a/packages/protocol/src/hand.ts
+++ b/packages/protocol/src/hand.ts
@@ -12,16 +12,9 @@ export interface HandUpdateMessage {
 }
 
 /**
- * A server-rejected command, reason-coded, delivered to the sender only.
- *
- * `hand-unavailable` answers a `get-hand` for an ordinal this Room cannot
- * serve — never recorded, incomplete, or disagreeing with its own audit
- * stream. One reason covers all three: which it was is filesystem detail, and
- * that stays in operational server logs (Phase 2 spec #129 §3).
- *
- * `recording-paused` answers a command a paused Room cannot record — a
- * recording failure, not a rule violation, so it lives here and never
- * reaches the engine's own `RejectionReason` (§3).
+ * A server-rejected command, sender-only. `hand-unavailable` covers every
+ * reason a Hand cannot be served; `recording-paused` is a recording failure,
+ * not a rule violation, so it never reaches the engine's `RejectionReason`.
  */
 export type ServerRejectionReason =
   | "invalid-command"

--- a/packages/protocol/src/replay-schema.ts
+++ b/packages/protocol/src/replay-schema.ts
@@ -1,17 +1,9 @@
 import { z } from "zod";
 
 /**
- * Wire-level shape of a replay request a client sends over the *existing*
- * room socket — no separate HTTP route, because the socket already carries
- * room and per-seat identity from connect time (Phase 2 spec #129 §5).
- *
- * A deliberate sibling of `ClientCommandSchema` rather than a member of it:
- * a replay request never reaches `decide`, but it is untrusted JSON crossing
- * the same boundary, so it is parsed by the same Zod seam before the server
- * acts on it.
- *
- * The room is never client-supplied here — the server reads it off the
- * authenticated socket, exactly as it does for a command.
+ * A sibling of `ClientCommandSchema`, not a member: a replay request never
+ * reaches `decide`, but crosses the same untrusted boundary. The room is read
+ * off the authenticated socket, never client-supplied.
  */
 export const ReplayRequestSchema = z.discriminatedUnion("type", [
   /** "Send me every hand this session has played." */

--- a/packages/protocol/src/replay.ts
+++ b/packages/protocol/src/replay.ts
@@ -1,21 +1,15 @@
 import type { HandEvent, TableView } from "@table-top-poker/engine";
 
 /**
- * One Replay position as the table may see it, pairing the Event with the
- * table projection of the state after applying it — `FoldedOutView` carries
- * no board, so a fold-out Hand's board is unreachable from views alone
- * (Phase 2 spec #129 §5). Position 0 carries `event: null`.
- *
- * There is deliberately no `Rejection` variant: rejections are sender-only
- * and never broadcast (#17), and the absence is enforced by this type rather
- * than by a runtime filter someone could forget.
+ * One Replay position as the table may see it. No `Rejection` variant: they
+ * are sender-only (#17), and the type enforces that rather than a runtime filter.
  */
 export interface TableReplayPosition {
   readonly event: HandEvent | null;
   readonly view: TableView;
 }
 
-/** One recorded Hand, whole — no chunking and no pagination (§5). */
+/** One recorded Hand, whole — no chunking and no pagination. */
 export interface HandReplayMessage {
   readonly type: "hand-replay";
   readonly handOrdinal: number;

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -187,33 +187,19 @@ export interface RoomEndedMessage {
   readonly type: "room-ended";
 }
 
-/**
- * The session's hands so far, oldest ordinal first — sent when a table
- * identity connects, and in answer to a `list-hands` request. Deliberately
- * its own message and not part of `RoomView`, which changes on a different
- * cadence (seats, presence) and should not grow on every seat change
- * (Phase 2 spec #129 §5). Replaces the recipient's list wholesale.
- */
+/** The session's hands, oldest first; its own message, and replaces the list wholesale. */
 export interface HandListMessage {
   readonly type: "hand-list";
   readonly summaries: readonly HandSummary[];
 }
 
-/**
- * One hand's summary, pushed the moment that hand completes. Appends to the
- * list a `hand-list` established, so a table that connected mid-session
- * never has to re-request the hands it already holds.
- */
+/** Appends to the list `hand-list` established, so nothing is re-requested. */
 export interface HandSummaryMessage {
   readonly type: "hand-summary";
   readonly summary: HandSummary;
 }
 
-/**
- * A failed append has blocked the Room: every socket is told play has
- * stopped, but never why — filesystem detail stays in operational server
- * logs (Phase 2 spec #129 §3). Only the table may choose an exit.
- */
+/** Play has stopped, but never why; only the table may choose an exit. */
 export interface RecordingPausedMessage {
   readonly type: "recording-paused";
 }
@@ -223,12 +209,7 @@ export interface RecordingResumedMessage {
   readonly type: "recording-resumed";
 }
 
-/**
- * Sent once "Continue without recording" resumes a paused Room without its
- * recording. A persistent notice, not a toggle: it is never followed by a
- * `recording-resumed` for the same Room, and a socket that joins afterward
- * gets it on connect (Phase 2 spec #129 §3, issue #122).
- */
+/** A persistent notice, not a toggle — see recording-paused in `docs/design/server.md`. */
 export interface RecordingStoppedMessage {
   readonly type: "recording-stopped";
 }

--- a/packages/protocol/src/summary.ts
+++ b/packages/protocol/src/summary.ts
@@ -1,12 +1,6 @@
 import type { Card, HandEvent, SeatId, Street } from "@table-top-poker/engine";
 
-/**
- * How the betting went, as a descriptor rather than a sentence (Phase 2
- * spec #129 §5). The felt's wording — *walk — folded round*, *raise war — 4
- * raises* — lives in `table-client` with the rest of its copy; putting it
- * here would force the dev stepper (§7) to parse English back into a number
- * `summarise` already had.
- */
+/** Structured, never prose — see Betting shape in `CONTEXT.md`. */
 export type BettingShape =
   | { readonly kind: "walk" }
   | { readonly kind: "preflop-raise" }
@@ -14,12 +8,7 @@ export type BettingShape =
   | { readonly kind: "one-raise" }
   | { readonly kind: "raise-war"; readonly raises: number };
 
-/**
- * One seat's showdown hand as the whole room saw it. Reveals only ever come
- * from a `ShowdownReached` event, which the engine emits solely for seats
- * that reached showdown live — so nothing here widens the visibility
- * boundary (Phase 1 spec #130 §4).
- */
+/** One seat's showdown hand; sourced only from `ShowdownReached`, so it widens no visibility. */
 export interface ShowdownReveal {
   readonly seatId: SeatId;
   readonly bestHand: readonly [Card, Card, Card, Card, Card];
@@ -49,11 +38,11 @@ export type HandOutcome =
 export interface HandSummaryContext {
   /** 1-based, matching the recording's `hand-NNNN` partition. */
   readonly handOrdinal: number;
-  /** ISO 8601 — the picker's start-time clock reads this (§6). */
+  /** ISO 8601 — the picker's start-time clock reads this (#129 §6). */
   readonly startedAt: string;
 }
 
-/** One row of the table device's hand picker, derived once and shared (§5). */
+/** One row of the table device's hand picker, derived once and shared (#129 §5). */
 export interface HandSummary {
   readonly handOrdinal: number;
   readonly startedAt: string;
@@ -71,20 +60,7 @@ export interface HandSummary {
 /** Raised when a recording is not a complete, valid hand — never for a well-formed one. */
 export class IncompleteHandError extends Error {}
 
-/**
- * The five shapes partition every hand, and the spec fixes the union without
- * fixing the predicates. Two boundary calls are made here deliberately:
- *
- * 1. **Two or more raises reads as a war wherever it happened**, so a preflop
- *    3-bet that ends preflop is `raise-war`, not `preflop-raise`. The count is
- *    the more informative fact, and `preflop-raise` — "preflop raise took it"
- *    — describes *one* raise winning uncontested.
- * 2. **`checked-down` is the residual**, so it also covers an unraised hand
- *    that saw a flop and then folded out. `walk` is reserved for the hand that
- *    died preflop, which is the distinction the picker needs (a walk is a
- *    visibly short row). The felt's copy for `checked-down` should therefore
- *    not promise a showdown — that is a `table-client` wording decision.
- */
+/** See Betting shape in `CONTEXT.md` for the two boundary calls. */
 function bettingShapeOf(
   raises: number,
   streetReached: Street,
@@ -99,18 +75,11 @@ function bettingShapeOf(
 }
 
 /**
- * Derives a hand's picker summary from the Events it produced.
+ * Derives a hand's picker summary from the Events it produced — pure, and the
+ * one derivation the live push and a replay from disk share.
  *
- * Pure: no I/O, no clock, no ambient state. The server calls it with the
- * Events it just broadcast; anything replaying from disk calls it with the
- * Events it just validated. Sharing one derivation is the point — two
- * independent ones would drift, and the picker would disagree with the scrub
- * it opens (Phase 2 spec #129 §5).
- *
- * Throws `IncompleteHandError` unless `events` is a complete hand: it must
- * open with `HandStarted`, close with `HandComplete`, and carry an outcome.
- * Callers holding a partial recording are expected to keep it out of the
- * listing rather than summarise it (§4).
+ * Throws `IncompleteHandError` unless `events` opens with `HandStarted`,
+ * closes with `HandComplete`, and carries an outcome.
  */
 export function summarise(
   events: readonly HandEvent[],

--- a/packages/recording/src/file-system.ts
+++ b/packages/recording/src/file-system.ts
@@ -9,42 +9,21 @@ import {
   writeFile,
 } from "node:fs/promises";
 
-/**
- * Every filesystem call a recording makes, named as a narrow set of
- * primitives and injected rather than imported — the same shape `ActionClock`
- * (`packages/server/src/action-clock.ts`) uses for its timers.
- *
- * The point is testability of the paths a real disk will not produce on
- * demand: offset truncation after a partial operation, retry, and the
- * rollback of a half-created Room. An in-memory fake (see
- * `memory-file-system.ts`) can fail any of these deliberately, which keeps
- * fault injection out of the production code — the server ships no way to
- * make itself fail.
- *
- * Atomicity is *not* a primitive here. `writeFile` + `rename` is how the
- * module composes an atomic replace, so a fake only has to be faithful about
- * each simple operation.
- */
+/** The filesystem seam — see Recording in `docs/design/server.md`. */
 export interface RecordingFileSystem {
-  /** Whether a file or directory is already there. */
   exists(target: string): Promise<boolean>;
-  /** The whole contents of `filePath`, or undefined if it is not there. */
   readFile(filePath: string): Promise<string | undefined>;
-  /** Creates `dir` and any missing parents; succeeds if it already exists. */
+  /** Idempotent: succeeds if `dir` already exists. */
   mkdir(dir: string): Promise<void>;
-  /** Creates or replaces `filePath` wholesale. */
   writeFile(filePath: string, contents: string): Promise<void>;
-  /** Appends to `filePath`, creating it if absent. */
   appendFile(filePath: string, contents: string): Promise<void>;
-  /** Atomically moves `from` over `to`. */
+  /** Atomic: the composition point for an atomic replace. */
   rename(from: string, to: string): Promise<void>;
-  /** Cuts `filePath` back to `length` bytes. */
   truncate(filePath: string, length: number): Promise<void>;
-  /** Removes a file or directory tree; succeeds if it is already gone. */
+  /** Idempotent: succeeds if `target` is already gone. */
   remove(target: string): Promise<void>;
 }
 
-/** The real disk. The only implementation production ever runs against. */
 export const nodeFileSystem: RecordingFileSystem = {
   async exists(target) {
     try {

--- a/packages/recording/src/hand-reader.ts
+++ b/packages/recording/src/hand-reader.ts
@@ -7,11 +7,7 @@ import type { RecordingFileSystem } from "./file-system.js";
 import { handRecordingPaths } from "./paths.js";
 import type { HandContext } from "./records.js";
 
-/**
- * What one Hand's three files hold, or why they could not be read. Nothing
- * here is a replay verdict: the engine's `replayHand` decides whether the
- * records agree, and this only reports the shapes it could not parse.
- */
+/** Not a replay verdict: this reports only the shapes it could not parse. */
 export type HandRecordingRead =
   | { readonly status: "read"; readonly input: ReplayInput }
   | { readonly status: "missing-file"; readonly file: string }
@@ -43,12 +39,7 @@ class MalformedRecordError extends Error {
   }
 }
 
-/**
- * Parses a JSONL file, tolerating an unterminated final line as torn rather
- * than malformed: append-as-you-go persistence (`RoomRecording`) never leaves
- * a torn line anywhere but the last, since every earlier write completed with
- * its trailing newline before the next one began.
- */
+/** A torn line can only ever be the last: every earlier write closed with its newline. */
 function parseJsonl<T>(file: string, contents: string): ParsedJsonl<T> {
   if (contents === "") return { records: [], tornRecord: null };
 
@@ -71,18 +62,7 @@ function parseJsonl<T>(file: string, contents: string): ParsedJsonl<T> {
   return { records, tornRecord: null };
 }
 
-/**
- * Reads Hand `handOrdinal` of the Room recording at `roomDir` into the
- * `ReplayInput` the engine's `replayHand` takes.
- *
- * The filesystem is injected rather than imported, so every caller reads
- * through the same seam the writer uses — which is what lets the server's
- * replay path be exercised against an in-memory disk (Phase 2 spec #129 §3).
- *
- * At most one of `commands.jsonl`/`events.jsonl` can carry a torn final line
- * — a crash lands mid-write of one file at a time — so `tornRecord` is
- * whichever one reports it.
- */
+/** At most one file can carry a torn final line: a crash lands mid-write of one. */
 export async function readHandRecording({
   fileSystem,
   roomDir,
@@ -92,10 +72,7 @@ export async function readHandRecording({
   // Independent files, read concurrently — none depends on another's content.
   const [contextText, commandsText, eventsText] = await Promise.all([
     fileSystem.readFile(paths.contextPath),
-    // A missing commands/events file reads as empty: an empty Command log is
-    // the engine's own `invalid-command-log` failure, and a commands file
-    // with no matching events file is the orphaned-trailing-Command case §4
-    // describes, not a missing file.
+    // Missing reads as empty: both cases are the engine's to name, not a read failure.
     fileSystem.readFile(paths.commandsPath).then((text) => text ?? ""),
     fileSystem.readFile(paths.eventsPath).then((text) => text ?? ""),
   ]);

--- a/packages/recording/src/hand-start-context.ts
+++ b/packages/recording/src/hand-start-context.ts
@@ -8,15 +8,9 @@ export interface HandPositions {
 }
 
 /**
- * The Hand context an operation opens a Hand with, or undefined when it opens
- * none. A Hand recording begins only when `startHand`/`nextHand` is
- * **accepted** (Phase 2 spec #129 §3), so the test is a generated
- * `HandStarted` event — never the Command's type, which is also what a
- * *rejected* `nextHand` looks like.
- *
- * `startedAt` is read here, as the operation is staged, rather than when its
- * append confirms: on a stalling disk those are seconds apart, and this
- * timestamp records when the Hand began for the players.
+ * Keyed on a generated `HandStarted`, never the Command's type — a *rejected*
+ * `nextHand` looks the same. `startedAt` is read here, as the operation is
+ * staged, so it records when the Hand began rather than when its append landed.
  */
 export function handStartContextFor(
   events: readonly HandEvent[],

--- a/packages/recording/src/memory-file-system.ts
+++ b/packages/recording/src/memory-file-system.ts
@@ -5,9 +5,7 @@ import type { RecordingFileSystem } from "./file-system.js";
 export type FailableOperation = keyof RecordingFileSystem;
 
 export interface MemoryFileSystem extends RecordingFileSystem {
-  /** Contents of one file, or undefined if it does not exist. */
   read(filePath: string): string | undefined;
-  /** Every file path currently on the fake disk, sorted. */
   paths(): string[];
   /** Fails the next `count` calls to `operation`, then behaves normally again. */
   failNext(operation: FailableOperation, count?: number): void;
@@ -31,12 +29,7 @@ class MissingDirectoryError extends Error {
   }
 }
 
-/**
- * An in-memory `RecordingFileSystem` with arm-a-failure controls, faithful
- * about the things the recording module depends on: a write into a directory
- * that was never created fails, appends accumulate, and truncate is a byte
- * count. Test-only — production wires `nodeFileSystem`.
- */
+/** An in-memory `RecordingFileSystem` with arm-a-failure controls. Test-only. */
 export function createMemoryFileSystem(): MemoryFileSystem {
   const files = new Map<string, string>();
   const dirs = new Set<string>(["/"]);
@@ -60,11 +53,7 @@ export function createMemoryFileSystem(): MemoryFileSystem {
     throw new Error(`EIO: injected failure, ${operation}`);
   }
 
-  /**
-   * Runs `work`, turning a thrown failure into a rejected promise — a real
-   * filesystem never throws synchronously, and code that only handles
-   * rejections must be exercised the same way here.
-   */
+  /** A real filesystem never throws synchronously, so an armed failure rejects. */
   function settle(work: () => void): Promise<void> {
     try {
       work();

--- a/packages/recording/src/paths.ts
+++ b/packages/recording/src/paths.ts
@@ -2,14 +2,7 @@ import path from "node:path";
 
 const ROOM_ID_PATTERN = /^[A-Za-z0-9._-]+$/;
 
-/**
- * The Room ID becomes a directory name, so it must be a safe path segment.
- *
- * The character class alone is not enough: `.` and `..` are built entirely
- * from characters it allows, and `..` resolves *above* the recordings root.
- * The server only ever supplies a UUID, but the harness takes `--room-id`
- * from a developer's argv.
- */
+/** `.` and `..` pass the character class but escape the root, so both are refused. */
 export function assertValidRoomId(roomId: string): void {
   if (!ROOM_ID_PATTERN.test(roomId) || roomId === "." || roomId === "..") {
     throw new Error(

--- a/packages/recording/src/recordings.ts
+++ b/packages/recording/src/recordings.ts
@@ -16,22 +16,10 @@ export interface CreateRoomRecordingOptions {
   readonly createdAt: string;
 }
 
-/**
- * Where Room recordings are created. A seam rather than a bare function so
- * the server can hold one for the process, and so tests can hand `buildApp`
- * a recordings root backed by an in-memory filesystem — there is deliberately
- * no way to hand it *nothing*, because recording is a Room invariant.
- */
+/** Where Room recordings are created — see Recording in `docs/design/server.md`. */
 export interface Recordings {
   create(options: CreateRoomRecordingOptions): Promise<RoomRecording>;
-  /**
-   * Reads one Hand of an already-created Room recording back.
-   *
-   * On the root rather than on {@link RoomRecording} deliberately: a
-   * recording on disk outlives its writer. "Continue without recording"
-   * closes the writer and never reopens it, and the Hands recorded before
-   * that failure must stay replayable (Phase 2 spec #129 §3).
-   */
+  /** On the root, not the writer: a recording on disk outlives its writer. */
   readHand(roomId: string, handOrdinal: number): Promise<HandRecordingRead>;
 }
 
@@ -53,12 +41,7 @@ export class DirectoryRecordings implements Recordings {
     this.#retries = retries;
   }
 
-  /**
-   * Creates the root and proves it accepts a write, throwing if it does not.
-   * The server calls this before it listens and refuses to start on failure:
-   * a Room that cannot be recorded must never become joinable, and an
-   * unwritable disk found at the first hand is found far too late.
-   */
+  /** Proves the root accepts a write before the server listens. */
   async ensureWritable(): Promise<void> {
     const probe = path.join(this.root, WRITE_PROBE_FILENAME);
     try {
@@ -72,14 +55,7 @@ export class DirectoryRecordings implements Recordings {
     }
   }
 
-  /**
-   * Opens a Room's recording by writing its immutable `room.json`. Resolving
-   * is the caller's licence to publish the Room; rejecting leaves no
-   * directory behind and must leave no joinable Room either.
-   *
-   * The manifest is published by rename, so a concurrent reader sees either
-   * no `room.json` or a complete one, never a half-written document.
-   */
+  /** Resolving is the licence to publish the Room; the manifest lands by rename. */
   async create(options: CreateRoomRecordingOptions): Promise<RoomRecording> {
     assertValidRoomId(options.roomId);
     const roomDir = path.join(this.root, options.roomId);
@@ -92,10 +68,7 @@ export class DirectoryRecordings implements Recordings {
     const manifestPath = roomManifestPath(roomDir);
     const stagingPath = `${manifestPath}.tmp`;
 
-    // `room.json` is immutable, so a directory that already has one is a
-    // finished recording — never something to reopen or write over. The
-    // server's ids are UUIDs and cannot collide, but the harness takes
-    // `--room-id` from argv and a developer will reuse one.
+    // The harness takes `--room-id` from argv, so a developer will reuse one.
     if (await this.#fs.exists(manifestPath)) {
       throw new Error(
         `could not create the recording for room ${options.roomId}: ${manifestPath} already exists`,
@@ -137,11 +110,7 @@ export class DirectoryRecordings implements Recordings {
     });
   }
 
-  /**
-   * A rollback is itself a write on the filesystem that just refused one.
-   * The create is failing either way, and that failure is what keeps the Room
-   * unjoinable, so a repair that cannot run must not mask it.
-   */
+  /** A rollback is itself a write; the create fails either way, so it must not mask it. */
   async #tolerate(work: () => Promise<void>): Promise<void> {
     try {
       await work();

--- a/packages/recording/src/records.ts
+++ b/packages/recording/src/records.ts
@@ -5,67 +5,37 @@ import type {
   SeatId,
 } from "@table-top-poker/engine";
 
-/**
- * The shape of a Room recording *directory* — `room.json`, the Hand context
- * sidecar, the Room ID keying. Deliberately not `ENGINE_LOG_VERSION`, which
- * versions the engine records inside those files and means something else
- * entirely (Phase 2 spec #129 §3, "Version tagging").
- *
- * It appears on `room.json` and nowhere else. A pre-Phase-2 directory is
- * recognised by having no `room.json` at all, not by comparing this number.
- */
+/** Versions the recording directory — see Recording in `docs/design/server.md`. */
 export const RECORDING_LAYOUT_VERSION = 1;
 
-/** A recorded command line is the bare `Command` plus a version tag. */
 export type RecordedCommand = Command & { readonly v: number };
 
-/** A recorded event line is the bare `HandEvent`/`Rejection` plus a version tag. */
 export type RecordedEvent = (HandEvent | Rejection) & { readonly v: number };
 
-/**
- * `room.json`: immutable Room metadata, written once before the Room is
- * joinable. Not a Seat manifest — seat claims, evictions, presence and
- * sitting-out transitions are not separately recorded. `code` is the live
- * four-character join code, or null for a recording (a harness run) that was
- * never joinable through one.
- */
+/** `room.json` — see Room recording in `CONTEXT.md`. */
 export interface RoomManifest {
   readonly layoutVersion: number;
   readonly roomId: string;
+  /** The live join code, or null for a recording never joinable through one. */
   readonly code: string | null;
   readonly createdAt: string;
 }
 
-/**
- * What a caller supplies when its operation starts a Hand. `startedAt` is
- * captured when the operation is *staged*, not when its append confirms —
- * on a stalling disk those are seconds apart, and this timestamp records
- * when the Hand began for the players.
- */
 export interface HandStartContext {
-  /** ISO 8601, the only clock anywhere in a Room recording. */
+  /** Captured when the operation is staged, not when its append confirms. */
   readonly startedAt: string;
   readonly seats: readonly SeatId[];
   readonly button: SeatId;
 }
 
-/**
- * `hand-NNNN.context.json`: the bootstrap Replay needs, and nothing more —
- * no cards, no state snapshot. Its presence is what leaves the Command JSONL
- * an exact Command-only stream.
- */
+/** `hand-NNNN.context.json` — see Hand context in `CONTEXT.md`. */
 export interface HandContext extends HandStartContext {
   readonly v: number;
   readonly roomId: string;
   readonly handOrdinal: number;
 }
 
-/**
- * One complete engine operation: the Command, whatever the engine made of it,
- * and — when this is the operation that starts a Hand — the context that Hand
- * opens with. Callers hand over the whole thing; they never coordinate
- * individual lines.
- */
+/** One complete engine operation, handed over whole. */
 export interface RoomOperation {
   /** Present only when this operation starts a Hand. */
   readonly context?: HandStartContext;

--- a/packages/recording/src/room-recording.ts
+++ b/packages/recording/src/room-recording.ts
@@ -34,20 +34,9 @@ function byteLength(text: string): number {
 }
 
 /**
- * One Room's durable recording: the append-as-you-go writer behind
- * `<RECORDINGS_DIR>/<room-id>/`. Created by {@link DirectoryRecordings},
- * which has already written the `room.json` this recording lives alongside.
- *
- * Callers hand it whole engine operations and nothing else. It owns version
- * tagging, serialization, which Hand's files a record belongs in, ordering
- * across concurrent callers, the confirmed byte offsets a partial write is
- * rolled back to, retry, and a clean close.
- *
- * An operation that still fails after its retries **latches** the recording:
- * every later operation is refused rather than written past the gap, because
- * a Command stream with a hole in it is worse than no Command stream. `retry`
- * and `discardLatched` are the table-facing recovery from that state — see
- * recording-paused in `docs/design/server.md`.
+ * One Room's durable recording — see Room recording in `CONTEXT.md` and
+ * recording-paused in `docs/design/server.md`. Callers hand it whole
+ * operations; it owns everything from version tagging to a clean close.
  */
 export class RoomRecording {
   readonly roomId: string;
@@ -69,11 +58,7 @@ export class RoomRecording {
     this.#retries = options.retries ?? 2;
   }
 
-  /**
-   * Appends one complete engine operation. Resolves once every line of it is
-   * confirmed on disk; rejects — leaving the files exactly as they were —
-   * once the retries are spent.
-   */
+  /** Resolves once confirmed on disk; rejects leaving the files as they were. */
   append(operation: RoomOperation): Promise<void> {
     if (this.#closing) {
       return Promise.reject(
@@ -100,14 +85,7 @@ export class RoomRecording {
     await this.#queue;
   }
 
-  /**
-   * Retries the operation a caller retained after this recording latched.
-   * Truncates its Hand's files back to the last confirmed offsets first — the
-   * failed attempt's own rollback may itself have failed on the same broken
-   * disk, and this defends against that torn tail surviving into the retry —
-   * then writes the operation fresh. Resolves once it is confirmed; rejects,
-   * leaving the recording latched, if the retry fails too.
-   */
+  /** Truncates to confirmed offsets first: the failed attempt's own rollback may also have failed. */
   retry(operation: RoomOperation): Promise<void> {
     if (this.#closing) {
       return Promise.reject(
@@ -131,12 +109,7 @@ export class RoomRecording {
     return this.#appendNow(operation);
   }
 
-  /**
-   * Discards the operation a caller retained after this recording latched,
-   * restoring its Hand's files to their last confirmed offsets on a
-   * best-effort basis — the exit a paused Room takes when the table chooses
-   * to end rather than retry. A no-op when the recording never latched.
-   */
+  /** Best-effort restore to confirmed offsets; a no-op when never latched. */
   async discardLatched(operation: RoomOperation | undefined): Promise<void> {
     if (this.#closing) {
       throw new Error(`recording for room ${this.roomId} is closed`);
@@ -247,16 +220,7 @@ export class RoomRecording {
     }
   }
 
-  /**
-   * Cuts a half-written operation back to the last offsets this recording
-   * confirmed, so the files stay a prefix of completed operations.
-   *
-   * Every repair here is itself a write, and the filesystem that just refused
-   * one may refuse these too — a worn card flips read-only and stays there.
-   * Failures are therefore swallowed: the operation is being reported as
-   * failed regardless, and §4's incomplete-Hand rule is what reads whatever
-   * is left behind.
-   */
+  /** Repairs are themselves writes, so failures are swallowed — the caller already reports failure. */
   async #rollback(
     paths: HandRecordingPaths,
     confirmed: ConfirmedOffsets,

--- a/packages/recording/src/testing.ts
+++ b/packages/recording/src/testing.ts
@@ -1,13 +1,6 @@
 /**
- * Test doubles for the recording seam, deliberately kept off the package's
- * main entrypoint (`@table-top-poker/recording`) and reachable only as
- * `@table-top-poker/recording/testing`.
- *
- * The split is the point: injection exists so the failure paths are testable
- * *and* so fault injection stays out of production code — the server must
- * ship no way to make itself fail (Phase 2 spec #129 §3). Importing this
- * module from anything but a test is the mistake it is arranged to make
- * visible.
+ * Test doubles, kept off the package's main entrypoint so fault injection stays
+ * out of production code — see Recording in `docs/design/server.md`.
  */
 export { createMemoryFileSystem } from "./memory-file-system.js";
 export type {
@@ -15,7 +8,6 @@ export type {
   MemoryFileSystem,
 } from "./memory-file-system.js";
 
-/** Parses a recorded JSONL file's contents into one value per line. */
 export function parseRecordedLines(contents: string | undefined): unknown[] {
   if (contents === undefined) return [];
   return contents

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -13,6 +13,7 @@ import {
   type ServerMessage,
 } from "@table-top-poker/protocol";
 import type { FastifyInstance } from "fastify";
+import { randomUUID } from "node:crypto";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -3008,6 +3009,39 @@ describe("hand summaries over WebSocket", () => {
     expect(summaries[0]?.summary.survivors).toHaveLength(1);
     expect(summaries[0]?.summary.outcome.kind).toBe("folded-out");
     expect(Date.parse(summaries[0]?.summary.startedAt ?? "")).not.toBeNaN();
+  });
+
+  it("dates the summary from the recording's clock, not a second one", async () => {
+    const recordingClock = new Date("2026-01-02T03:04:05.000Z");
+    const laterClock = new Date("2026-01-02T03:09:09.000Z");
+    await app.close();
+    rooms = new RoomStore(
+      Math.random,
+      randomUUID,
+      randomUUID,
+      randomUUID,
+      () => recordingClock,
+    );
+    app = await buildApp({
+      rooms,
+      recordings: testRecordings(),
+      now: () => laterClock,
+    });
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected a bound TCP address");
+    }
+    port = address.port;
+
+    const { code, table, seats } = await seatedRoom();
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+    await foldToTheEnd(code, seats);
+
+    expect(summariesIn(table.messages)[0]?.summary.startedAt).toBe(
+      recordingClock.toISOString(),
+    );
   });
 
   it("never pushes a summary to a player's socket", async () => {

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -21,11 +21,7 @@ import {
   type SeatMove,
   type ServerMessage,
 } from "@table-top-poker/protocol";
-import type {
-  Recordings,
-  RoomOperation,
-  RoomRecording,
-} from "@table-top-poker/recording";
+import type { Recordings, RoomRecording } from "@table-top-poker/recording";
 import Fastify, {
   type FastifyInstance,
   type FastifyReply,
@@ -55,6 +51,7 @@ import {
   RoomStore,
   toRoomView,
 } from "./rooms.js";
+import { RoomRecordings, type PausedRoom } from "./room-recordings.js";
 
 const publicDir = fileURLToPath(new URL("../public", import.meta.url));
 const publicIndexPath = fileURLToPath(
@@ -76,13 +73,7 @@ export interface BuildAppOptions {
   readonly testMode?: boolean;
   readonly botRng?: BotRng;
   readonly botActionDelayMs?: number | readonly [number, number];
-  /**
-   * Where each Room's durable recording is created. Required, and with no
-   * "off" value: recording is a Room invariant (Phase 2 spec #129 §3), so a
-   * Room that cannot be recorded is never created. Tests pass a
-   * `DirectoryRecordings` over an in-memory filesystem, which records
-   * everything a real run would without touching a disk.
-   */
+  /** Required, and with no "off" value: recording is a Room invariant. */
   readonly recordings: Recordings;
   /** Overridable for tests only; production reads the wall clock. */
   readonly now?: () => Date;
@@ -221,6 +212,12 @@ function seatCountBodyError(
     : "invalid-request-body";
 }
 
+const RECORDING_EVENT = {
+  paused: "recording-paused",
+  resumed: "recording-resumed",
+  stopped: "recording-stopped",
+} as const;
+
 export async function buildApp(
   options: BuildAppOptions,
 ): Promise<FastifyInstance> {
@@ -232,39 +229,24 @@ export async function buildApp(
   assertBotActionDelay(botActionDelay);
   const now = options.now ?? (() => new Date());
   /** One open recording per live room, keyed by join code like every other map here. */
-  const roomRecordings = new Map<string, RoomRecording>();
-  /** A Room enters here the moment an append fails — see recording-paused in `docs/design/server.md`. */
-  interface PausedRoom {
-    readonly operation: RoomOperation;
-    readonly transaction?: DispatchTransaction;
-    readonly onSettled?: () => void;
-  }
-  const pausedRooms = new Map<string, PausedRoom>();
-  /**
-   * A Room enters here once "Continue without recording" resumes it — see
-   * recording-paused in `docs/design/server.md`. Latched for the Room's
-   * life: nothing ever removes a code from this set.
-   */
-  const recordingStopped = new Set<string>();
-  /**
-   * Every completed hand of a room, oldest first, held for the Room's life —
-   * no disk read is involved (Phase 2 spec #129 §5). A server restart
-   * destroys the Room outright, so there is no session whose listing would
-   * need rebuilding.
-   */
+  const roomRecordings = new RoomRecordings({
+    suspend(code) {
+      cancelActionClock(code);
+      clearBotActionTimer(code);
+    },
+    resume(code, paused) {
+      resumePausedTransaction(code, paused);
+    },
+    announce(code, event) {
+      broadcastToRoom(code, { type: RECORDING_EVENT[event] });
+    },
+    logError(code, message, error) {
+      app.log.error({ err: error, room: code }, message);
+    },
+  });
+  /** Every completed hand, oldest first, for the Room's life; no disk read. */
   const handSummaries = new Map<string, HandSummary[]>();
-  /**
-   * The hand currently being dealt, accumulating the Events the room has
-   * already broadcast, so `summarise` can be handed the whole hand the
-   * moment it completes. `startedAt` is stamped here rather than inside
-   * `summarise`, which stays free of a clock.
-   *
-   * `handOrdinal` is stamped at `HandStarted` and counts hands *started*, not
-   * hands completed — that is what `HandLog` numbers its `hand-NNNN`
-   * partitions by, and a summary's ordinal is the address `get-hand` will
-   * resolve against a recording. Counting completions instead would silently
-   * desynchronise the two the first time a hand was abandoned mid-deal.
-   */
+  /** The hand being dealt — see Recording in `docs/design/server.md`. */
   const handsInProgress = new Map<
     string,
     {
@@ -395,27 +377,7 @@ export async function buildApp(
     }
   }
 
-  /**
-   * Drains and closes a room's recording as the room goes away. What is on
-   * disk stays there — closing releases the writer, it does not discard the
-   * recording. `discardLatched` restores a paused Room's confirmed tail
-   * first; it is a no-op when `pausedOperation` is undefined.
-   */
-  async function drainRecording(
-    code: string,
-    pausedOperation: RoomOperation | undefined,
-  ): Promise<void> {
-    const recording = roomRecordings.get(code);
-    if (recording === undefined) return;
-    roomRecordings.delete(code);
-    try {
-      await recording.discardLatched(pausedOperation);
-      await recording.close();
-    } catch (error) {
-      app.log.error({ err: error, room: code }, "recording close failed");
-    }
-  }
-
+  /** Closing releases the writer; what is on disk stays there. */
   /** Cosmetic presence toggle for a seat's socket — never touches `rooms.dispatch`. */
   function markPresence(socket: WebSocket, disconnected: boolean): void {
     const identity = socketIdentity.get(socket);
@@ -436,15 +398,7 @@ export async function buildApp(
     broadcastRoomView(code);
   }
 
-  /**
-   * Ends a room the same way whether triggered by "End session" or the
-   * table device's own reconnect grace window elapsing (Phase 1 spec #130
-   * §7): notify every socket, close them, discard the transport bookkeeping,
-   * drain and close the recording, then discard the room itself. The Room
-   * recording on disk is closed, not removed — Phase 1's keep-everything-
-   * forever retention is binding. See "End session" under recording-paused
-   * in `docs/design/server.md` for the paused case.
-   */
+  /** Ends a room from either trigger — see "End session" in `docs/design/server.md`. */
   async function endRoom(code: string): Promise<void> {
     const sockets = roomSockets.get(code);
     if (sockets) {
@@ -467,21 +421,11 @@ export async function buildApp(
     handSummaries.delete(code);
     handsInProgress.delete(code);
     handsStarted.delete(code);
-    const paused = pausedRooms.get(code);
-    pausedRooms.delete(code);
-    paused?.transaction?.discard();
-    await drainRecording(code, paused?.operation);
-    // A future Room may collide on this join code once it is re-rolled —
-    // leaving this set would start it already believing it has no recording.
-    recordingStopped.delete(code);
+    await roomRecordings.forget(code);
     rooms.end(code);
   }
 
-  /**
-   * The hand listing is a table-device surface (Phase 2 spec #129 §6), so
-   * summaries go only to table identities — a player's socket never receives
-   * one, and never asks for one.
-   */
+  /** The hand listing is a table-device surface: a player never receives one. */
   function sendToTables(code: string, message: ServerMessage): void {
     const sockets = roomSockets.get(code);
     if (!sockets) return;
@@ -497,20 +441,7 @@ export async function buildApp(
     });
   }
 
-  /**
-   * Answers a `get-hand` with the whole Hand — every position of it, in one
-   * message (Phase 2 spec #129 §5).
-   *
-   * The listing is the authority on which ordinals may be served: it holds
-   * exactly the Hands this Room saw complete, so an ordinal missing from it
-   * is one still being dealt, abandoned mid-deal, or never recorded at all.
-   * Checking it here keeps the "an incomplete Hand is never offered" rule
-   * (§4) from resting on the picker alone.
-   *
-   * Reading takes no turn in the Room's queue: a completed Hand's files are
-   * final, and every later operation writes to a different Hand's — so
-   * queueing would only make replay wait on a disk that is already stalling.
-   */
+  /** Answers a `get-hand` whole — see Recording in `docs/design/server.md`. */
   function sendHandReplay(
     socket: WebSocket,
     code: string,
@@ -549,27 +480,19 @@ export async function buildApp(
       });
   }
 
-  /**
-   * Feeds the Events the room just broadcast into the hand being recorded,
-   * and summarises that hand the moment it completes — the same moment
-   * "Review hands" becomes reachable (§6). Only a hand seen whole, from its
-   * `HandStarted` to its `HandComplete`, is ever summarised, so a listing
-   * can't be built from a partial recording (§4). Once "Continue without
-   * recording" has latched, no hand completing from here has a recording to
-   * replay — including the one already in flight — so none of them enter
-   * the listing either (§3, issue #122).
-   */
+  /** Summarises a hand only once seen whole, and never once recording stopped. */
   function accumulateHandSummary(
     code: string,
-    steps: readonly DispatchStep[],
+    transaction: DispatchTransaction,
   ): void {
-    for (const step of steps) {
+    for (const step of transaction.steps) {
       if (step.event.type === "HandStarted") {
         const handOrdinal = (handsStarted.get(code) ?? 0) + 1;
         handsStarted.set(code, handOrdinal);
         handsInProgress.set(code, {
           handOrdinal,
-          startedAt: new Date().toISOString(),
+          startedAt:
+            transaction.operation.context?.startedAt ?? now().toISOString(),
           events: [],
         });
       }
@@ -579,7 +502,7 @@ export async function buildApp(
       if (step.event.type !== "HandComplete") continue;
 
       handsInProgress.delete(code);
-      if (recordingStopped.has(code)) continue;
+      if (roomRecordings.hasStopped(code)) continue;
       let summary: HandSummary;
       try {
         summary = summarise(inProgress.events, {
@@ -587,7 +510,7 @@ export async function buildApp(
           startedAt: inProgress.startedAt,
         });
       } catch {
-        // Only complete, valid hands enter the listing (§4). Unreachable by
+        // Only complete, valid hands enter the listing (#129 §4). Unreachable by
         // construction — this ran because the room broadcast `HandComplete`
         // — but `publishDispatch` is also called from the action clock's
         // timer, where a throw would surface as an unhandled rejection long
@@ -602,75 +525,12 @@ export async function buildApp(
     }
   }
 
-  /**
-   * Hands the room's recording one whole engine operation and waits for it to
-   * be confirmed on disk. Answers whether the operation may now be applied and
-   * broadcast.
-   */
-  async function appendOperation(
-    code: string,
-    operation: RoomOperation,
-  ): Promise<boolean> {
-    // "Continue without recording" latches this — no later operation is
-    // ever offered to the recording again, so nothing here re-pauses the
-    // Room on the very disk it just chose to stop trusting (§3, issue #122).
-    if (recordingStopped.has(code)) return true;
-    const recording = roomRecordings.get(code);
-    if (recording === undefined) {
-      // A bug of ours rather than a disk failure, so it is loud but not fatal
-      // to the table — see `docs/design/server.md`.
-      app.log.error({ room: code }, "dispatch in a room with no recording");
-      return true;
-    }
-
-    try {
-      await recording.append(operation);
-      return true;
-    } catch (error) {
-      // Filesystem detail belongs in operational logs, never on the wire —
-      // the table-facing recovery is `pauseRecording` below.
-      app.log.error({ err: error, room: code }, "recording append failed");
-      return false;
-    }
-  }
-
-  function isRecordingPaused(code: string): boolean {
-    return pausedRooms.has(code);
-  }
-
+  /** Waits for the operation to confirm on disk before it may be broadcast. */
   /** Stops the Actor's clock without arming a replacement — a bare cancel. */
   function cancelActionClock(code: string): void {
     actionClock.clear(code);
     const room = rooms.get(code);
     if (room !== undefined) room.turnEndsAt = null;
-  }
-
-  function broadcastRecordingPaused(code: string): void {
-    broadcastToRoom(code, { type: "recording-paused" });
-  }
-
-  function broadcastRecordingResumed(code: string): void {
-    broadcastToRoom(code, { type: "recording-resumed" });
-  }
-
-  /** Blocks the Room on a failed append — see recording-paused in `docs/design/server.md`. */
-  function pauseRecording(
-    code: string,
-    operation: RoomOperation,
-    settled: Omit<PausedRoom, "operation"> = {},
-  ): void {
-    if (pausedRooms.has(code)) {
-      // Every mutation route checks `isRecordingPaused` before it can reach
-      // an append, so a second pause while one is already retained is a bug
-      // rather than a real disk failure — refusing keeps the first retained
-      // operation intact instead of losing it under a replacement.
-      app.log.error({ room: code }, "recording paused again while paused");
-      return;
-    }
-    cancelActionClock(code);
-    clearBotActionTimer(code);
-    pausedRooms.set(code, { operation, ...settled });
-    broadcastRecordingPaused(code);
   }
 
   /** Answers whether the Rejection was recorded; pauses the Room otherwise. */
@@ -679,8 +539,8 @@ export async function buildApp(
     rejection: DispatchRejection,
   ): Promise<boolean> {
     if (rejection.operation === undefined) return true;
-    const recorded = await appendOperation(code, rejection.operation);
-    if (!recorded) pauseRecording(code, rejection.operation);
+    const recorded = await roomRecordings.append(code, rejection.operation);
+    if (!recorded) roomRecordings.pause(code, rejection.operation);
     return recorded;
   }
 
@@ -710,10 +570,7 @@ export async function buildApp(
     // must land before that Room's recording closes, or it is dropped rather
     // than lost loudly.
     await Promise.all([...roomQueues.values()]);
-    const draining = [...roomRecordings.keys()].map((code) =>
-      drainRecording(code, pausedRooms.get(code)?.operation),
-    );
-    await Promise.all(draining);
+    await roomRecordings.drainAll();
   });
 
   function fanOutHandUpdate(code: string, step: DispatchStep): void {
@@ -804,7 +661,7 @@ export async function buildApp(
       () => {
         botActionTimers.delete(code);
         enqueueDetached(code, async () => {
-          if (isRecordingPaused(code)) return;
+          if (roomRecordings.isPaused(code)) return;
           const currentRoom = rooms.get(code);
           if (!currentRoom || rooms.currentActor(code) !== actor) return;
           const currentSeat = currentRoom.seats[actor];
@@ -865,7 +722,7 @@ export async function buildApp(
     const scheduledAt = room.revision;
     actionClock.schedule(code, timeoutMs, () => {
       enqueueDetached(code, async () => {
-        if (isRecordingPaused(code)) return;
+        if (roomRecordings.isPaused(code)) return;
         const currentRoom = rooms.get(code);
         if (currentRoom?.revision !== scheduledAt) return;
         if (rooms.currentActor(code) !== actor) {
@@ -892,11 +749,7 @@ export async function buildApp(
     });
   }
 
-  /**
-   * Everything that happens once a dispatch's operation is confirmed on
-   * disk — shared by the normal commit path and a Retry that resumes a
-   * paused Room, so the commit seam has exactly one place that runs it.
-   */
+  /** The one place the live path and a resuming Retry both settle through. */
   function settleDispatch(
     code: string,
     transaction: DispatchTransaction,
@@ -913,7 +766,7 @@ export async function buildApp(
     }
     // After the fan-out: the summary describes a hand the room has already
     // seen, so no table learns of a completed hand before its last Event.
-    accumulateHandSummary(code, transaction.steps);
+    accumulateHandSummary(code, transaction);
     if (
       testMode &&
       transaction.steps.some((step) => step.event.type === "HandComplete")
@@ -923,14 +776,7 @@ export async function buildApp(
     scheduleBotAction(code);
   }
 
-  /**
-   * Records an accepted dispatch, commits it, and only then tells the room —
-   * including arming the clock, so append latency costs nobody their thinking
-   * time. See the commit seam in `docs/design/server.md`. `onSettled` runs
-   * once the commit lands, live or via a later Retry, so a caller with
-   * follow-up work (freeing a seat, refreshing the room view) never has to
-   * duplicate it for the resumed path.
-   */
+  /** See the commit seam in `docs/design/server.md`; `onSettled` also runs on Retry. */
   async function publishDispatch(
     code: string,
     transaction: DispatchTransaction,
@@ -939,10 +785,10 @@ export async function buildApp(
       readonly onSettled?: () => void;
     } = {},
   ): Promise<boolean> {
-    if (!(await appendOperation(code, transaction.operation))) {
+    if (!(await roomRecordings.append(code, transaction.operation))) {
       // The transaction is retained, not discarded — a paused Room's Retry
-      // commits this exact operation once recording is confirmed (§3).
-      pauseRecording(code, transaction.operation, {
+      // commits this exact operation once recording is confirmed (#129 §3).
+      roomRecordings.pause(code, transaction.operation, {
         transaction,
         ...(options.onSettled === undefined
           ? {}
@@ -955,14 +801,7 @@ export async function buildApp(
     return true;
   }
 
-  /**
-   * Settles a paused Room's retained operation exactly as a live dispatch
-   * would, once the reason it couldn't be applied has been resolved one way
-   * or another (recorded via Retry, or waved through by Continue without
-   * recording) — the one place Retry and Continue share for resuming play,
-   * so they cannot drift apart on it. A retained Rejection has no
-   * transaction to settle: only the clock restarts.
-   */
+  /** The one place Retry and Continue share for resuming play. */
   function resumePausedTransaction(code: string, paused: PausedRoom): void {
     if (paused.transaction !== undefined) {
       settleDispatch(code, paused.transaction, "reschedule");
@@ -971,73 +810,6 @@ export async function buildApp(
       rescheduleActionClock(code, "reschedule");
       scheduleBotAction(code);
     }
-  }
-
-  /**
-   * Resumes a paused Room: retries the operation it retained and, once
-   * confirmed, settles it exactly as a live dispatch would. The Actor's
-   * clock always restarts at a fresh full interval — a player who lost
-   * thinking time to the outage is not penalised for it (§3).
-   */
-  async function retryRecording(
-    code: string,
-  ): Promise<"resumed" | "still-paused" | "not-paused"> {
-    const paused = pausedRooms.get(code);
-    if (paused === undefined) return "not-paused";
-    const recording = roomRecordings.get(code);
-    if (recording === undefined) {
-      // The Room is still marked paused, so this is a bug rather than a
-      // disk failure a retry could fix — see `pauseRecording`.
-      app.log.error({ room: code }, "retry attempted with no recording");
-      return "still-paused";
-    }
-
-    try {
-      await recording.retry(paused.operation);
-    } catch (error) {
-      app.log.error({ err: error, room: code }, "recording retry failed");
-      return "still-paused";
-    }
-
-    pausedRooms.delete(code);
-    resumePausedTransaction(code, paused);
-    broadcastRecordingResumed(code);
-    return "resumed";
-  }
-
-  /**
-   * Resumes a paused Room without repairing or ever writing to its
-   * recording again — the exit for a disk that will not accept a write a
-   * second time (§3, issue #122). The retained operation commits live
-   * exactly as `retryRecording` would, but nothing is appended for it: the
-   * repairs Retry performs (truncating to confirmed offsets, restoring a
-   * parseable tail) are themselves writes, and cannot run on the filesystem
-   * that just refused one. The recording is closed as it stands —
-   * `RoomRecording.close` touches no file — and `recordingStopped` latches
-   * the choice so no later operation, in this Hand or any after it, is ever
-   * offered to a recording again.
-   */
-  async function continueWithoutRecording(
-    code: string,
-  ): Promise<"resumed" | "not-paused"> {
-    const paused = pausedRooms.get(code);
-    if (paused === undefined) return "not-paused";
-    pausedRooms.delete(code);
-    recordingStopped.add(code);
-
-    const recording = roomRecordings.get(code);
-    roomRecordings.delete(code);
-    if (recording !== undefined) {
-      try {
-        await recording.close();
-      } catch (error) {
-        app.log.error({ err: error, room: code }, "recording close failed");
-      }
-    }
-
-    resumePausedTransaction(code, paused);
-    broadcastToRoom(code, { type: "recording-stopped" });
-    return "resumed";
   }
 
   await app.register(fastifyStatic, { root: publicDir, index: false });
@@ -1079,7 +851,7 @@ export async function buildApp(
     }
 
     const room = staged.commit();
-    roomRecordings.set(room.code, recording);
+    roomRecordings.open(room.code, recording);
     const url = joinUrl(request.headers.host ?? "localhost", room.code);
     const qrCodeDataUrl = await roomQrCodeDataUrl(url);
     return { code: room.code, joinUrl: url, qrCodeDataUrl };
@@ -1095,7 +867,7 @@ export async function buildApp(
       const room = findRoomOrReject(rooms, request.params.code, reply);
       if (!room) return;
       const result = await enqueue(room.code, () => {
-        if (isRecordingPaused(room.code)) {
+        if (roomRecordings.isPaused(room.code)) {
           return { error: "recording-paused" as const };
         }
         const added = rooms.addBots(room, body.data.count);
@@ -1151,7 +923,7 @@ export async function buildApp(
       // A retained startHand/nextHand transaction snapshots the seats it
       // deals in; a repack behind its back would make its Retry commit
       // against seats that no longer match `room.seats`.
-      if (isRecordingPaused(room.code)) {
+      if (roomRecordings.isPaused(room.code)) {
         return { error: "recording-paused" as const };
       }
       const change = rooms.changeSeatCount(room.code, body.data.seatCount);
@@ -1245,7 +1017,7 @@ export async function buildApp(
       }
       const code = request.params.code;
       const result = await enqueue(code, () => {
-        if (isRecordingPaused(code)) {
+        if (roomRecordings.isPaused(code)) {
           return { error: "recording-paused" as const };
         }
         const claim = rooms.claimSeat(code, seatId, body.data.displayName);
@@ -1267,11 +1039,7 @@ export async function buildApp(
     },
   );
 
-  /**
-   * Publishes the fold a freed seat owed, then broadcasts the seat itself.
-   * Answers false when that fold could not be recorded: the seat is still
-   * holding its hand, so it must not be taken from its player either.
-   */
+  /** False when the owed fold could not be recorded: the seat keeps its hand. */
   async function publishSeatRelease(
     code: string,
     seatId: SeatId,
@@ -1310,7 +1078,7 @@ export async function buildApp(
       const released = await enqueue(
         room.code,
         async (): Promise<boolean | "recording-paused"> => {
-          if (isRecordingPaused(room.code)) return "recording-paused";
+          if (roomRecordings.isPaused(room.code)) return "recording-paused";
           return publishSeatRelease(
             room.code,
             seatId,
@@ -1344,7 +1112,7 @@ export async function buildApp(
       }
       const code = request.params.code;
       const refusal = await enqueue(code, async () => {
-        if (isRecordingPaused(code)) return "recording-paused" as const;
+        if (roomRecordings.isPaused(code)) return "recording-paused" as const;
         const result = rooms.leaveSeat(code, seatId, body.data.token);
         if ("error" in result) return result.error;
         return (await publishSeatRelease(code, seatId, result, false))
@@ -1371,7 +1139,9 @@ export async function buildApp(
     async (request, reply) => {
       const room = findRoomOrReject(rooms, request.params.code, reply);
       if (!room) return;
-      const result = await enqueue(room.code, () => retryRecording(room.code));
+      const result = await enqueue(room.code, () =>
+        roomRecordings.retry(room.code),
+      );
       if (result === "not-paused") {
         return reply.code(409).send({ error: "not-paused" });
       }
@@ -1388,7 +1158,7 @@ export async function buildApp(
       const room = findRoomOrReject(rooms, request.params.code, reply);
       if (!room) return;
       const result = await enqueue(room.code, () =>
-        continueWithoutRecording(room.code),
+        roomRecordings.continueWithout(room.code),
       );
       if (result === "not-paused") {
         return reply.code(409).send({ error: "not-paused" });
@@ -1474,17 +1244,17 @@ export async function buildApp(
           // recording-stopped are each told once at the moment they start,
           // and a socket that connects after that moment would otherwise
           // never learn play has stopped, or that it is no longer recorded.
-          if (isRecordingPaused(code)) {
+          if (roomRecordings.isPaused(code)) {
             send(socket, { type: "recording-paused" });
-          } else if (recordingStopped.has(code)) {
+          } else if (roomRecordings.hasStopped(code)) {
             send(socket, { type: "recording-stopped" });
           }
           // Incremental pushes alone would leave a reloaded table with an
           // empty picker for hands it had already seen — Phase 1's catch-up
-          // is one view snapshot, which carries no summaries (§5). Sent even
+          // is one view snapshot, which carries no summaries (#129 §5). Sent even
           // when empty, so the picker has a definite starting state.
           if (joined === "table") sendHandList(socket, code);
-          // One fresh snapshot on connect, never event replay (§7, §9).
+          // One fresh snapshot on connect, never event replay (#129 §7, §9).
           if (room.engine === null) return;
           if (joined === "table") {
             send(socket, {
@@ -1520,7 +1290,7 @@ export async function buildApp(
           if (!parseResult.success) {
             // A replay request rides this same socket and this same Zod
             // boundary, in its own schema, even though it never reaches
-            // `decide` (§5).
+            // `decide` (#129 §5).
             const replay = ReplayRequestSchema.safeParse(parsed);
             if (!replay.success) {
               sendRejection(socket, "invalid-command");
@@ -1549,7 +1319,7 @@ export async function buildApp(
             }
             const sittingOut = parseResult.data.type === "sitOut";
             enqueueDetached(code, () => {
-              if (isRecordingPaused(code)) {
+              if (roomRecordings.isPaused(code)) {
                 sendRejection(socket, "recording-paused");
                 return;
               }
@@ -1570,7 +1340,7 @@ export async function buildApp(
           }
           const commandType = parseResult.data.type;
           enqueueDetached(code, async () => {
-            if (isRecordingPaused(code)) {
+            if (roomRecordings.isPaused(code)) {
               sendRejection(socket, "recording-paused");
               return;
             }

--- a/packages/server/src/hand-replay.ts
+++ b/packages/server/src/hand-replay.ts
@@ -3,12 +3,7 @@ import type { TableReplayPosition } from "@table-top-poker/protocol";
 import type { HandRecordingRead } from "@table-top-poker/recording";
 import { redactEventFor } from "./redact-event.js";
 
-/**
- * A replayed Hand, or the reason it cannot be served. The reason never
- * reaches the table — a `hand-unavailable` rejection says only that much —
- * so `diagnostic` exists for the operational log, where filesystem and
- * corruption detail belongs (Phase 2 spec #129 §3).
- */
+/** `diagnostic` is for the operational log; the table only ever sees `hand-unavailable`. */
 export type TableHandReplay =
   | {
       readonly status: "replayed";
@@ -16,23 +11,7 @@ export type TableHandReplay =
     }
   | { readonly status: "unavailable"; readonly diagnostic: string };
 
-/**
- * Turns one read Hand recording into the positions the table may see.
- *
- * This is the server's whole replay adapter, and the boundary the visibility
- * guarantee rests on: the engine's flipbook carries complete `EngineState`,
- * and every position leaves here projected through `view(state, "table")`
- * into a protocol type that cannot hold one (§7). It takes no audience,
- * redaction option or `revealEverything` flag, and there is no other way out
- * of the engine's replay on this side of the wire. Each position's Event goes
- * through the same `redactEventFor` the live fan-out uses, so the table is
- * shown exactly what it was shown live and no more.
- *
- * Only a `complete` replay is served. An incomplete one — a torn tail, or a
- * Command with no recorded outcome — is refused rather than truncated: the
- * picker must not offer such a Hand at all (§4), so one arriving here means
- * the listing and the recording have already disagreed.
- */
+/** The server's replay adapter — see Secrecy in `docs/design/server.md`. */
 export function tableReplayOf(read: HandRecordingRead): TableHandReplay {
   if (read.status === "missing-file") {
     return { status: "unavailable", diagnostic: `missing ${read.file}` };

--- a/packages/server/src/redact-event.ts
+++ b/packages/server/src/redact-event.ts
@@ -1,14 +1,6 @@
 import type { HandEvent, SeatId } from "@table-top-poker/protocol";
 
-/**
- * The Event as one identity may see it. Only `HoleCardsDealt` carries
- * anything private: the table is told the deal happened and to whom nothing,
- * and a seat is told only its own two cards (Phase 1 spec #130 §4).
- *
- * Shared by the live fan-out and the replay adapter so the visibility
- * boundary is one function — a replay that re-derived it could drift into
- * showing the room cards it never saw live.
- */
+/** One function for the live fan-out and replay alike — see Secrecy in `docs/design/server.md`. */
 export function redactEventFor(
   event: HandEvent,
   identity: SeatId | "table",

--- a/packages/server/src/room-recordings.ts
+++ b/packages/server/src/room-recordings.ts
@@ -1,0 +1,156 @@
+import type { RoomOperation, RoomRecording } from "@table-top-poker/recording";
+import type { DispatchTransaction } from "./rooms.js";
+
+export interface PausedRoom {
+  readonly operation: RoomOperation;
+  readonly transaction?: DispatchTransaction;
+  readonly onSettled?: () => void;
+}
+
+export type RetryOutcome = "resumed" | "still-paused" | "not-paused";
+export type ContinueOutcome = "resumed" | "not-paused";
+
+export interface RoomRecordingsPorts {
+  /** Stops the Actor's clock and any pending bot action, without arming a replacement. */
+  suspend(code: string): void;
+  /** Settles whatever the pause retained, exactly as a live dispatch would. */
+  resume(code: string, paused: PausedRoom): void;
+  announce(code: string, event: "paused" | "resumed" | "stopped"): void;
+  logError(code: string, message: string, error?: unknown): void;
+}
+
+/**
+ * Every Room's open recording and the paused state a failed append puts it in
+ * — see Recording and recording-paused in `docs/design/server.md`. Owns the
+ * three pieces of state that move together: the open writers, the operation a
+ * paused Room retains, and the Rooms that have stopped recording for good.
+ */
+export class RoomRecordings {
+  readonly #open = new Map<string, RoomRecording>();
+  readonly #paused = new Map<string, PausedRoom>();
+  readonly #stopped = new Set<string>();
+  readonly #ports: RoomRecordingsPorts;
+
+  constructor(ports: RoomRecordingsPorts) {
+    this.#ports = ports;
+  }
+
+  open(code: string, recording: RoomRecording): void {
+    this.#open.set(code, recording);
+  }
+
+  isPaused(code: string): boolean {
+    return this.#paused.has(code);
+  }
+
+  hasStopped(code: string): boolean {
+    return this.#stopped.has(code);
+  }
+
+  /** Appends one whole operation, answering whether it is confirmed on disk. */
+  async append(code: string, operation: RoomOperation): Promise<boolean> {
+    if (this.#stopped.has(code)) return true;
+    const recording = this.#open.get(code);
+    if (recording === undefined) {
+      this.#ports.logError(code, "dispatch in a room with no recording");
+      return true;
+    }
+    try {
+      await recording.append(operation);
+      return true;
+    } catch (error) {
+      this.#ports.logError(code, "recording append failed", error);
+      return false;
+    }
+  }
+
+  /** Blocks the Room on a failed append, retaining what could not be recorded. */
+  pause(
+    code: string,
+    operation: RoomOperation,
+    settled: Omit<PausedRoom, "operation"> = {},
+  ): void {
+    if (this.#paused.has(code)) {
+      // Every mutation route checks `isPaused` first, so a second pause is a
+      // bug; refusing keeps the first retained operation rather than losing it.
+      this.#ports.logError(code, "recording paused again while paused");
+      return;
+    }
+    this.#ports.suspend(code);
+    this.#paused.set(code, { operation, ...settled });
+    this.#ports.announce(code, "paused");
+  }
+
+  async retry(code: string): Promise<RetryOutcome> {
+    const paused = this.#paused.get(code);
+    if (paused === undefined) return "not-paused";
+    const recording = this.#open.get(code);
+    if (recording === undefined) {
+      this.#ports.logError(code, "retry attempted with no recording");
+      return "still-paused";
+    }
+
+    try {
+      await recording.retry(paused.operation);
+    } catch (error) {
+      this.#ports.logError(code, "recording retry failed", error);
+      return "still-paused";
+    }
+
+    this.#paused.delete(code);
+    this.#ports.resume(code, paused);
+    this.#ports.announce(code, "resumed");
+    return "resumed";
+  }
+
+  async continueWithout(code: string): Promise<ContinueOutcome> {
+    const paused = this.#paused.get(code);
+    if (paused === undefined) return "not-paused";
+    this.#paused.delete(code);
+    this.#stopped.add(code);
+
+    const recording = this.#open.get(code);
+    this.#open.delete(code);
+    if (recording !== undefined) {
+      try {
+        await recording.close();
+      } catch (error) {
+        this.#ports.logError(code, "recording close failed", error);
+      }
+    }
+
+    this.#ports.resume(code, paused);
+    this.#ports.announce(code, "stopped");
+    return "resumed";
+  }
+
+  /** Drains and closes one Room's recording; what is on disk stays there. */
+  async drain(code: string): Promise<void> {
+    const pausedOperation = this.#paused.get(code)?.operation;
+    const recording = this.#open.get(code);
+    if (recording === undefined) return;
+    this.#open.delete(code);
+    try {
+      await recording.discardLatched(pausedOperation);
+      await recording.close();
+    } catch (error) {
+      this.#ports.logError(code, "recording close failed", error);
+    }
+  }
+
+  async drainAll(): Promise<void> {
+    await Promise.all([...this.#open.keys()].map((code) => this.drain(code)));
+  }
+
+  /** Discards a Room's retained transaction and forgets it entirely. */
+  async forget(code: string): Promise<void> {
+    this.#paused.get(code)?.transaction?.discard();
+    // Drains before forgetting the pause: the retained operation is what
+    // `discardLatched` restores the confirmed tail against.
+    await this.drain(code);
+    this.#paused.delete(code);
+    // A future Room may collide on this join code once it is re-rolled —
+    // leaving this set would start it already believing it has no recording.
+    this.#stopped.delete(code);
+  }
+}

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -44,11 +44,7 @@ export interface Seat {
 }
 
 export interface Room {
-  /**
-   * The Room's durable opaque identity, naming its Room recording directory
-   * on disk. Distinct from `code`, which is a live human-typed handle that is
-   * re-rolled on collision and means nothing once the Room ends.
-   */
+  /** See Room ID in `CONTEXT.md`. */
   readonly id: string;
   readonly code: string;
   readonly seats: Seat[];
@@ -62,13 +58,7 @@ export interface Room {
   shotClockSettings: ShotClockSettings;
 }
 
-/**
- * A Room that has its durable identity and a reserved join code but is not
- * yet joinable. Room creation is transactional with recording creation: the
- * caller stages, writes `room.json`, and only then commits — so a Room whose
- * recording could not be created never enters the live store and never hands
- * out a code or a QR.
- */
+/** Staged, not yet joinable: Room creation is transactional with recording creation. */
 export interface StagedRoom {
   readonly room: Room;
   /** Publishes the Room into the live store and returns it. */
@@ -331,11 +321,7 @@ function resolveButtonFor(
   return ordered.find((id) => id > previousButton) ?? first;
 }
 
-/**
- * Turns an accepted dispatch into the whole operation the recording takes.
- * The state right after `HandStarted` is where a Hand's seats and button are
- * fixed; nothing later in the same operation moves them.
- */
+/** The state right after `HandStarted` is where a Hand's seats and button are fixed. */
 function toRoomOperation(
   success: DispatchSuccess,
   now: () => Date,
@@ -388,13 +374,7 @@ export class RoomStore {
     this.#now = now;
   }
 
-  /**
-   * Stages a room sized to the creator's chosen seat count (issue #74),
-   * without publishing it. The range is a domain rule, not a UI one, so an
-   * out-of-range count is a caller bug and throws — the HTTP edge parses the
-   * untrusted body with `CreateRoomRequestSchema` and answers 400 before ever
-   * reaching here.
-   */
+  /** An out-of-range count is a caller bug and throws; the HTTP edge answers 400 first. */
   stage(seatCount: number = DEFAULT_SEAT_COUNT): StagedRoom {
     if (!SeatCountSchema.safeParse(seatCount).success) {
       throw new RangeError(
@@ -431,11 +411,7 @@ export class RoomStore {
     };
   }
 
-  /**
-   * Stages and immediately publishes a room. The uninterrupted path is only
-   * safe where nothing else has to succeed first; the HTTP create route uses
-   * {@link stage} so the Room's recording is written before it is joinable.
-   */
+  /** Only safe where nothing else has to succeed first; the HTTP route uses {@link stage}. */
   create(seatCount: number = DEFAULT_SEAT_COUNT): Room {
     return this.stage(seatCount).commit();
   }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,11 +1,7 @@
 import { DirectoryRecordings } from "@table-top-poker/recording";
 import { buildApp } from "./app.js";
 
-/**
- * Where Room recordings live. Unset is a default, never an off switch —
- * recording is a Room invariant (Phase 2 spec #129 §3), and this process
- * refuses to start if the root will not take a write.
- */
+/** Unset is a default, never an off switch: recording is a Room invariant. */
 const DEFAULT_RECORDINGS_DIR = "./recordings";
 
 async function main(): Promise<void> {
@@ -13,18 +9,14 @@ async function main(): Promise<void> {
   const recordings = new DirectoryRecordings(
     process.env.RECORDINGS_DIR ?? DEFAULT_RECORDINGS_DIR,
   );
-  // Before listening, not at the first hand: an unwritable disk discovered
-  // mid-session is discovered far too late, and a room already has players in
-  // it by then.
+  // Before listening: an unwritable disk found mid-session is found far too late.
   await recordings.ensureWritable();
 
   const app = await buildApp({ recordings, testMode });
   const port = Number(process.env.PORT ?? 3000);
   const host = process.env.HOST ?? "127.0.0.1";
 
-  // A deploy is `systemctl restart poker`, so SIGTERM is the normal way this
-  // process ends. Closing the app drains every open recording first; without
-  // this the append in flight at that moment is simply lost.
+  // SIGTERM is the normal end (a deploy restarts the unit); closing drains first.
   for (const signal of ["SIGINT", "SIGTERM"] as const) {
     process.once(signal, () => {
       app.log.info(`${signal} received, draining recordings`);

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -145,7 +145,7 @@ export function App() {
     setMenuSeatId(null);
   }, [roomCode, menuSeatId]);
 
-  const forgetSession = useCallback(() => {
+  const forgetRoom = useCallback(() => {
     clearHostedRoom(window.localStorage);
     setSettingsOpen(false);
     setHandPickerOpen(false);
@@ -155,7 +155,7 @@ export function App() {
     clearHandHistory();
   }, [clearRoom, clearHand, clearHandHistory, closeReview]);
 
-  const { send } = useWebSocket(roomCode, { onRoomEnded: forgetSession });
+  const { send } = useWebSocket(roomCode, { onRoomEnded: forgetRoom });
 
   const [seatCount, setSeatCount] = useState(DEFAULT_SEAT_COUNT);
   const handleCreateRoom = useCallback(() => {
@@ -173,11 +173,11 @@ export function App() {
   const handleEndSession = useCallback(() => {
     if (!roomCode) return;
     endSession(roomCode)
-      .then(forgetSession)
+      .then(forgetRoom)
       .catch((error: unknown) => {
         console.error(error);
       });
-  }, [roomCode, forgetSession]);
+  }, [roomCode, forgetRoom]);
 
   const handleAddBot = useCallback(() => {
     if (roomCode === null || !testMode) return;

--- a/packages/table-client/src/HandPicker.tsx
+++ b/packages/table-client/src/HandPicker.tsx
@@ -15,6 +15,7 @@ import {
 } from "@table-top-poker/ui-shared";
 import { useEffect, useMemo, useState, type CSSProperties } from "react";
 import { seatLabel } from "./seatLabel.js";
+import { showdownVerdict } from "./showdownVerdict.js";
 
 export interface HandPickerProps {
   readonly summaries: readonly HandSummary[];
@@ -26,7 +27,7 @@ export interface HandPickerProps {
 /**
  * Polls `Date.now()` on an interval rather than computing the relative
  * label once at mount, so it visibly goes stale ("just now" -> "1m ago")
- * while the picker stays open (§6).
+ * while the picker stays open (#129 §6).
  */
 function useNow(): number {
   const [now, setNow] = useState(() => Date.now());
@@ -84,11 +85,11 @@ function outcomeText(hand: HandSummary, seats: readonly SeatView[]): string {
   if (outcome.kind === "folded-out") {
     return `${seatLabel(outcome.winner, seats)} wins — everyone folded`;
   }
-  const names = outcome.winners.map((seatId) => seatLabel(seatId, seats));
-  const verb = outcome.winners.length > 1 ? "split" : "wins";
-  const description = outcome.reveals.find((reveal) =>
-    outcome.winners.includes(reveal.seatId),
-  )?.description;
+  const { names, verb, description } = showdownVerdict(
+    outcome.winners,
+    outcome.reveals,
+    seats,
+  );
   const headline = `${names.join(" & ")} ${verb}`;
   return description ? `${headline} — ${description}` : headline;
 }

--- a/packages/table-client/src/replay/CaptionStrip.test.tsx
+++ b/packages/table-client/src/replay/CaptionStrip.test.tsx
@@ -6,34 +6,27 @@ import {
   CaptionStrip,
   FELT_LAYER,
 } from "./CaptionStrip.js";
-
-const TRANSPORT = 10.2;
+import { TRANSPORT_HEIGHT } from "./ReplayTransport.js";
 
 describe("CaptionStrip", () => {
   it("names the beat in a band of its own, above the transport", () => {
-    const html = renderToStaticMarkup(
-      <CaptionStrip caption="The turn" transportHeight={TRANSPORT} />,
-    );
+    const html = renderToStaticMarkup(<CaptionStrip caption="The turn" />);
     const style =
       /data-testid="replay-caption"[^>]*style="([^"]*)"/.exec(html)?.[1] ?? "";
 
     expect(html).toContain("The turn");
-    expect(style).toContain(`bottom:${String(TRANSPORT)}em`);
+    expect(style).toContain(`bottom:${String(TRANSPORT_HEIGHT)}em`);
     expect(style).toContain(`height:${String(CAPTION_BAND)}em`);
   });
 
   it("renders an empty band when there is no beat to name", () => {
-    const html = renderToStaticMarkup(
-      <CaptionStrip caption={null} transportHeight={TRANSPORT} />,
-    );
+    const html = renderToStaticMarkup(<CaptionStrip caption={null} />);
 
     expect(html).toContain('data-testid="replay-caption"');
   });
 
   it("gives way to a pod that reaches into its band, never over it", () => {
-    const html = renderToStaticMarkup(
-      <CaptionStrip caption="The turn" transportHeight={TRANSPORT} />,
-    );
+    const html = renderToStaticMarkup(<CaptionStrip caption="The turn" />);
 
     expect(html).toContain(`z-index:${String(CAPTION_LAYER)}`);
     expect(CAPTION_LAYER).toBeLessThan(FELT_LAYER);

--- a/packages/table-client/src/replay/CaptionStrip.tsx
+++ b/packages/table-client/src/replay/CaptionStrip.tsx
@@ -1,23 +1,21 @@
 import { color, font, fontSize } from "@table-top-poker/ui-shared";
+import { TRANSPORT_HEIGHT } from "./ReplayTransport.js";
 
 export interface CaptionStripProps {
   readonly caption: string | null;
-  /** Height in `em` of the transport chrome the strip sits above. */
-  readonly transportHeight: number;
 }
 
 /** The band the Caption owns, which `ReplayStage` lays the felt out above. */
 export const CAPTION_BAND = 2.4;
 
 /**
- * A bottom-row pod grows below its anchor, so on a short felt it can reach
- * into this band. The strip stays under the felt layer, so what gives is the
- * caption rather than the table. See Caption in `CONTEXT.md`.
+ * `ReplayStage` reserves `BOTTOM_BAND` above this one, so a pod growing below
+ * its anchor stays out of it. The layering is the backstop, not the mechanism.
  */
 export const CAPTION_LAYER = 0;
 export const FELT_LAYER = 1;
 
-export function CaptionStrip({ caption, transportHeight }: CaptionStripProps) {
+export function CaptionStrip({ caption }: CaptionStripProps) {
   return (
     <div
       data-testid="replay-caption"
@@ -25,7 +23,7 @@ export function CaptionStrip({ caption, transportHeight }: CaptionStripProps) {
         position: "absolute",
         left: "1.8em",
         right: "1.8em",
-        bottom: `${String(transportHeight)}em`,
+        bottom: `${String(TRANSPORT_HEIGHT)}em`,
         height: `${String(CAPTION_BAND)}em`,
         zIndex: CAPTION_LAYER,
         display: "flex",

--- a/packages/table-client/src/replay/HandReview.tsx
+++ b/packages/table-client/src/replay/HandReview.tsx
@@ -7,7 +7,7 @@ import { beatAt, chaptersOf, holdAt, toBeats } from "./beats.js";
 import { captionFor } from "./caption.js";
 import { CaptionStrip } from "./CaptionStrip.js";
 import { ReplayStage } from "./ReplayStage.js";
-import { ReplayTransport, TRANSPORT_HEIGHT } from "./ReplayTransport.js";
+import { ReplayTransport } from "./ReplayTransport.js";
 
 export interface HandReviewProps {
   readonly review: HandReviewState;
@@ -99,18 +99,10 @@ export function HandReview({ review, seats, onClose }: HandReviewProps) {
   return (
     <>
       {view !== undefined && (
-        <ReplayStage
-          view={view}
-          seats={seats}
-          transportHeight={TRANSPORT_HEIGHT}
-          actionLabels={labels}
-        />
+        <ReplayStage view={view} seats={seats} actionLabels={labels} />
       )}
       <BackToHands onClose={onClose} />
-      <CaptionStrip
-        caption={captionFor(event, seats)}
-        transportHeight={TRANSPORT_HEIGHT}
-      />
+      <CaptionStrip caption={captionFor(event, seats)} />
       <ReplayTransport
         beats={beats}
         chapters={chapters}

--- a/packages/table-client/src/replay/ReplayStage.test.tsx
+++ b/packages/table-client/src/replay/ReplayStage.test.tsx
@@ -3,7 +3,8 @@ import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import { CAPTION_BAND, FELT_LAYER } from "./CaptionStrip.js";
-import { ReplayStage, TOP_BAND } from "./ReplayStage.js";
+import { TRANSPORT_HEIGHT } from "./ReplayTransport.js";
+import { BOTTOM_BAND, ReplayStage, TOP_BAND } from "./ReplayStage.js";
 
 const seats: readonly SeatView[] = [0, 1, 2, 3].map((id) => ({
   id,
@@ -30,32 +31,30 @@ const view: TableView = {
   seats: seats.map((seat) => ({ seatId: seat.id, folded: false })),
 };
 
-const TRANSPORT = 10.2;
-
 describe("ReplayStage", () => {
   it("lays the table out between reserved bands, clear of the transport", () => {
     const html = renderToStaticMarkup(
-      <ReplayStage
-        view={view}
-        seats={seats}
-        transportHeight={TRANSPORT}
-        actionLabels={new Map()}
-      />,
+      <ReplayStage view={view} seats={seats} actionLabels={new Map()} />,
     );
 
     expect(html).toContain(`top:${String(TOP_BAND)}em`);
-    expect(html).toContain(`bottom:${String(TRANSPORT + CAPTION_BAND)}em`);
+    expect(html).toContain(
+      `bottom:${String(TRANSPORT_HEIGHT + CAPTION_BAND + BOTTOM_BAND)}em`,
+    );
     expect(html).toContain(`z-index:${String(FELT_LAYER)}`);
+  });
+
+  it("reserves the Caption's band rather than letting a pod grow into it", () => {
+    const feltBottom = TRANSPORT_HEIGHT + CAPTION_BAND + BOTTOM_BAND;
+    const captionTop = TRANSPORT_HEIGHT + CAPTION_BAND;
+
+    expect(feltBottom).toBeGreaterThan(captionTop);
+    expect(feltBottom - captionTop).toBe(BOTTOM_BAND);
   });
 
   it("renders the felt through the live Seats and Board, projected", () => {
     const html = renderToStaticMarkup(
-      <ReplayStage
-        view={view}
-        seats={seats}
-        transportHeight={TRANSPORT}
-        actionLabels={new Map()}
-      />,
+      <ReplayStage view={view} seats={seats} actionLabels={new Map()} />,
     );
 
     expect(html).toContain('data-testid="seats"');

--- a/packages/table-client/src/replay/ReplayStage.tsx
+++ b/packages/table-client/src/replay/ReplayStage.tsx
@@ -3,37 +3,26 @@ import { Board } from "../Board.js";
 import { Seats } from "../Seats.js";
 import type { SeatActionLabels } from "../actionWords.js";
 import { CAPTION_BAND, FELT_LAYER } from "./CaptionStrip.js";
+import { TRANSPORT_HEIGHT } from "./ReplayTransport.js";
 
 export interface ReplayStageProps {
   readonly view: TableView;
   readonly seats: readonly SeatView[];
-  /** Height in `em` of the transport chrome drawn along the bottom. */
-  readonly transportHeight: number;
   readonly actionLabels: SeatActionLabels;
 }
 
-/**
- * A seat pod is anchored by its avatar and grows *around* that anchor, so a
- * top-row pod carrying a showdown description reaches further up than
- * `posFor`'s 10% and clips the felt's edge. The bottom row overlaps the
- * transport for the mirror reason (Phase 2 spec #129 §6).
- */
+/** A pod grows around its avatar anchor, so it reaches past `posFor`'s 10%. */
 export const TOP_BAND = 4.5;
 
+/** The mirror of {@link TOP_BAND}: what the bottom row needs to clear the Caption. */
+export const BOTTOM_BAND = TOP_BAND;
+
 /**
- * The felt at one position of a replayed hand: the live `Seats` and `Board`,
- * fed the position's `view(state, "table")`. No `replay` flag and no parallel
- * rendering path — the visibility guarantee is inherited, not re-implemented.
- *
- * `Board` is deliberately not keyed on the position: it decides for itself
- * which cards have just arrived, so scrubbing does not re-deal all five.
+ * The live `Seats` and `Board` fed one replay position — no parallel rendering
+ * path, so the visibility guarantee is inherited. `Board` is deliberately not
+ * keyed on the position: scrubbing must not re-deal all five cards.
  */
-export function ReplayStage({
-  view,
-  seats,
-  transportHeight,
-  actionLabels,
-}: ReplayStageProps) {
+export function ReplayStage({ view, seats, actionLabels }: ReplayStageProps) {
   return (
     <div
       data-testid="replay-stage"
@@ -42,7 +31,7 @@ export function ReplayStage({
         top: `${String(TOP_BAND)}em`,
         left: 0,
         right: 0,
-        bottom: `${String(transportHeight + CAPTION_BAND)}em`,
+        bottom: `${String(TRANSPORT_HEIGHT + CAPTION_BAND + BOTTOM_BAND)}em`,
         zIndex: FELT_LAYER,
       }}
     >

--- a/packages/table-client/src/replay/ReplayTransport.tsx
+++ b/packages/table-client/src/replay/ReplayTransport.tsx
@@ -15,10 +15,7 @@ export interface ReplayTransportProps {
   readonly currentStreet: Chapter["street"] | null;
 }
 
-/**
- * Comfortably past the ~44px touch-target floor at the table device's root
- * size, and wide enough to hit without aiming.
- */
+/** Past the ~44px touch-target floor at the table device's root size. */
 const CHIP_HEIGHT = 3.4;
 const ROW_GAP = 0.8;
 /** The grab zone, deliberately far taller than the 6px rail it draws. */
@@ -29,14 +26,7 @@ const BOTTOM_MARGIN = 1.4;
 export const TRANSPORT_HEIGHT =
   CHIP_HEIGHT + ROW_GAP + TRACK_HEIGHT + BOTTOM_MARGIN;
 
-/**
- * The scrub: a ticked track the width of the felt, chaptered by street, with
- * autoplay demoted to a chip beside the chapters.
- *
- * Sized for a finger rather than a cursor — the grab zone is the full height
- * of the track row, well past the visible rail, and the chips clear the touch
- * target floor (Phase 2 spec #129 §6).
- */
+/** The Scrub (`CONTEXT.md`), sized for a finger rather than a cursor. */
 export function ReplayTransport({
   beats,
   chapters,

--- a/packages/table-client/src/replay/beats.ts
+++ b/packages/table-client/src/replay/beats.ts
@@ -4,21 +4,13 @@ import type {
   TableReplayPosition,
 } from "@table-top-poker/protocol";
 
-/**
- * One Event ordinal, dressed for the transport. Position is the Event ordinal
- * throughout (Phase 2 spec #129 §2) — beat *n* is the state after applying
- * *n* Events, so position 0 has no beat.
- */
+/** One Event ordinal, dressed for the transport — see Replay position in `CONTEXT.md`. */
 export interface Beat {
   readonly position: number;
   readonly street: Street | null;
   /** How long autoplay holds here, in ms. */
   readonly weight: number;
-  /**
-   * The first beat of its street: the track draws it heavier and a Chapter
-   * seeks to it. One flag for both, so a chip can never land beside the tick
-   * marking the boundary it names.
-   */
+  /** One flag for the heavier tick and the Chapter seek, so the two cannot drift apart. */
   readonly isStreetBoundary: boolean;
 }
 
@@ -29,10 +21,7 @@ export const streetLabel: Record<Street, string> = {
   river: "River",
 };
 
-/**
- * Autoplay's per-event pacing: beats that *change what is on the felt* are
- * held, and beats that only advance the bookkeeping go past quickly (§6).
- */
+/** Autoplay pacing: what changes the felt is held, bookkeeping goes past quickly. */
 const WEIGHTS: Record<HandEvent["type"], number> = {
   HandStarted: 900,
   HoleCardsDealt: 1400,
@@ -101,11 +90,7 @@ export function beatAt(beats: readonly Beat[], position: number): Beat | null {
 /** A hand opens on an empty felt, where there is nothing to hold on. */
 const LEAD_IN = 400;
 
-/**
- * How long autoplay stays at `position`: the weight of the Event that put the
- * felt in the state now on screen, so a board deal is held and a
- * `StreetClosed` is passed straight through.
- */
+/** The weight of the Event that put the felt in the state now on screen. */
 export function holdAt(beats: readonly Beat[], position: number): number {
   return beatAt(beats, position)?.weight ?? LEAD_IN;
 }

--- a/packages/table-client/src/replay/caption.ts
+++ b/packages/table-client/src/replay/caption.ts
@@ -1,6 +1,7 @@
 import type { HandEvent, SeatView } from "@table-top-poker/protocol";
 import { actionVerb } from "../actionWords.js";
 import { seatLabel } from "../seatLabel.js";
+import { showdownVerdict } from "../showdownVerdict.js";
 import { streetLabel } from "./beats.js";
 
 const boardName = {
@@ -18,15 +19,13 @@ function showdownCaption(
   event: Extract<HandEvent, { type: "ShowdownReached" }>,
   seats: readonly SeatView[],
 ): string {
-  const winners = joinNames(
-    event.winners.map((seatId) => seatLabel(seatId, seats)),
+  const { names, verb, description } = showdownVerdict(
+    event.winners,
+    event.results,
+    seats,
   );
-  const description = event.results.find((result) =>
-    event.winners.includes(result.seatId),
-  )?.description;
-  const verb = event.winners.length > 1 ? "split" : "wins";
   const hand = description === undefined ? "" : ` with ${description}`;
-  return `Showdown — ${winners} ${verb}${hand}`;
+  return `Showdown — ${joinNames(names)} ${verb}${hand}`;
 }
 
 /** The beat just landed on — see Caption in `CONTEXT.md`. */

--- a/packages/table-client/src/replay/track.ts
+++ b/packages/table-client/src/replay/track.ts
@@ -1,6 +1,6 @@
 import type { Beat } from "./beats.js";
 
-/** Where one-tick-per-ordinal stops being legible on a table device (§6). */
+/** Where one-tick-per-ordinal stops being legible on a table device (#129 §6). */
 export const MAX_TICKS = 240;
 
 /** Maps a fraction along the track to the ordinal it names. */
@@ -12,7 +12,7 @@ export function positionAtRatio(ratio: number, total: number): number {
 /**
  * The ticks the track draws. Ticks are a visual affordance and may collapse on
  * a long hand; street boundaries never do, because chapters are the
- * navigation contract (§6).
+ * navigation contract (#129 §6).
  */
 export function ticksFor(beats: readonly Beat[]): readonly Beat[] {
   if (beats.length <= MAX_TICKS) return beats;

--- a/packages/table-client/src/showdownVerdict.ts
+++ b/packages/table-client/src/showdownVerdict.ts
@@ -1,0 +1,26 @@
+import type { SeatView } from "@table-top-poker/protocol";
+import { seatLabel } from "./seatLabel.js";
+
+interface Revealed {
+  readonly seatId: number;
+  readonly description: string;
+}
+
+export interface ShowdownVerdict {
+  readonly names: readonly string[];
+  readonly verb: "wins" | "split";
+  readonly description: string | undefined;
+}
+
+export function showdownVerdict(
+  winners: readonly number[],
+  revealed: readonly Revealed[],
+  seats: readonly SeatView[],
+): ShowdownVerdict {
+  return {
+    names: winners.map((seatId) => seatLabel(seatId, seats)),
+    verb: winners.length > 1 ? "split" : "wins",
+    description: revealed.find((reveal) => winners.includes(reveal.seatId))
+      ?.description,
+  };
+}


### PR DESCRIPTION
Closes the nine findings from the two-axis review of `replay` against `main`, ahead of the merge to `main`. Base is `replay`.

## Spec axis

**`startedAt` divergence (#116/#129 §3+§6)** — `accumulateHandSummary` re-read the wall clock, but it runs from `settleDispatch`, *after* the append confirms; the recorded Hand context takes the same timestamp at staging. The two diverged by exactly the append latency the spec singles out, so a summary derived from disk disagreed with the one pushed live. The summary now carries the context's `startedAt` through. Regression test asserts it against a `RoomStore` and a `buildApp` given deliberately different clocks — verified red without the fix.

**Caption band (#127)** — "never overlaps a seat pod" was met by z-order: the strip sat *under* the felt, so a bottom-row pod covered the caption. `ReplayStage` now reserves `BOTTOM_BAND`, the mirror of the `TOP_BAND` it already reserves for the top row. Layering stays as a backstop.

**`startingPositionOnly` (#120)** — kept, and now specified. It emits position 0 (real data, derived from the Hand context that read cleanly) when the first Command line is torn, which matches `CONTEXT.md`'s "the dev stepper shows the prefix with a warning". Documented in the harness README so it is no longer undocumented added behaviour. **Flagging for a second opinion:** removing it instead is a product call, not mine.

## Standards axis

**Comment breach** — 962 added comment lines across non-test source, against zero in the files they grew from. Load-bearing rationale moved to where `CLAUDE.md` sends it (`docs/design/server.md`, `docs/design/engine.md`, `CONTEXT.md`, the harness README); the rest deleted or cut to one referring line. **962 → 388.** The sharpest case: `app.ts:1008` restated `docs/design/server.md:183` near-verbatim.

**`§` references** — 107 of them, many bare (`§6` naming no document). All now qualified.

**`forgetSession`** — renamed `forgetRoom`; `CONTEXT.md` lists Session under Room's _Avoid_. The player-facing "game" copy was left alone: `PlayerMenu.tsx:22` already says "Leave the game?" on `main`.

**Duplicated showdown headline** — one shared `showdownVerdict` behind `HandPicker` and the scrub caption.

**Divergent change in `app.ts`** — the recording writers, the paused-Room state machine and the stopped-Room latch always moved together; they now live behind `RoomRecordings` with the clock, bot timers, broadcast and log injected as ports. **`app.ts` 1639 → 1409.**

**Repeated switches** — left alone, as the review judged them defensible.

## Verification

- `npm run build` (`tsc --build`) clean
- `npm run lint` (eslint + prettier) clean
- **831 tests pass** across `server`, `table-client`, `protocol`, `recording`, `engine`, `harness`

One real regression was caught and fixed mid-refactor: the first cut of `RoomRecordings.forget` deleted the paused entry before `drain` read it, so `discardLatched` no longer restored the confirmed tail on End session. `app.test.ts` caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfSrG1V67R3NDwgrePLyFV