### PR TITLE
feat(engine): showdown visibility, the reveal/show commands, and optional showing

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,8 +84,10 @@ to their Device at deal time (not fetched later at reveal).
 
 **Hole-card reveal**:
 Turning a Player's own Hole cards persistently face-up on their own Device.
-Local presentation only: it does not change poker visibility, server state, or
-Showdown. Distinct from the Showdown reveal, which is a Hand event.
+Local presentation only: it does not change poker visibility or server state,
+and it never publishes a Hand. Distinct from a *Showdown show*, which is a
+Command the Player sends deliberately, and from the table's *Reveal*, which
+turns the compulsory Hands over for the whole room.
 
 **Hole-card peek**:
 Temporarily lifting a corner of a Player's own Hole cards to read them, closing
@@ -161,9 +163,26 @@ preflop but last on every subsequent street — the standard heads-up
 reversal.
 
 **Showdown**:
-The state where all live hands (still in the Hand after River closes) are
-ranked, the winner(s) declared, and ties reported as splits. Skipped
-entirely when a Hand ends early by fold-out — no reveal in that case.
+The state where the Hands still live after River closes are ranked, the
+winner(s) declared, and ties reported as splits. Skipped entirely when a Hand
+ends early by fold-out. Reaching it does not publish anything: the Hand rests
+until the table reveals (ADR-0008).
+
+**Contestant**:
+A Seat that reached Showdown, shown or not. Every view names the contestants;
+only a Seat that has shown appears in `results`, so holding a `RevealedResult`
+is proof the cards are public.
+
+**Showdown show**:
+Publishing a contestant's Hole cards to the whole room, irreversibly. Two
+Commands produce it. The table's `reveal` turns over the compulsory set — the
+River's last aggressor plus every all-in Seat, or the winning Seat when that
+set is empty — and publishes the winners. Every other contestant may then
+`show`, in any order, on their own Device. Both are idempotent: a second press
+changes nothing and is not an error. The window closes when the table deals
+the next Hand, which mucks whatever was not shown.
+_Avoid_: Confusing a show with *Hole-card reveal*, which stays local to one
+Device and can be undone.
 
 **Pot**:
 The physical chips in the middle of the table — a spoken/table term only.
@@ -331,10 +350,12 @@ Seats dealt in, which folding never reduces.
    RIVER (a Street)      — 1 board card dealt, betting round
         │ street closes (last-aggressor logic)
         ▼
-   SHOWDOWN               — live hands ranked, winner(s) declared,
-        │                   ties reported as splits
+   SHOWDOWN               — contestants named, nothing published;
+        │                   the table's Reveal turns over the
+        │                   compulsory Hands and declares winners
         ▼
-   HAND_COMPLETE           — winning hand shown on the table; a
+   HAND_COMPLETE           — shown hands rest on the table while any
+        │                    other contestant may still show; a
         │                    "Next hand" button appears
         ▼
 [Room: seated, awaiting hand]  (button rotates)
@@ -342,7 +363,7 @@ Seats dealt in, which folding never reduces.
 
 **Early-out**: from any betting Street, if a fold drops live players to 1,
 the Hand transitions directly to HAND_COMPLETE — Showdown is skipped, no
-remaining board cards are dealt, no hands are revealed. All-in Seats count as
+remaining board cards are dealt, no hands are shown. All-in Seats count as
 live here, so a Seat that has shoved cannot be folded out of a pot it has
 already bought a claim to (ADR-0007).
 

--- a/packages/engine/src/all-in.test.ts
+++ b/packages/engine/src/all-in.test.ts
@@ -194,7 +194,9 @@ describe("all-in and the automatic run-out", () => {
 
     const final = showdown(playAll(state, [{ type: "allInCall", seatId: 1 }]));
     expect(final.board).toHaveLength(5);
-    expect(final.results.map((result) => result.seatId)).toEqual([1, 0]);
+    expect(final.contestants.map((contestant) => contestant.seatId)).toEqual([
+      1, 0,
+    ]);
   });
 
   it("still opens the flop normally when two seats can act", () => {
@@ -251,7 +253,9 @@ describe("all-in and fold-out", () => {
     ]);
 
     const final = showdown(playAll(state, [{ type: "fold", seatId: 2 }]));
-    expect(final.results.map((result) => result.seatId).sort()).toEqual([0, 3]);
+    expect(
+      final.contestants.map((contestant) => contestant.seatId).sort(),
+    ).toEqual([0, 3]);
   });
 
   it("still folds out a hand where only one seat is left unfolded", () => {

--- a/packages/engine/src/apply.ts
+++ b/packages/engine/src/apply.ts
@@ -9,7 +9,13 @@ import {
   rotateFromButton,
   smallBlindSeat,
 } from "./table.js";
-import type { BettingHandState, EngineState, HandEvent } from "./types.js";
+import type {
+  BettingHandState,
+  Contestant,
+  EngineState,
+  HandEvent,
+  ShowdownCompleteHandState,
+} from "./types.js";
 import { must } from "./util.js";
 
 function asBetting(state: EngineState): BettingHandState {
@@ -21,6 +27,14 @@ function asBetting(state: EngineState): BettingHandState {
 
 function seatState(hand: BettingHandState, seat: number) {
   return must(hand.players.get(seat), `unknown seat ${String(seat)}`);
+}
+
+function asAwaitingShowdown(state: EngineState): ShowdownCompleteHandState {
+  const hand = state.hand;
+  if (hand?.status !== "complete" || hand.reason !== "showdown") {
+    throw new Error("expected a hand at showdown");
+  }
+  return hand;
 }
 
 function resolvedBlinds(hand: BettingHandState) {
@@ -53,6 +67,7 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
           ),
           toAct: [],
           raiseOccurred: false,
+          lastAggressor: null,
         },
       };
     }
@@ -99,9 +114,13 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
         ? requeueAfterRaise(hand.ring, players, event.seatId)
         : hand.toAct.filter((seat) => seat !== event.seatId);
 
+      const lastAggressor = reopensBetting(event.action)
+        ? event.seatId
+        : hand.lastAggressor;
+
       return {
         ...state,
-        hand: { ...hand, players, raiseOccurred, toAct },
+        hand: { ...hand, players, raiseOccurred, toAct, lastAggressor },
       };
     }
 
@@ -116,6 +135,7 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
           ...hand,
           street: event.street,
           board: [...hand.board, ...event.cards],
+          lastAggressor: null,
         },
       };
     }
