### PR TITLE
docs: record the all-in and showdown-visibility decisions

### DIFF
--- a/docs/adr/0007-all-in-as-declared-actions-without-chip-values.md
+++ b/docs/adr/0007-all-in-as-declared-actions-without-chip-values.md
@@ -1,0 +1,76 @@
+# 0007 — All-in is two declared actions, without tracking a chip value
+
+## Status
+
+Accepted. Extends [ADR-0001](0001-preflop-legality-without-tracked-blind-values.md)
+without reopening it: no chip amount, Pot, or stack is introduced.
+
+## Context
+
+The engine never stores a chip amount (`docs/design/engine.md`, ADR-0001), and
+until now `ActionType` was `fold | check | call | raise`. That set has no way to
+say "this seat has no chips left", which makes an all-in unrepresentable: the
+seat stays in `toAct` and is asked to decide again on the next street, where
+`check` is illegal facing a bet and every other action is a lie.
+
+Showdown visibility (ADR-0008) needs the same fact for a different reason — a
+seat that cannot fold cannot be allowed to conceal — so the gap had to close
+before optional showing could be built.
+
+The hard part is that "all-in" is two different poker events wearing one name. A
+short stack putting their last chips in to match a bet does not reopen the
+betting; a deeper stack shoving over a bet does. A value-less engine cannot tell
+these apart, because the distinction is entirely about an amount it refuses to
+know.
+
+Three ways out were considered. Inferring aggression from `facingBet` alone gets
+the re-raise-all-in case wrong. A single `allIn` action that always reopens
+betting hands out turns to seats that have already acted. Marking a seat all-in
+from the table device puts a poker decision on the wrong screen.
+
+## Decision
+
+`ActionType` gains **two** actions, `allInCall` and `allInRaise`. Both remove the
+acting seat from `toAct` for the remainder of the hand; they differ only in
+whether they reopen the betting:
+
+| Action | Reopens betting (`requeueAfterRaise`) | Can act again |
+| --- | --- | --- |
+| `allInRaise` | yes | no |
+| `allInCall` | no | no |
+| `call` | n/a | yes |
+
+The distinction is declared by the human, who is the only party that knows their
+own stack. Both are offered whenever the seat faces a bet; when it does not,
+`allInRaise` is the only all-in available and the client labels it "All in".
+A player who covers a shove and wants to continue simply presses `call` — the
+engine needs no notion that they covered it, because "can this seat act again"
+is the only fact that matters.
+
+`allInRaise` sets `lastAggressor` (ADR-0008); `allInCall` does not.
+
+Consequent rule changes:
+
+- **Fold-out counts all-in seats as unfolded.** A shover cannot be folded out of
+  a pot they have already bought a claim to, so `HandFoldedOut` fires only when
+  exactly one seat is unfolded counting all-in seats.
+- **The run-out is automatic.** When fewer than two seats can still act,
+  remaining streets deal without opening — `BoardDealt` with no `StreetStarted`,
+  through to the river. There is no betting turn with nothing to bet against.
+- **Both all-in actions are confirmed before they send.** They are irreversible
+  and self-excluding, and a misdeclared `allInCall` locks a covered player out of
+  their own hand.
+
+## Consequences
+
+- Side pots remain a physical-chips problem. The engine can rank hands but
+  cannot say who wins which pot, which is why showdown leads with a rank order
+  rather than a single winner (ADR-0008).
+- `legalActions` stays the single source of truth: it gains the two actions and
+  the `facingBet` predicate that already separates `check` from `call` now also
+  decides which all-in labels a client shows.
+- The client paces the automatic run-out itself; `boardDeal.ts` already stages
+  the board, so three streets emitted at once still read as three beats.
+- A misdeclaration is not recoverable. There is no undo, and adding one would be
+  a general facility touching replay, not part of this decision.
+- Phase 4 chip/stake/Pot tracking remains out of scope and untouched.

