### PR TITLE
feat(engine): all-in as two declared actions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -348,8 +348,9 @@ already bought a claim to (ADR-0007).
 
 **Run-out**: once fewer than two Seats can still act, the remaining Streets
 deal without opening — board cards arrive, no betting round starts — through
-the River and on to Showdown. There is no turn to take with nothing to bet
-against.
+the River and on to Showdown. A Street already open ends as soon as nobody
+left to act faces a bet, for the same reason: there is no turn to take with
+nothing to bet against. A Seat facing a shove still gets its fold-or-call.
 
 **Street closure**: a Street ends once every live Player has acted since
 the most recent bet or raise and none still owes a response

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,10 +109,23 @@ _Avoid_: Treating the Muck as storage, or as somewhere a Hand can be read
 back from — a fold is final, and nothing is kept.
 
 **Action**:
-A completed poker decision for a Seat — fold, check, call, or raise — whether
-chosen by its Player or synthesized by the server when the Seat cannot act.
-Logged as an Event. Distinct from *to act* / the *Actor* (see below), which is
-about whose turn it is, not a decision that has happened.
+A completed poker decision for a Seat — fold, check, call, raise, all-in call
+or all-in raise — whether chosen by its Player or synthesized by the server
+when the Seat cannot act. Logged as an Event. Distinct from *to act* / the
+*Actor* (see below), which is about whose turn it is, not a decision that has
+happened.
+
+**All in**:
+A Seat that has put its last chips in and can take no further Action this
+Hand. Declared by the Player, who is the only party that knows their own
+stack, as one of two Actions: an *all-in call*, which does not reopen the
+betting, or an *all-in raise*, which requeues every other live Seat exactly
+as a raise does (ADR-0007). Both retire the Seat from the betting for the
+rest of the Hand; neither carries a chip amount. A Player who covers a shove
+and wants to keep acting simply calls.
+_Avoid_: Treating all-in as a folded Seat — an all-in Seat is live, keeps its
+claim on the pot, and is revealed at Showdown. Side pots stay a
+physical-chips problem the humans settle at the table.
 
 **Actor**:
 The Player whose turn it currently is. A derived property of Hand state,
@@ -329,7 +342,14 @@ Seats dealt in, which folding never reduces.
 
 **Early-out**: from any betting Street, if a fold drops live players to 1,
 the Hand transitions directly to HAND_COMPLETE — Showdown is skipped, no
-remaining board cards are dealt, no hands are revealed.
+remaining board cards are dealt, no hands are revealed. All-in Seats count as
+live here, so a Seat that has shoved cannot be folded out of a pot it has
+already bought a claim to (ADR-0007).
+
+**Run-out**: once fewer than two Seats can still act, the remaining Streets
+deal without opening — board cards arrive, no betting round starts — through
+the River and on to Showdown. There is no turn to take with nothing to bet
+against.
 
 **Street closure**: a Street ends once every live Player has acted since
 the most recent bet or raise and none still owes a response

--- a/docs/design/engine.md
+++ b/docs/design/engine.md
@@ -53,16 +53,23 @@ rules exist only to keep legality mirroring the physical chips without a value:
 betting; they differ only in whether they reopen it (ADR-0007). Three predicates
 in `table.ts` carry the distinction:
 
-- `canAct`/`actingSeats`: unfolded *and* not all-in — who a street may open on,
+- `canStillAct`/`actingSeats`: unfolded *and* not all-in — who a street may open on,
   and who `requeueAfterRaise` may requeue.
 - `liveSeats`: unfolded, all-in included — who the fold-out check counts and who
   is ranked at showdown. A shover therefore cannot be folded out.
 - `reopensBetting`/`isAllIn`: the two facts `apply` needs from an action.
 
-When a street closes with fewer than two acting seats, `decide` runs the board
-out: the remaining `BoardDealt` events with no `StreetStarted`, through the
-river and on to `ShowdownReached`. Because `hand.street` no longer advances
-during a run-out, `streetOf` reads the street from the board length instead.
+`canOpenABettingRound` (fewer than two acting seats) drives both halves of the
+run-out. A street that closes without it deals the remaining `BoardDealt`
+events with no `StreetStarted`, through the river and on to `ShowdownReached`.
+A street *already* open ends the moment nobody left in `toAct` faces a bet
+(`stillOwesADecision`), so the last deep seat is never asked to check against
+opponents who cannot answer — while a lone seat that *does* face a shove still
+gets its fold-or-call.
+
+`BoardDealt` advances `hand.street`, so a run-out's intermediate states never
+pair a five-card board with a stale `preflop`, and `StreetStarted` only
+confirms the street the board already moved to.
 
 ## `apply` details
 