@@ -137,13 +157,17 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
 
     case "ShowdownReached": {
       const hand = asBetting(state);
-      const results = event.results.map((result) => ({
-        ...result,
-        holeCards: must(
-          seatState(hand, result.seatId).holeCards,
-          "a live seat at showdown always has hole cards",
-        ),
-      }));
+      const contestants: Contestant[] = event.contestants.map((seatId) => {
+        const seat = seatState(hand, seatId);
+        return {
+          seatId,
+          holeCards: must(
+            seat.holeCards,
+            "a live seat at showdown always has hole cards",
+          ),
+          allIn: seat.allIn,
+        };
+      });
       return {
         ...state,
         hand: {
@@ -153,10 +177,28 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
           button: hand.button,
           ...resolvedBlinds(hand),
           board: hand.board,
-          results,
-          winners: event.winners,
+          contestants,
+          lastAggressor: hand.lastAggressor,
+          results: [],
+          winners: null,
         },
       };
+    }
+
+    case "HoleCardsShown": {
+      const hand = asAwaitingShowdown(state);
+      if (hand.results.some((shown) => shown.seatId === event.result.seatId)) {
+        return state;
+      }
+      return {
+        ...state,
+        hand: { ...hand, results: [...hand.results, event.result] },
+      };
+    }
+
+    case "WinnersDeclared": {
+      const hand = asAwaitingShowdown(state);
+      return { ...state, hand: { ...hand, winners: event.winners } };
     }
 
     case "HandComplete": {

--- a/packages/engine/src/complete-hand-state.test.ts
+++ b/packages/engine/src/complete-hand-state.test.ts
@@ -35,10 +35,11 @@ describe("CompleteHandState carries how the hand ended", () => {
     if (state.hand?.status !== "complete") throw new Error("expected complete");
     expect(state.hand.reason).toBe("showdown");
     if (state.hand.reason === "showdown") {
-      expect(state.hand.results).toHaveLength(2);
-      expect(state.hand.winners.length).toBeGreaterThan(0);
-      for (const result of state.hand.results) {
-        expect(result.holeCards).toHaveLength(2);
+      expect(state.hand.contestants).toHaveLength(2);
+      expect(state.hand.results).toEqual([]);
+      expect(state.hand.winners).toBeNull();
+      for (const contestant of state.hand.contestants) {
+        expect(contestant.holeCards).toHaveLength(2);
       }
     }
   });

--- a/packages/engine/src/decide.ts
+++ b/packages/engine/src/decide.ts
@@ -1,5 +1,5 @@
 import { apply } from "./apply.js";
-import { evaluate, winnersOf } from "./evaluate.js";
+import { revealedResultFor, winnersOf } from "./evaluate.js";
 import {
   actingSeats,
   canStillAct,
@@ -15,13 +15,14 @@ import {
 import type {
   ActionType,
   BettingHandState,
-  Card,
   Command,
   EngineState,
   HandEvent,
   Rejection,
   RejectionReason,
+  RevealedResult,
   SeatId,
+  ShowdownCompleteHandState,
 } from "./types.js";
 import { must } from "./util.js";
 
@@ -66,7 +67,78 @@ export function decide(
 
     case "evict":
       return decideEviction(state, command);
+
+    case "reveal":
+      return decideReveal(state, command);
+
+    case "show":
+      return decideShow(state, command);
   }
+}
+
+function awaitingShowdown(
+  state: EngineState,
+): ShowdownCompleteHandState | null {
+  const hand = state.hand;
+  if (hand?.status !== "complete" || hand.reason !== "showdown") return null;
+  return hand;
+}
+
+/**
+ * The river's last aggressor and every all-in Seat, or the winning Seat when
+ * that set is empty — see ADR-0008.
+ */
+function compelledToShow(
+  hand: ShowdownCompleteHandState,
+  results: readonly RevealedResult[],
+): readonly SeatId[] {
+  const compelled = hand.contestants
+    .filter(
+      (contestant) =>
+        contestant.allIn || contestant.seatId === hand.lastAggressor,
+    )
+    .map((contestant) => contestant.seatId);
+  return compelled.length > 0 ? compelled : winnersOf(results);
+}
+
+function decideReveal(
+  state: EngineState,
+  command: Extract<Command, { type: "reveal" }>,
+): HandEvent[] | Rejection {
+  const hand = awaitingShowdown(state);
+  if (hand === null) return reject("not-at-showdown", command);
+  if (hand.winners !== null) return [];
+
+  const results = hand.contestants.map((contestant) =>
+    revealedResultFor(hand.board, contestant),
+  );
+  const compelled = new Set(compelledToShow(hand, results));
+  const shows: HandEvent[] = results
+    .filter((result) => compelled.has(result.seatId))
+    .map((result) => ({ type: "HoleCardsShown", result }));
+
+  return [...shows, { type: "WinnersDeclared", winners: winnersOf(results) }];
+}
+
+function decideShow(
+  state: EngineState,
+  command: Extract<Command, { type: "show" }>,
+): HandEvent[] | Rejection {
+  const hand = awaitingShowdown(state);
+  if (hand === null) return reject("not-at-showdown", command);
+
+  const contestant = hand.contestants.find(
+    (candidate) => candidate.seatId === command.seatId,
+  );
+  if (contestant === undefined) return reject("not-at-showdown", command);
+  if (hand.results.some((shown) => shown.seatId === command.seatId)) return [];
+
+  return [
+    {
+      type: "HoleCardsShown",
+      result: revealedResultFor(hand.board, contestant),
+    },
+  ];
 }
 
 function beginHand(state: EngineState, seed: string): HandEvent[] {
@@ -267,27 +339,9 @@ function finishAtShowdown(
   scratch: EngineState,
   events: HandEvent[],
 ): HandEvent[] {
-  const hand = asBetting(scratch);
-  const results = liveSeats(hand).map((seatId) => {
-    const holeCards = must(
-      hand.players.get(seatId)?.holeCards,
-      "a live seat at showdown always has hole cards",
-    );
-    const { rank, bestHand, description } = evaluate([
-      ...holeCards,
-      ...hand.board,
-    ]);
-    return {
-      seatId,
-      rank,
-      bestHand: [...bestHand] as [Card, Card, Card, Card, Card],
-      description,
-    };
-  });
   const showdownReached: HandEvent = {
     type: "ShowdownReached",
-    results,
-    winners: winnersOf(results),
+    contestants: liveSeats(asBetting(scratch)),
   };
   events.push(showdownReached);
   const afterShowdown = apply(scratch, showdownReached);

--- a/packages/engine/src/evaluate.ts
+++ b/packages/engine/src/evaluate.ts
@@ -1,7 +1,13 @@
 import { categorize } from "./poker/categorize.js";
 import { describe } from "./poker/describe.js";
 import { scoreOf } from "./poker/score.js";
-import type { Card, HandRank, SeatId } from "./types.js";
+import type {
+  Card,
+  Contestant,
+  HandRank,
+  RevealedResult,
+  SeatId,
+} from "./types.js";
 
 export interface HandEvaluation {
   readonly rank: HandRank;
@@ -15,6 +21,23 @@ export function evaluate(cards: readonly Card[]): HandEvaluation {
     rank: scoreOf(category, tiebreak),
     bestHand,
     description: describe(category, tiebreak),
+  };
+}
+
+export function revealedResultFor(
+  board: readonly Card[],
+  contestant: Contestant,
+): RevealedResult {
+  const { rank, bestHand, description } = evaluate([
+    ...contestant.holeCards,
+    ...board,
+  ]);
+  return {
+    seatId: contestant.seatId,
+    holeCards: contestant.holeCards,
+    rank,
+    bestHand,
+    description,
   };
 }
 

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -25,6 +25,7 @@ export type {
   Card,
   Command,
   CompleteHandState,
+  Contestant,
   EngineState,
   FoldedOutCompleteHandState,
   HandEvent,
@@ -43,4 +44,9 @@ export type {
   Suit,
 } from "./types.js";
 export { view } from "./view.js";
-export type { PlayerView, TableView } from "./view.js";
+export type {
+  PlayerShowdownView,
+  PlayerView,
+  ShowdownView,
+  TableView,
+} from "./view.js";

--- a/packages/engine/src/lifecycle.test.ts
+++ b/packages/engine/src/lifecycle.test.ts
@@ -56,8 +56,7 @@ describe("a full hand, 3 seats, start to showdown", () => {
     const showdown = riverEvents.find((e) => e.type === "ShowdownReached");
     expect(showdown).toBeDefined();
     if (showdown?.type === "ShowdownReached") {
-      expect(showdown.results.map((r) => r.seatId).sort()).toEqual([0, 2]);
-      expect(showdown.winners).toEqual([2]);
+      expect([...showdown.contestants].sort()).toEqual([0, 2]);
     }
     expect(riverEvents.at(-1)?.type).toBe("HandComplete");
   });

--- a/packages/engine/src/showdown.test.ts
+++ b/packages/engine/src/showdown.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import { apply } from "./apply.js";
 import { decide } from "./decide.js";
 import { createInitialState } from "./room.js";
-import type { Command, EngineState, HandEvent } from "./types.js";
+import { play, playAll } from "./test-utils.js";
+import type { Command, EngineState, HandEvent, SeatId } from "./types.js";
+import { view } from "./view.js";
 
 function playAndCollect(state: EngineState, commands: Command[]): HandEvent[] {
   const all: HandEvent[] = [];
@@ -20,7 +22,7 @@ function playAndCollect(state: EngineState, commands: Command[]): HandEvent[] {
   return all;
 }
 
-const headsUpToRiver: Command[] = [
+const checkedThroughToRiver: Command[] = [
   { type: "call", seatId: 0 },
   { type: "check", seatId: 1 },
   { type: "check", seatId: 1 },
@@ -31,51 +33,51 @@ const headsUpToRiver: Command[] = [
   { type: "check", seatId: 0 },
 ];
 
-function showdownFor(
-  seed: string,
-): Extract<HandEvent, { type: "ShowdownReached" }> {
-  const state = createInitialState([0, 1]);
-  const events = playAndCollect(state, [
+const raisedOnTheRiver: Command[] = [
+  ...checkedThroughToRiver.slice(0, -1),
+  { type: "raise", seatId: 0 },
+  { type: "call", seatId: 1 },
+];
+
+function headsUpAt(commands: Command[], seed = "s0"): EngineState {
+  return playAll(createInitialState([0, 1]), [
     { type: "startHand", seatId: 0, seed },
-    ...headsUpToRiver,
+    ...commands,
   ]);
-  const showdown = events.find((e) => e.type === "ShowdownReached");
-  if (showdown?.type !== "ShowdownReached") {
-    throw new Error("expected a ShowdownReached event");
-  }
-  return showdown;
 }
 
-describe("ShowdownReached, heads-up to river", () => {
-  it("reports real ranks, best-five cards and descriptions for every live seat", () => {
-    const showdown = showdownFor("s0");
-    expect(showdown.results).toHaveLength(2);
-    for (const result of showdown.results) {
-      expect(result.bestHand).toHaveLength(5);
-      expect(typeof result.rank).toBe("number");
-      expect(result.description.length).toBeGreaterThan(0);
+function showdownState(state: EngineState) {
+  const hand = state.hand;
+  if (hand?.status !== "complete" || hand.reason !== "showdown") {
+    throw new Error("expected a hand at showdown");
+  }
+  return hand;
+}
+
+function reveal(state: EngineState): EngineState {
+  return playAll(state, [{ type: "reveal", seatId: 0 }]);
+}
+
+function shownSeats(state: EngineState): SeatId[] {
+  return showdownState(state).results.map((result) => result.seatId);
+}
+
+describe("ShowdownReached", () => {
+  it("names every seat that reached showdown and reveals nothing about them", () => {
+    const events = playAndCollect(createInitialState([0, 1]), [
+      { type: "startHand", seatId: 0, seed: "s0" },
+      ...checkedThroughToRiver,
+    ]);
+    const showdown = events.find((event) => event.type === "ShowdownReached");
+    if (showdown?.type !== "ShowdownReached") {
+      throw new Error("expected a ShowdownReached event");
     }
+    expect([...showdown.contestants].sort()).toEqual([0, 1]);
+    expect(Object.keys(showdown)).toEqual(["type", "contestants"]);
   });
 
-  it("reports exactly one winner for a constructed clear-winner scenario", () => {
-    const showdown = showdownFor("s0");
-    expect(showdown.winners).toHaveLength(1);
-    const bestRank = Math.max(...showdown.results.map((r) => r.rank));
-    const winner = showdown.results.find((r) => r.rank === bestRank);
-    expect(showdown.winners).toEqual([winner?.seatId]);
-  });
-
-  it("reports both seats as winners for a constructed tie scenario", () => {
-    const showdown = showdownFor("s36");
-    expect(showdown.winners.sort()).toEqual([0, 1]);
-    expect(showdown.results[0]?.rank).toBe(showdown.results[1]?.rank);
-  });
-});
-
-describe("ShowdownReached omits folded seats", () => {
-  it("never reveals a seat that folded, even though it was live earlier", () => {
-    const state = createInitialState([0, 1, 2]);
-    const events = playAndCollect(state, [
+  it("omits a seat that folded, even though it was live earlier", () => {
+    const events = playAndCollect(createInitialState([0, 1, 2]), [
       { type: "startHand", seatId: 0, seed: "seed-1" },
       { type: "call", seatId: 0 },
       { type: "call", seatId: 1 },
@@ -92,11 +94,195 @@ describe("ShowdownReached omits folded seats", () => {
       { type: "raise", seatId: 0 },
       { type: "call", seatId: 2 },
     ]);
-    const showdown = events.find((e) => e.type === "ShowdownReached");
+    const showdown = events.find((event) => event.type === "ShowdownReached");
     if (showdown?.type !== "ShowdownReached") {
       throw new Error("expected a ShowdownReached event");
     }
-    expect(showdown.results.map((r) => r.seatId).sort()).toEqual([0, 2]);
-    expect(showdown.results.some((r) => r.seatId === 1)).toBe(false);
+    expect([...showdown.contestants].sort()).toEqual([0, 2]);
+  });
+});
+
+describe("the hand rests before it resolves", () => {
+  it("carries no hole cards, results or winners in any view", () => {
+    const state = headsUpAt(checkedThroughToRiver);
+
+    const table = view(state, "table");
+    if (table.phase !== "showdown") throw new Error("expected showdown");
+    expect(table.contestants).toEqual([1, 0]);
+    expect(table.results).toEqual([]);
+    expect(table.winners).toBeNull();
+    expect(JSON.stringify(table)).not.toContain("holeCards");
+  });
+
+  it("still tells a player their own hand and that they may show", () => {
+    const player = view(headsUpAt(checkedThroughToRiver), 0);
+    if (player.phase !== "showdown") throw new Error("expected showdown");
+    expect(player.yourResult?.holeCards).toHaveLength(2);
+    expect(player.canShow).toBe(true);
+  });
+});
+
+describe("reveal turns over exactly the compulsory set", () => {
+  it("compels the river's last aggressor", () => {
+    const state = reveal(headsUpAt(raisedOnTheRiver));
+    expect(shownSeats(state)).toEqual([0]);
+    expect(showdownState(state).winners).not.toBeNull();
+  });
+
+  it("forgets an aggressor from an earlier street", () => {
+    const state = reveal(
+      headsUpAt([
+        { type: "call", seatId: 0 },
+        { type: "check", seatId: 1 },
+        { type: "check", seatId: 1 },
+        { type: "raise", seatId: 0 },
+        { type: "call", seatId: 1 },
+        { type: "check", seatId: 1 },
+        { type: "check", seatId: 0 },
+        { type: "check", seatId: 1 },
+        { type: "check", seatId: 0 },
+      ]),
+    );
+    expect(shownSeats(state)).toEqual(showdownState(state).winners);
+  });
+
+  it("compels the winning seat when the river was checked through", () => {
+    const state = reveal(headsUpAt(checkedThroughToRiver));
+    const hand = showdownState(state);
+    expect(hand.winners).not.toBeNull();
+    expect(shownSeats(state)).toEqual(hand.winners);
+  });
+
+  it("compels every all-in seat", () => {
+    const state = reveal(
+      headsUpAt([
+        { type: "call", seatId: 0 },
+        { type: "allInCall", seatId: 1 },
+      ]),
+    );
+    expect(shownSeats(state)).toContain(1);
+  });
+
+  it("publishes winners over every contestant, shown or not", () => {
+    const state = reveal(headsUpAt(raisedOnTheRiver));
+    const hand = showdownState(state);
+    const ranked = [...hand.contestants].map((contestant) => contestant.seatId);
+    expect(hand.winners?.every((seat) => ranked.includes(seat))).toBe(true);
+  });
+
+  it("is an idempotent no-op when pressed again", () => {
+    const revealed = reveal(headsUpAt(raisedOnTheRiver));
+    const outcome = play(revealed, { type: "reveal", seatId: 0 });
+    if ("rejection" in outcome) throw new Error("expected a no-op");
+    expect(outcome.events).toEqual([]);
+  });
+
+  it("is rejected before the river closes", () => {
+    const state = headsUpAt([{ type: "call", seatId: 0 }]);
+    const outcome = play(state, { type: "reveal", seatId: 0 });
+    if (!("rejection" in outcome)) throw new Error("expected a rejection");
+    expect(outcome.rejection.reason).toBe("not-at-showdown");
+  });
+});
+
+describe("show", () => {
+  it("lets any other contestant turn over, in any order", () => {
+    const revealed = reveal(headsUpAt(raisedOnTheRiver));
+    expect(shownSeats(revealed)).toEqual([0]);
+    const shown = playAll(revealed, [{ type: "show", seatId: 1 }]);
+    expect(shownSeats(shown)).toEqual([0, 1]);
+  });
+
+  it("cannot conceal a hand once shown", () => {
+    const shown = playAll(reveal(headsUpAt(raisedOnTheRiver)), [
+      { type: "show", seatId: 1 },
+    ]);
+    const outcome = play(shown, { type: "show", seatId: 1 });
+    if ("rejection" in outcome) throw new Error("expected a no-op");
+    expect(outcome.events).toEqual([]);
+    expect(shownSeats(shown)).toEqual([0, 1]);
+  });
+
+  it("is rejected from a seat that folded", () => {
+    const state = playAll(createInitialState([0, 1, 2]), [
+      { type: "startHand", seatId: 0, seed: "seed-1" },
+      { type: "call", seatId: 0 },
+      { type: "call", seatId: 1 },
+      { type: "raise", seatId: 2 },
+      { type: "call", seatId: 0 },
+      { type: "call", seatId: 1 },
+      { type: "check", seatId: 1 },
+      { type: "check", seatId: 2 },
+      { type: "check", seatId: 0 },
+      { type: "fold", seatId: 1 },
+      { type: "check", seatId: 2 },
+      { type: "check", seatId: 0 },
+      { type: "check", seatId: 2 },
+      { type: "raise", seatId: 0 },
+      { type: "call", seatId: 2 },
+    ]);
+    const outcome = play(state, { type: "show", seatId: 1 });
+    if (!("rejection" in outcome)) throw new Error("expected a rejection");
+    expect(outcome.rejection.reason).toBe("not-at-showdown");
+  });
+
+  it("is rejected once the hand has closed", () => {
+    const next = playAll(reveal(headsUpAt(raisedOnTheRiver)), [
+      { type: "nextHand", seatId: 0, seed: "s1" },
+    ]);
+    const outcome = play(next, { type: "show", seatId: 1 });
+    if (!("rejection" in outcome)) throw new Error("expected a rejection");
+    expect(outcome.rejection.reason).toBe("not-at-showdown");
+  });
+});
+
+describe("an unshown seat leaks nothing derived from its cards", () => {
+  it("appears in contestants and nowhere else, for the table or a rival", () => {
+    const state = reveal(headsUpAt(raisedOnTheRiver));
+    const concealed = showdownState(state).contestants.find(
+      (contestant) => !shownSeats(state).includes(contestant.seatId),
+    );
+    if (concealed === undefined) throw new Error("expected a concealed seat");
+
+    for (const projected of [view(state, "table"), view(state, 0)]) {
+      if (projected.phase !== "showdown") throw new Error("expected showdown");
+      expect(projected.contestants).toContain(concealed.seatId);
+      expect(
+        projected.results.some((result) => result.seatId === concealed.seatId),
+      ).toBe(false);
+      expect(JSON.stringify(projected)).not.toContain(
+        JSON.stringify(concealed.holeCards[0]),
+      );
+    }
+  });
+});
+
+describe("the next hand closes the window", () => {
+  it("mucks whatever was not shown", () => {
+    const next = playAll(reveal(headsUpAt(raisedOnTheRiver)), [
+      { type: "nextHand", seatId: 0, seed: "s1" },
+    ]);
+    expect(next.hand?.status).toBe("betting");
+    const table = view(next, "table");
+    expect(table.phase).toBe("betting");
+  });
+});
+
+describe("replay reproduces exactly who showed", () => {
+  it("keeps a concealed hand concealed when the events are folded again", () => {
+    const commands: Command[] = [
+      { type: "startHand", seatId: 0, seed: "s0" },
+      ...raisedOnTheRiver,
+      { type: "reveal", seatId: 0 },
+    ];
+    const events = playAndCollect(createInitialState([0, 1]), commands);
+
+    let replayed = createInitialState([0, 1]);
+    for (const event of events) replayed = apply(replayed, event);
+
+    expect(shownSeats(replayed)).toEqual([0]);
+    expect(showdownState(replayed).winners).toEqual(
+      showdownState(playAll(createInitialState([0, 1]), commands)).winners,
+    );
   });
 });

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -21,7 +21,9 @@ export type Command =
   | { type: "startHand"; seatId: SeatId; seed: string }
   | { type: ActionType; seatId: SeatId }
   | { type: "evict"; seatId: SeatId }
-  | { type: "nextHand"; seatId: SeatId; seed: string };
+  | { type: "nextHand"; seatId: SeatId; seed: string }
+  | { type: "reveal"; seatId: SeatId }
+  | { type: "show"; seatId: SeatId };
 
 export type HandEvent =
   | { type: "HandStarted"; seed: string; button: SeatId }
@@ -34,16 +36,9 @@ export type HandEvent =
   | { type: "StreetClosed"; street: Street }
   | { type: "BoardDealt"; street: "flop" | "turn" | "river"; cards: Card[] }
   | { type: "HandFoldedOut"; winner: SeatId }
-  | {
-      type: "ShowdownReached";
-      results: {
-        seatId: SeatId;
-        rank: HandRank;
-        bestHand: [Card, Card, Card, Card, Card];
-        description: string;
-      }[];
-      winners: SeatId[];
-    }
+  | { type: "ShowdownReached"; contestants: SeatId[] }
+  | { type: "HoleCardsShown"; result: RevealedResult }
+  | { type: "WinnersDeclared"; winners: SeatId[] }
   | { type: "HandComplete" };
 
 export type RejectionReason =
@@ -51,7 +46,8 @@ export type RejectionReason =
   | "action-not-legal"
   | "hand-not-in-progress"
   | "hand-already-in-progress"
-  | "stale-next-hand";
+  | "stale-next-hand"
+  | "not-at-showdown";
 
 export interface Rejection {
   readonly type: "Rejection";
@@ -75,6 +71,7 @@ export interface BettingHandState {
   readonly players: ReadonlyMap<SeatId, SeatHandState>;
   readonly toAct: readonly SeatId[];
   readonly raiseOccurred: boolean;
+  readonly lastAggressor: SeatId | null;
 }
 
 export interface ShowdownResult {
@@ -86,6 +83,12 @@ export interface ShowdownResult {
 
 export interface RevealedResult extends ShowdownResult {
   readonly holeCards: readonly [Card, Card];
+}
+
+export interface Contestant {
+  readonly seatId: SeatId;
+  readonly holeCards: readonly [Card, Card];
+  readonly allIn: boolean;
 }
 
 export interface HandPositions {
@@ -107,8 +110,10 @@ export interface ShowdownCompleteHandState extends HandPositions {
   readonly reason: "showdown";
   readonly seed: string;
   readonly board: readonly Card[];
+  readonly contestants: readonly Contestant[];
+  readonly lastAggressor: SeatId | null;
   readonly results: readonly RevealedResult[];
-  readonly winners: readonly SeatId[];
+  readonly winners: readonly SeatId[] | null;
 }
 
 export type CompleteHandState =

--- a/packages/engine/src/version.test.ts
+++ b/packages/engine/src/version.test.ts
@@ -7,7 +7,7 @@ describe("ENGINE_LOG_VERSION", () => {
     expect(ENGINE_LOG_VERSION).toBeGreaterThan(0);
   });
 
-  it("uses the next version for the corrected preflop action order", () => {
-    expect(ENGINE_LOG_VERSION).toBe(4);
+  it("uses the next version for showdown visibility as engine state", () => {
+    expect(ENGINE_LOG_VERSION).toBe(5);
   });
 });

--- a/packages/engine/src/version.ts
+++ b/packages/engine/src/version.ts
@@ -1,1 +1,1 @@
-export const ENGINE_LOG_VERSION = 4;
+export const ENGINE_LOG_VERSION = 5;

--- a/packages/engine/src/view.test.ts
+++ b/packages/engine/src/view.test.ts
@@ -229,9 +229,11 @@ function assertNoLeak(
   dealtCards: ReadonlyMap<SeatId, readonly [Card, Card]>,
   seats: readonly SeatId[],
 ): void {
-  const revealed = new Set<SeatId>();
+  const shown = new Set<SeatId>();
+  const contestants = new Set<SeatId>();
   if (state.hand?.status === "complete" && state.hand.reason === "showdown") {
-    for (const result of state.hand.results) revealed.add(result.seatId);
+    for (const result of state.hand.results) shown.add(result.seatId);
+    for (const c of state.hand.contestants) contestants.add(c.seatId);
   }
 
   const viewers: (SeatId | "table")[] = [...seats, "table"];
@@ -242,21 +244,15 @@ function assertNoLeak(
     const cardKeys = new Set(cardsInView.map((c) => `${c.rank}${c.suit}`));
 
     for (const [seatId, cards] of dealtCards) {
-      const isRevealed = revealed.has(seatId);
-      const isLiveOwner =
+      const isOwner =
         v === seatId &&
-        state.hand?.status === "betting" &&
-        !must(state.hand.players.get(seatId)).folded;
+        (state.hand?.status === "betting"
+          ? !must(state.hand.players.get(seatId)).folded
+          : contestants.has(seatId));
 
       for (const card of cards) {
         const present = cardKeys.has(`${card.rank}${card.suit}`);
-        if (isRevealed) {
-          expect(present).toBe(true);
-        } else if (isLiveOwner) {
-          expect(present).toBe(true);
-        } else {
-          expect(present).toBe(false);
-        }
+        expect(present).toBe(shown.has(seatId) || isOwner);
       }
     }
   }
@@ -304,6 +300,16 @@ describe("property: view never leaks a hole card it isn't entitled to", () => {
                 ? "check"
                 : action;
             const result = decide(state, { type: legal, seatId: actor });
+            if (!Array.isArray(result)) continue;
+            for (const event of result) state = apply(state, event);
+            assertNoLeak(state, dealtCards, seats);
+          }
+
+          for (const command of [
+            { type: "reveal", seatId: firstPlayer },
+            ...seats.map((seatId) => ({ type: "show", seatId }) as const),
+          ] as const) {
+            const result = decide(state, command);
             if (!Array.isArray(result)) continue;
             for (const event of result) state = apply(state, event);
             assertNoLeak(state, dealtCards, seats);

--- a/packages/engine/src/view.ts
+++ b/packages/engine/src/view.ts
@@ -1,3 +1,4 @@
+import { revealedResultFor } from "./evaluate.js";
 import { bigBlindSeat, legalActions, smallBlindSeat } from "./table.js";
 import type {
   ActionType,
@@ -24,11 +25,21 @@ interface FoldedOutView extends HandPositions {
   readonly winner: SeatId;
 }
 
-interface ShowdownView extends HandPositions {
+export interface ShowdownView extends HandPositions {
   readonly phase: "showdown";
   readonly board: readonly Card[];
+  /** Every Seat that reached showdown, shown or not — see ADR-0008. */
+  readonly contestants: readonly SeatId[];
+  /** Shown Seats only, in the order they were turned over. */
   readonly results: readonly RevealedResult[];
-  readonly winners: readonly SeatId[];
+  /** Null until the table reveals: the Hand rests before it resolves. */
+  readonly winners: readonly SeatId[] | null;
+}
+
+export interface PlayerShowdownView extends ShowdownView {
+  readonly yourSeatId: SeatId;
+  readonly yourResult: RevealedResult | null;
+  readonly canShow: boolean;
 }
 
 export interface PlayerViewBetting extends HandPositions {
@@ -53,7 +64,7 @@ export interface TableViewBetting extends HandPositions {
 }
 
 export type PlayerView =
-  NoHandView | PlayerViewBetting | FoldedOutView | ShowdownView;
+  NoHandView | PlayerViewBetting | FoldedOutView | PlayerShowdownView;
 
 export type TableView =
   NoHandView | TableViewBetting | FoldedOutView | ShowdownView;
@@ -95,15 +106,30 @@ export function view(
   }
 
   if (hand.status === "complete") {
-    return {
+    const showdownView: ShowdownView = {
       phase: "showdown",
       button: hand.button,
       smallBlind: hand.smallBlind,
       bigBlind: hand.bigBlind,
       dealtSeatCount: hand.dealtSeatCount,
       board: hand.board,
-      winners: hand.winners,
+      contestants: hand.contestants.map((contestant) => contestant.seatId),
       results: hand.results,
+      winners: hand.winners,
+    };
+    if (seatId === "table") return showdownView;
+
+    const yours = hand.contestants.find(
+      (contestant) => contestant.seatId === seatId,
+    );
+    return {
+      ...showdownView,
+      yourSeatId: seatId,
+      yourResult:
+        yours === undefined ? null : revealedResultFor(hand.board, yours),
+      canShow:
+        yours !== undefined &&
+        !hand.results.some((shown) => shown.seatId === seatId),
     };
   }
 

--- a/packages/harness/fixtures/hand-1.commands.jsonl
+++ b/packages/harness/fixtures/hand-1.commands.jsonl
@@ -13,3 +13,5 @@
 {"type":"check","seatId":2}
 {"type":"raise","seatId":0}
 {"type":"call","seatId":2}
+{"type":"reveal","seatId":0}
+{"type":"show","seatId":2}

--- a/packages/harness/fixtures/hand-1.expected.jsonl
+++ b/packages/harness/fixtures/hand-1.expected.jsonl
@@ -25,5 +25,8 @@
 {"type":"ActionTaken","seatId":0,"action":"raise"}
 {"type":"ActionTaken","seatId":2,"action":"call"}
 {"type":"StreetClosed","street":"river"}
-{"type":"ShowdownReached","results":[{"seatId":2,"rank":1250655,"bestHand":[{"rank":"9","suit":"spades"},{"rank":"9","suit":"clubs"},{"rank":"10","suit":"hearts"},{"rank":"8","suit":"clubs"},{"rank":"7","suit":"diamonds"}],"description":"Pair of nines"},{"seatId":0,"rank":3594375,"bestHand":[{"rank":"J","suit":"clubs"},{"rank":"10","suit":"hearts"},{"rank":"9","suit":"clubs"},{"rank":"8","suit":"clubs"},{"rank":"7","suit":"hearts"}],"description":"Straight, jack high"}],"winners":[0]}
+{"type":"ShowdownReached","contestants":[2,0]}
 {"type":"HandComplete"}
+{"type":"HoleCardsShown","result":{"seatId":0,"holeCards":[{"rank":"J","suit":"clubs"},{"rank":"7","suit":"hearts"}],"rank":3594375,"bestHand":[{"rank":"J","suit":"clubs"},{"rank":"10","suit":"hearts"},{"rank":"9","suit":"clubs"},{"rank":"8","suit":"clubs"},{"rank":"7","suit":"hearts"}],"description":"Straight, jack high"}}
+{"type":"WinnersDeclared","winners":[0]}
+{"type":"HoleCardsShown","result":{"seatId":2,"holeCards":[{"rank":"9","suit":"spades"},{"rank":"2","suit":"clubs"}],"rank":1250655,"bestHand":[{"rank":"9","suit":"spades"},{"rank":"9","suit":"clubs"},{"rank":"10","suit":"hearts"},{"rank":"8","suit":"clubs"},{"rank":"7","suit":"diamonds"}],"description":"Pair of nines"}}

--- a/packages/harness/src/fixtures.test.ts
+++ b/packages/harness/src/fixtures.test.ts
@@ -54,7 +54,7 @@ describe("hand-1 fixture: replay through the engine", () => {
     let state = createInitialState([0, 1, 2]);
     for (const event of events) state = apply(state, event);
 
-    expect(ENGINE_LOG_VERSION).toBe(4);
+    expect(ENGINE_LOG_VERSION).toBe(5);
     if (state.hand?.status !== "complete") throw new Error("expected complete");
     expect(state.hand.button).toBe(0);
     expect(state.hand.smallBlind).toBe(1);

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -241,7 +241,7 @@ describe("Hand", () => {
   });
 
   describe("showdown", () => {
-    const showdownView: PlayerView = {
+    const shownTable = {
       phase: "showdown",
       button: 0,
       smallBlind: 1,
@@ -254,6 +254,7 @@ describe("Hand", () => {
         { rank: "9", suit: "diamonds" },
         { rank: "4", suit: "spades" },
       ],
+      contestants: [0, 1],
       results: [
         {
           seatId: 0,
@@ -289,11 +290,22 @@ describe("Hand", () => {
         },
       ],
       winners: [0],
-    };
+    } as const;
+
+    function showdownViewFor(seatId: number): PlayerView {
+      const yourResult =
+        shownTable.results.find((result) => result.seatId === seatId) ?? null;
+      return {
+        ...shownTable,
+        yourSeatId: seatId,
+        yourResult,
+        canShow: false,
+      };
+    }
 
     it("shows the winner's own hole cards and a win banner, never an opponent's cards", () => {
       const html = renderToStaticMarkup(
-        <Hand view={showdownView} seatId={0} />,
+        <Hand view={showdownViewFor(0)} seatId={0} />,
       );
 
       expect(html).toMatch(/data-testid="hand"[^>]*data-phase="showdown"/);
@@ -307,7 +319,7 @@ describe("Hand", () => {
 
     it("hands the pair to showdown locked, so it renders revealed and inert", () => {
       const html = renderToStaticMarkup(
-        <Hand view={showdownView} seatId={0} />,
+        <Hand view={showdownViewFor(0)} seatId={0} />,
       );
 
       expect(html).toContain('data-presentation="Revealed"');
@@ -316,7 +328,7 @@ describe("Hand", () => {
 
     it("shows the loser's own hole cards and a loss banner naming the winner", () => {
       const html = renderToStaticMarkup(
-        <Hand view={showdownView} seatId={1} />,
+        <Hand view={showdownViewFor(1)} seatId={1} />,
       );
 
       expect(html).toMatch(/data-testid="turn-banner"[^>]*data-tone="loss"/);
@@ -329,7 +341,7 @@ describe("Hand", () => {
 
     it("reads a fold message and shows no hole cards for a seat that folded before showdown", () => {
       const html = renderToStaticMarkup(
-        <Hand view={showdownView} seatId={2} />,
+        <Hand view={showdownViewFor(2)} seatId={2} />,
       );
 
       expect(html).toMatch(/data-testid="no-hole-cards"/);
@@ -452,8 +464,12 @@ describe("Hand", () => {
           bigBlind: 2,
           dealtSeatCount: 3,
           board: [],
+          contestants: [0, 1],
           results: [],
           winners: [1],
+          yourSeatId: 0,
+          yourResult: null,
+          canShow: true,
         },
       ],
       [

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -138,12 +138,20 @@ function bannerFor(
   }
 
   if (view.phase === "showdown") {
-    const iWon = view.winners.includes(seatId);
+    const winners = view.winners;
+    if (winners === null) {
+      return {
+        kicker: "Showdown",
+        text: "Waiting for the table to turn the hands over",
+        tone: "idle",
+      };
+    }
+    const iWon = winners.includes(seatId);
     const winnerResult = view.results.find(
-      (result) => result.seatId === view.winners[0],
+      (result) => result.seatId === winners[0],
     );
     if (iWon) {
-      const label = view.winners.length > 1 ? "You split the pot" : "You win";
+      const label = winners.length > 1 ? "You split the pot" : "You win";
       return {
         kicker: "Hand complete",
         text: winnerResult
@@ -152,13 +160,13 @@ function bannerFor(
         tone: "win",
       };
     }
-    const winnerNames = view.winners
+    const winnerNames = winners
       .map((winner) => seatLabel(winner, seats))
       .join(" & ");
     const winClause = winnerResult
       ? `${winnerNames} wins with ${winnerResult.description}`
       : `${winnerNames} wins`;
-    const myResult = view.results.find((result) => result.seatId === seatId);
+    const myResult = view.yourResult;
     const yourClause = myResult
       ? ` — you had ${myResult.description}`
       : " — you folded earlier";
@@ -412,7 +420,7 @@ export function Hand({
   }
 
   if (view.phase === "showdown") {
-    const myResult = view.results.find((result) => result.seatId === seatId);
+    const myResult = view.yourResult;
     return (
       <div
         data-testid="hand"

--- a/packages/player-client/src/actions/rejectionCopy.ts
+++ b/packages/player-client/src/actions/rejectionCopy.ts
@@ -17,6 +17,8 @@ export function rejectionCopy(
       return "A hand is already in progress.";
     case "stale-next-hand":
       return "That hand has already moved on.";
+    case "not-at-showdown":
+      return "There's no hand of yours to show.";
     case "invalid-command":
       return "That didn't go through — try again.";
     case "room-not-found":

--- a/packages/protocol/src/command-schema.ts
+++ b/packages/protocol/src/command-schema.ts
@@ -7,6 +7,8 @@ export const ClientCommandSchema = z.discriminatedUnion("type", [
   z.strictObject({ type: z.literal("call") }),
   z.strictObject({ type: z.literal("raise") }),
   z.strictObject({ type: z.literal("nextHand") }),
+  z.strictObject({ type: z.literal("reveal") }),
+  z.strictObject({ type: z.literal("show") }),
   z.strictObject({ type: z.literal("sitOut") }),
   z.strictObject({ type: z.literal("sitIn") }),
 ]);

--- a/packages/protocol/src/summary.test.ts
+++ b/packages/protocol/src/summary.test.ts
@@ -73,10 +73,13 @@ function foldedOut(winner: SeatId): HandEvent[] {
 function showdown(seats: readonly SeatId[], winners: SeatId[]): HandEvent[] {
   return [
     { type: "StreetClosed", street: "river" },
-    {
-      type: "ShowdownReached",
-      results: seats.map((seatId) => ({
+    { type: "ShowdownReached", contestants: [...seats] },
+    { type: "HandComplete" },
+    ...seats.map((seatId): HandEvent => ({
+      type: "HoleCardsShown",
+      result: {
         seatId,
+        holeCards: [FLOP[0], FLOP[1]] as [Card, Card],
         rank: winners.includes(seatId) ? 2 : 1,
         bestHand: [...FLOP, ...TURN, ...RIVER] as [
           Card,
@@ -86,10 +89,9 @@ function showdown(seats: readonly SeatId[], winners: SeatId[]): HandEvent[] {
           Card,
         ],
         description: `seat ${String(seatId)}'s hand`,
-      })),
-      winners,
-    },
-    { type: "HandComplete" },
+      },
+    })),
+    { type: "WinnersDeclared", winners },
   ];
 }
 
@@ -286,6 +288,7 @@ describe("summarise", () => {
       );
       expect(summary.outcome).toEqual({
         kind: "showdown",
+        contestants: [0, 1],
         winners: [1],
         reveals: [
           {

--- a/packages/protocol/src/summary.ts
+++ b/packages/protocol/src/summary.ts
@@ -8,7 +8,7 @@ export type BettingShape =
   | { readonly kind: "one-raise" }
   | { readonly kind: "raise-war"; readonly raises: number };
 
-/** One seat's showdown hand; sourced only from `ShowdownReached`, so it widens no visibility. */
+/** One seat's showdown hand; sourced only from `HoleCardsShown`, so it widens no visibility. */
 export interface ShowdownReveal {
   readonly seatId: SeatId;
   readonly bestHand: readonly [Card, Card, Card, Card, Card];
@@ -19,6 +19,7 @@ export type HandOutcome =
   | { readonly kind: "folded-out"; readonly winner: SeatId }
   | {
       readonly kind: "showdown";
+      readonly contestants: readonly SeatId[];
       readonly winners: readonly SeatId[];
       readonly reveals: readonly ShowdownReveal[];
     };
@@ -121,13 +122,30 @@ export function summarise(
       case "ShowdownReached":
         outcome = {
           kind: "showdown",
-          winners: [...event.winners],
-          reveals: event.results.map(({ seatId, bestHand, description }) => ({
-            seatId,
-            bestHand: [...bestHand] as [Card, Card, Card, Card, Card],
-            description,
-          })),
+          contestants: [...event.contestants],
+          winners: [],
+          reveals: [],
         };
+        break;
+      case "HoleCardsShown": {
+        if (outcome?.kind !== "showdown") break;
+        const { seatId, bestHand, description } = event.result;
+        outcome = {
+          ...outcome,
+          reveals: [
+            ...outcome.reveals,
+            {
+              seatId,
+              bestHand: [...bestHand] as [Card, Card, Card, Card, Card],
+              description,
+            },
+          ],
+        };
+        break;
+      }
+      case "WinnersDeclared":
+        if (outcome?.kind !== "showdown") break;
+        outcome = { ...outcome, winners: [...event.winners] };
         break;
       default:
         break;

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -1400,7 +1400,7 @@ describe("hand command dispatch over WebSocket", () => {
         if (message.type !== "hand-update") continue;
         const v = message.view;
         if (
-          "yourSeatId" in v &&
+          "yourHoleCards" in v &&
           v.yourSeatId === seatId &&
           v.yourHoleCards !== null
         ) {
@@ -2827,7 +2827,7 @@ describe("presence and reconnection", () => {
       throw new Error("expected a view-snapshot");
     }
     const view = snapshot.view;
-    if (!("yourSeatId" in view) || toAct !== 0) {
+    if (!("yourHoleCards" in view) || toAct !== 0) {
       return;
     }
     expect(view.yourHoleCards).toBeNull();

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -480,6 +480,16 @@ export async function buildApp(
       });
   }
 
+  /**
+   * The showing window outlives `HandComplete` (ADR-0008), so the picker row is
+   * re-derived and re-sent as each Hand is turned over.
+   */
+  const RESUMMARISES: ReadonlySet<HandEvent["type"]> = new Set([
+    "HandComplete",
+    "HoleCardsShown",
+    "WinnersDeclared",
+  ]);
+
   /** Summarises a hand only once seen whole, and never once recording stopped. */
   function accumulateHandSummary(
     code: string,
@@ -487,6 +497,7 @@ export async function buildApp(
   ): void {
     for (const step of transaction.steps) {
       if (step.event.type === "HandStarted") {
+        handsInProgress.delete(code);
         const handOrdinal = (handsStarted.get(code) ?? 0) + 1;
         handsStarted.set(code, handOrdinal);
         handsInProgress.set(code, {
@@ -499,9 +510,8 @@ export async function buildApp(
       const inProgress = handsInProgress.get(code);
       if (inProgress === undefined) continue;
       inProgress.events.push(step.event);
-      if (step.event.type !== "HandComplete") continue;
+      if (!RESUMMARISES.has(step.event.type)) continue;
 
-      handsInProgress.delete(code);
       if (roomRecordings.hasStopped(code)) continue;
       let summary: HandSummary;
       try {
@@ -519,7 +529,11 @@ export async function buildApp(
         continue;
       }
       const summaries = handSummaries.get(code) ?? [];
-      summaries.push(summary);
+      const existing = summaries.findIndex(
+        (listed) => listed.handOrdinal === summary.handOrdinal,
+      );
+      if (existing === -1) summaries.push(summary);
+      else summaries[existing] = summary;
       handSummaries.set(code, summaries);
       sendToTables(code, { type: "hand-summary", summary });
     }

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -1110,6 +1110,20 @@ describe("RoomStore", () => {
       return room;
     }
 
+    /** Checks the Hand down to Showdown, calling only where a check is illegal. */
+    function playToShowdown(store: RoomStore, code: string): void {
+      commitDispatch(store, code, "table", "startHand");
+      for (let step = 0; step < MAX_ACTIONS_TO_SHOWDOWN; step++) {
+        const actor = store.currentActor(code);
+        if (actor === undefined) return;
+        const checked = commitDispatch(store, code, actor, "check");
+        if ("reason" in checked) commitDispatch(store, code, actor, "call");
+      }
+      throw new Error("hand never reached showdown");
+    }
+
+    const MAX_ACTIONS_TO_SHOWDOWN = 16;
+
     function stagedDispatch(
       store: RoomStore,
       code: string,
@@ -1281,6 +1295,45 @@ describe("RoomStore", () => {
         command: rejected.command,
         outcome: rejected.rejection,
       });
+    });
+
+    it("takes reveal from the table and stamps a seat on it", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, [0, 1]);
+      playToShowdown(store, room.code);
+
+      const revealed = commitDispatch(store, room.code, "table", "reveal");
+
+      if (!("steps" in revealed)) throw new Error("expected a transaction");
+      expect(revealed.command).toEqual({ type: "reveal", seatId: 0 });
+      expect(revealed.steps.map((step) => step.event.type)).toContain(
+        "WinnersDeclared",
+      );
+    });
+
+    it("refuses reveal from a player and show from the table", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, [0, 1]);
+      playToShowdown(store, room.code);
+
+      expect(store.dispatch(room.code, 0, "reveal")).toEqual({
+        error: "not-permitted",
+      });
+      expect(store.dispatch(room.code, "table", "show")).toEqual({
+        error: "not-permitted",
+      });
+    });
+
+    it("shows a player's own hand on their own command", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, [0, 1]);
+      playToShowdown(store, room.code);
+      commitDispatch(store, room.code, "table", "reveal");
+
+      const shown = commitDispatch(store, room.code, 1, "show");
+
+      if (!("steps" in shown)) throw new Error("expected a transaction");
+      expect(shown.command).toEqual({ type: "show", seatId: 1 });
     });
 
     it("has no operation for a refusal the engine never ruled on", () => {

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -132,7 +132,11 @@ export type SeatCommandType = Exclude<ClientCommandType, "sitOut" | "sitIn">;
 const TABLE_ONLY_COMMANDS: ReadonlySet<SeatCommandType> = new Set([
   "startHand",
   "nextHand",
+  "reveal",
 ]);
+
+/** The table has no Seat of its own; a table-originated Command still needs one stamped. */
+const TABLE_SEAT_ID = 0;
 
 function makeSeats(seatCount: number): Seat[] {
   return Array.from({ length: seatCount }, (_, id) => ({
@@ -222,11 +226,17 @@ function remapCompletedEngineState(
     hand: {
       ...hand,
       button: map(hand.button),
+      contestants: hand.contestants.map((contestant) => ({
+        ...contestant,
+        seatId: map(contestant.seatId),
+      })),
+      lastAggressor:
+        hand.lastAggressor === null ? null : map(hand.lastAggressor),
       results: hand.results.map((result) => ({
         ...result,
         seatId: map(result.seatId),
       })),
-      winners: hand.winners.map(map),
+      winners: hand.winners === null ? null : hand.winners.map(map),
     },
   };
 }
@@ -793,6 +803,7 @@ export class RoomStore {
     if (type === "startHand" || type === "nextHand") {
       return { type, seatId: 0, seed: this.#generateSeed() };
     }
+    if (type === "reveal") return { type, seatId: TABLE_SEAT_ID };
     return { type, seatId: identity as SeatId };
   }
 }

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -69,6 +69,7 @@ const showdownHand: TableView = {
     { rank: "7", suit: "diamonds" },
     { rank: "9", suit: "clubs" },
   ],
+  contestants: [0, 1],
   winners: [0],
   results: [
     {

--- a/packages/table-client/src/Board.test.tsx
+++ b/packages/table-client/src/Board.test.tsx
@@ -83,6 +83,7 @@ describe("Board", () => {
       smallBlind: 1,
       bigBlind: 2,
       dealtSeatCount: 3,
+      contestants: [0, 1],
       board: [
         { rank: "A", suit: "spades" },
         { rank: "K", suit: "hearts" },
@@ -165,6 +166,7 @@ describe("Board", () => {
       bigBlind: 2,
       dealtSeatCount: 3,
       board,
+      contestants: [0, 1],
       winners: [0],
       results: [],
     };

--- a/packages/table-client/src/HandPicker.test.tsx
+++ b/packages/table-client/src/HandPicker.test.tsx
@@ -75,6 +75,7 @@ const showdown: HandSummary = {
   bettingShape: { kind: "one-raise" },
   outcome: {
     kind: "showdown",
+    contestants: [0, 1],
     winners: [0],
     reveals: [
       {

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -322,6 +322,7 @@ describe("Seats", () => {
         { rank: "7", suit: "diamonds" },
         { rank: "9", suit: "clubs" },
       ],
+      contestants: [0],
       winners: [0],
       results: [
         {
@@ -363,6 +364,7 @@ describe("Seats", () => {
         { rank: "7", suit: "diamonds" },
         { rank: "9", suit: "clubs" },
       ],
+      contestants: [2],
       winners: [2],
       results: [
         {
@@ -714,6 +716,7 @@ describe("Seats: position markers", () => {
         ...headsUpPositions,
         phase: "showdown",
         board: [],
+        contestants: [0, 1],
         winners: [0],
         results: [],
       } satisfies TableView,

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -78,15 +78,11 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
     view?.phase === "betting"
       ? view.seats.find((s) => s.seatId === seat.id)
       : undefined;
-  const showdownResult =
-    view?.phase === "showdown"
-      ? view.results.find((r) => r.seatId === seat.id)
-      : undefined;
   const participatedInCurrentHand =
     view?.phase === "betting"
       ? handSeat !== undefined
       : view?.phase === "showdown"
-        ? showdownResult !== undefined
+        ? view.contestants.includes(seat.id)
         : view?.phase === "folded-out"
           ? view.winner === seat.id
           : false;

--- a/packages/table-client/src/ShowdownOverlay.test.tsx
+++ b/packages/table-client/src/ShowdownOverlay.test.tsx
@@ -32,6 +32,7 @@ const showdown: ShowdownView = {
     { rank: "7", suit: "diamonds" },
     { rank: "9", suit: "clubs" },
   ],
+  contestants: [0, 1],
   winners: [0],
   results: [
     {

--- a/packages/table-client/src/ShowdownOverlay.tsx
+++ b/packages/table-client/src/ShowdownOverlay.tsx
@@ -278,7 +278,7 @@ export function ShowdownOverlay({
   onNextHand,
   onViewTable,
 }: ShowdownOverlayProps) {
-  const winnerIds = new Set(view.winners);
+  const winnerIds = new Set(view.winners ?? []);
   const winners = view.results.filter((result) => winnerIds.has(result.seatId));
   const rest = view.results.filter((result) => !winnerIds.has(result.seatId));
   const { stageRef, contentRef, scale } = useFitToBox();

--- a/packages/table-client/src/replay/beats.ts
+++ b/packages/table-client/src/replay/beats.ts
@@ -31,6 +31,8 @@ const WEIGHTS: Record<HandEvent["type"], number> = {
   BoardDealt: 1600,
   HandFoldedOut: 2400,
   ShowdownReached: 3200,
+  HoleCardsShown: 1600,
+  WinnersDeclared: 2400,
   HandComplete: 2000,
 };
 

--- a/packages/table-client/src/replay/caption.test.ts
+++ b/packages/table-client/src/replay/caption.test.ts
@@ -16,15 +16,20 @@ const named: readonly SeatView[] = seats.map((seat) =>
 
 const card = (rank: Card["rank"]): Card => ({ rank, suit: "clubs" });
 
-const showdown = (winners: number[]): HandEvent => ({
-  type: "ShowdownReached",
+const winnersDeclared = (winners: number[]): HandEvent => ({
+  type: "WinnersDeclared",
   winners,
-  results: [0, 1].map((seatId) => ({
+});
+
+const holeCardsShown = (seatId: number): HandEvent => ({
+  type: "HoleCardsShown",
+  result: {
     seatId,
+    holeCards: [card("2"), card("3")],
     rank: 1,
     bestHand: [card("2"), card("3"), card("4"), card("5"), card("6")],
     description: "a straight",
-  })),
+  },
 });
 
 describe("captionFor", () => {
@@ -68,15 +73,17 @@ describe("captionFor", () => {
     );
   });
 
-  it("names a showdown's winner and their hand", () => {
-    expect(captionFor(showdown([1]), named)).toBe(
-      "Showdown — Ada wins with a straight",
-    );
+  it("names the seat turning its hand over and what it holds", () => {
+    expect(captionFor(holeCardsShown(1), named)).toBe("Ada shows a straight");
+  });
+
+  it("names a showdown's winner", () => {
+    expect(captionFor(winnersDeclared([1]), named)).toBe("Ada wins");
   });
 
   it("names both halves of a split pot", () => {
-    expect(captionFor(showdown([0, 1]), named)).toBe(
-      "Showdown — Seat 1 and Ada split with a straight",
+    expect(captionFor(winnersDeclared([0, 1]), named)).toBe(
+      "Seat 1 and Ada split",
     );
   });
 
@@ -89,7 +96,9 @@ describe("captionFor", () => {
       { type: "StreetClosed", street: "preflop" },
       { type: "BoardDealt", street: "flop", cards: [card("2")] },
       { type: "HandFoldedOut", winner: 1 },
-      showdown([1]),
+      { type: "ShowdownReached", contestants: [0, 1] },
+      holeCardsShown(1),
+      winnersDeclared([1]),
       { type: "HandComplete" },
     ];
 

--- a/packages/table-client/src/replay/caption.ts
+++ b/packages/table-client/src/replay/caption.ts
@@ -15,17 +15,12 @@ function joinNames(names: readonly string[]): string {
   return `${names.slice(0, -1).join(", ")} and ${String(names.at(-1))}`;
 }
 
-function showdownCaption(
-  event: Extract<HandEvent, { type: "ShowdownReached" }>,
+function winnersCaption(
+  event: Extract<HandEvent, { type: "WinnersDeclared" }>,
   seats: readonly SeatView[],
 ): string {
-  const { names, verb, description } = showdownVerdict(
-    event.winners,
-    event.results,
-    seats,
-  );
-  const hand = description === undefined ? "" : ` with ${description}`;
-  return `Showdown — ${joinNames(names)} ${verb}${hand}`;
+  const { names, verb } = showdownVerdict(event.winners, [], seats);
+  return `${joinNames(names)} ${verb}`;
 }
 
 /** The beat just landed on — see Caption in `CONTEXT.md`. */
@@ -51,7 +46,11 @@ export function captionFor(
     case "HandFoldedOut":
       return `${seatLabel(event.winner, seats)} wins, everyone else folded`;
     case "ShowdownReached":
-      return showdownCaption(event, seats);
+      return "Showdown";
+    case "HoleCardsShown":
+      return `${seatLabel(event.result.seatId, seats)} shows ${event.result.description}`;
+    case "WinnersDeclared":
+      return winnersCaption(event, seats);
     case "HandComplete":
       return "Hand complete";
   }

--- a/packages/table-client/src/store/handHistorySlice.ts
+++ b/packages/table-client/src/store/handHistorySlice.ts
@@ -4,6 +4,7 @@ import type { StateCreator } from "zustand";
 export interface HandHistorySlice {
   readonly handSummaries: readonly HandSummary[];
   readonly setHandList: (summaries: readonly HandSummary[]) => void;
+  /** Replaces the row of the same ordinal: a Hand is re-summarised as it is shown. */
   readonly addHandSummary: (summary: HandSummary) => void;
   readonly clearHandHistory: () => void;
 }
@@ -16,7 +17,14 @@ export const createHandHistorySlice: StateCreator<HandHistorySlice> = (
     set({ handSummaries: summaries });
   },
   addHandSummary: (summary) => {
-    set((state) => ({ handSummaries: [...state.handSummaries, summary] }));
+    set((state) => ({
+      handSummaries: [
+        ...state.handSummaries.filter(
+          (listed) => listed.handOrdinal !== summary.handOrdinal,
+        ),
+        summary,
+      ],
+    }));
   },
   clearHandHistory: () => {
     set({ handSummaries: [] });

--- a/packages/ui-shared/src/positionMarker.test.ts
+++ b/packages/ui-shared/src/positionMarker.test.ts
@@ -75,6 +75,7 @@ describe("positionMarkerFor", () => {
           phase: "showdown",
           ...headsUp,
           board: [],
+          contestants: [0, 1],
           results: [],
           winners: [0],
         },

--- a/packages/ui-shared/src/sound/engine.ts
+++ b/packages/ui-shared/src/sound/engine.ts
@@ -105,6 +105,8 @@ export function createSoundEngine(
       case "StreetStarted":
       case "StreetClosed":
       case "ShowdownReached":
+      case "HoleCardsShown":
+      case "WinnersDeclared":
       case "HandFoldedOut":
       case "HandComplete":
         break;


### PR DESCRIPTION
Implements [ADR-0008](../blob/showdown-v2/docs/adr/0008-showdown-visibility-is-engine-state.md). Closes #251.

## What changed

**The Hand rests before it resolves.** `ShowdownReached` now carries only `contestants` — the Seats that reached Showdown. No view carries a Hole card, a `result`, a `rank`, a `bestHand`, a `description` or a `winner` until the table reveals.

**Two commands turn Hands over.**

- `reveal`, table-originated in the pattern of `startHand`/`nextHand` (the server stamps the Seat id). Shows the compulsory set — the River's `lastAggressor` plus every all-in Seat, or the winning Seat when that set is empty — then declares the winners over *every* contestant, shown or not.
- `show`, sent by a Player for their own Seat. Any other contestant, in any order, and never reversible.

Both emit `HoleCardsShown`; `reveal` also emits `WinnersDeclared`. Repeat presses return no events at all — a shared table screen will be double-pressed and that is not an error. `RejectionReason` gains `not-at-showdown` for `show` from a folded Seat, `show` after the Hand closed, and `reveal` before the River closes.

**`lastAggressor: SeatId | null`** on the Hand, set by `raise` and `allInRaise`, reset by `BoardDealt` — which is every Street change after preflop, including the automatic run-out, so a checked-through River genuinely has none.

**`RevealedResult` now exists only for a shown Seat**, so holding one is proof the cards are public. The Showdown view carries `contestants` separately from `results`; `deriveSeat` in the table client reads `contestants`, so a concealing Seat still renders as having played. A Player's own view gains `yourResult` and `canShow`.

**Protocol, server, docs, fixtures.** `reveal`/`show` in `ClientCommandSchema`; `reveal` added to the table-only set; `HandSummary`'s showdown outcome sourced from `HoleCardsShown`/`WinnersDeclared` and re-derived as each Hand is turned over (the store upserts the row by ordinal); `CONTEXT.md` gains **Contestant** and **Showdown show** and amends **Hole-card reveal**; `ENGINE_LOG_VERSION` bumped to 5 and the harness fixture regenerated, now exercising both commands.

## Notes for review

- **`HandComplete` still fires immediately after `ShowdownReached`.** The showing window is a state of a *complete* Hand, not a fourth phase — Hand recordings partition on the Command that opens the next Hand, so deferring `HandComplete` to `nextHand` would file it under the wrong Hand. The picker row is therefore re-sent as shows arrive.
- The engine keeps every contestant's Hole cards in the complete Hand state; concealment is a `view()` boundary, exactly as it is for Hole cards during betting. The property test in `view.test.ts` now drives `reveal` and `show` and asserts the boundary holds for every viewer at every step.
- No legacy reveal-everything branch. Existing recordings replay as Showdowns where nobody showed, as #251 accepts.
- Client surfaces are #252 (table) and #253 (player); this PR keeps them compiling and honest — the overlay and the player banner handle an un-revealed Showdown — but adds no Reveal or Show control.

## Verification

`npx tsc -b` clean, `npm run lint` clean, and the affected suites pass (engine, protocol, server, harness, both clients, ui-shared — 1109 tests). Full suite is CI's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nyg8H7osWtxHAYdJ4ceA1A