--- a/docs/adr/0008-showdown-visibility-is-engine-state.md
+++ b/docs/adr/0008-showdown-visibility-is-engine-state.md
@@ -1,0 +1,73 @@
+# 0008 — Showing at showdown is optional, and lives in engine state
+
+## Status
+
+Accepted. Depends on [ADR-0007](0007-all-in-as-declared-actions-without-chip-values.md)
+for the all-in actions this decision compels to show.
+
+## Context
+
+Reaching showdown revealed every surviving Seat's Hole cards unconditionally:
+`ShowdownCompleteHandState.results` is a list of `RevealedResult`, and `view()`
+hands the same list to the table and to every player. That is not how Texas
+Hold'em is played. Showing is compulsory only for the last aggressor, and a
+losing hand may muck rather than expose how it was played.
+
+Two constraints shaped the answer. `CONTEXT.md` makes the table surface obey
+live visibility "exactly by re-projecting `view(state, 'table')`", so any
+concealment implemented as a client-side filter would be re-revealed by Replay —
+a mucked hand has to stay mucked. And the presentation was a full-screen
+`ShowdownOverlay`, a second table that hid the one people were already looking
+at.
+
+## Decision
+
+**Showing is engine state.** Two new commands — `reveal`, table-originated in the
+pattern of `startHand`/`nextHand`, and `show`, sent by a player — produce events
+that Replay re-runs. Hole cards a Seat has not shown do not leave `view()`, and
+neither does anything derived from them: no `rank`, no `bestHand`, no
+`description`. `RevealedResult` becomes the type that exists *only* for a shown
+Seat, so holding one is proof the cards are public. The showdown view carries
+`contestants` — every Seat that reached showdown, shown or not — separately from
+`results`, so the table can render a concealed Seat without learning its hand.
+
+**The hand rests before it resolves.** River close leaves the hand awaiting
+reveal: no Hole cards and no `winners` in any view. The table's Reveal press
+turns over the compulsory hands and publishes `winners`. Compulsory means the
+river's last aggressor (`lastAggressor`, reset each street, so a checked-through
+river has none) plus every all-in Seat; if that set is empty, the winning Seat is
+compelled instead, because a pot must never be awarded to two face-down cards.
+Every other contestant may then show, in any order, and a Seat that has shown
+cannot conceal again. The window closes when the table deals the next hand,
+which mucks whatever was not shown.
+
+**Showdown happens on the table, not over it.** Shown cards appear on the Seat
+plate, oriented toward the table centre, with the verdict and a rank badge —
+hands are ranked best-first with ties sharing a badge, listing shown hands only,
+because with side pots (ADR-0007) "who won" has more than one answer and the
+humans settle the chips. Card backs sit above an unshown Seat while the window is
+open and vanish when the hand closes. `ShowdownOverlay` survives as a house rule,
+defaulting off and persisted per-room. A player's own device shows only their own
+hand and the verdict: the table is the shared surface.
+
+## Consequences
+
+- Showing is a distinct concept from *Hole-card reveal*, which stays local
+  presentation and keeps its gesture. The player's show control is a separate,
+  explicit button, because irreversible publication should not ride on the
+  gesture used all hand for a private, freely reversible peek. `CONTEXT.md` gains
+  *Showdown show* and amends *Hole-card reveal*, whose current text states that
+  reveal never affects Showdown.
+- `RejectionReason` gains `not-at-showdown`. Repeat presses of `reveal` and
+  `show` are idempotent no-ops — a shared table screen will be double-pressed,
+  and that is not an error.
+- `deriveSeat` in the table client currently infers hand participation from
+  presence in `results`; it must read `contestants` instead, or a concealing Seat
+  renders as though it never played.
+- Existing Hand recordings contain no `reveal`/`show` commands and replay as
+  showdowns where nobody showed. Fixtures are regenerated. No legacy
+  reveal-everything branch is added: the visibility path stays single, which is
+  the property that made this decision implementable at all.
+- Six or more shown hands cluster at the table centre and may force smaller cards
+  than the overlay used. This is a layout risk to test at 6–8 seats, not a reason
+  to keep the overlay as the primary surface.


### PR DESCRIPTION
Two ADRs from a grilling session on optional showing at showdown.

**ADR-0007 — all-in as two declared actions.** `ActionType` gains `allInCall` and `allInRaise`. Both remove the Seat from `toAct` for the rest of the Hand; only `allInRaise` reopens the betting. The distinction is declared by the human, because it is entirely about an amount the engine refuses to know. Extends ADR-0001 without reopening it — no chip value is introduced. Consequent rules: fold-out counts all-in Seats as unfolded, and the run-out deals automatically once fewer than two Seats can act.

**ADR-0008 — showing at showdown is engine state.** `reveal` (table) and `show` (Player) become commands, so a concealed Hand stays concealed through Replay. Nothing derived from unshown Hole cards leaves `view()`; `RevealedResult` exists only for a shown Seat, and `contestants` splits from `results`. The Hand rests before it resolves — `winners` is withheld until the table's Reveal press. Showdown moves onto the Seat plates and `ShowdownOverlay` is demoted to a house rule, defaulting off.

Docs only. Implementation follows in separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nyg8H7osWtxHAYdJ4ceA1A