--- a/docs/design/engine.md
+++ b/docs/design/engine.md
@@ -20,8 +20,10 @@ rules exist only to keep legality mirroring the physical chips without a value:
   also their "option" (it's the last of the preflop lap).
 - `legalActions` is the **single source of truth** for action legality, consumed
   by both `decide` (enforcement) and `view` (the client's `legalActions` field)
-  so the two can never drift. Fold and raise are always legal; check and call
-  are mutually exclusive and follow `facingBet`.
+  so the two can never drift. Fold, raise and both all-ins are always legal;
+  check and call are mutually exclusive and follow `facingBet`. Clients read the
+  same `facingBet` predicate to decide whether to offer the all-in pair or a
+  single "All in" (ADR-0007).
 
 ## Positions and action order
 
@@ -42,7 +44,25 @@ rules exist only to keep legality mirroring the physical chips without a value:
   special machinery: every street closes the same way, when `toAct` drains.
 - `requeueAfterRaise`: after a raise, every *other* live seat gets one more turn
   in position order starting after the raiser; the raiser isn't re-added, so the
-  street closes when the queue drains.
+  street closes when the queue drains. All-in seats are skipped, which is also
+  what keeps an `allInRaise` from requeueing itself.
+
+## All-in and the run-out
+
+`allInCall` and `allInRaise` mark the seat `allIn` and retire it from the
+betting; they differ only in whether they reopen it (ADR-0007). Three predicates
+in `table.ts` carry the distinction:
+
+- `canAct`/`actingSeats`: unfolded *and* not all-in — who a street may open on,
+  and who `requeueAfterRaise` may requeue.
+- `liveSeats`: unfolded, all-in included — who the fold-out check counts and who
+  is ranked at showdown. A shover therefore cannot be folded out.
+- `reopensBetting`/`isAllIn`: the two facts `apply` needs from an action.
+
+When a street closes with fewer than two acting seats, `decide` runs the board
+out: the remaining `BoardDealt` events with no `StreetStarted`, through the
+river and on to `ShowdownReached`. Because `hand.street` no longer advances
+during a run-out, `streetOf` reads the street from the board length instead.
 
 ## `apply` details
 

--- a/packages/engine/src/all-in.test.ts
+++ b/packages/engine/src/all-in.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+import { decide } from "./decide.js";
+import { createInitialState } from "./room.js";
+import { legalActions } from "./table.js";
+import { play, playAll } from "./test-utils.js";
+import type { BettingHandState, EngineState, HandEvent } from "./types.js";
+import { must } from "./util.js";
+import { view } from "./view.js";
+
+function betting(state: EngineState): BettingHandState {
+  if (state.hand?.status !== "betting") throw new Error("expected betting");
+  return state.hand;
+}
+
+function showdown(state: EngineState) {
+  if (state.hand?.status !== "complete" || state.hand.reason !== "showdown") {
+    throw new Error("expected a showdown");
+  }
+  return state.hand;
+}
+
+function foldedOut(state: EngineState) {
+  if (state.hand?.status !== "complete" || state.hand.reason !== "folded-out") {
+    throw new Error("expected a fold-out");
+  }
+  return state.hand;
+}
+
+function events(state: EngineState, command: Parameters<typeof decide>[1]) {
+  const result = decide(state, command);
+  if (!Array.isArray(result)) {
+    throw new Error(`unexpected rejection: ${result.reason}`);
+  }
+  return result;
+}
+
+function typesOf(list: readonly HandEvent[]): string[] {
+  return list.map((event) => event.type);
+}
+
+function started(seats: number[], seed: string): EngineState {
+  return playAll(createInitialState(seats), [
+    { type: "startHand", seatId: must(seats[0]), seed },
+  ]);
+}
+
+describe("all-in legality", () => {
+  it("offers both all-ins wherever raise is legal, facing a bet or not", () => {
+    const state = started([0, 1, 2], "legality");
+    const hand = betting(state);
+
+    expect(legalActions(hand, 0)).toEqual([
+      "fold",
+      "call",
+      "raise",
+      "allInCall",
+      "allInRaise",
+    ]);
+    expect(legalActions(hand, 2)).toEqual([
+      "fold",
+      "check",
+      "raise",
+      "allInCall",
+      "allInRaise",
+    ]);
+  });
+
+  it("reports both all-ins through the acting seat's view", () => {
+    const state = started([0, 1, 2], "legality-view");
+
+    expect(view(state, 0)).toMatchObject({
+      legalActions: ["fold", "call", "raise", "allInCall", "allInRaise"],
+    });
+    expect(view(state, 1)).toMatchObject({ legalActions: [] });
+  });
+
+  it("rejects an all-in from a seat that is not to act", () => {
+    const state = started([0, 1, 2], "out-of-turn");
+
+    const outcome = play(state, { type: "allInRaise", seatId: 1 });
+    if (!("rejection" in outcome)) throw new Error("expected a rejection");
+    expect(outcome.rejection.reason).toBe("not-your-turn");
+  });
+
+  it("rejects an all-in when no hand is in progress", () => {
+    const state = createInitialState([0, 1, 2]);
+
+    const outcome = play(state, { type: "allInCall", seatId: 0 });
+    if (!("rejection" in outcome)) throw new Error("expected a rejection");
+    expect(outcome.rejection.reason).toBe("hand-not-in-progress");
+  });
+
+  it("never offers an action to a seat that is already all-in", () => {
+    let state = started([0, 1, 2, 3], "no-second-turn");
+    state = playAll(state, [{ type: "allInCall", seatId: 3 }]);
+
+    expect(betting(state).toAct).not.toContain(3);
+
+    const outcome = play(state, { type: "check", seatId: 3 });
+    if (!("rejection" in outcome)) throw new Error("expected a rejection");
+    expect(outcome.rejection.reason).toBe("not-your-turn");
+  });
+});
+
+describe("all-in and the betting queue", () => {
+  it("requeues the other live seats for an allInRaise", () => {
+    let state = started([0, 1, 2], "requeue");
+    state = playAll(state, [{ type: "call", seatId: 0 }]);
+    expect(betting(state).toAct).toEqual([1, 2]);
+
+    state = playAll(state, [{ type: "allInRaise", seatId: 1 }]);
+    expect(betting(state).toAct).toEqual([2, 0]);
+  });
+
+  it("leaves the queue alone for an allInCall", () => {
+    let state = started([0, 1, 2], "no-requeue");
+    state = playAll(state, [{ type: "call", seatId: 0 }]);
+
+    state = playAll(state, [{ type: "allInCall", seatId: 1 }]);
+    expect(betting(state).toAct).toEqual([2]);
+  });
+
+  it("makes an allInRaise face the seats behind it with a bet", () => {
+    let state = started([0, 1, 2, 3], "reopens");
+    state = playAll(state, [
+      { type: "call", seatId: 3 },
+      { type: "call", seatId: 0 },
+      { type: "call", seatId: 1 },
+      { type: "check", seatId: 2 },
+      { type: "allInRaise", seatId: 1 },
+    ]);
+
+    expect(legalActions(betting(state), 2)).toContain("call");
+    expect(legalActions(betting(state), 2)).not.toContain("check");
+  });
+
+  it("keeps a seat that called a shove acting on later streets", () => {
+    let state = started([0, 1, 2, 3], "caller-keeps-acting");
+    state = playAll(state, [
+      { type: "allInRaise", seatId: 3 },
+      { type: "call", seatId: 0 },
+      { type: "call", seatId: 1 },
+      { type: "call", seatId: 2 },
+    ]);
+
+    const hand = betting(state);
+    expect(hand.street).toBe("flop");
+    expect(hand.toAct).toEqual([1, 2, 0]);
+  });
+});
+
+describe("all-in and the automatic run-out", () => {
+  it("deals every remaining street without opening it when only one seat can act", () => {
+    let state = started([0, 1, 2], "run-out");
+    state = playAll(state, [
+      { type: "allInRaise", seatId: 0 },
+      { type: "allInCall", seatId: 1 },
+    ]);
+
+    const tail = events(state, { type: "call", seatId: 2 });
+
+    expect(typesOf(tail)).toEqual([
+      "ActionTaken",
+      "StreetClosed",
+      "BoardDealt",
+      "BoardDealt",
+      "BoardDealt",
+      "ShowdownReached",
+      "HandComplete",
+    ]);
+  });
+
+  it("runs out to showdown when every remaining seat is all-in", () => {
+    let state = started([0, 1], "heads-up-shove");
+    state = playAll(state, [{ type: "allInRaise", seatId: 0 }]);
+
+    const tail = events(state, { type: "allInCall", seatId: 1 });
+
+    expect(tail.some((event) => event.type === "StreetStarted")).toBe(false);
+    expect(typesOf(tail).filter((type) => type === "BoardDealt")).toHaveLength(
+      3,
+    );
+
+    const final = showdown(playAll(state, [{ type: "allInCall", seatId: 1 }]));
+    expect(final.board).toHaveLength(5);
+    expect(final.results.map((result) => result.seatId)).toEqual([1, 0]);
+  });
+
+  it("still opens the flop normally when two seats can act", () => {
+    let state = started([0, 1, 2, 3], "no-run-out");
+    state = playAll(state, [
+      { type: "allInRaise", seatId: 3 },
+      { type: "call", seatId: 0 },
+      { type: "fold", seatId: 1 },
+      { type: "call", seatId: 2 },
+    ]);
+
+    expect(betting(state).street).toBe("flop");
+    expect(betting(state).board).toHaveLength(3);
+  });
+});
+
+describe("all-in and fold-out", () => {
+  it("counts an all-in seat as unfolded, so a lone caller still reaches showdown", () => {
+    let state = started([0, 1, 2, 3], "shove-plus-caller");
+    state = playAll(state, [
+      { type: "allInRaise", seatId: 3 },
+      { type: "call", seatId: 0 },
+      { type: "fold", seatId: 1 },
+    ]);
+
+    const tail = events(state, { type: "fold", seatId: 2 });
+
+    expect(tail.some((event) => event.type === "HandFoldedOut")).toBe(false);
+    expect(tail.some((event) => event.type === "ShowdownReached")).toBe(true);
+  });
+
+  it("runs the board out when the last deep seat's opponent folds a later street", () => {
+    let state = started([0, 1, 2, 3], "turn-fold");
+    state = playAll(state, [
+      { type: "allInRaise", seatId: 3 },
+      { type: "call", seatId: 0 },
+      { type: "call", seatId: 1 },
+      { type: "call", seatId: 2 },
+      { type: "check", seatId: 1 },
+      { type: "check", seatId: 2 },
+      { type: "check", seatId: 0 },
+    ]);
+    expect(betting(state).street).toBe("turn");
+
+    state = playAll(state, [
+      { type: "fold", seatId: 1 },
+      { type: "fold", seatId: 2 },
+    ]);
+    expect(betting(state).toAct).toEqual([0]);
+
+    const final = showdown(playAll(state, [{ type: "check", seatId: 0 }]));
+    expect(final.results.map((result) => result.seatId).sort()).toEqual([0, 3]);
+  });
+
+  it("still folds out a hand where only one seat is left unfolded", () => {
+    let state = started([0, 1, 2], "genuine-fold-out");
+    state = playAll(state, [{ type: "allInRaise", seatId: 0 }]);
+
+    const tail = events(state, { type: "fold", seatId: 1 });
+    expect(tail.some((event) => event.type === "HandFoldedOut")).toBe(false);
+
+    const final = foldedOut(
+      playAll(state, [
+        { type: "fold", seatId: 1 },
+        { type: "fold", seatId: 2 },
+      ]),
+    );
+    expect(final.winner).toBe(0);
+  });
+});
+
+describe("all-in and eviction", () => {
+  it("refuses to fold an all-in seat out of a pot it has already bought into", () => {
+    let state = started([0, 1, 2], "evict-all-in");
+    state = playAll(state, [{ type: "allInCall", seatId: 0 }]);
+
+    const outcome = play(state, { type: "evict", seatId: 0 });
+    if (!("rejection" in outcome)) throw new Error("expected a rejection");
+    expect(outcome.rejection.reason).toBe("action-not-legal");
+  });
+});

--- a/packages/engine/src/all-in.test.ts
+++ b/packages/engine/src/all-in.test.ts
@@ -150,6 +150,17 @@ describe("all-in and the betting queue", () => {
 });
 
 describe("all-in and the automatic run-out", () => {
+  it("still asks a lone deep seat to answer a shove", () => {
+    const state = started([0, 1], "lone-seat-answers");
+
+    const tail = events(state, { type: "allInRaise", seatId: 0 });
+
+    expect(typesOf(tail)).toEqual(["ActionTaken"]);
+    expect(
+      betting(playAll(state, [{ type: "allInRaise", seatId: 0 }])).toAct,
+    ).toEqual([1]);
+  });
+
   it("deals every remaining street without opening it when only one seat can act", () => {
     let state = started([0, 1, 2], "run-out");
     state = playAll(state, [
@@ -215,7 +226,7 @@ describe("all-in and fold-out", () => {
     expect(tail.some((event) => event.type === "ShowdownReached")).toBe(true);
   });
 
-  it("runs the board out when the last deep seat's opponent folds a later street", () => {
+  it("closes the turn without a lone check when the last opponent folds", () => {
     let state = started([0, 1, 2, 3], "turn-fold");
     state = playAll(state, [
       { type: "allInRaise", seatId: 3 },
@@ -228,13 +239,18 @@ describe("all-in and fold-out", () => {
     ]);
     expect(betting(state).street).toBe("turn");
 
-    state = playAll(state, [
-      { type: "fold", seatId: 1 },
-      { type: "fold", seatId: 2 },
-    ]);
-    expect(betting(state).toAct).toEqual([0]);
+    state = playAll(state, [{ type: "fold", seatId: 1 }]);
+    expect(betting(state).toAct).toEqual([2, 0]);
 
-    const final = showdown(playAll(state, [{ type: "check", seatId: 0 }]));
+    expect(typesOf(events(state, { type: "fold", seatId: 2 }))).toEqual([
+      "ActionTaken",
+      "StreetClosed",
+      "BoardDealt",
+      "ShowdownReached",
+      "HandComplete",
+    ]);
+
+    const final = showdown(playAll(state, [{ type: "fold", seatId: 2 }]));
     expect(final.results.map((result) => result.seatId).sort()).toEqual([0, 3]);
   });
 

--- a/packages/engine/src/apply.ts
+++ b/packages/engine/src/apply.ts
@@ -1,7 +1,10 @@
 import {
   bigBlindSeat,
+  canAct,
   initialToAct,
+  isAllIn,
   nextButtonAfter,
+  reopensBetting,
   requeueAfterRaise,
   rotateFromButton,
   smallBlindSeat,
@@ -45,7 +48,7 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
           players: new Map(
             state.seats.map((seat) => [
               seat,
-              { holeCards: null, folded: false },
+              { holeCards: null, folded: false, allIn: false },
             ]),
           ),
           toAct: [],
@@ -66,8 +69,8 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
 
     case "StreetStarted": {
       const hand = asBetting(state);
-      const live = hand.ring.filter((seat) => !seatState(hand, seat).folded);
-      const toAct = initialToAct(hand.ring, live, hand.button, event.street);
+      const acting = hand.ring.filter((seat) => canAct(seatState(hand, seat)));
+      const toAct = initialToAct(hand.ring, acting, hand.button, event.street);
       return {
         ...state,
         hand: {
@@ -82,16 +85,17 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
     case "ActionTaken": {
       const hand = asBetting(state);
       const players = new Map(hand.players);
+      const prior = seatState(hand, event.seatId);
       if (event.action === "fold") {
-        const prior = seatState(hand, event.seatId);
         players.set(event.seatId, { ...prior, folded: true });
+      } else if (isAllIn(event.action)) {
+        players.set(event.seatId, { ...prior, allIn: true });
       }
-      const raiseOccurred = hand.raiseOccurred || event.action === "raise";
+      const raiseOccurred = hand.raiseOccurred || reopensBetting(event.action);
 
-      const toAct =
-        event.action === "raise"
-          ? requeueAfterRaise(hand.ring, players, event.seatId)
-          : hand.toAct.filter((seat) => seat !== event.seatId);
+      const toAct = reopensBetting(event.action)
+        ? requeueAfterRaise(hand.ring, players, event.seatId)
+        : hand.toAct.filter((seat) => seat !== event.seatId);
 
       return {
         ...state,

--- a/packages/engine/src/apply.ts
+++ b/packages/engine/src/apply.ts
@@ -1,6 +1,6 @@
 import {
   bigBlindSeat,
-  canAct,
+  canStillAct,
   initialToAct,
   isAllIn,
   nextButtonAfter,
@@ -69,7 +69,9 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
 
     case "StreetStarted": {
       const hand = asBetting(state);
-      const acting = hand.ring.filter((seat) => canAct(seatState(hand, seat)));
+      const acting = hand.ring.filter((seat) =>
+        canStillAct(seatState(hand, seat)),
+      );
       const toAct = initialToAct(hand.ring, acting, hand.button, event.street);
       return {
         ...state,
@@ -110,7 +112,11 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
       const hand = asBetting(state);
       return {
         ...state,
-        hand: { ...hand, board: [...hand.board, ...event.cards] },
+        hand: {
+          ...hand,
+          street: event.street,
+          board: [...hand.board, ...event.cards],
+        },
       };
     }
 

--- a/packages/engine/src/decide.ts
+++ b/packages/engine/src/decide.ts
@@ -1,6 +1,8 @@
 import { apply } from "./apply.js";
 import { evaluate, winnersOf } from "./evaluate.js";
 import {
+  actingSeats,
+  canAct,
   dealCommunityCards,
   dealHoleCards,
   initialToAct,
@@ -19,6 +21,7 @@ import type {
   Rejection,
   RejectionReason,
   SeatId,
+  Street,
 } from "./types.js";
 import { must } from "./util.js";
 
@@ -57,6 +60,8 @@ export function decide(
     case "check":
     case "call":
     case "raise":
+    case "allInCall":
+    case "allInRaise":
       return decideAction(state, command);
 
     case "evict":
@@ -122,7 +127,7 @@ function decideEviction(
     return reject("hand-not-in-progress", command);
   }
   const player = state.hand.players.get(command.seatId);
-  if (player === undefined || player.folded) {
+  if (player === undefined || !canAct(player)) {
     return reject("action-not-legal", command);
   }
 
@@ -134,10 +139,7 @@ function decideActionEvents(
   seatId: SeatId,
   action: ActionType,
 ): HandEvent[] {
-  const hand = state.hand;
-  if (hand?.status !== "betting") {
-    throw new Error("expected a betting hand while resolving an action");
-  }
+  const hand = asBetting(state);
   const events: HandEvent[] = [];
 
   const actionTaken: HandEvent = {
@@ -147,9 +149,8 @@ function decideActionEvents(
   };
   events.push(actionTaken);
   let scratch = apply(state, actionTaken);
-  const handAfterAction = scratch.hand as BettingHandState;
 
-  const live = liveSeats(handAfterAction);
+  const live = liveSeats(asBetting(scratch));
   if (live.length === 1) {
     const foldedOut: HandEvent = {
       type: "HandFoldedOut",
@@ -163,7 +164,7 @@ function decideActionEvents(
     return events;
   }
 
-  if (handAfterAction.toAct.length > 0) {
+  if (asBetting(scratch).toAct.length > 0) {
     return events;
   }
 
@@ -175,45 +176,57 @@ function decideActionEvents(
   scratch = apply(scratch, streetClosed);
 
   if (hand.street === "river") {
-    const results = live.map((seatId) => {
-      const holeCards = must(
-        handAfterAction.players.get(seatId)?.holeCards,
-        "a live seat at showdown always has hole cards",
-      );
-      const { rank, bestHand, description } = evaluate([
-        ...holeCards,
-        ...handAfterAction.board,
-      ]);
-      return {
-        seatId,
-        rank,
-        bestHand: [...bestHand] as [Card, Card, Card, Card, Card],
-        description,
-      };
-    });
-    const showdownReached: HandEvent = {
-      type: "ShowdownReached",
-      results,
-      winners: winnersOf(results),
-    };
-    events.push(showdownReached);
-    scratch = apply(scratch, showdownReached);
-    const handComplete: HandEvent = { type: "HandComplete" };
-    events.push(handComplete);
-    apply(scratch, handComplete);
-    return events;
+    return finishAtShowdown(scratch, events);
   }
 
+  scratch = dealNextStreet(state, scratch, events);
+
+  if (actingSeats(asBetting(scratch)).length < MIN_SEATS_TO_OPEN_A_STREET) {
+    return runOut(state, scratch, events);
+  }
+
+  const opened = asBetting(scratch);
+  const nextToAct = initialToAct(
+    opened.ring,
+    actingSeats(opened),
+    opened.button,
+    opened.street,
+  );
+  const streetStarted: HandEvent = {
+    type: "StreetStarted",
+    street: streetOf(opened.board.length),
+    actor: must(nextToAct[0], "a fresh street always has a first actor"),
+  };
+  events.push(streetStarted);
+  apply(scratch, streetStarted);
+
+  return events;
+}
+
+const MIN_SEATS_TO_OPEN_A_STREET = 2;
+
+function asBetting(state: EngineState): BettingHandState {
+  if (state.hand?.status !== "betting") {
+    throw new Error("expected a betting hand while resolving an action");
+  }
+  return state.hand;
+}
+
+function dealNextStreet(
+  state: EngineState,
+  scratch: EngineState,
+  events: HandEvent[],
+): EngineState {
+  const hand = asBetting(scratch);
   const nextStreet = must(
-    nextStreetOf(hand.street),
+    nextStreetOf(streetOf(hand.board.length)),
     "a non-river street always has a next street",
   );
-  const count = nextStreet === "flop" ? 3 : 1;
   const cards = dealCommunityCards(
     hand.seed,
     state.seats.length,
     hand.board.length,
-    count,
+    nextStreet === "flop" ? FLOP_CARDS : 1,
   );
   const boardDealt: HandEvent = {
     type: "BoardDealt",
@@ -221,21 +234,69 @@ function decideActionEvents(
     cards,
   };
   events.push(boardDealt);
-  scratch = apply(scratch, boardDealt);
+  return apply(scratch, boardDealt);
+}
 
-  const nextToAct = initialToAct(
-    handAfterAction.ring,
-    live,
-    hand.button,
-    nextStreet,
+const FLOP_CARDS = 3;
+
+const STREET_BY_BOARD_LENGTH: Record<number, Street> = {
+  0: "preflop",
+  3: "flop",
+  4: "turn",
+  5: "river",
+};
+
+function streetOf(boardLength: number): Street {
+  return must(
+    STREET_BY_BOARD_LENGTH[boardLength],
+    `no street has ${String(boardLength)} board cards`,
   );
-  const streetStarted: HandEvent = {
-    type: "StreetStarted",
-    street: nextStreet,
-    actor: must(nextToAct[0], "a fresh street always has a first actor"),
-  };
-  events.push(streetStarted);
-  apply(scratch, streetStarted);
+}
 
+function runOut(
+  state: EngineState,
+  scratch: EngineState,
+  events: HandEvent[],
+): HandEvent[] {
+  let current = scratch;
+  while (asBetting(current).board.length < FULL_BOARD) {
+    current = dealNextStreet(state, current, events);
+  }
+  return finishAtShowdown(current, events);
+}
+
+const FULL_BOARD = 5;
+
+function finishAtShowdown(
+  scratch: EngineState,
+  events: HandEvent[],
+): HandEvent[] {
+  const hand = asBetting(scratch);
+  const results = liveSeats(hand).map((seatId) => {
+    const holeCards = must(
+      hand.players.get(seatId)?.holeCards,
+      "a live seat at showdown always has hole cards",
+    );
+    const { rank, bestHand, description } = evaluate([
+      ...holeCards,
+      ...hand.board,
+    ]);
+    return {
+      seatId,
+      rank,
+      bestHand: [...bestHand] as [Card, Card, Card, Card, Card],
+      description,
+    };
+  });
+  const showdownReached: HandEvent = {
+    type: "ShowdownReached",
+    results,
+    winners: winnersOf(results),
+  };
+  events.push(showdownReached);
+  const afterShowdown = apply(scratch, showdownReached);
+  const handComplete: HandEvent = { type: "HandComplete" };
+  events.push(handComplete);
+  apply(afterShowdown, handComplete);
   return events;
 }

--- a/packages/engine/src/decide.ts
+++ b/packages/engine/src/decide.ts
@@ -2,8 +2,9 @@ import { apply } from "./apply.js";
 import { evaluate, winnersOf } from "./evaluate.js";
 import {
   actingSeats,
-  canAct,
+  canStillAct,
   dealCommunityCards,
+  facingBet,
   dealHoleCards,
   initialToAct,
   legalActions,
@@ -21,7 +22,6 @@ import type {
   Rejection,
   RejectionReason,
   SeatId,
-  Street,
 } from "./types.js";
 import { must } from "./util.js";
 
@@ -127,7 +127,7 @@ function decideEviction(
     return reject("hand-not-in-progress", command);
   }
   const player = state.hand.players.get(command.seatId);
-  if (player === undefined || !canAct(player)) {
+  if (player === undefined || !canStillAct(player)) {
     return reject("action-not-legal", command);
   }
 
@@ -164,7 +164,7 @@ function decideActionEvents(
     return events;
   }
 
-  if (asBetting(scratch).toAct.length > 0) {
+  if (stillOwesADecision(asBetting(scratch))) {
     return events;
   }
 
@@ -181,11 +181,11 @@ function decideActionEvents(
 
   scratch = dealNextStreet(state, scratch, events);
 
-  if (actingSeats(asBetting(scratch)).length < MIN_SEATS_TO_OPEN_A_STREET) {
+  const opened = asBetting(scratch);
+  if (!canOpenABettingRound(opened)) {
     return runOut(state, scratch, events);
   }
 
-  const opened = asBetting(scratch);
   const nextToAct = initialToAct(
     opened.ring,
     actingSeats(opened),
@@ -194,7 +194,7 @@ function decideActionEvents(
   );
   const streetStarted: HandEvent = {
     type: "StreetStarted",
-    street: streetOf(opened.board.length),
+    street: opened.street,
     actor: must(nextToAct[0], "a fresh street always has a first actor"),
   };
   events.push(streetStarted);
@@ -203,7 +203,19 @@ function decideActionEvents(
   return events;
 }
 
-const MIN_SEATS_TO_OPEN_A_STREET = 2;
+const MIN_SEATS_TO_BET = 2;
+
+function canOpenABettingRound(hand: BettingHandState): boolean {
+  return actingSeats(hand).length >= MIN_SEATS_TO_BET;
+}
+
+function stillOwesADecision(hand: BettingHandState): boolean {
+  if (hand.toAct.length === 0) return false;
+  return (
+    canOpenABettingRound(hand) ||
+    hand.toAct.some((seat) => facingBet(hand, seat))
+  );
+}
 
 function asBetting(state: EngineState): BettingHandState {
   if (state.hand?.status !== "betting") {
@@ -219,7 +231,7 @@ function dealNextStreet(
 ): EngineState {
   const hand = asBetting(scratch);
   const nextStreet = must(
-    nextStreetOf(streetOf(hand.board.length)),
+    nextStreetOf(hand.street),
     "a non-river street always has a next street",
   );
   const cards = dealCommunityCards(
@@ -239,33 +251,17 @@ function dealNextStreet(
 
 const FLOP_CARDS = 3;
 
-const STREET_BY_BOARD_LENGTH: Record<number, Street> = {
-  0: "preflop",
-  3: "flop",
-  4: "turn",
-  5: "river",
-};
-
-function streetOf(boardLength: number): Street {
-  return must(
-    STREET_BY_BOARD_LENGTH[boardLength],
-    `no street has ${String(boardLength)} board cards`,
-  );
-}
-
 function runOut(
   state: EngineState,
   scratch: EngineState,
   events: HandEvent[],
 ): HandEvent[] {
   let current = scratch;
-  while (asBetting(current).board.length < FULL_BOARD) {
+  while (asBetting(current).street !== "river") {
     current = dealNextStreet(state, current, events);
   }
   return finishAtShowdown(current, events);
 }
-
-const FULL_BOARD = 5;
 
 function finishAtShowdown(
   scratch: EngineState,

--- a/packages/engine/src/properties.test.ts
+++ b/packages/engine/src/properties.test.ts
@@ -4,7 +4,7 @@ import { apply } from "./apply.js";
 import { decide } from "./decide.js";
 import { createInitialState } from "./room.js";
 import { legalActions } from "./table.js";
-import type { BettingHandState, EngineState } from "./types.js";
+import type { ActionType, BettingHandState, EngineState } from "./types.js";
 import { must } from "./util.js";
 
 const seatsArb = fc
@@ -12,11 +12,13 @@ const seatsArb = fc
   .map((raw) => [...new Set(raw)])
   .filter((seats) => seats.length >= 2);
 
-const actionArb = fc.constantFrom<"fold" | "check" | "call" | "raise">(
+const actionArb = fc.constantFrom<ActionType>(
   "fold",
   "check",
   "call",
   "raise",
+  "allInCall",
+  "allInRaise",
 );
 
 function deepFreeze<T>(value: T): T {
@@ -114,6 +116,7 @@ function assertBettingInvariants(hand: BettingHandState): void {
     expect(seen.has(seat)).toBe(false);
     seen.add(seat);
     expect(must(hand.players.get(seat)).folded).toBe(false);
+    expect(must(hand.players.get(seat)).allIn).toBe(false);
   }
 
   const live = hand.ring.filter((seat) => !must(hand.players.get(seat)).folded);
@@ -121,12 +124,12 @@ function assertBettingInvariants(hand: BettingHandState): void {
 }
 
 describe("property: decide/apply keep the betting invariants across a random hand", () => {
-  it("toAct always has an actor, no duplicates, no folded seats, and >=2 live", () => {
+  it("toAct always has an actor, no duplicates, nobody folded or all-in, and >=2 live", () => {
     fc.assert(
       fc.property(
         seatsArb,
         fc.string({ minLength: 1, maxLength: 10 }),
-        fc.array(fc.nat(2), { minLength: 0, maxLength: 60 }),
+        fc.array(fc.nat(4), { minLength: 0, maxLength: 60 }),
         (seats, seed, choices) => {
           let state: EngineState = createInitialState(seats);
           const started = decide(state, {

--- a/packages/engine/src/table.test.ts
+++ b/packages/engine/src/table.test.ts
@@ -4,7 +4,7 @@ import { legalActions } from "./table.js";
 import { playAll } from "./test-utils.js";
 
 describe("legalActions", () => {
-  it("offers fold/call/raise to a seat facing a bet preflop", () => {
+  it("offers the facing-a-bet actions to a seat facing a bet preflop", () => {
     const state = createInitialState([0, 1, 2]);
     const started = playAll(state, [
       { type: "startHand", seatId: 0, seed: "s" },
@@ -12,10 +12,16 @@ describe("legalActions", () => {
     if (started.hand?.status !== "betting") {
       throw new Error("expected betting");
     }
-    expect(legalActions(started.hand, 1)).toEqual(["fold", "call", "raise"]);
+    expect(legalActions(started.hand, 1)).toEqual([
+      "fold",
+      "call",
+      "raise",
+      "allInCall",
+      "allInRaise",
+    ]);
   });
 
-  it("offers fold/check/raise to the big blind on an unraised preflop", () => {
+  it("offers the unopened actions to the big blind on an unraised preflop", () => {
     const state = createInitialState([0, 1, 2]);
     const started = playAll(state, [
       { type: "startHand", seatId: 0, seed: "s" },
@@ -30,6 +36,12 @@ describe("legalActions", () => {
     if (afterLap.hand?.status !== "betting") {
       throw new Error("expected betting");
     }
-    expect(legalActions(afterLap.hand, 2)).toEqual(["fold", "check", "raise"]);
+    expect(legalActions(afterLap.hand, 2)).toEqual([
+      "fold",
+      "check",
+      "raise",
+      "allInCall",
+      "allInRaise",
+    ]);
   });
 });

--- a/packages/engine/src/table.ts
+++ b/packages/engine/src/table.ts
@@ -3,6 +3,7 @@ import type {
   ActionType,
   BettingHandState,
   Card,
+  SeatHandState,
   SeatId,
   Street,
 } from "./types.js";
@@ -33,13 +34,12 @@ export function liveSeats(hand: BettingHandState): SeatId[] {
 }
 
 export function actingSeats(hand: BettingHandState): SeatId[] {
-  return hand.ring.filter((seat) => canAct(seatState(hand, seat)));
+  return hand.ring.filter((seat) => canStillAct(seatState(hand, seat)));
 }
 
-export function canAct(seat: {
-  readonly folded: boolean;
-  readonly allIn: boolean;
-}): boolean {
+export function canStillAct(
+  seat: Pick<SeatHandState, "folded" | "allIn">,
+): boolean {
   return !seat.folded && !seat.allIn;
 }
 
@@ -112,17 +112,14 @@ export function legalActions(
 
 export function requeueAfterRaise(
   ring: readonly SeatId[],
-  players: ReadonlyMap<
-    SeatId,
-    { readonly folded: boolean; readonly allIn: boolean }
-  >,
+  players: ReadonlyMap<SeatId, Pick<SeatHandState, "folded" | "allIn">>,
   raiser: SeatId,
 ): SeatId[] {
   const idx = ring.indexOf(raiser);
   const result: SeatId[] = [];
   for (let step = 1; step < ring.length; step++) {
     const candidate = must(ring[(idx + step) % ring.length]);
-    if (canAct(must(players.get(candidate)))) {
+    if (canStillAct(must(players.get(candidate)))) {
       result.push(candidate);
     }
   }

--- a/packages/engine/src/table.ts
+++ b/packages/engine/src/table.ts
@@ -32,6 +32,25 @@ export function liveSeats(hand: BettingHandState): SeatId[] {
   return hand.ring.filter((seat) => !seatState(hand, seat).folded);
 }
 
+export function actingSeats(hand: BettingHandState): SeatId[] {
+  return hand.ring.filter((seat) => canAct(seatState(hand, seat)));
+}
+
+export function canAct(seat: {
+  readonly folded: boolean;
+  readonly allIn: boolean;
+}): boolean {
+  return !seat.folded && !seat.allIn;
+}
+
+export function reopensBetting(action: ActionType): boolean {
+  return action === "raise" || action === "allInRaise";
+}
+
+export function isAllIn(action: ActionType): boolean {
+  return action === "allInCall" || action === "allInRaise";
+}
+
 export function initialToAct(
   ring: readonly SeatId[],
   live: readonly SeatId[],
@@ -87,20 +106,23 @@ export function legalActions(
   actorSeat: SeatId,
 ): ActionType[] {
   return facingBet(hand, actorSeat)
-    ? ["fold", "call", "raise"]
-    : ["fold", "check", "raise"];
+    ? ["fold", "call", "raise", "allInCall", "allInRaise"]
+    : ["fold", "check", "raise", "allInCall", "allInRaise"];
 }
 
 export function requeueAfterRaise(
   ring: readonly SeatId[],
-  players: ReadonlyMap<SeatId, { readonly folded: boolean }>,
+  players: ReadonlyMap<
+    SeatId,
+    { readonly folded: boolean; readonly allIn: boolean }
+  >,
   raiser: SeatId,
 ): SeatId[] {
   const idx = ring.indexOf(raiser);
   const result: SeatId[] = [];
   for (let step = 1; step < ring.length; step++) {
     const candidate = must(ring[(idx + step) % ring.length]);
-    if (!must(players.get(candidate)).folded) {
+    if (canAct(must(players.get(candidate)))) {
       result.push(candidate);
     }
   }

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -12,7 +12,8 @@ export type SeatId = number;
 
 export type Street = "preflop" | "flop" | "turn" | "river";
 
-export type ActionType = "fold" | "check" | "call" | "raise";
+export type ActionType =
+  "fold" | "check" | "call" | "raise" | "allInCall" | "allInRaise";
 
 export type HandRank = number;
 
@@ -61,6 +62,7 @@ export interface Rejection {
 export interface SeatHandState {
   readonly holeCards: readonly [Card, Card] | null;
   readonly folded: boolean;
+  readonly allIn: boolean;
 }
 
 export interface BettingHandState {

--- a/packages/engine/src/view.test.ts
+++ b/packages/engine/src/view.test.ts
@@ -69,7 +69,13 @@ describe("view: legalActions", () => {
 
     const actorView = view(state, actor);
     if (actorView.phase !== "betting") throw new Error("expected betting");
-    expect(actorView.legalActions).toEqual(["fold", "check", "raise"]);
+    expect(actorView.legalActions).toEqual([
+      "fold",
+      "check",
+      "raise",
+      "allInCall",
+      "allInRaise",
+    ]);
 
     const other = must(state.hand.ring.find((seat) => seat !== actor));
     const otherView = view(state, other);

--- a/packages/player-client/src/ActionBar.tsx
+++ b/packages/player-client/src/ActionBar.tsx
@@ -22,14 +22,16 @@ export interface ActionBarProps {
 
 const ACTIONS = ["fold", "check", "call", "raise"] as const;
 
-const LABELS: Record<ActionType, string> = {
+type OfferedAction = (typeof ACTIONS)[number];
+
+const LABELS: Record<OfferedAction, string> = {
   fold: "Fold",
   check: "Check",
   call: "Call",
   raise: "Raise",
 };
 
-const SUB_LABELS: Record<ActionType, string> = {
+const SUB_LABELS: Record<OfferedAction, string> = {
   fold: "muck",
   check: "no bet",
   call: "match",
@@ -48,7 +50,7 @@ const primaryToneStyle: CSSProperties = {
   color: color.textBright,
 };
 
-const toneStyle: Record<ActionType, CSSProperties> = {
+const toneStyle: Record<OfferedAction, CSSProperties> = {
   fold: {
     border: "1px solid rgba(232,139,125,.42)",
     background: "rgba(232,139,125,.13)",
@@ -82,7 +84,7 @@ export function ActionBar({
   onCall,
   onRaise,
 }: ActionBarProps) {
-  const handlers: Record<ActionType, () => void> = {
+  const handlers: Record<OfferedAction, () => void> = {
     fold: onFold,
     check: onCheck,
     call: onCall,

--- a/packages/player-client/src/actions/useActionIntent.ts
+++ b/packages/player-client/src/actions/useActionIntent.ts
@@ -14,6 +14,8 @@ export interface ActionIntent {
   readonly raise: () => void;
 }
 
+type SendableAction = Extract<ClientCommand["type"], ActionType>;
+
 export function canAct(
   legalActions: readonly ActionType[],
   pendingAction: ActionType | null,
@@ -33,7 +35,7 @@ export function useActionIntent(
   const legalActions = legalActionsFromView(handView);
 
   const act = useCallback(
-    (action: ActionType) => {
+    (action: SendableAction) => {
       if (!canAct(legalActions, pendingAction, action)) return;
       sendStarted(action);
       send({ type: action });

--- a/packages/server/src/bot-policy.test.ts
+++ b/packages/server/src/bot-policy.test.ts
@@ -8,9 +8,9 @@ import {
   shouldSitIn,
   shouldSitOut,
 } from "./bot-policy.js";
-import type { ActionType } from "@table-top-poker/protocol";
+import type { BotAction } from "./bot-policy.js";
 
-const actionTypes: ActionType[] = ["fold", "check", "call", "raise"];
+const actionTypes: BotAction[] = ["fold", "check", "call", "raise"];
 const greatestRollBelowOne = 0.9999999999999999;
 
 const legalActionsArb = fc.subarray(actionTypes, { minLength: 1 });
@@ -35,7 +35,7 @@ describe("chooseBotAction", () => {
 
   it("keeps a facing bet alive while reaching call, fold, and raise", () => {
     const legalActions = ["fold", "call", "raise"] as const;
-    const reached = new Set<ActionType>();
+    const reached = new Set<BotAction>();
     let folds = 0;
     let calls = 0;
     for (let i = 0; i < 10_000; i++) {
@@ -72,11 +72,29 @@ describe("chooseBotAction", () => {
 
   it("leaves every supplied action reachable", () => {
     const legalActions = ["fold", "check", "raise"] as const;
-    const reached = new Set<ActionType>();
+    const reached = new Set<BotAction>();
     for (let i = 0; i < 10_000; i++) {
       reached.add(chooseBotAction(legalActions, () => (i + 0.5) / 10_000));
     }
     expect(reached).toEqual(new Set(legalActions));
+  });
+
+  it("never declares an all-in, however the RNG falls", () => {
+    const legalActions = [
+      "fold",
+      "call",
+      "raise",
+      "allInCall",
+      "allInRaise",
+    ] as const;
+    for (let i = 0; i < 1000; i++) {
+      const action = chooseBotAction(legalActions, () => (i + 0.5) / 1000);
+      expect(actionTypes).toContain(action);
+    }
+  });
+
+  it("rejects a legal-action list with nothing a bot will play", () => {
+    expect(() => chooseBotAction(["allInRaise"], () => 0)).toThrow(RangeError);
   });
 
   it("rejects an empty legal-action list", () => {

--- a/packages/server/src/bot-policy.ts
+++ b/packages/server/src/bot-policy.ts
@@ -2,13 +2,22 @@ import type { ActionType } from "@table-top-poker/protocol";
 
 export type BotRng = () => number;
 
-export const DEFAULT_BOT_ACTION_WEIGHTS: Readonly<Record<ActionType, number>> =
+/** Bots stay off the all-ins until a human client can declare one. */
+const BOT_ACTIONS = ["fold", "check", "call", "raise"] as const;
+
+export type BotAction = (typeof BOT_ACTIONS)[number];
+
+export const DEFAULT_BOT_ACTION_WEIGHTS: Readonly<Record<BotAction, number>> =
   Object.freeze({
     fold: 1,
     check: 12,
     call: 12,
     raise: 2,
   });
+
+function isBotAction(action: ActionType): action is BotAction {
+  return (BOT_ACTIONS as readonly ActionType[]).includes(action);
+}
 
 export const DEFAULT_SIT_OUT_PROBABILITY = 0.1;
 
@@ -34,19 +43,20 @@ function assertProbability(probability: number): void {
 export function chooseBotAction(
   legalActions: readonly ActionType[],
   rng: BotRng = Math.random,
-): ActionType {
-  if (legalActions.length === 0) {
+): BotAction {
+  const candidates = legalActions.filter(isBotAction);
+  if (candidates.length === 0) {
     throw new RangeError("chooseBotAction needs at least one legal action");
   }
 
-  const total = legalActions.reduce(
+  const total = candidates.reduce(
     (sum, action) => sum + DEFAULT_BOT_ACTION_WEIGHTS[action],
     0,
   );
   const target = unitRandom(rng) * total;
 
   let cumulative = 0;
-  for (const action of legalActions) {
+  for (const action of candidates) {
     cumulative += DEFAULT_BOT_ACTION_WEIGHTS[action];
     if (target < cumulative) return action;
   }

--- a/packages/server/src/bot-policy.ts
+++ b/packages/server/src/bot-policy.ts
@@ -2,7 +2,6 @@ import type { ActionType } from "@table-top-poker/protocol";
 
 export type BotRng = () => number;
 
-/** Bots stay off the all-ins until a human client can declare one. */
 const BOT_ACTIONS = ["fold", "check", "call", "raise"] as const;
 
 export type BotAction = (typeof BOT_ACTIONS)[number];

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -54,6 +54,8 @@ const actionTone: Record<
   check: { background: color.actionPassive, ink: color.textMuted },
   call: { background: color.actionCall, ink: "#fff" },
   raise: { background: color.actionRaise, ink: color.pillInk },
+  allInCall: { background: color.actionCall, ink: "#fff" },
+  allInRaise: { background: color.actionRaise, ink: color.pillInk },
 };
 
 type SeatStatus =

--- a/packages/table-client/src/actionWords.ts
+++ b/packages/table-client/src/actionWords.ts
@@ -9,4 +9,6 @@ export const actionVerb: Record<ActionType, string> = {
   check: "checked",
   call: "called",
   raise: "raised",
+  allInCall: "all in",
+  allInRaise: "all in",
 };


### PR DESCRIPTION
Implements [ADR-0007](https://github.com/ewanhardingham/table-top-poker/blob/showdown-v2/docs/adr/0007-all-in-as-declared-actions-without-chip-values.md) for #250. Engine-only: `ActionType` gains `allInCall` and `allInRaise`, both of which retire the acting Seat from the betting for the rest of the Hand; only `allInRaise` reopens it. No chip amount, Pot or stack is introduced — ADR-0001 stands.

## What changed

- **`legalActions`** offers both all-ins wherever `raise` is legal, facing a bet or not. It stays the single source of truth for `decide` and `view`, and clients read the existing `facingBet` predicate to decide whether to show the pair or one "All in".
- **`SeatHandState.allIn`** is the new fact. Three predicates in `table.ts` carry the distinction: `canStillAct`/`actingSeats` (unfolded *and* not all-in — who a Street may open on, who `requeueAfterRaise` may requeue), `liveSeats` (unfolded, all-in included — the fold-out count and the Showdown ranking), and `reopensBetting`/`isAllIn`.
- **Fold-out counts all-in Seats as unfolded**, so a shover cannot be folded out of a pot they have already bought a claim to.
- **The run-out is automatic.** A Street that closes with fewer than two acting Seats deals the rest of the board — `BoardDealt` with no `StreetStarted` — through the River to `ShowdownReached`. A Street already open ends the moment nobody left in `toAct` faces a bet, so the last deep Seat is never asked to check against opponents who cannot answer; a Seat facing a shove still gets its fold-or-call.
- **Eviction refuses an all-in Seat**, for the same reason fold-out does. The server already handles that rejection by freeing the Seat without folding it.

## Notes for review

- **The base branch carries the ADRs.** `showdown-v2` was cut from `origin/main`, then the ADR commit from #249 was cherry-picked onto it, so ADR-0007 and ADR-0008 are present here. #249 still holds the same commit for `main`.
- **Non-engine files were touched only to keep the build green**, since widening `ActionType` breaks every exhaustive `Record<ActionType, …>`. The player client still offers Fold/Check/Call/Raise (its Records are now keyed by the offered set), bots pick only from those four via a new `BotAction` type, and the table client gains "all in" verb/tone entries so an incoming Event never renders `undefined`. The client work proper is #251/#253.
- The property test now draws from all six actions, and asserts `toAct` never holds a folded or all-in Seat.

## Testing

`npm run build`, `npm run lint`, and the full vitest suite (1140 tests) all pass locally.

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nyg8H7osWtxHAYdJ4ceA1A