### PR TITLE
feat(table): showdown on the Seat plates, replacing the overlay

### DIFF
--- a/docs/adr/0008-showdown-visibility-is-engine-state.md
+++ b/docs/adr/0008-showdown-visibility-is-engine-state.md
@@ -3,7 +3,9 @@
 ## Status
 
 Accepted. Depends on [ADR-0007](0007-all-in-as-declared-actions-without-chip-values.md)
-for the all-in actions this decision compels to show.
+for the all-in actions this decision compels to show. The rank badge in
+"Showdown happens on the table, not over it" was dropped while building it —
+see [Amendments](#amendments). The rest stands.
 
 ## Context
 
@@ -45,8 +47,9 @@ which mucks whatever was not shown.
 plate, oriented toward the table centre, with the verdict and a rank badge —
 hands are ranked best-first with ties sharing a badge, listing shown hands only,
 because with side pots (ADR-0007) "who won" has more than one answer and the
-humans settle the chips. Card backs sit above an unshown Seat while the window is
-open and vanish when the hand closes. `ShowdownOverlay` survives as a house rule,
+humans settle the chips (rank badge dropped — see [Amendments](#amendments)).
+Card backs sit above an unshown Seat while the window is open and vanish when the
+hand closes. `ShowdownOverlay` survives as a house rule,
 defaulting off and persisted per-room. A player's own device shows only their own
 hand and the verdict: the table is the shared surface.
 
@@ -71,3 +74,21 @@ hand and the verdict: the table is the shared surface.
 - Six or more shown hands cluster at the table centre and may force smaller cards
   than the overlay used. This is a layout risk to test at 6–8 seats, not a reason
   to keep the overlay as the primary surface.
+
+## Amendments
+
+### The rank badge is dropped; only the winner is badged (#252)
+
+Ranking the shown hands is unsound in the visibility model this ADR itself
+establishes. `results` holds shown hands only, so a winner who was never
+compelled to show is absent from it, and the best *shown* hand — a loser — takes
+first place. The table then reads "1st" on one Seat and "wins" on another. Even
+where every winner shows, ordinals read as finishing places to the room rather
+than as an ordering of the hands in front of them.
+
+The Seat plate carries the verdict alone: `wins`, or `splits` where the winners
+are more than one, and nothing on a Seat that did not win. The cards stay the
+result and the room reads them, which was already this ADR's rule for the hand's
+*description*. Ordering the hands for the humans who settle the chips is left to
+the cards themselves; when side pots (ADR-0007) arrive and "who won" needs more
+than one answer, that answer is a decision of its own, not an ordinal.

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -326,6 +326,22 @@ describe("Hand", () => {
       expect(html).toContain('aria-disabled="true"');
     });
 
+    it("keeps an unshown contestant's own cards face down and still peekable", () => {
+      const concealing: PlayerView = {
+        ...shownTable,
+        results: [],
+        winners: null,
+        yourSeatId: 1,
+        yourResult: shownTable.results[1],
+        canShow: true,
+      };
+      const html = renderToStaticMarkup(<Hand view={concealing} seatId={1} />);
+
+      expect(html).toContain('data-presentation="FaceDown"');
+      expect(html).not.toContain('data-presentation="Revealed"');
+      expect(html).toContain('aria-disabled="false"');
+    });
+
     it("shows the loser's own hole cards and a loss banner naming the winner", () => {
       const html = renderToStaticMarkup(
         <Hand view={showdownViewFor(1)} seatId={1} />,

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -421,6 +421,9 @@ export function Hand({
 
   if (view.phase === "showdown") {
     const myResult = view.yourResult;
+    const iHaveShown = view.results.some(
+      (result) => result.seatId === view.yourSeatId,
+    );
     return (
       <div
         data-testid="hand"
@@ -442,7 +445,7 @@ export function Hand({
         {myResult ? (
           <HoleCardsRegion
             cards={myResult.holeCards}
-            locked
+            locked={iHaveShown}
             actions={actions}
           />
         ) : (

--- a/packages/player-client/src/store/store.test.ts
+++ b/packages/player-client/src/store/store.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SHOT_CLOCK,
+  DEFAULT_SHOWDOWN_OVERLAY,
   DEFAULT_SOUND_SETTINGS,
 } from "@table-top-poker/protocol";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -75,6 +76,7 @@ describe("usePlayerStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownOverlay: DEFAULT_SHOWDOWN_OVERLAY,
       seats: [
         {
           id: 0,
@@ -100,6 +102,7 @@ describe("usePlayerStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownOverlay: DEFAULT_SHOWDOWN_OVERLAY,
       seats: [
         {
           id: 0,
@@ -135,6 +138,7 @@ describe("usePlayerStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownOverlay: DEFAULT_SHOWDOWN_OVERLAY,
       seats: [
         {
           id: 0,
@@ -165,6 +169,7 @@ describe("usePlayerStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownOverlay: DEFAULT_SHOWDOWN_OVERLAY,
       seats: [
         {
           id: 0,
@@ -198,6 +203,7 @@ describe("usePlayerStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownOverlay: DEFAULT_SHOWDOWN_OVERLAY,
       seats: [
         {
           id: 0,

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -82,6 +82,28 @@ export type ChangeSoundSettingsRequest = z.infer<
 export type SoundSettingsChangeError =
   "room-not-found" | "invalid-request-body";
 
+/** ADR-0008: the Seat-anchored Showdown is the default; the overlay is the fallback. */
+export interface ShowdownOverlaySettings {
+  readonly enabled: boolean;
+}
+
+export const DEFAULT_SHOWDOWN_OVERLAY: ShowdownOverlaySettings = {
+  enabled: false,
+};
+
+export const ShowdownOverlaySettingsSchema = z.strictObject({
+  enabled: z.boolean(),
+});
+
+export const ChangeShowdownOverlayRequestSchema = ShowdownOverlaySettingsSchema;
+
+export type ChangeShowdownOverlayRequest = z.infer<
+  typeof ChangeShowdownOverlayRequestSchema
+>;
+
+export type ShowdownOverlayChangeError =
+  "room-not-found" | "invalid-request-body";
+
 export const MIN_SHOT_CLOCK_SECONDS = 5;
 export const MAX_SHOT_CLOCK_SECONDS = 600;
 
@@ -163,6 +185,7 @@ export interface RoomView {
   readonly pendingShotClock: ShotClockSettings | null;
   readonly soundSettings: SoundSettings;
   readonly shotClockSettings: ShotClockSettings;
+  readonly showdownOverlay: ShowdownOverlaySettings;
 }
 
 export interface RoomViewMessage {

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_SEAT_COUNT,
   DEFAULT_SHOT_CLOCK,
+  DEFAULT_SHOWDOWN_OVERLAY,
   ENGINE_LOG_VERSION,
   legalActions,
   DEFAULT_SOUND_SETTINGS,
@@ -201,6 +202,7 @@ describe("rooms HTTP routes", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownOverlay: DEFAULT_SHOWDOWN_OVERLAY,
       seats: unclaimedSeats(),
     });
   });
@@ -278,6 +280,71 @@ describe("GET /config", () => {
 
     expect(response.statusCode).toBe(200);
     expect(response.json()).toEqual({ testMode: true });
+  });
+});
+
+describe("POST /rooms/:code/showdown-overlay", () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    app = await buildApp({ recordings: testRecordings() });
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  async function createRoom(): Promise<string> {
+    const created = await app.inject({
+      method: "POST",
+      url: "/rooms",
+      payload: { seatCount: DEFAULT_SEAT_COUNT },
+    });
+    return created.json<RoomCreatedBody>().code;
+  }
+
+  it("starts off and persists the room's choice", async () => {
+    const code = await createRoom();
+    const before = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/join`,
+    });
+    expect(before.json<RoomView>().showdownOverlay).toEqual({
+      enabled: false,
+    });
+
+    const response = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/showdown-overlay`,
+      payload: { enabled: true },
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ enabled: true });
+
+    const joined = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/join`,
+    });
+    expect(joined.json<RoomView>().showdownOverlay).toEqual({ enabled: true });
+  });
+
+  it("rejects a malformed body", async () => {
+    const code = await createRoom();
+    const response = await app.inject({
+      method: "POST",
+      url: `/rooms/${code}/showdown-overlay`,
+      payload: { enabled: "yes" },
+    });
+    expect(response.statusCode).toBe(400);
+  });
+
+  it("404s an unknown room", async () => {
+    const response = await app.inject({
+      method: "POST",
+      url: "/rooms/ZZZZ/showdown-overlay",
+      payload: { enabled: true },
+    });
+    expect(response.statusCode).toBe(404);
   });
 });
 
@@ -1272,6 +1339,7 @@ describe("WebSocket upgrade", () => {
         pendingShotClock: null,
         soundSettings: DEFAULT_SOUND_SETTINGS,
         shotClockSettings: DEFAULT_SHOT_CLOCK,
+        showdownOverlay: DEFAULT_SHOWDOWN_OVERLAY,
         seats: unclaimedSeats(),
       },
     });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -4,6 +4,7 @@ import {
   AddBotsRequestSchema,
   ChangeSeatCountRequestSchema,
   ChangeShotClockRequestSchema,
+  ChangeShowdownOverlayRequestSchema,
   ChangeSoundSettingsRequestSchema,
   ClaimSeatRequestSchema,
   LeaveSeatRequestSchema,
@@ -982,6 +983,27 @@ export async function buildApp(
     }
     return result;
   });
+
+  app.post<RoomCodeRoute>(
+    "/rooms/:code/showdown-overlay",
+    async (request, reply) => {
+      const body = ChangeShowdownOverlayRequestSchema.safeParse(request.body);
+      if (!body.success) {
+        return reply.code(400).send({ error: "invalid-request-body" });
+      }
+      const room = findRoomOrReject(rooms, request.params.code, reply);
+      if (!room) return;
+      const result = await enqueue(room.code, () => {
+        const settings = rooms.changeShowdownOverlay(room.code, body.data);
+        if (!("error" in settings)) broadcastRoomView(room.code);
+        return settings;
+      });
+      if ("error" in result) {
+        return reply.code(404).send({ error: result.error });
+      }
+      return result;
+    },
+  );
 
   app.post<RoomCodeRoute>("/rooms/:code/shot-clock", async (request, reply) => {
     const body = ChangeShotClockRequestSchema.safeParse(request.body);

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_SEAT_COUNT,
   DEFAULT_SHOT_CLOCK,
+  DEFAULT_SHOWDOWN_OVERLAY,
   DEFAULT_SOUND_SETTINGS,
   MAX_DISPLAY_NAME_LENGTH,
   MAX_SEAT_COUNT,
@@ -132,6 +133,20 @@ describe("RoomStore", () => {
 
     expect(room.shotClockSettings).toEqual(DEFAULT_SHOT_CLOCK);
     expect(toRoomView(room).shotClockSettings).toEqual(DEFAULT_SHOT_CLOCK);
+  });
+
+  it("creates a room with the showdown overlay off, and remembers a change", () => {
+    const store = new RoomStore();
+    const room = store.create();
+
+    expect(toRoomView(room).showdownOverlay).toEqual(DEFAULT_SHOWDOWN_OVERLAY);
+    expect(store.changeShowdownOverlay(room.code, { enabled: true })).toEqual({
+      enabled: true,
+    });
+    expect(toRoomView(room).showdownOverlay).toEqual({ enabled: true });
+    expect(store.changeShowdownOverlay("ZZZZ", { enabled: true })).toEqual({
+      error: "room-not-found",
+    });
   });
 
   it("creates a room with the seat count the creator chose", () => {
@@ -1407,6 +1422,7 @@ describe("toRoomView", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownOverlay: DEFAULT_SHOWDOWN_OVERLAY,
       seats: [
         {
           id: 0,

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -29,6 +29,8 @@ import {
   type ShotClockSettings,
   type SittingOutReason,
   type SoundSettings,
+  DEFAULT_SHOWDOWN_OVERLAY,
+  type ShowdownOverlaySettings,
 } from "@table-top-poker/protocol";
 import { generateRoomCode } from "./room-code.js";
 
@@ -55,6 +57,7 @@ export interface Room {
   turnEndsAt: number | null;
   pendingShotClock: ShotClockSettings | null;
   soundSettings: SoundSettings;
+  showdownOverlay: ShowdownOverlaySettings;
   shotClockSettings: ShotClockSettings;
 }
 
@@ -406,6 +409,7 @@ export class RoomStore {
       turnEndsAt: null,
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
+      showdownOverlay: DEFAULT_SHOWDOWN_OVERLAY,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
     };
     return {
@@ -608,6 +612,16 @@ export class RoomStore {
     if (!room) return { error: "room-not-found" };
     room.soundSettings = settings;
     return room.soundSettings;
+  }
+
+  changeShowdownOverlay(
+    code: string,
+    settings: ShowdownOverlaySettings,
+  ): ShowdownOverlaySettings | { error: "room-not-found" } {
+    const room = this.#rooms.get(code);
+    if (!room) return { error: "room-not-found" };
+    room.showdownOverlay = settings;
+    return room.showdownOverlay;
   }
 
   changeShotClockSettings(
@@ -815,6 +829,7 @@ export function toRoomView(room: Room): RoomView {
     pendingShotClock: room.pendingShotClock,
     soundSettings: room.soundSettings,
     shotClockSettings: room.shotClockSettings,
+    showdownOverlay: room.showdownOverlay,
     seats: room.seats.map((seat) => {
       const reason = sittingOutReason(room, seat.id);
       return {

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -107,6 +107,19 @@ function enterRoom(
   };
 }
 
+function enableShowdownOverlay() {
+  store.overrides = {
+    ...store.overrides,
+    showdownOverlay: { enabled: true },
+  };
+}
+
+const awaitingReveal: TableView = {
+  ...showdownHand,
+  winners: null,
+  results: [],
+};
+
 describe("App", () => {
   afterEach(() => {
     store.overrides = {};
@@ -203,6 +216,7 @@ describe("App", () => {
 
   it("renders the showdown reveal overlay at showdown, gating Next hand on player count", () => {
     enterRoom(2, showdownHand);
+    enableShowdownOverlay();
     const html = renderToStaticMarkup(<App />);
 
     expect(html).toContain('data-testid="showdown-overlay"');
@@ -216,12 +230,37 @@ describe("App", () => {
 
   it("disables the overlay's Next hand once the table drops below two players", () => {
     enterRoom(1, showdownHand);
+    enableShowdownOverlay();
     const html = renderToStaticMarkup(<App />);
 
     expect(html).toMatch(
       /data-testid="showdown-next-hand-button"[^>]*disabled/,
     );
     expect(html).toContain('data-testid="showdown-next-hand-blocked-hint"');
+  });
+
+  it("plays showdown on the seats, with no overlay, unless the house rule is on", () => {
+    enterRoom(2, showdownHand);
+    const html = renderToStaticMarkup(<App />);
+
+    expect(html).not.toContain('data-testid="showdown-overlay"');
+    expect(html).not.toContain('data-testid="view-showdown-button"');
+    expect(html).toContain('data-testid="seat-pod-0-showdown"');
+    expect(html).toContain('data-testid="next-hand-button"');
+  });
+
+  it("puts Reveal where Next hand goes until the table has revealed", () => {
+    enterRoom(2, awaitingReveal);
+    const revealing = renderToStaticMarkup(<App />);
+
+    expect(revealing).toContain('data-testid="reveal-button"');
+    expect(revealing).not.toContain('data-testid="next-hand-button"');
+
+    enterRoom(2, showdownHand);
+    const revealed = renderToStaticMarkup(<App />);
+
+    expect(revealed).not.toContain('data-testid="reveal-button"');
+    expect(revealed).toContain('data-testid="next-hand-button"');
   });
 
   it("does not render the overlay for a fold-out ending", () => {

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -5,6 +5,7 @@ import {
   isHandLive,
   MIN_SEAT_COUNT,
   type ShotClockSettings,
+  type ShowdownOverlaySettings,
   type SoundSettings,
 } from "@table-top-poker/protocol";
 import {
@@ -18,6 +19,7 @@ import { useCallback, useEffect, useState, type CSSProperties } from "react";
 import {
   changeSeatCount,
   changeShotClockSettings,
+  changeShowdownOverlay,
   changeSoundSettings,
   createRoom,
   addBots,
@@ -91,6 +93,7 @@ export function App() {
   const pendingShotClock = useTableStore((state) => state.pendingShotClock);
   const soundSettings = useTableStore((state) => state.soundSettings);
   const shotClockSettings = useTableStore((state) => state.shotClockSettings);
+  const showdownOverlay = useTableStore((state) => state.showdownOverlay);
   const testMode = useTableStore((state) => state.testMode);
   const connectionStatus = useTableStore((state) => state.connectionStatus);
   const handView = useTableStore((state) => state.handView);
@@ -128,6 +131,8 @@ export function App() {
 
   const [showdownCollapsed, setShowdownCollapsed] = useState(false);
   const atShowdown = handView?.phase === "showdown";
+  const awaitingReveal =
+    handView?.phase === "showdown" && handView.winners === null;
   useEffect(() => {
     if (!atShowdown) setShowdownCollapsed(false);
   }, [atShowdown]);
@@ -204,6 +209,16 @@ export function App() {
     [roomCode],
   );
 
+  const handleChangeShowdownOverlay = useCallback(
+    (next: ShowdownOverlaySettings) => {
+      if (roomCode === null) return;
+      changeShowdownOverlay(roomCode, next).catch((error: unknown) => {
+        console.error(error);
+      });
+    },
+    [roomCode],
+  );
+
   const handleChangeShotClockSettings = useCallback(
     async (next: ShotClockSettings): Promise<void> => {
       if (roomCode === null) return;
@@ -220,6 +235,10 @@ export function App() {
   const handleNextHand = useCallback(() => {
     void unlockAudio();
     send({ type: "nextHand" });
+  }, [send]);
+
+  const handleReveal = useCallback(() => {
+    send({ type: "reveal" });
   }, [send]);
 
   const handleSelectHand = useCallback(
@@ -370,9 +389,11 @@ export function App() {
                 handInProgress={isHandLive(handView)}
                 soundSettings={soundSettings}
                 shotClockSettings={shotClockSettings}
+                showdownOverlay={showdownOverlay}
                 onApply={handleChangeSeatCount}
                 onApplyShotClock={handleChangeShotClockSettings}
                 onChangeSoundSettings={handleChangeSoundSettings}
+                onChangeShowdownOverlay={handleChangeShowdownOverlay}
                 onClose={() => {
                   setSettingsOpen(false);
                 }}
@@ -383,9 +404,11 @@ export function App() {
                 canStartHand={canStartHand}
                 handComplete={handComplete}
                 canDealNextHand={enoughPlayers}
-                atShowdown={atShowdown}
+                atShowdown={atShowdown && showdownOverlay.enabled}
+                awaitingReveal={awaitingReveal}
                 onStartHand={handleStartHand}
                 onNextHand={handleNextHand}
+                onReveal={handleReveal}
                 onEndSession={handleEndSession}
                 testMode={testMode}
                 onAddBot={handleAddBot}
@@ -407,12 +430,14 @@ export function App() {
                 }}
               />
             )}
-            {handView?.phase === "showdown" && (
+            {handView?.phase === "showdown" && showdownOverlay.enabled && (
               <ShowdownOverlay
                 view={handView}
                 seats={seats}
                 collapsed={showdownCollapsed}
                 canDealNextHand={enoughPlayers}
+                awaitingReveal={awaitingReveal}
+                onReveal={handleReveal}
                 onNextHand={handleNextHand}
                 onViewTable={() => {
                   setShowdownCollapsed(true);

--- a/packages/table-client/src/HouseRulesSheet.test.tsx
+++ b/packages/table-client/src/HouseRulesSheet.test.tsx
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SHOT_CLOCK,
+  DEFAULT_SHOWDOWN_OVERLAY,
   DEFAULT_SOUND_SETTINGS,
   type SeatView,
 } from "@table-top-poker/protocol";
@@ -99,8 +100,10 @@ function renderSheet(
       seats={seats.slice(0, 4)}
       handInProgress
       soundSettings={DEFAULT_SOUND_SETTINGS}
+      showdownOverlay={DEFAULT_SHOWDOWN_OVERLAY}
       onApply={noop}
       onChangeSoundSettings={noop}
+      onChangeShowdownOverlay={noop}
       onClose={noop}
       {...overrides}
     />
@@ -147,6 +150,29 @@ async function settleReactUpdates(): Promise<void> {
 }
 
 describe("HouseRulesSheet", () => {
+  it("offers the showdown overlay as a house rule, off by default", () => {
+    const html = renderToStaticMarkup(renderSheet());
+
+    expect(html).toContain('data-testid="showdown-settings"');
+    expect(html).toMatch(
+      /aria-checked="false"[^>]*data-testid="showdown-overlay-toggle"/,
+    );
+  });
+
+  it("reports a showdown overlay change straight away", () => {
+    const onChangeShowdownOverlay = vi.fn();
+    let renderer!: TestRenderer;
+    act(() => {
+      renderer = create(renderSheet({ onChangeShowdownOverlay }));
+    });
+
+    act(() => {
+      findNode(renderer, "showdown-overlay-toggle").props.onClick?.();
+    });
+
+    expect(onChangeShowdownOverlay).toHaveBeenCalledWith({ enabled: true });
+  });
+
   it("shows the chosen house-rules surface and a repack preview", () => {
     const html = renderToStaticMarkup(
       <HouseRulesSheet
@@ -156,8 +182,10 @@ describe("HouseRulesSheet", () => {
         seats={seats}
         handInProgress
         soundSettings={DEFAULT_SOUND_SETTINGS}
+        showdownOverlay={DEFAULT_SHOWDOWN_OVERLAY}
         onApply={noop}
         onChangeSoundSettings={noop}
+        onChangeShowdownOverlay={noop}
         onClose={noop}
       />,
     );
@@ -178,8 +206,10 @@ describe("HouseRulesSheet", () => {
         seats={seats}
         handInProgress
         soundSettings={DEFAULT_SOUND_SETTINGS}
+        showdownOverlay={DEFAULT_SHOWDOWN_OVERLAY}
         onApply={noop}
         onChangeSoundSettings={noop}
+        onChangeShowdownOverlay={noop}
         onClose={noop}
       />,
     );
@@ -200,8 +230,10 @@ describe("HouseRulesSheet", () => {
         seats={seats.slice(0, 4)}
         handInProgress
         soundSettings={DEFAULT_SOUND_SETTINGS}
+        showdownOverlay={DEFAULT_SHOWDOWN_OVERLAY}
         onApply={noop}
         onChangeSoundSettings={noop}
+        onChangeShowdownOverlay={noop}
         onClose={noop}
       />,
     );
@@ -223,8 +255,10 @@ describe("HouseRulesSheet", () => {
           actions: true,
           notifications: true,
         }}
+        showdownOverlay={DEFAULT_SHOWDOWN_OVERLAY}
         onApply={noop}
         onChangeSoundSettings={noop}
+        onChangeShowdownOverlay={noop}
         onClose={noop}
       />,
     );
@@ -255,8 +289,10 @@ describe("HouseRulesSheet", () => {
           actions: true,
           notifications: true,
         }}
+        showdownOverlay={DEFAULT_SHOWDOWN_OVERLAY}
         onApply={noop}
         onChangeSoundSettings={noop}
+        onChangeShowdownOverlay={noop}
         onClose={noop}
       />,
     );
@@ -278,9 +314,11 @@ describe("HouseRulesSheet", () => {
         seats={seats.slice(0, 4)}
         handInProgress
         soundSettings={DEFAULT_SOUND_SETTINGS}
+        showdownOverlay={DEFAULT_SHOWDOWN_OVERLAY}
         onApply={noop}
         onApplyShotClock={noop}
         onChangeSoundSettings={noop}
+        onChangeShowdownOverlay={noop}
         onClose={noop}
       />,
     );

--- a/packages/table-client/src/HouseRulesSheet.tsx
+++ b/packages/table-client/src/HouseRulesSheet.tsx
@@ -6,6 +6,7 @@ import {
   type SeatView,
   type SeatMove,
   type ShotClockSettings,
+  type ShowdownOverlaySettings,
   type SoundSettings,
 } from "@table-top-poker/protocol";
 import {
@@ -28,11 +29,13 @@ export interface HouseRulesSheetProps {
   readonly handInProgress: boolean;
   readonly soundSettings: SoundSettings;
   readonly shotClockSettings: ShotClockSettings;
+  readonly showdownOverlay: ShowdownOverlaySettings;
   readonly onApply: (seatCount: number) => void | Promise<void>;
   readonly onApplyShotClock: (
     settings: ShotClockSettings,
   ) => void | Promise<void>;
   readonly onChangeSoundSettings: (next: SoundSettings) => void;
+  readonly onChangeShowdownOverlay: (next: ShowdownOverlaySettings) => void;
   readonly onClose: () => void;
 }
 
@@ -181,9 +184,11 @@ export function HouseRulesSheet({
   handInProgress,
   soundSettings,
   shotClockSettings,
+  showdownOverlay,
   onApply,
   onApplyShotClock,
   onChangeSoundSettings,
+  onChangeShowdownOverlay,
   onClose,
 }: HouseRulesSheetProps) {
   const [draft, setDraft] = useState(pendingSeatCount ?? seatCount);
@@ -478,6 +483,38 @@ export function HouseRulesSheet({
                 onChangeSoundSettings({ ...soundSettings, notifications });
               }}
             />
+          </div>
+
+          <div
+            data-testid="showdown-settings"
+            style={{
+              paddingTop: 20,
+              display: "flex",
+              flexDirection: "column",
+              gap: 8,
+              borderTop: `1px solid ${color.mutedSurface}`,
+              marginTop: 20,
+            }}
+          >
+            <Toggle
+              label="Showdown overlay"
+              checked={showdownOverlay.enabled}
+              disabled={saving}
+              testId="showdown-overlay-toggle"
+              onChange={(enabled) => {
+                onChangeShowdownOverlay({ enabled });
+              }}
+            />
+            <span
+              style={{
+                fontSize: fontSize.caption,
+                lineHeight: 1.45,
+                color: color.textDim,
+              }}
+            >
+              Off, showdown plays out on the seats. On, it takes the whole
+              screen.
+            </span>
           </div>
 
           <div

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -1,9 +1,27 @@
 import type { SeatView, TableView } from "@table-top-poker/protocol";
 import { color } from "@table-top-poker/ui-shared";
+/* eslint-disable @typescript-eslint/no-deprecated -- React 19's DOM-free component test renderer is deprecated but remains the available interaction harness here. */
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { act, create } from "react-test-renderer";
+import { describe, expect, it, vi } from "vitest";
 import { Seats } from "./Seats.js";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+interface StoppableClickNode {
+  readonly props: {
+    readonly onClick?: (event: { stopPropagation: () => void }) => void;
+  };
+}
+
+interface ClickableTree {
+  readonly root: {
+    findByProps(props: Record<string, unknown>): StoppableClickNode;
+  };
+}
 
 const seats: SeatView[] = [
   {
@@ -308,7 +326,7 @@ describe("Seats", () => {
     expect(html).not.toContain('data-testid="seat-pod-0-disconnected"');
   });
 
-  it("reveals nothing on the felt at showdown — no hole cards, hand, or winner mark", () => {
+  it("tables a shown hand on the seat plate with its rank badge, naming no hand", () => {
     const view: TableView = {
       phase: "showdown",
       button: 0,
@@ -344,10 +362,10 @@ describe("Seats", () => {
       ],
     };
     const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
-    expect(html).toMatch(/data-testid="seat-pod-0"[^>]*data-winner="false"/);
-    expect(html).not.toContain("hole-cards");
-    expect(html).not.toContain('data-testid="seat-pod-0-hand"');
+    expect(html).toContain('data-testid="seat-pod-0-showdown"');
+    expect(html).toContain("wins");
     expect(html).not.toContain("Pair of Aces");
+    expect(html).not.toContain('data-testid="seat-pod-1-showdown"');
   });
 
   it("keeps a revealed player in-hand when they sit out for the next hand", () => {
@@ -838,5 +856,324 @@ describe("Seats: action labels", () => {
     );
 
     expect(styleOf(html, "seat-pod-3-action")).toContain("rotate(180deg)");
+  });
+});
+
+describe("Seats at showdown", () => {
+  const board: TableView & { phase: "showdown" } = {
+    phase: "showdown",
+    button: 0,
+    smallBlind: 1,
+    bigBlind: 2,
+    dealtSeatCount: 4,
+    board: [
+      { rank: "A", suit: "spades" },
+      { rank: "K", suit: "hearts" },
+      { rank: "2", suit: "clubs" },
+      { rank: "7", suit: "diamonds" },
+      { rank: "9", suit: "clubs" },
+    ],
+    contestants: [0, 1],
+    winners: null,
+    results: [],
+  };
+
+  function shown(seatId: number, rank: number, description: string) {
+    return {
+      seatId,
+      rank,
+      description,
+      holeCards: [
+        { rank: "A", suit: "clubs" },
+        { rank: "3", suit: "hearts" },
+      ],
+      bestHand: [
+        { rank: "A", suit: "spades" },
+        { rank: "A", suit: "clubs" },
+        { rank: "K", suit: "hearts" },
+        { rank: "9", suit: "clubs" },
+        { rank: "7", suit: "diamonds" },
+      ],
+    } as const;
+  }
+
+  it("fans two backs for a contestant who has not shown", () => {
+    const html = renderToStaticMarkup(<Seats seats={seats} view={board} />);
+
+    expect(html).toMatch(
+      /data-testid="seat-pod-0-showdown"[^>]*data-shown="false"/,
+    );
+    expect(subtreeOf(html, "seat-pod-0-showdown-card-0")).toContain(
+      'data-face-down="true"',
+    );
+    expect(subtreeOf(html, "seat-pod-0-showdown-card-1")).toContain(
+      'data-face-down="true"',
+    );
+    expect(html).not.toContain('data-testid="seat-pod-0-showdown-badges"');
+  });
+
+  it("lays nothing on the felt for a seat that never reached showdown", () => {
+    const html = renderToStaticMarkup(<Seats seats={seats} view={board} />);
+
+    expect(html).not.toContain('data-testid="seat-pod-2-showdown"');
+    expect(html).not.toContain('data-testid="seat-pod-3-showdown"');
+  });
+
+  it("keeps a concealing seat in the hand it played", () => {
+    const html = renderToStaticMarkup(
+      <Seats
+        seats={seats}
+        view={{
+          ...board,
+          winners: [0],
+          results: [shown(0, 30, "Pair of Aces")],
+        }}
+      />,
+    );
+
+    expect(html).toMatch(/data-testid="seat-pod-1"[^>]*data-status="in-hand"/);
+    expect(html).toMatch(
+      /data-testid="seat-pod-1-showdown"[^>]*data-shown="false"/,
+    );
+    expect(styleOf(html, "seat-pod-1-surface")).toContain(
+      color.seatTabledBackground,
+    );
+  });
+
+  it("calls a split without placing the hands that made it", () => {
+    const html = renderToStaticMarkup(
+      <Seats
+        seats={seats}
+        view={{
+          ...board,
+          contestants: [0, 1, 2],
+          winners: [0, 1],
+          results: [
+            shown(0, 30, "Pair of Aces"),
+            shown(1, 30, "Pair of Aces"),
+            shown(2, 10, "Ace high"),
+          ],
+        }}
+      />,
+    );
+
+    expect(html).toContain("splits");
+    expect(html).not.toContain("Pair of Aces");
+    expect(html).not.toContain("Ace high");
+    expect(html).toContain('data-testid="seat-pod-0-showdown-verdict"');
+    expect(html).toContain('data-testid="seat-pod-1-showdown-verdict"');
+    expect(html).not.toContain('data-testid="seat-pod-2-showdown-badges"');
+  });
+
+  it("names a winner who was never compelled to show", () => {
+    const html = renderToStaticMarkup(
+      <Seats
+        seats={seats}
+        view={{
+          ...board,
+          contestants: [0, 1],
+          winners: [1],
+          results: [shown(0, 30, "Pair of Aces")],
+        }}
+      />,
+    );
+
+    expect(html).toMatch(
+      /data-testid="seat-pod-1-showdown"[^>]*data-shown="false"/,
+    );
+    expect(html).toContain("wins");
+    expect(html).toContain('data-testid="seat-pod-1-showdown-verdict"');
+    expect(html).not.toContain("Pair of Aces");
+  });
+
+  it("never spells out the hand a seat made — the cards are the result", () => {
+    const html = renderToStaticMarkup(
+      <Seats
+        seats={seats}
+        view={{
+          ...board,
+          winners: [0],
+          results: [
+            shown(0, 30, "Straight flush, king high"),
+            shown(1, 10, "Ace high"),
+          ],
+        }}
+      />,
+    );
+
+    expect(html).not.toContain("Straight flush");
+    expect(html).not.toContain("Ace high");
+    expect(html).toContain('data-testid="seat-pod-0-showdown-verdict"');
+    expect(html).not.toContain('data-testid="seat-pod-1-showdown-badges"');
+  });
+
+  it("keeps a tap on a tabled hand out of the seat menu", () => {
+    const onSeatClick = vi.fn();
+    const view = {
+      ...board,
+      winners: [0],
+      results: [shown(0, 30, "Pair of Aces")],
+    };
+    let renderer!: ClickableTree;
+    act(() => {
+      renderer = create(
+        <Seats seats={seats} view={view} onSeatClick={onSeatClick} />,
+      );
+    });
+
+    const stopPropagation = vi.fn();
+    act(() => {
+      renderer.root
+        .findByProps({ "data-testid": "seat-pod-0-showdown" })
+        .props.onClick?.({ stopPropagation });
+    });
+
+    expect(stopPropagation).toHaveBeenCalled();
+    expect(onSeatClick).not.toHaveBeenCalled();
+  });
+
+  it("fills the plate opaque when a tabled hand sits behind it", () => {
+    const view = {
+      ...board,
+      winners: [0],
+      results: [shown(0, 30, "Pair of Aces")],
+    };
+    const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
+
+    expect(styleOf(html, "seat-pod-1-surface")).toContain(
+      color.seatTabledBackground,
+    );
+    expect(styleOf(html, "seat-pod-2-surface")).not.toContain(
+      color.seatTabledBackground,
+    );
+  });
+
+  it("tucks each tabled hand behind its plate, fanning toward the centre", () => {
+    const view = {
+      ...board,
+      contestants: [0, 3],
+      winners: [0],
+      results: [shown(0, 30, "Pair of Aces"), shown(3, 10, "Ace high")],
+    };
+    const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
+
+    expect(styleOf(html, "seat-pod-0-showdown")).toContain("bottom:8%");
+    expect(styleOf(html, "seat-pod-3-showdown")).toContain("top:8%");
+  });
+
+  it("stacks the fan so neither card buries the other's corner index", () => {
+    const view = {
+      ...board,
+      contestants: [0, 3],
+      winners: [0],
+      results: [shown(0, 30, "Pair of Aces"), shown(3, 10, "Ace high")],
+    };
+    const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
+
+    expect(styleOf(html, "seat-pod-0-showdown-card-1")).toContain("z-index:1");
+    expect(styleOf(html, "seat-pod-3-showdown-card-0")).toContain("z-index:1");
+  });
+
+  it("places no hand, shown or not, at a showdown", () => {
+    const html = renderToStaticMarkup(
+      <Seats
+        seats={seats}
+        view={{
+          ...board,
+          contestants: [0, 1, 2],
+          winners: [2],
+          results: [shown(0, 30, "Pair of Aces"), shown(1, 10, "Ace high")],
+        }}
+      />,
+    );
+
+    expect(html).not.toContain("showdown-rank");
+    expect(html).not.toContain("1st");
+    expect(html).not.toContain("2nd");
+    expect(html).toContain('data-testid="seat-pod-2-showdown-verdict"');
+  });
+
+  it("badges no one until the winners are declared", () => {
+    const html = renderToStaticMarkup(
+      <Seats
+        seats={seats}
+        view={{
+          ...board,
+          contestants: [0, 1],
+          winners: null,
+          results: [shown(0, 30, "Pair of Aces")],
+        }}
+      />,
+    );
+
+    expect(html).toContain('data-testid="seat-pod-0-showdown"');
+    expect(html).not.toContain("showdown-badges");
+    expect(html).not.toContain("wins");
+  });
+
+  it("flips a top-row seat's showdown badges with the rest of its plate", () => {
+    const html = renderToStaticMarkup(
+      <Seats
+        seats={seats}
+        view={{
+          ...board,
+          contestants: [0, 3],
+          winners: [0, 3],
+          results: [shown(0, 30, "Pair of Aces"), shown(3, 30, "Pair of Aces")],
+        }}
+      />,
+    );
+
+    expect(styleOf(html, "seat-pod-3-showdown-badges")).toContain(
+      "transform:rotate(180deg)",
+    );
+    expect(styleOf(html, "seat-pod-3-surface")).toContain(
+      "flex-direction:row-reverse",
+    );
+    expect(styleOf(html, "seat-pod-0-showdown-badges")).not.toContain("rotate");
+    expect(styleOf(html, "seat-pod-0-surface")).toContain("flex-direction:row");
+  });
+
+  it("leaves no seat glowing to act once the hand has finished", () => {
+    const html = renderToStaticMarkup(
+      <Seats
+        seats={seats}
+        view={{
+          ...board,
+          winners: [0],
+          results: [shown(0, 30, "Pair of Aces")],
+        }}
+      />,
+    );
+
+    expect(html).not.toContain("seat-actor-glow");
+  });
+});
+
+describe("Seats to-act glow", () => {
+  it("glows only the seat that is to act", () => {
+    const view: TableView = {
+      phase: "betting",
+      turnEndsAt: null,
+      button: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      dealtSeatCount: 3,
+      street: "flop",
+      board: [],
+      toAct: [1],
+      seats: [
+        { seatId: 0, folded: false },
+        { seatId: 1, folded: false },
+      ],
+    };
+    const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
+
+    expect(html).toMatch(
+      /data-testid="seat-pod-1-surface"[^>]*class="seat-actor-glow"/,
+    );
+    expect(html).not.toMatch(
+      /data-testid="seat-pod-0-surface"[^>]*class="seat-actor-glow"/,
+    );
   });
 });

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -1,9 +1,12 @@
 import type {
   ActionType,
+  RevealedResult,
+  SeatId,
   SeatView,
   TableView,
 } from "@table-top-poker/protocol";
 import {
+  Card,
   color,
   font,
   positionMarkerColor,
@@ -71,6 +74,180 @@ interface SeatVisual {
   readonly isWinner: boolean;
   readonly avatarBackground: string;
   readonly avatarColor: string;
+}
+
+/** Sized off the Seat plate the fan tucks behind, which is the size container. */
+const FAN_SCALE = "12.5cqw";
+const FAN_WIDTH = "6.26em";
+const FAN_HEIGHT = "5.6em";
+
+/**
+ * The fan's near edge sits this far inside the plate, measured off the plate so
+ * it can never fall below it. At FAN_SCALE the plate is about half a card tall,
+ * so what clears it is the readable top half.
+ */
+const FAN_TUCK = "8%";
+
+interface ShowdownSeat {
+  readonly hand: RevealedResult | null;
+  readonly isWinner: boolean;
+  readonly splitting: boolean;
+}
+
+function showdownSeats(view: TableView | null): Map<SeatId, ShowdownSeat> {
+  const bySeat = new Map<SeatId, ShowdownSeat>();
+  if (view?.phase !== "showdown") return bySeat;
+
+  const winners = view.winners ?? [];
+  const shown = new Map(
+    view.results.map((result) => [result.seatId, result] as const),
+  );
+  for (const seatId of view.contestants) {
+    bySeat.set(seatId, {
+      hand: shown.get(seatId) ?? null,
+      isWinner: winners.includes(seatId),
+      splitting: winners.length > 1,
+    });
+  }
+  return bySeat;
+}
+/**
+ * The Hand a Seat made is never spelled out and never placed — the cards are
+ * the result and the room reads them. Only the outcome is the engine's to say.
+ */
+function outcomeOf(showdown: ShowdownSeat): string | null {
+  if (!showdown.isWinner) return null;
+  return showdown.splitting ? "splits" : "wins";
+}
+
+/**
+ * The outcome rides the Seat plate rather than the cards: a chip laid over a
+ * tabled Hand covers the corner index that has to stay readable.
+ */
+function ShowdownBadges({
+  seatId,
+  showdown,
+  isTopRow,
+}: {
+  readonly seatId: SeatId;
+  readonly showdown: ShowdownSeat;
+  readonly isTopRow: boolean;
+}) {
+  const testId = `seat-pod-${String(seatId)}-showdown`;
+  const outcome = outcomeOf(showdown);
+  if (outcome === null) return null;
+
+  return (
+    <div
+      data-testid={`${testId}-badges`}
+      data-flipped={isTopRow}
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "stretch",
+        gap: "0.3em",
+        transform: isTopRow ? "rotate(180deg)" : undefined,
+      }}
+    >
+      <span
+        data-testid={`${testId}-verdict`}
+        style={{
+          flex: "none",
+          padding: "0.2em 0.5em",
+          borderRadius: "999px",
+          fontFamily: font.mono,
+          fontSize: "0.58rem",
+          fontWeight: 700,
+          letterSpacing: "0.12em",
+          textTransform: "uppercase",
+          whiteSpace: "nowrap",
+          lineHeight: 1.35,
+          textAlign: "center",
+          background: color.winPlate,
+          border: `1px solid ${color.winBorder}`,
+          color: color.winBright,
+        }}
+      >
+        {outcome}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * The Hand fans out of the plate on the table-centre side, its near edge tucked
+ * behind the Seat so only the readable end of the cards shows. A contestant who
+ * has not shown fans two backs while the window is open, and lays nothing down
+ * once the Hand closes — a muck keeps nothing.
+ *
+ * Which half clears the plate decides the stacking: the bottom row shows the
+ * cards' top corner indices, the top row their mirrored bottom ones, so the
+ * overlap has to fall the other way round or it buries the under card's only
+ * index.
+ */
+function ShowdownHand({
+  seatId,
+  hand,
+  isWinner,
+  isTopRow,
+}: {
+  readonly seatId: SeatId;
+  readonly hand: RevealedResult | null;
+  readonly isWinner: boolean;
+  readonly isTopRow: boolean;
+}) {
+  const faces = hand === null ? [null, null] : [...hand.holeCards];
+
+  return (
+    <div
+      data-testid={`seat-pod-${String(seatId)}-showdown`}
+      data-shown={hand !== null}
+      data-winner={isWinner}
+      onClick={(event) => {
+        event.stopPropagation();
+      }}
+      style={{
+        position: "absolute",
+        left: 0,
+        right: 0,
+        zIndex: 0,
+        containerType: "inline-size",
+        cursor: "default",
+        ...(isTopRow ? { top: FAN_TUCK } : { bottom: FAN_TUCK }),
+      }}
+    >
+      <div
+        style={{
+          position: "relative",
+          margin: "0 auto",
+          fontSize: FAN_SCALE,
+          width: FAN_WIDTH,
+          height: FAN_HEIGHT,
+        }}
+      >
+        {faces.map((card, index) => (
+          <div
+            key={index}
+            data-testid={`seat-pod-${String(seatId)}-showdown-card-${String(index)}`}
+            style={{
+              position: "absolute",
+              left: index === 0 ? "0.33em" : "2.43em",
+              top: index === 0 ? "0.3em" : 0,
+              zIndex: isTopRow === (index === 0) ? 1 : 0,
+              transform: `rotate(${String(index === 0 ? -8 : 7)}deg)`,
+              filter: `drop-shadow(${shadow.card})`,
+            }}
+          >
+            {card === null ? (
+              <Card faceDown />
+            ) : (
+              <Card rank={card.rank} suit={card.suit} />
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
 }
 
 function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
@@ -143,11 +320,15 @@ export function Seats({
   onSeatClick,
   actionLabels,
 }: SeatsProps) {
+  const showdown = showdownSeats(view);
+
   return (
     <div data-testid="seats" style={{ position: "absolute", inset: 0 }}>
       {seats.map((seat) => {
         const visual = deriveSeat(seat, view);
+        const seatShowdown = showdown.get(seat.id);
         const acted = visual.isActor ? undefined : actionLabels?.get(seat.id);
+        const tabledHand = seatShowdown?.hand ?? null;
         const pos = posFor(seat.id, seats.length);
         const isTopRow = pos.top < 50;
         const flipDegrees = isTopRow ? 180 : 0;
@@ -344,6 +525,72 @@ export function Seats({
           </div>
         );
 
+        /**
+         * The Seat plate keeps the anchor `posFor` gave it, and a tabled Hand
+         * is hung off it rather than laid in the pod's flow, so cards are
+         * additive and never push a plate off the felt.
+         */
+        const plate = (
+          <div
+            data-testid={`seat-pod-${String(seat.id)}-surface`}
+            className={visual.isActor ? "seat-actor-glow" : undefined}
+            style={{
+              boxShadow: shadow.seatResting,
+              position: "relative",
+              zIndex: 1,
+              borderRadius: "1em",
+              padding: "0.5em",
+              display: "flex",
+              flexDirection: seatShowdown
+                ? isTopRow
+                  ? "row-reverse"
+                  : "row"
+                : "column",
+              alignItems: "center",
+              gap: seatShowdown ? "0.7em" : "0.4em",
+              minWidth: seatShowdown ? "12.5em" : undefined,
+              justifyContent: "center",
+              background: seatShowdown
+                ? visual.isWinner
+                  ? `linear-gradient(${color.seatWinnerBackground},${color.seatWinnerBackground}),${color.seatTabledBackground}`
+                  : color.seatTabledBackground
+                : visual.isWinner
+                  ? color.seatWinnerBackground
+                  : visual.isActor
+                    ? color.seatActorBackground
+                    : visual.status === "sitting-out"
+                      ? color.seatSittingOutBackground
+                      : "transparent",
+              border: `1px solid ${
+                seatShowdown && !visual.isWinner
+                  ? color.seatTabledBorder
+                  : visual.isWinner
+                    ? color.seatWinnerBorder
+                    : visual.isActor
+                      ? color.accent
+                      : visual.status === "sitting-out"
+                        ? color.seatSittingOutBorder
+                        : "transparent"
+              }`,
+              opacity:
+                visual.status === "folded"
+                  ? 0.34
+                  : visual.status === "sitting-out"
+                    ? 0.82
+                    : 1,
+            }}
+          >
+            {seatShowdown && (
+              <ShowdownBadges
+                seatId={seat.id}
+                showdown={seatShowdown}
+                isTopRow={isTopRow}
+              />
+            )}
+            {podContent}
+          </div>
+        );
+
         return (
           <div
             key={seat.id}
@@ -375,52 +622,19 @@ export function Seats({
               cursor: seat.claimed && onSeatClick ? "pointer" : undefined,
             }}
           >
-            <motion.div
-              data-testid={`seat-pod-${String(seat.id)}-surface`}
-              animate={{
-                boxShadow: visual.isActor
-                  ? [...shadow.seatActorGlow]
-                  : shadow.seatResting,
-              }}
-              transition={
-                visual.isActor
-                  ? { duration: 1.7, repeat: Infinity, ease: "easeInOut" }
-                  : { duration: 0.3 }
-              }
-              style={{
-                position: "relative",
-                borderRadius: "1em",
-                padding: "0.5em",
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                gap: "0.4em",
-                background: visual.isWinner
-                  ? color.seatWinnerBackground
-                  : visual.isActor
-                    ? color.seatActorBackground
-                    : visual.status === "sitting-out"
-                      ? color.seatSittingOutBackground
-                      : "transparent",
-                border: `1px solid ${
-                  visual.isWinner
-                    ? color.seatWinnerBorder
-                    : visual.isActor
-                      ? color.accent
-                      : visual.status === "sitting-out"
-                        ? color.seatSittingOutBorder
-                        : "transparent"
-                }`,
-                opacity:
-                  visual.status === "folded"
-                    ? 0.34
-                    : visual.status === "sitting-out"
-                      ? 0.82
-                      : 1,
-              }}
-            >
-              {podContent}
-            </motion.div>
+            {seatShowdown ? (
+              <div style={{ position: "relative", display: "flex" }}>
+                <ShowdownHand
+                  seatId={seat.id}
+                  hand={tabledHand}
+                  isWinner={seatShowdown.isWinner}
+                  isTopRow={isTopRow}
+                />
+                {plate}
+              </div>
+            ) : (
+              plate
+            )}
             <AnimatePresence>
               {visual.isActor ? (
                 <motion.div

--- a/packages/table-client/src/ShowdownOverlay.test.tsx
+++ b/packages/table-client/src/ShowdownOverlay.test.tsx
@@ -80,6 +80,8 @@ function render(
       seats={seats}
       collapsed={false}
       canDealNextHand
+      awaitingReveal={false}
+      onReveal={() => undefined}
       onNextHand={() => undefined}
       onViewTable={() => undefined}
       {...props}
@@ -141,6 +143,8 @@ describe("ShowdownOverlay", () => {
         seats={[seat(1, "Devin")]}
         collapsed={false}
         canDealNextHand
+        awaitingReveal={false}
+        onReveal={() => undefined}
         onNextHand={() => undefined}
         onViewTable={() => undefined}
       />,

--- a/packages/table-client/src/ShowdownOverlay.tsx
+++ b/packages/table-client/src/ShowdownOverlay.tsx
@@ -57,6 +57,8 @@ export interface ShowdownOverlayProps {
   readonly seats: readonly SeatView[];
   readonly collapsed: boolean;
   readonly canDealNextHand: boolean;
+  readonly awaitingReveal: boolean;
+  readonly onReveal: () => void;
   readonly onNextHand: () => void;
   readonly onViewTable: () => void;
 }
@@ -191,10 +193,14 @@ function OverlayPlayer({
 
 function OverlayButtons({
   canDealNextHand,
+  awaitingReveal,
+  onReveal,
   onNextHand,
   onViewTable,
 }: {
   readonly canDealNextHand: boolean;
+  readonly awaitingReveal: boolean;
+  readonly onReveal: () => void;
   readonly onNextHand: () => void;
   readonly onViewTable: () => void;
 }) {
@@ -236,29 +242,34 @@ function OverlayButtons({
         </button>
         <button
           type="button"
-          data-testid="showdown-next-hand-button"
-          disabled={!canDealNextHand}
-          onClick={onNextHand}
+          data-testid={
+            awaitingReveal
+              ? "showdown-reveal-button"
+              : "showdown-next-hand-button"
+          }
+          disabled={!awaitingReveal && !canDealNextHand}
+          onClick={awaitingReveal ? onReveal : onNextHand}
           style={{
             padding: "0.7rem 2.2rem",
             borderRadius: "999px",
             border: "none",
-            cursor: canDealNextHand ? "pointer" : "not-allowed",
+            cursor:
+              awaitingReveal || canDealNextHand ? "pointer" : "not-allowed",
             background: color.pillGradient,
             color: color.pillInk,
             fontFamily: font.display,
             fontSize: "1rem",
             fontWeight: 800,
             letterSpacing: "0.04em",
-            opacity: canDealNextHand ? 1 : 0.5,
+            opacity: awaitingReveal || canDealNextHand ? 1 : 0.5,
             boxShadow:
               "0 16px 40px -14px rgba(229,68,60,.6), inset 0 1px 0 rgba(255,255,255,.5)",
           }}
         >
-          Next hand →
+          {awaitingReveal ? "Reveal" : "Next hand →"}
         </button>
       </div>
-      {!canDealNextHand && (
+      {!awaitingReveal && !canDealNextHand && (
         <div
           data-testid="showdown-next-hand-blocked-hint"
           style={{ fontSize: "0.8rem", color: color.textDim }}
@@ -275,6 +286,8 @@ export function ShowdownOverlay({
   seats,
   collapsed,
   canDealNextHand,
+  awaitingReveal,
+  onReveal,
   onNextHand,
   onViewTable,
 }: ShowdownOverlayProps) {
@@ -397,6 +410,8 @@ export function ShowdownOverlay({
 
               <OverlayButtons
                 canDealNextHand={canDealNextHand}
+                awaitingReveal={awaitingReveal}
+                onReveal={onReveal}
                 onNextHand={onNextHand}
                 onViewTable={onViewTable}
               />

--- a/packages/table-client/src/TableControls.test.tsx
+++ b/packages/table-client/src/TableControls.test.tsx
@@ -38,6 +38,37 @@ describe("TableControls", () => {
     expect(html).toContain('data-testid="next-hand-button"');
   });
 
+  it("swaps Next hand for Reveal until the table has revealed", () => {
+    const awaiting = renderToStaticMarkup(
+      <TableControls
+        canStartHand={false}
+        handComplete
+        canDealNextHand
+        awaitingReveal
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+        onReveal={noop}
+      />,
+    );
+    expect(awaiting).toContain('data-testid="reveal-button"');
+    expect(awaiting).not.toContain('data-testid="next-hand-button"');
+
+    const revealed = renderToStaticMarkup(
+      <TableControls
+        canStartHand={false}
+        handComplete
+        canDealNextHand
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+        onReveal={noop}
+      />,
+    );
+    expect(revealed).not.toContain('data-testid="reveal-button"');
+    expect(revealed).toContain('data-testid="next-hand-button"');
+  });
+
   it("swaps Next hand for View showdown at showdown", () => {
     const html = renderToStaticMarkup(
       <TableControls

--- a/packages/table-client/src/TableControls.tsx
+++ b/packages/table-client/src/TableControls.tsx
@@ -46,6 +46,8 @@ export interface TableControlsProps {
   readonly testMode?: boolean;
   readonly onAddBot?: () => void;
   readonly atShowdown?: boolean;
+  readonly awaitingReveal?: boolean;
+  readonly onReveal?: () => void;
   readonly onViewShowdown?: () => void;
   readonly placement?: TableControlsPlacement;
   readonly onReviewHands?: () => void;
@@ -61,6 +63,8 @@ export function TableControls({
   testMode = false,
   onAddBot,
   atShowdown = false,
+  awaitingReveal = false,
+  onReveal,
   onViewShowdown,
   placement = "rail",
   onReviewHands,
@@ -80,7 +84,15 @@ export function TableControls({
           Deal hand
         </PillButton>
       )}
-      {atShowdown ? (
+      {awaitingReveal ? (
+        <PillButton
+          data-testid="reveal-button"
+          onClick={onReveal}
+          style={actionButtonStyle}
+        >
+          Reveal
+        </PillButton>
+      ) : atShowdown ? (
         <PillButton
           data-testid="view-showdown-button"
           onClick={onViewShowdown}

--- a/packages/table-client/src/api/rooms.ts
+++ b/packages/table-client/src/api/rooms.ts
@@ -2,6 +2,7 @@ import type {
   RoomView,
   SeatCountChange,
   ShotClockSettings,
+  ShowdownOverlaySettings,
   SoundSettings,
 } from "@table-top-poker/protocol";
 
@@ -122,4 +123,21 @@ export async function changeShotClockSettings(
     );
   }
   return (await response.json()) as ShotClockSettings;
+}
+
+export async function changeShowdownOverlay(
+  code: string,
+  settings: ShowdownOverlaySettings,
+): Promise<ShowdownOverlaySettings> {
+  const response = await fetch(`/rooms/${code}/showdown-overlay`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(settings),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `failed to change showdown overlay: ${String(response.status)}`,
+    );
+  }
+  return (await response.json()) as ShowdownOverlaySettings;
 }

--- a/packages/table-client/src/app-shell.css
+++ b/packages/table-client/src/app-shell.css
@@ -67,3 +67,24 @@ body {
 .showdown-win-glow {
   animation: showdown-win-pulse 2s ease-in-out infinite;
 }
+
+/* The Seat plate's to-act glow. A CSS animation rather than an animated
+ * box-shadow so it ends the moment the Seat stops being the actor. The colour
+ * is ui-shared's `color.accent` (#e5443c), hard-coded here for the keyframe. */
+@keyframes seat-actor-pulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 2px rgba(229, 68, 60, 0.95),
+      0 0 34px 6px rgba(229, 68, 60, 0.3);
+  }
+  50% {
+    box-shadow:
+      0 0 0 3px rgba(255, 120, 110, 1),
+      0 0 54px 14px rgba(229, 68, 60, 0.5);
+  }
+}
+
+.seat-actor-glow {
+  animation: seat-actor-pulse 1.7s ease-in-out infinite;
+}

--- a/packages/table-client/src/replay/ReplayStage.test.tsx
+++ b/packages/table-client/src/replay/ReplayStage.test.tsx
@@ -62,3 +62,56 @@ describe("ReplayStage", () => {
     expect(html).toContain('data-phase="betting"');
   });
 });
+
+describe("ReplayStage at showdown", () => {
+  const showdown: TableView = {
+    phase: "showdown",
+    button: 0,
+    smallBlind: 1,
+    bigBlind: 2,
+    dealtSeatCount: 4,
+    board: [
+      { rank: "A", suit: "spades" },
+      { rank: "K", suit: "hearts" },
+      { rank: "2", suit: "clubs" },
+      { rank: "7", suit: "diamonds" },
+      { rank: "9", suit: "clubs" },
+    ],
+    contestants: [0, 1],
+    winners: [0],
+    results: [
+      {
+        seatId: 0,
+        rank: 30,
+        description: "Pair of Aces",
+        holeCards: [
+          { rank: "A", suit: "clubs" },
+          { rank: "3", suit: "hearts" },
+        ],
+        bestHand: [
+          { rank: "A", suit: "spades" },
+          { rank: "A", suit: "clubs" },
+          { rank: "K", suit: "hearts" },
+          { rank: "9", suit: "clubs" },
+          { rank: "7", suit: "diamonds" },
+        ],
+      },
+    ],
+  };
+
+  it("replays the shown hand and keeps the concealed one face down", () => {
+    const html = renderToStaticMarkup(
+      <ReplayStage view={showdown} seats={seats} actionLabels={new Map()} />,
+    );
+
+    expect(html).toContain("wins");
+    expect(html).not.toContain("Pair of Aces");
+    expect(html).toMatch(
+      /data-testid="seat-pod-0-showdown"[^>]*data-shown="true"/,
+    );
+    expect(html).toMatch(
+      /data-testid="seat-pod-1-showdown"[^>]*data-shown="false"/,
+    );
+    expect(html).not.toContain('data-testid="seat-pod-2-showdown"');
+  });
+});

--- a/packages/table-client/src/store/roomSlice.ts
+++ b/packages/table-client/src/store/roomSlice.ts
@@ -1,9 +1,11 @@
 import {
   DEFAULT_SHOT_CLOCK,
+  DEFAULT_SHOWDOWN_OVERLAY,
   DEFAULT_SOUND_SETTINGS,
   type RoomView,
   type SeatView,
   type ShotClockSettings,
+  type ShowdownOverlaySettings,
   type SoundSettings,
 } from "@table-top-poker/protocol";
 import type { StateCreator } from "zustand";
@@ -17,6 +19,7 @@ export interface RoomSlice {
   readonly pendingShotClock: ShotClockSettings | null;
   readonly soundSettings: SoundSettings;
   readonly shotClockSettings: ShotClockSettings;
+  readonly showdownOverlay: ShowdownOverlaySettings;
   /**
    * Latched true once "Continue without recording" resumes the Room —
    * never cleared while the Room lives, since recording never comes back
@@ -42,6 +45,7 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
   pendingShotClock: null,
   soundSettings: DEFAULT_SOUND_SETTINGS,
   shotClockSettings: DEFAULT_SHOT_CLOCK,
+  showdownOverlay: DEFAULT_SHOWDOWN_OVERLAY,
   recordingStopped: false,
   setRoomCreated: ({ code, joinUrl, qrCodeDataUrl }) => {
     set({
@@ -60,6 +64,7 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
       pendingShotClock: view.pendingShotClock,
       soundSettings: view.soundSettings,
       shotClockSettings: view.shotClockSettings,
+      showdownOverlay: view.showdownOverlay,
     });
   },
   setRecordingStopped: () => {
@@ -75,6 +80,7 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownOverlay: DEFAULT_SHOWDOWN_OVERLAY,
       recordingStopped: false,
     });
   },

--- a/packages/table-client/src/store/store.test.ts
+++ b/packages/table-client/src/store/store.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SHOT_CLOCK,
+  DEFAULT_SHOWDOWN_OVERLAY,
   DEFAULT_SOUND_SETTINGS,
   type HandSummary,
   type TableReplayPosition,
@@ -67,6 +68,7 @@ describe("useTableStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownOverlay: DEFAULT_SHOWDOWN_OVERLAY,
       seats: [
         {
           id: 0,
@@ -96,6 +98,7 @@ describe("useTableStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownOverlay: DEFAULT_SHOWDOWN_OVERLAY,
       seats: [
         {
           id: 0,
@@ -128,6 +131,7 @@ describe("useTableStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownOverlay: DEFAULT_SHOWDOWN_OVERLAY,
       seats: [],
     });
     expect(useTableStore.getState().recordingStopped).toBe(true);
@@ -140,6 +144,7 @@ describe("useTableStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownOverlay: DEFAULT_SHOWDOWN_OVERLAY,
       seats: [
         {
           id: 0,

--- a/packages/ui-shared/src/theme.ts
+++ b/packages/ui-shared/src/theme.ts
@@ -65,6 +65,9 @@ export const color = {
   seatWinnerBorder: "rgba(250,234,231,.7)",
   seatWinnerBackground: "rgba(250,234,231,.14)",
   seatActorBackground: "rgba(20,7,8,.72)",
+  /** Opaque: a tabled Hand sits behind the plate, which must stay readable. */
+  seatTabledBackground: "#2a1013",
+  seatTabledBorder: "rgba(255,255,255,.14)",
   buttonMarker: "#faf6f0",
   blindSmallMarker: "#5aa9f0",
   blindBigMarker: "#f2c14e",


### PR DESCRIPTION
Implements the presentation half of [ADR-0008](../blob/showdown-v2/docs/adr/0008-showdown-visibility-is-engine-state.md). Closes #252.

## What changed

**Showdown moved onto the live table.** Each contestant carries its own Hand on its Seat plate, pushed toward the table centre so every tabled Hand sits in one band beside the Board it is read against. A shown Hand fans out from behind its plate; a contestant who has not shown fans two card backs; the verdict rides the plate beside the placard. The next deal closes the window and leaves nothing behind — a muck keeps nothing.

**The fan.** Its near edge is tucked inside the plate, measured off the plate rather than off the cards so it can never fall below the Seat however wide the plate grows, and the cards are scaled so what clears it is the readable top half. The two rows mirror each other: the bottom row shows the cards' top corner indices, the top row their mirrored bottom ones, so the overlap stacks the other way round above the felt's midline or the under card's only index is buried. The cards themselves are never rotated — the whole room reads them from one orientation.

**Only the winners are badged — `wins`, or `splits` — and nobody is badged before Reveal.** ADR-0008 called for a rank badge as well; building it showed the ranking to be unsound in the visibility model the same ADR establishes. `results` carries shown Hands only, so a winner who was never compelled to show is absent from it and the best *shown* Hand — a loser — takes first place: a live table read `1ST` on one Seat and `WINS` on another. Ordinals also read as finishing places to the room. The cards are the result and the room reads them. **ADR-0008 gains an Amendments section** recording the change, and #252's acceptance criteria are updated to match.

**A top-row Seat's badges flip with the rest of its plate**, so that side of the table reads them upright.

**Reveal takes the primary table control** for as long as the Hand rests awaiting it, then hands it back to Next hand. One primary action at a time, so nobody deals over a Showdown nobody has looked at.

**`ShowdownOverlay` is demoted to a house rule**, off by default and persisted per Room alongside seat count, shot clock and sound (`POST /rooms/:code/showdown-overlay`). Turned on it behaves as before, save that its primary button is Reveal while the Hand rests — leaving Next hand there would let someone deal over an unrevealed Showdown.

**Replay inherits all of it**: it already re-projects `view(state, 'table')` through the live `Seats`.

`deriveSeat` already reads `contestants` rather than `results` — that landed with #251 — and there is now a test holding it there.

## Bugs found on a live table and fixed here

- The compulsory set is the River's last aggressor plus every all-in Seat, so the winning Hand is **not always among it**. `reveal` can declare a winner who has shown nothing; that Seat rendered as two highlighted card backs with no words, while the losing Hand that did show carried the only rank badge. Resolved by dropping the rank badge entirely (above); a concealed winner says `wins` and nothing else.
- The verdict line sized itself from the Seat pod rather than the cards beside it, so at a small viewport a long description kept full width while `nowrap` walked it into the neighbouring plate. Bounded now.
- Tabling a Hand put cards inside the Seat pod's click target, so leaning in to look at someone's cards opened their Seat menu — the one offering **Evict**. The tabled Hand now swallows the press.
- **The to-act glow outlived the Hand.** It animated `box-shadow` between a repeating two-layer keyframe glow and a one-layer resting shadow, structures Motion cannot interpolate, and a Seat that was to act when the Hand ended kept pulsing through Showdown. It is a CSS class now (`.seat-actor-glow`, beside the existing overlay win glow), so it stops the moment the Seat stops being the actor.
- **Contestants who had not shown laid nothing on the felt**, against this issue's own criterion. They now fan two card backs for the duration of the window.

## Not in scope, and visible on a live table

No Player can table a Hand voluntarily yet: the `show` command exists in the engine, the schema and the server, but the Player client never sends it, so only the compelled Seats' cards appear and a Player's own Hole-card reveal stays local by design. That control is #253.

## The 6–8 seat layout risk

ADR-0008 flags this as a risk to test. It holds. The design does not pile hands at the centre — each Hand sits on its own plate, pushed toward the middle. At 8 seats the plates are 24% apart, the fan is sized off the plate it tucks behind (`12.5cqw` of a size container floored at `12.5em`), so it stays inside its own Seat's share of the felt, and only its top half is above the plate. Reviewed on the real table chrome at 6 and 8 seats, all shown and 3 shown / 5 mucked.

## How the fan was settled

The treatment was chosen from a throwaway prototype rendering four variants on the real table chrome. It is kept on [`proto/252-showdown-card-treatments`](https://github.com/ewanhardingham/table-top-poker/tree/proto/252-showdown-card-treatments) and linked from #252; the scaffolding is deleted from this branch.

## Verification

`tsc --build`, `npm run lint` (eslint + prettier) and the tests for every touched package — engine, protocol, server, table-client, player-client, ui-shared — all pass locally (982 tests). CI runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nyg8H7osWtxHAYdJ4ceA1A
