### PR TITLE
feat(player): all-in actions and showing at Showdown

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -124,7 +124,10 @@ stack, as one of two Actions: an *all-in call*, which does not reopen the
 betting, or an *all-in raise*, which requeues every other live Seat exactly
 as a raise does (ADR-0007). Both retire the Seat from the betting for the
 rest of the Hand; neither carries a chip amount. A Player who covers a shove
-and wants to keep acting simply calls.
+and wants to keep acting simply calls. On the Player Device both all-in
+buttons take a confirm press, and once the Seat is all in its Action bar goes
+away and its Hole cards are *sealed* — held, inert, and still face-down until
+the table's Reveal.
 _Avoid_: Treating all-in as a folded Seat — an all-in Seat is live, keeps its
 claim on the pot, and is revealed at Showdown. Side pots stay a
 physical-chips problem the humans settle at the table.
@@ -178,8 +181,9 @@ Publishing a contestant's Hole cards to the whole room, irreversibly. Two
 Commands produce it. The table's `reveal` turns over the compulsory set — the
 River's last aggressor plus every all-in Seat, or the winning Seat when that
 set is empty — and publishes the winners. Every other contestant may then
-`show`, in any order, on their own Device. Both are idempotent: a second press
-changes nothing and is not an error. The window closes when the table deals
+`show`, in any order, on their own Device, through a "Show my hand" button
+that appears only once the Reveal has landed and disappears once used. Both
+are idempotent: a second press changes nothing and is not an error. The window closes when the table deals
 the next Hand, which mucks whatever was not shown.
 _Avoid_: Confusing a show with *Hole-card reveal*, which stays local to one
 Device and can be undone.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -126,12 +126,15 @@ stack, as one of two Actions: an *all-in call*, which does not reopen the
 betting, or an *all-in raise*, which requeues every other live Seat exactly
 as a raise does (ADR-0007). Both retire the Seat from the betting for the
 rest of the Hand; neither carries a chip amount. A Player who covers a shove
-and wants to keep acting simply calls. The Player Device offers one wide
-"All in" while no Seat has shoved, and splits it into "All-in call" and
-"All-in raise" once another Seat is all in — the fork only means something
-against chips already committed. Both take a confirm press, and once the Seat
-is all in its Action bar goes away and its Hole cards are *sealed* — held,
-inert, and still face-down until the table's Reveal.
+and wants to keep acting simply calls. `legalActions` offers each arm only
+where it means something: an *all-in call* needs a bet to match, and either
+raise needs a Seat left able to answer it — against a table already all in
+there is nothing to raise into, so only the call stands. The Player Device
+offers one wide "All in" while no Seat has shoved and splits it into
+"All-in call" and "All-in raise" once another Seat is all in, showing whichever
+arms are legal. Both take a confirm press, and once the Seat is all in its
+Action bar goes away and its Hole cards are *sealed* — held, inert, and still
+face-down until the table's Reveal.
 _Avoid_: Treating all-in as a folded Seat — an all-in Seat is live, keeps its
 claim on the pot, and is revealed at Showdown. Side pots stay a
 physical-chips problem the humans settle at the table.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,10 +84,12 @@ to their Device at deal time (not fetched later at reveal).
 
 **Hole-card reveal**:
 Turning a Player's own Hole cards persistently face-up on their own Device.
-Local presentation only: it does not change poker visibility or server state,
-and it never publishes a Hand. Distinct from a *Showdown show*, which is a
-Command the Player sends deliberately, and from the table's *Reveal*, which
-turns the compulsory Hands over for the whole room.
+Local presentation for the whole Hand: it does not change poker visibility or
+server state. The one exception is the Showdown showing window, where the same
+gesture *is* the *Showdown show* and publishes the Hand to the room (#253).
+The window opens the Player's cards face-down for exactly this reason, so the
+reveal that publishes is always a deliberate one. Distinct from the table's
+*Reveal*, which turns the compulsory Hands over for the whole room.
 
 **Hole-card peek**:
 Temporarily lifting a corner of a Player's own Hole cards to read them, closing
@@ -124,10 +126,12 @@ stack, as one of two Actions: an *all-in call*, which does not reopen the
 betting, or an *all-in raise*, which requeues every other live Seat exactly
 as a raise does (ADR-0007). Both retire the Seat from the betting for the
 rest of the Hand; neither carries a chip amount. A Player who covers a shove
-and wants to keep acting simply calls. On the Player Device both all-in
-buttons take a confirm press, and once the Seat is all in its Action bar goes
-away and its Hole cards are *sealed* — held, inert, and still face-down until
-the table's Reveal.
+and wants to keep acting simply calls. The Player Device offers one wide
+"All in" while no Seat has shoved, and splits it into "All-in call" and
+"All-in raise" once another Seat is all in — the fork only means something
+against chips already committed. Both take a confirm press, and once the Seat
+is all in its Action bar goes away and its Hole cards are *sealed* — held,
+inert, and still face-down until the table's Reveal.
 _Avoid_: Treating all-in as a folded Seat — an all-in Seat is live, keeps its
 claim on the pot, and is revealed at Showdown. Side pots stay a
 physical-chips problem the humans settle at the table.
@@ -181,9 +185,11 @@ Publishing a contestant's Hole cards to the whole room, irreversibly. Two
 Commands produce it. The table's `reveal` turns over the compulsory set — the
 River's last aggressor plus every all-in Seat, or the winning Seat when that
 set is empty — and publishes the winners. Every other contestant may then
-`show`, in any order, on their own Device, through a "Show my hand" button
-that appears only once the Reveal has landed and disappears once used. Both
-are idempotent: a second press changes nothing and is not an error. The window closes when the table deals
+`show`, in any order, on their own Device, by revealing their Hole cards with
+the ordinary reveal gesture while the window is open — there is no separate
+control. Both are idempotent: a second press changes nothing and is not an
+error. A Seat's verdict is withheld from the table until that Seat's cards are
+public, so `wins` never sits over two face-down cards. The window closes when the table deals
 the next Hand, which mucks whatever was not shown.
 _Avoid_: Confusing a show with *Hole-card reveal*, which stays local to one
 Device and can be undone.

--- a/docs/adr/0007-all-in-as-declared-actions-without-chip-values.md
+++ b/docs/adr/0007-all-in-as-declared-actions-without-chip-values.md
@@ -68,7 +68,9 @@ Consequent rule changes:
   rather than a single winner (ADR-0008).
 - `legalActions` stays the single source of truth: it gains the two actions and
   the `facingBet` predicate that already separates `check` from `call` now also
-  decides which all-in labels a client shows.
+  decides which all-in labels a client shows. (Refined in #253 — `legalActions`
+  now reads the Seats as well as the street: an all-in call needs a bet to
+  match, and either raise needs a Seat left able to answer it.)
 - The client paces the automatic run-out itself; `boardDeal.ts` already stages
   the board, so three streets emitted at once still read as three beats.
 - A misdeclaration is not recoverable. There is no undo, and adding one would be

--- a/docs/adr/0008-showdown-visibility-is-engine-state.md
+++ b/docs/adr/0008-showdown-visibility-is-engine-state.md
@@ -4,8 +4,10 @@
 
 Accepted. Depends on [ADR-0007](0007-all-in-as-declared-actions-without-chip-values.md)
 for the all-in actions this decision compels to show. The rank badge in
-"Showdown happens on the table, not over it" was dropped while building it —
-see [Amendments](#amendments). The rest stands.
+"Showdown happens on the table, not over it" was dropped while building it, the
+player's separate show button was dropped in favour of the reveal gesture, and
+the verdict now waits for the cards — see [Amendments](#amendments). The rest
+stands.
 
 ## Context
 
@@ -60,7 +62,8 @@ hand and the verdict: the table is the shared surface.
   explicit button, because irreversible publication should not ride on the
   gesture used all hand for a private, freely reversible peek. `CONTEXT.md` gains
   *Showdown show* and amends *Hole-card reveal*, whose current text states that
-  reveal never affects Showdown.
+  reveal never affects Showdown. (Superseded — see
+  [Amendments](#amendments).)
 - `RejectionReason` gains `not-at-showdown`. Repeat presses of `reveal` and
   `show` are idempotent no-ops — a shared table screen will be double-pressed,
   and that is not an error.
@@ -92,3 +95,31 @@ result and the room reads them, which was already this ADR's rule for the hand's
 *description*. Ordering the hands for the humans who settle the chips is left to
 the cards themselves; when side pots (ADR-0007) arrive and "who won" needs more
 than one answer, that answer is a decision of its own, not an ordinal.
+
+### The reveal gesture is the show; the separate button is dropped (#253)
+
+The explicit "Show my hand" button was redundant next to the gesture beside it.
+A player at showdown who turns their own cards face-up has, in the room, shown
+their hand — a device that answers that act by keeping the cards private and
+asking them to press a second control is arguing with what they just did.
+
+So inside the showing window the reveal gesture *is* the `show`: a committed
+flip face-up publishes the hand and locks it face-up. The peek does not, because
+a peek is transient and closes itself. Nor does a pair that merely happened to
+be face-up when the window opened: opening the window returns the pair
+face-down, so the reveal that publishes is always an act taken with the window
+already open. Outside the window — every other moment of the hand — reveal stays
+exactly as local as this ADR's Consequences say it is.
+
+This reverses the "separate, explicit button" consequence above. The reasoning
+it was based on stands as a *description of the risk*: publication is
+irreversible and the gesture is used all hand for a reversible peek. The
+window-opening reset is what answers that risk, in place of a second control.
+
+### The verdict waits for the cards (#253)
+
+`wins` was derived from `winners` alone, so a winning Seat that was never
+compelled to show wore the badge over two face-down cards — the table announcing
+a hand it could not see. The verdict now requires the Seat to be in `results`.
+A winner who has not shown is simply unbadged until they do, which is also the
+room's own convention: you do not collect on a hand you have not tabled.

--- a/docs/design/holecards.md
+++ b/docs/design/holecards.md
@@ -60,6 +60,15 @@ no simulated pointer.
     because an all-in Hand is still private until the table's Reveal. It clears
     the fold gesture with it, which is the point: an all-in Seat cannot fold.
 
+`revealPublishes(from, to, showLegal)` is the other predicate the hook reads off
+the lifecycle, alongside `releaseCommitsFold`. Inside the Showdown showing
+window a committed flip face-up **is** the `show` (ADR-0008's #253 amendment):
+entering `Turning` publishes the Hand. A peek does not — it never reaches
+`Turning` — and neither does a pair already face-up when the window opened,
+because `showLegal` rising emits `RESET` and puts it face-down first. That reset
+is the whole safeguard against publishing by accident, so it is load-bearing,
+not tidiness.
+
 `CardState`/`CardEvent` are intentionally **complete**: every event name the
 phase needs is declared even where an arm does not yet answer it, so later
 slices add arms against this shape rather than reshaping it.

--- a/docs/design/holecards.md
+++ b/docs/design/holecards.md
@@ -51,9 +51,14 @@ no simulated pointer.
 - `Recognizer`: `Idle | Pressing | Bending | FoldDragging | Ignored | Committed`.
 - `armed`: whether releasing now commits the Fold. Only ever true while
   `FoldDragging`.
-- `locked`: showdown reached with this seat still live (story 48). Its own field
-  rather than a recognizer state or presentation, because the lock is not a
-  gesture outcome and `Revealed` is reachable two ways where only one is final.
+- `locked`: the pair is inert. Set two ways, and its own field rather than a
+  recognizer state or presentation, because the lock is not a gesture outcome
+  and `Revealed` is reachable two ways where only one is final.
+  - `SHOWDOWN_REVEAL` — showdown reached with this seat still live (story 48):
+    inert and face-**up**.
+  - `SEALED` — the seat declared all in (issue #253): inert and face-**down**,
+    because an all-in Hand is still private until the table's Reveal. It clears
+    the fold gesture with it, which is the point: an all-in Seat cannot fold.
 
 `CardState`/`CardEvent` are intentionally **complete**: every event name the
 phase needs is declared even where an arm does not yet answer it, so later
@@ -62,7 +67,8 @@ slices add arms against this shape rather than reshaping it.
 ### Key reducer rules
 
 - **Lock allow-list.** A locked pair hears only `DEALT`, `CARDS_GONE`,
-  `SHOWDOWN_REVEAL`, `TURN_FINISHED` (`survivesLock`). Enforced once at the top
+  `SEALED`, `SHOWDOWN_REVEAL`, `TURN_FINISHED` (`survivesLock`). `SHOWDOWN_REVEAL`
+  surviving the lock is what turns a sealed all-in pair face-up at the Reveal. Enforced once at the top
   of `reduce`, so tap/gesture events added later are inert against a decided
   hand *by default* and cannot reach one by being forgotten. `RESET` is
   deliberately **not** on the list: backgrounding must not conceal a showdown
@@ -235,8 +241,8 @@ produce nothing.
 - Cards arriving is the deal signal (there is no hand id on `PlayerView`), by
   card *identity* not reference, with a value comparison as a defensive second
   signal for a betting→betting swap without an intervening empty view.
-- `SHOWDOWN_REVEAL` is ordered *after* `DEALT`, so a seat whose cards only
-  arrive at showdown is dealt in before it's revealed.
+- `SEALED` and `SHOWDOWN_REVEAL` are ordered *after* `DEALT`, so a seat whose
+  cards only arrive at showdown is dealt in before it's revealed.
 - Only the falling edge of `pending` produces `PENDING_RESOLVED` (the pair
   already moved itself to `Leaving` on release); acknowledged vs rejected is
   read off the cards, not off any rejection state.

--- a/packages/engine/src/all-in.test.ts
+++ b/packages/engine/src/all-in.test.ts
@@ -45,7 +45,7 @@ function started(seats: number[], seed: string): EngineState {
 }
 
 describe("all-in legality", () => {
-  it("offers both all-ins wherever raise is legal, facing a bet or not", () => {
+  it("offers the all-in call only where there is a bet to match", () => {
     const state = started([0, 1, 2], "legality");
     const hand = betting(state);
 
@@ -60,7 +60,6 @@ describe("all-in legality", () => {
       "fold",
       "check",
       "raise",
-      "allInCall",
       "allInRaise",
     ]);
   });

--- a/packages/engine/src/decide.ts
+++ b/packages/engine/src/decide.ts
@@ -126,6 +126,7 @@ function decideShow(
 ): HandEvent[] | Rejection {
   const hand = awaitingShowdown(state);
   if (hand === null) return reject("not-at-showdown", command);
+  if (hand.winners === null) return reject("not-at-showdown", command);
 
   const contestant = hand.contestants.find(
     (candidate) => candidate.seatId === command.seatId,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -43,6 +43,7 @@ export type {
   Street,
   Suit,
 } from "./types.js";
+export { canStillAct } from "./table.js";
 export { view } from "./view.js";
 export type {
   PlayerShowdownView,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -47,6 +47,7 @@ export { view } from "./view.js";
 export type {
   PlayerShowdownView,
   PlayerView,
+  SeatSnapshot,
   ShowdownView,
   TableView,
 } from "./view.js";

--- a/packages/engine/src/showdown.test.ts
+++ b/packages/engine/src/showdown.test.ts
@@ -157,7 +157,8 @@ describe("reveal turns over exactly the compulsory set", () => {
     const state = reveal(
       headsUpAt([
         { type: "call", seatId: 0 },
-        { type: "allInCall", seatId: 1 },
+        { type: "allInRaise", seatId: 1 },
+        { type: "call", seatId: 0 },
       ]),
     );
     expect(shownSeats(state)).toContain(1);
@@ -224,6 +225,14 @@ describe("show", () => {
     const outcome = play(state, { type: "show", seatId: 1 });
     if (!("rejection" in outcome)) throw new Error("expected a rejection");
     expect(outcome.rejection.reason).toBe("not-at-showdown");
+  });
+
+  it("is rejected before the table has revealed — the hand rests first", () => {
+    const resting = headsUpAt(raisedOnTheRiver);
+    const outcome = play(resting, { type: "show", seatId: 1 });
+    if (!("rejection" in outcome)) throw new Error("expected a rejection");
+    expect(outcome.rejection.reason).toBe("not-at-showdown");
+    expect(shownSeats(resting)).toEqual([]);
   });
 
   it("is rejected once the hand has closed", () => {

--- a/packages/engine/src/table.test.ts
+++ b/packages/engine/src/table.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createInitialState } from "./room.js";
 import { legalActions } from "./table.js";
 import { playAll } from "./test-utils.js";
+import { must } from "./util.js";
 
 describe("legalActions", () => {
   it("offers the facing-a-bet actions to a seat facing a bet preflop", () => {
@@ -40,8 +41,44 @@ describe("legalActions", () => {
       "fold",
       "check",
       "raise",
-      "allInCall",
       "allInRaise",
+    ]);
+  });
+
+  it("withholds the all-in call where there is no bet to match", () => {
+    const state = createInitialState([0, 1, 2]);
+    const started = playAll(state, [
+      { type: "startHand", seatId: 0, seed: "s" },
+    ]);
+    const afterLap = playAll(started, [
+      { type: "call", seatId: 0 },
+      { type: "call", seatId: 1 },
+    ]);
+    if (afterLap.hand?.status !== "betting") {
+      throw new Error("expected betting");
+    }
+    expect(legalActions(afterLap.hand, 2)).not.toContain("allInCall");
+  });
+
+  it("withholds both raises once every other seat is all in", () => {
+    const state = createInitialState([0, 1]);
+    const started = playAll(state, [
+      { type: "startHand", seatId: 0, seed: "s" },
+    ]);
+    if (started.hand?.status !== "betting") {
+      throw new Error("expected betting");
+    }
+    const shover = must(started.hand.toAct[0]);
+    const shoved = playAll(started, [{ type: "allInRaise", seatId: shover }]);
+    if (shoved.hand?.status !== "betting") {
+      throw new Error("expected betting");
+    }
+    const covering = must(shoved.hand.toAct[0]);
+
+    expect(legalActions(shoved.hand, covering)).toEqual([
+      "fold",
+      "call",
+      "allInCall",
     ]);
   });
 });

--- a/packages/engine/src/table.ts
+++ b/packages/engine/src/table.ts
@@ -101,13 +101,27 @@ export function facingBet(
   );
 }
 
+/**
+ * A raise needs someone left to answer it and an all-in call needs chips to
+ * match, so both arms are conditional: see ADR-0007 and issue #253.
+ */
 export function legalActions(
-  hand: Pick<BettingHandState, "street" | "ring" | "button" | "raiseOccurred">,
+  hand: Pick<
+    BettingHandState,
+    "street" | "ring" | "button" | "raiseOccurred" | "players"
+  >,
   actorSeat: SeatId,
 ): ActionType[] {
-  return facingBet(hand, actorSeat)
-    ? ["fold", "call", "raise", "allInCall", "allInRaise"]
-    : ["fold", "check", "raise", "allInCall", "allInRaise"];
+  const facing = facingBet(hand, actorSeat);
+  const answerable = hand.ring.some(
+    (seat) => seat !== actorSeat && canStillAct(must(hand.players.get(seat))),
+  );
+
+  const actions: ActionType[] = ["fold", facing ? "call" : "check"];
+  if (answerable) actions.push("raise");
+  if (facing) actions.push("allInCall");
+  if (answerable) actions.push("allInRaise");
+  return actions;
 }
 
 export function requeueAfterRaise(

--- a/packages/engine/src/view.test.ts
+++ b/packages/engine/src/view.test.ts
@@ -135,6 +135,30 @@ describe("view: folded seats", () => {
   });
 });
 
+describe("view: all-in seats", () => {
+  it("marks the all-in seat in every viewer's seat snapshots", () => {
+    let state = onTheFlopThreeWay();
+    if (state.hand?.status !== "betting") throw new Error("expected betting");
+    const shover = must(state.hand.toAct[0]);
+    state = playAll(state, [{ type: "allInRaise", seatId: shover }]);
+
+    const viewers: readonly (SeatId | "table")[] = [0, 1, "table"];
+    for (const viewer of viewers) {
+      const seen =
+        viewer === "table" ? view(state, viewer) : view(state, viewer);
+      if (seen.phase !== "betting") throw new Error("expected betting phase");
+      expect(seen.seats).toContainEqual({
+        seatId: shover,
+        folded: false,
+        allIn: true,
+      });
+      for (const snapshot of seen.seats) {
+        if (snapshot.seatId !== shover) expect(snapshot.allIn).toBe(false);
+      }
+    }
+  });
+});
+
 describe("view: table view", () => {
   it("sees no hole card pre-showdown, even with a board dealt", () => {
     const state = onTheFlopThreeWay();

--- a/packages/engine/src/view.test.ts
+++ b/packages/engine/src/view.test.ts
@@ -73,7 +73,6 @@ describe("view: legalActions", () => {
       "fold",
       "check",
       "raise",
-      "allInCall",
       "allInRaise",
     ]);
 

--- a/packages/engine/src/view.ts
+++ b/packages/engine/src/view.ts
@@ -13,6 +13,7 @@ import type {
 export interface SeatSnapshot {
   readonly seatId: SeatId;
   readonly folded: boolean;
+  readonly allIn: boolean;
 }
 
 interface NoHandView {
@@ -136,6 +137,7 @@ export function view(
   const seats: SeatSnapshot[] = [...hand.players].map(([seat, seatState]) => ({
     seatId: seat,
     folded: seatState.folded,
+    allIn: seatState.allIn,
   }));
 
   const tableView: TableViewBetting = {

--- a/packages/player-client/src/ActionBar.test.tsx
+++ b/packages/player-client/src/ActionBar.test.tsx
@@ -24,6 +24,7 @@ describe("ActionBar", () => {
         onCheck={noop}
         onCall={noop}
         onRaise={noop}
+        onAllIn={noop}
       />,
     );
 
@@ -43,6 +44,7 @@ describe("ActionBar", () => {
         onCheck={noop}
         onCall={noop}
         onRaise={noop}
+        onAllIn={noop}
       />,
     );
 
@@ -61,6 +63,7 @@ describe("ActionBar", () => {
         onCheck={noop}
         onCall={noop}
         onRaise={noop}
+        onAllIn={noop}
       />,
     );
 
@@ -68,6 +71,61 @@ describe("ActionBar", () => {
     expect(html).toContain("no bet");
     expect(html).toContain("match");
     expect(html).toContain("put in more");
+  });
+
+  it("offers the all-in fork alongside the four ordinary actions", () => {
+    const html = renderToStaticMarkup(
+      <ActionBar
+        legalActions={["fold", "call", "raise", "allInCall", "allInRaise"]}
+        pendingAction={null}
+        rejection={null}
+        onFold={noop}
+        onCheck={noop}
+        onCall={noop}
+        onRaise={noop}
+        onAllIn={noop}
+      />,
+    );
+
+    expect(html).toContain("All-in call");
+    expect(html).toContain("All-in raise");
+  });
+
+  it("leaves the all-in row out when it is not the player's turn", () => {
+    const html = renderToStaticMarkup(
+      <ActionBar
+        legalActions={[]}
+        pendingAction={null}
+        rejection={null}
+        onFold={noop}
+        onCheck={noop}
+        onCall={noop}
+        onRaise={noop}
+        onAllIn={noop}
+      />,
+    );
+
+    expect(html).not.toContain('data-testid="all-in-row"');
+  });
+
+  it("attributes a rejected all-in to the all-in row", () => {
+    const html = renderToStaticMarkup(
+      <ActionBar
+        legalActions={["fold", "call", "raise", "allInCall", "allInRaise"]}
+        pendingAction={null}
+        rejection={{ action: "allInRaise", reason: "not-your-turn" }}
+        onFold={noop}
+        onCheck={noop}
+        onCall={noop}
+        onRaise={noop}
+        onAllIn={noop}
+      />,
+    );
+
+    expect(html).toMatch(
+      /data-testid="action-rejection"[^>]*data-rejected-action="allInRaise"/,
+    );
+    expect(html).toContain("It&#x27;s not your turn yet.");
   });
 
   it("shows the rejection reason inline", () => {
@@ -80,6 +138,7 @@ describe("ActionBar", () => {
         onCheck={noop}
         onCall={noop}
         onRaise={noop}
+        onAllIn={noop}
       />,
     );
 
@@ -104,6 +163,7 @@ describe("ActionBar", () => {
         onCheck={noop}
         onCall={noop}
         onRaise={noop}
+        onAllIn={noop}
       />,
     );
 

--- a/packages/player-client/src/ActionBar.test.tsx
+++ b/packages/player-client/src/ActionBar.test.tsx
@@ -25,6 +25,7 @@ describe("ActionBar", () => {
         onCall={noop}
         onRaise={noop}
         onAllIn={noop}
+        facingAllIn={false}
       />,
     );
 
@@ -45,6 +46,7 @@ describe("ActionBar", () => {
         onCall={noop}
         onRaise={noop}
         onAllIn={noop}
+        facingAllIn={false}
       />,
     );
 
@@ -64,6 +66,7 @@ describe("ActionBar", () => {
         onCall={noop}
         onRaise={noop}
         onAllIn={noop}
+        facingAllIn={false}
       />,
     );
 
@@ -73,7 +76,7 @@ describe("ActionBar", () => {
     expect(html).toContain("put in more");
   });
 
-  it("offers the all-in fork alongside the four ordinary actions", () => {
+  it("offers one wide all-in alongside the four ordinary actions", () => {
     const html = renderToStaticMarkup(
       <ActionBar
         legalActions={["fold", "call", "raise", "allInCall", "allInRaise"]}
@@ -84,6 +87,26 @@ describe("ActionBar", () => {
         onCall={noop}
         onRaise={noop}
         onAllIn={noop}
+        facingAllIn={false}
+      />,
+    );
+
+    expect(html).toContain("All in");
+    expect(html).not.toContain("All-in call");
+  });
+
+  it("splits the all-in once another seat has shoved", () => {
+    const html = renderToStaticMarkup(
+      <ActionBar
+        legalActions={["fold", "call", "raise", "allInCall", "allInRaise"]}
+        pendingAction={null}
+        rejection={null}
+        onFold={noop}
+        onCheck={noop}
+        onCall={noop}
+        onRaise={noop}
+        onAllIn={noop}
+        facingAllIn
       />,
     );
 
@@ -102,6 +125,7 @@ describe("ActionBar", () => {
         onCall={noop}
         onRaise={noop}
         onAllIn={noop}
+        facingAllIn={false}
       />,
     );
 
@@ -119,6 +143,7 @@ describe("ActionBar", () => {
         onCall={noop}
         onRaise={noop}
         onAllIn={noop}
+        facingAllIn
       />,
     );
 
@@ -139,6 +164,7 @@ describe("ActionBar", () => {
         onCall={noop}
         onRaise={noop}
         onAllIn={noop}
+        facingAllIn={false}
       />,
     );
 
@@ -164,6 +190,7 @@ describe("ActionBar", () => {
         onCall={noop}
         onRaise={noop}
         onAllIn={noop}
+        facingAllIn={false}
       />,
     );
 

--- a/packages/player-client/src/ActionBar.tsx
+++ b/packages/player-client/src/ActionBar.tsx
@@ -6,8 +6,15 @@ import {
   radius,
   shadow,
 } from "@table-top-poker/ui-shared";
-import type { CSSProperties } from "react";
-import { rejectionCopy } from "./actions/rejectionCopy.js";
+import { useEffect, useState, type CSSProperties } from "react";
+import { AllInRow } from "./AllInRow.js";
+import {
+  allInChoices,
+  isAllInAction,
+  pressAllIn,
+  type AllInAction,
+} from "./actions/allIn.js";
+import { RejectionNotice } from "./actions/RejectionNotice.js";
 import type { ActionRejection } from "./store/actionSlice.js";
 
 export interface ActionBarProps {
@@ -18,6 +25,7 @@ export interface ActionBarProps {
   readonly onCheck: () => void;
   readonly onCall: () => void;
   readonly onRaise: () => void;
+  readonly onAllIn: (action: AllInAction) => void;
 }
 
 const ACTIONS = ["fold", "check", "call", "raise"] as const;
@@ -66,15 +74,6 @@ const toneStyle: Record<OfferedAction, CSSProperties> = {
   },
 };
 
-const rejectionStyle: CSSProperties = {
-  padding: "0.7em 0.9em",
-  borderRadius: radius.control,
-  background: "rgba(232,139,125,.13)",
-  border: "1px solid rgba(232,139,125,.34)",
-  fontSize: fontSize.caption,
-  color: "#f0aa9d",
-};
-
 export function ActionBar({
   legalActions,
   pendingAction,
@@ -83,12 +82,26 @@ export function ActionBar({
   onCheck,
   onCall,
   onRaise,
+  onAllIn,
 }: ActionBarProps) {
   const handlers: Record<OfferedAction, () => void> = {
     fold: onFold,
     check: onCheck,
     call: onCall,
     raise: onRaise,
+  };
+  const [armedAllIn, setArmedAllIn] = useState<AllInAction | null>(null);
+  const choices = allInChoices(legalActions);
+
+  const offer = legalActions.join(",");
+  useEffect(() => {
+    setArmedAllIn(null);
+  }, [offer]);
+
+  const pressAllInChoice = (action: AllInAction) => {
+    const press = pressAllIn(armedAllIn, action);
+    setArmedAllIn(press.armed);
+    if (press.send !== null) onAllIn(press.send);
   };
 
   return (
@@ -102,13 +115,7 @@ export function ActionBar({
       }}
     >
       {rejection !== null && rejection.action === null && (
-        <div
-          data-testid="action-rejection"
-          data-rejected-action=""
-          style={rejectionStyle}
-        >
-          {rejectionCopy(rejection.reason)}
-        </div>
+        <RejectionNotice rejection={rejection} />
       )}
       <div
         style={{
@@ -168,18 +175,24 @@ export function ActionBar({
                 </span>
               </button>
               {rejection !== null && rejection.action === action && (
-                <div
-                  data-testid="action-rejection"
-                  data-rejected-action={action}
-                  style={rejectionStyle}
-                >
-                  {rejectionCopy(rejection.reason)}
-                </div>
+                <RejectionNotice rejection={rejection} attributedTo={action} />
               )}
             </div>
           );
         })}
       </div>
+      <AllInRow
+        choices={choices}
+        armed={armedAllIn}
+        pending={pendingAction !== null}
+        onPress={pressAllInChoice}
+      />
+      {rejection !== null && isAllInAction(rejection.action) && (
+        <RejectionNotice
+          rejection={rejection}
+          attributedTo={rejection.action}
+        />
+      )}
     </div>
   );
 }

--- a/packages/player-client/src/ActionBar.tsx
+++ b/packages/player-client/src/ActionBar.tsx
@@ -25,6 +25,7 @@ export interface ActionBarProps {
   readonly onCheck: () => void;
   readonly onCall: () => void;
   readonly onRaise: () => void;
+  readonly facingAllIn: boolean;
   readonly onAllIn: (action: AllInAction) => void;
 }
 
@@ -82,6 +83,7 @@ export function ActionBar({
   onCheck,
   onCall,
   onRaise,
+  facingAllIn,
   onAllIn,
 }: ActionBarProps) {
   const handlers: Record<OfferedAction, () => void> = {
@@ -91,7 +93,7 @@ export function ActionBar({
     raise: onRaise,
   };
   const [armedAllIn, setArmedAllIn] = useState<AllInAction | null>(null);
-  const choices = allInChoices(legalActions);
+  const choices = allInChoices(legalActions, facingAllIn);
 
   const offer = legalActions.join(",");
   useEffect(() => {

--- a/packages/player-client/src/AllInRow.test.tsx
+++ b/packages/player-client/src/AllInRow.test.tsx
@@ -6,20 +6,14 @@ import { allInChoices } from "./actions/allIn.js";
 
 const noop = () => undefined;
 
-const facingBet = allInChoices([
-  "fold",
-  "call",
-  "raise",
-  "allInCall",
-  "allInRaise",
-]);
-const unopposed = allInChoices([
-  "fold",
-  "check",
-  "raise",
-  "allInCall",
-  "allInRaise",
-]);
+const split = allInChoices(
+  ["fold", "call", "raise", "allInCall", "allInRaise"],
+  true,
+);
+const whole = allInChoices(
+  ["fold", "call", "raise", "allInCall", "allInRaise"],
+  false,
+);
 
 describe("AllInRow", () => {
   it("renders nothing when no all-in is on offer", () => {
@@ -30,14 +24,9 @@ describe("AllInRow", () => {
     expect(html).toBe("");
   });
 
-  it("offers both forks against a bet", () => {
+  it("offers both forks once another seat is all in", () => {
     const html = renderToStaticMarkup(
-      <AllInRow
-        choices={facingBet}
-        armed={null}
-        pending={false}
-        onPress={noop}
-      />,
+      <AllInRow choices={split} armed={null} pending={false} onPress={noop} />,
     );
 
     expect(html).toContain("All-in call");
@@ -46,14 +35,9 @@ describe("AllInRow", () => {
     expect(html).toContain('data-testid="action-allInRaise"');
   });
 
-  it("offers a single all in when there is no bet to call", () => {
+  it("offers a single wide all in while nobody has shoved", () => {
     const html = renderToStaticMarkup(
-      <AllInRow
-        choices={unopposed}
-        armed={null}
-        pending={false}
-        onPress={noop}
-      />,
+      <AllInRow choices={whole} armed={null} pending={false} onPress={noop} />,
     );
 
     expect(html).toContain("All in");
@@ -63,7 +47,7 @@ describe("AllInRow", () => {
   it("asks for a confirm on the armed choice only", () => {
     const html = renderToStaticMarkup(
       <AllInRow
-        choices={facingBet}
+        choices={split}
         armed="allInCall"
         pending={false}
         onPress={noop}
@@ -81,12 +65,7 @@ describe("AllInRow", () => {
 
   it("disables every choice while an action is in flight", () => {
     const html = renderToStaticMarkup(
-      <AllInRow
-        choices={facingBet}
-        armed={null}
-        pending={true}
-        onPress={noop}
-      />,
+      <AllInRow choices={split} armed={null} pending={true} onPress={noop} />,
     );
 
     expect(html).toMatch(/data-testid="action-allInCall"[^>]*disabled/);

--- a/packages/player-client/src/AllInRow.test.tsx
+++ b/packages/player-client/src/AllInRow.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { AllInRow } from "./AllInRow.js";
+import { allInChoices } from "./actions/allIn.js";
+
+const noop = () => undefined;
+
+const facingBet = allInChoices([
+  "fold",
+  "call",
+  "raise",
+  "allInCall",
+  "allInRaise",
+]);
+const unopposed = allInChoices([
+  "fold",
+  "check",
+  "raise",
+  "allInCall",
+  "allInRaise",
+]);
+
+describe("AllInRow", () => {
+  it("renders nothing when no all-in is on offer", () => {
+    const html = renderToStaticMarkup(
+      <AllInRow choices={[]} armed={null} pending={false} onPress={noop} />,
+    );
+
+    expect(html).toBe("");
+  });
+
+  it("offers both forks against a bet", () => {
+    const html = renderToStaticMarkup(
+      <AllInRow
+        choices={facingBet}
+        armed={null}
+        pending={false}
+        onPress={noop}
+      />,
+    );
+
+    expect(html).toContain("All-in call");
+    expect(html).toContain("All-in raise");
+    expect(html).toContain('data-testid="action-allInCall"');
+    expect(html).toContain('data-testid="action-allInRaise"');
+  });
+
+  it("offers a single all in when there is no bet to call", () => {
+    const html = renderToStaticMarkup(
+      <AllInRow
+        choices={unopposed}
+        armed={null}
+        pending={false}
+        onPress={noop}
+      />,
+    );
+
+    expect(html).toContain("All in");
+    expect(html).not.toContain('data-testid="action-allInCall"');
+  });
+
+  it("asks for a confirm on the armed choice only", () => {
+    const html = renderToStaticMarkup(
+      <AllInRow
+        choices={facingBet}
+        armed="allInCall"
+        pending={false}
+        onPress={noop}
+      />,
+    );
+
+    expect(html).toMatch(
+      /data-testid="action-allInCall"[^>]*data-armed="true"/,
+    );
+    expect(html).toMatch(
+      /data-testid="action-allInRaise"[^>]*data-armed="false"/,
+    );
+    expect(html).toContain("Confirm");
+  });
+
+  it("disables every choice while an action is in flight", () => {
+    const html = renderToStaticMarkup(
+      <AllInRow
+        choices={facingBet}
+        armed={null}
+        pending={true}
+        onPress={noop}
+      />,
+    );
+
+    expect(html).toMatch(/data-testid="action-allInCall"[^>]*disabled/);
+    expect(html).toMatch(/data-testid="action-allInRaise"[^>]*disabled/);
+  });
+});

--- a/packages/player-client/src/AllInRow.tsx
+++ b/packages/player-client/src/AllInRow.tsx
@@ -1,0 +1,89 @@
+import { color, font, fontSize, radius } from "@table-top-poker/ui-shared";
+import type { CSSProperties } from "react";
+import type { AllInAction, AllInChoice } from "./actions/allIn.js";
+
+export interface AllInRowProps {
+  readonly choices: readonly AllInChoice[];
+  readonly armed: AllInAction | null;
+  readonly pending: boolean;
+  readonly onPress: (action: AllInAction) => void;
+}
+
+const restingStyle: CSSProperties = {
+  border: `1px solid ${color.accentBorder}`,
+  background: "rgba(229,68,60,.10)",
+  color: color.textBright,
+};
+
+const armedStyle: CSSProperties = {
+  border: `1px solid ${color.accentBright}`,
+  background: "rgba(229,68,60,.34)",
+  color: color.textBright,
+};
+
+const disabledStyle: CSSProperties = {
+  border: `1px solid ${color.border}`,
+  background: "rgba(255,255,255,.03)",
+  color: color.textFaint,
+};
+
+export function AllInRow({ choices, armed, pending, onPress }: AllInRowProps) {
+  if (choices.length === 0) return null;
+
+  return (
+    <div
+      data-testid="all-in-row"
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${String(choices.length)}, 1fr)`,
+        gap: "0.7em",
+      }}
+    >
+      {choices.map((choice) => {
+        const isArmed = armed === choice.action;
+        return (
+          <button
+            key={choice.action}
+            type="button"
+            data-testid={`action-${choice.action}`}
+            data-armed={isArmed}
+            disabled={pending}
+            onClick={() => {
+              onPress(choice.action);
+            }}
+            style={{
+              height: "3.6em",
+              borderRadius: radius.control,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "0.2em",
+              fontFamily: font.body,
+              ...(pending
+                ? disabledStyle
+                : isArmed
+                  ? armedStyle
+                  : restingStyle),
+            }}
+          >
+            <span style={{ fontSize: fontSize.md, fontWeight: 700 }}>
+              {isArmed ? "Confirm" : choice.label}
+            </span>
+            <span
+              style={{
+                fontFamily: font.mono,
+                fontSize: fontSize.xs,
+                letterSpacing: "0.18em",
+                textTransform: "uppercase",
+                opacity: 0.72,
+              }}
+            >
+              {isArmed ? choice.label : "no way back"}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/player-client/src/AllInRow.tsx
+++ b/packages/player-client/src/AllInRow.tsx
@@ -79,7 +79,7 @@ export function AllInRow({ choices, armed, pending, onPress }: AllInRowProps) {
                 opacity: 0.72,
               }}
             >
-              {isArmed ? choice.label : "no way back"}
+              {isArmed ? choice.label : "put in stack"}
             </span>
           </button>
         );

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -3,6 +3,7 @@ import { unlockAudio } from "@table-top-poker/ui-shared";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { ActionBar } from "./ActionBar.js";
 import { claimSeat, joinRoom, leaveSeat } from "./api/rooms.js";
+import { otherSeatIsAllIn } from "./actions/allIn.js";
 import { useActionIntent } from "./actions/useActionIntent.js";
 import { claimErrorCode } from "./claimError.js";
 import { Hand } from "./Hand.js";
@@ -251,6 +252,7 @@ export function App() {
             onCheck={intent.check}
             onCall={intent.call}
             onRaise={intent.raise}
+            facingAllIn={otherSeatIsAllIn(handView.seats, handView.yourSeatId)}
             onAllIn={intent.allIn}
           />
         )}

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -159,6 +159,11 @@ export function App() {
   }, [roomCode, seatId, seatToken, dropSeat, clearRoom]);
 
   const intent = useActionIntent(send);
+  const allIn =
+    handView?.phase === "betting" &&
+    (handView.seats.find((snapshot) => snapshot.seatId === handView.yourSeatId)
+      ?.allIn ??
+      false);
 
   const handleJoin = useCallback(
     (code: string) => {
@@ -237,7 +242,7 @@ export function App() {
             intent={intent}
           />
         )}
-        {handView !== null && handView.phase === "betting" && (
+        {handView !== null && handView.phase === "betting" && !allIn && (
           <ActionBar
             legalActions={intent.legalActions}
             pendingAction={intent.pendingAction}
@@ -246,6 +251,7 @@ export function App() {
             onCheck={intent.check}
             onCall={intent.call}
             onRaise={intent.raise}
+            onAllIn={intent.allIn}
           />
         )}
       </>

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -22,7 +22,7 @@ describe("Hand", () => {
       street: "flop",
       board: [],
       toAct: [1],
-      seats: [{ seatId: 0, folded: false }],
+      seats: [{ seatId: 0, folded: false, allIn: false }],
       yourSeatId: 0,
       yourHoleCards: [
         { rank: "Q", suit: "diamonds" },
@@ -73,7 +73,7 @@ describe("Hand", () => {
         { rank: "2", suit: "clubs" },
       ],
       toAct: [0],
-      seats: [{ seatId: 0, folded: false }],
+      seats: [{ seatId: 0, folded: false, allIn: false }],
       yourSeatId: 0,
       yourHoleCards: [
         { rank: "Q", suit: "diamonds" },
@@ -102,8 +102,8 @@ describe("Hand", () => {
       board: [],
       toAct: [1],
       seats: [
-        { seatId: 0, folded: true },
-        { seatId: 1, folded: false },
+        { seatId: 0, folded: true, allIn: false },
+        { seatId: 1, folded: false, allIn: false },
       ],
       yourSeatId: 0,
       yourHoleCards: null,
@@ -127,7 +127,7 @@ describe("Hand", () => {
       street: "flop",
       board: [],
       toAct: [1],
-      seats: [{ seatId: 1, folded: false }],
+      seats: [{ seatId: 1, folded: false, allIn: false }],
       yourSeatId: 0,
       yourHoleCards: null,
       legalActions: [],
@@ -151,7 +151,7 @@ describe("Hand", () => {
       street: "turn",
       board: [],
       toAct: [0],
-      seats: [{ seatId: 0, folded: false }],
+      seats: [{ seatId: 0, folded: false, allIn: false }],
       yourSeatId: 0,
       yourHoleCards: [
         { rank: "Q", suit: "diamonds" },
@@ -177,7 +177,7 @@ describe("Hand", () => {
       street: "turn",
       board: [],
       toAct: [0],
-      seats: [{ seatId: 0, folded: false }],
+      seats: [{ seatId: 0, folded: false, allIn: false }],
       yourSeatId: 0,
       yourHoleCards: null,
       legalActions: ["fold", "check"],
@@ -200,8 +200,8 @@ describe("Hand", () => {
       board: [],
       toAct: [1],
       seats: [
-        { seatId: 0, folded: false },
-        { seatId: 1, folded: false },
+        { seatId: 0, folded: false, allIn: false },
+        { seatId: 1, folded: false, allIn: false },
       ],
       yourSeatId: 0,
       yourHoleCards: null,
@@ -223,7 +223,7 @@ describe("Hand", () => {
       street: "turn",
       board: [],
       toAct: [0],
-      seats: [{ seatId: 0, folded: false }],
+      seats: [{ seatId: 0, folded: false, allIn: false }],
       yourSeatId: 0,
       yourHoleCards: [
         { rank: "Q", suit: "diamonds" },
@@ -238,6 +238,57 @@ describe("Hand", () => {
     expect(html).toMatch(/data-testid="turn-banner"[^>]*data-tone="offline"/);
     expect(html).toContain("Reconnecting");
     expect(html).not.toContain("Your turn");
+  });
+
+  describe("all in", () => {
+    function allInView(overrides: Partial<PlayerView> = {}): PlayerView {
+      return {
+        phase: "betting",
+        turnEndsAt: null,
+        button: 0,
+        smallBlind: 1,
+        bigBlind: 2,
+        dealtSeatCount: 3,
+        street: "turn",
+        board: [],
+        toAct: [1],
+        seats: [
+          { seatId: 0, folded: false, allIn: true },
+          { seatId: 1, folded: false, allIn: false },
+        ],
+        yourSeatId: 0,
+        yourHoleCards: [
+          { rank: "Q", suit: "diamonds" },
+          { rank: "J", suit: "clubs" },
+        ],
+        legalActions: [],
+        ...overrides,
+      } as PlayerView;
+    }
+
+    it("banners the run-out for the seat that is all in", () => {
+      const html = renderToStaticMarkup(<Hand view={allInView()} seatId={0} />);
+
+      expect(html).toMatch(/data-testid="turn-banner"[^>]*data-tone="all-in"/);
+      expect(html).toContain("All in");
+    });
+
+    it("keeps the all-in seat's cards face down and inert through the run-out", () => {
+      const html = renderToStaticMarkup(<Hand view={allInView()} seatId={0} />);
+
+      expect(html).toContain('data-presentation="FaceDown"');
+      expect(html).toContain('aria-disabled="true"');
+    });
+
+    it("leaves a covering seat's own cards live", () => {
+      const covering = allInView({ yourSeatId: 1, toAct: [1] });
+      const html = renderToStaticMarkup(<Hand view={covering} seatId={1} />);
+
+      expect(html).toContain('aria-disabled="false"');
+      expect(html).not.toMatch(
+        /data-testid="turn-banner"[^>]*data-tone="all-in"/,
+      );
+    });
   });
 
   describe("showdown", () => {
@@ -342,6 +393,83 @@ describe("Hand", () => {
       expect(html).toContain('aria-disabled="false"');
     });
 
+    it("offers Show my hand once the table has revealed and this seat has not shown", () => {
+      const concealing: PlayerView = {
+        ...shownTable,
+        results: [shownTable.results[0]],
+        winners: [0],
+        yourSeatId: 1,
+        yourResult: shownTable.results[1],
+        canShow: true,
+      };
+      const html = renderToStaticMarkup(<Hand view={concealing} seatId={1} />);
+
+      expect(html).toContain('data-testid="show-my-hand"');
+      expect(html).toContain("Show my hand");
+    });
+
+    it("says why a show did not go through, on the screen that offered it", () => {
+      const concealing: PlayerView = {
+        ...shownTable,
+        results: [shownTable.results[0]],
+        winners: [0],
+        yourSeatId: 1,
+        yourResult: shownTable.results[1],
+        canShow: true,
+      };
+      const html = renderToStaticMarkup(
+        <Hand
+          view={concealing}
+          seatId={1}
+          intent={{
+            legalActions: [],
+            pendingAction: null,
+            rejection: { action: null, reason: "not-at-showdown" },
+            fold: () => undefined,
+            check: () => undefined,
+            call: () => undefined,
+            raise: () => undefined,
+            allIn: () => undefined,
+            show: () => undefined,
+          }}
+        />,
+      );
+
+      expect(html).toContain('data-testid="action-rejection"');
+      expect(html).toContain("There&#x27;s no hand of yours to show.");
+    });
+
+    it("withholds Show my hand until the table's reveal", () => {
+      const resting: PlayerView = {
+        ...shownTable,
+        results: [],
+        winners: null,
+        yourSeatId: 1,
+        yourResult: shownTable.results[1],
+        canShow: true,
+      };
+      const html = renderToStaticMarkup(<Hand view={resting} seatId={1} />);
+
+      expect(html).not.toContain('data-testid="show-my-hand"');
+    });
+
+    it("drops Show my hand once the hand has been shown", () => {
+      const html = renderToStaticMarkup(
+        <Hand view={showdownViewFor(1)} seatId={1} />,
+      );
+
+      expect(html).not.toContain('data-testid="show-my-hand"');
+    });
+
+    it("never puts another seat's shown cards on a player's phone", () => {
+      const html = renderToStaticMarkup(
+        <Hand view={showdownViewFor(1)} seatId={1} />,
+      );
+
+      expect(html).toContain('data-rank="K"');
+      expect(html).not.toContain('data-rank="7"');
+    });
+
     it("shows the loser's own hole cards and a loss banner naming the winner", () => {
       const html = renderToStaticMarkup(
         <Hand view={showdownViewFor(1)} seatId={1} />,
@@ -431,10 +559,10 @@ describe("Hand", () => {
       board: [],
       toAct: [3],
       seats: [
-        { seatId: 0, folded: false },
-        { seatId: 1, folded: false },
-        { seatId: 2, folded: false },
-        { seatId: 3, folded: false },
+        { seatId: 0, folded: false, allIn: false },
+        { seatId: 1, folded: false, allIn: false },
+        { seatId: 2, folded: false, allIn: false },
+        { seatId: 3, folded: false, allIn: false },
       ],
       yourSeatId: 0,
       yourHoleCards: null,

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -2,7 +2,7 @@ import type { PlayerView } from "@table-top-poker/protocol";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { Hand } from "./Hand.js";
+import { Hand, revealWouldShow } from "./Hand.js";
 
 describe("Hand", () => {
   it("shows a waiting state before any hand has started", () => {
@@ -393,7 +393,25 @@ describe("Hand", () => {
       expect(html).toContain('aria-disabled="false"');
     });
 
-    it("offers Show my hand once the table has revealed and this seat has not shown", () => {
+    it("arms the reveal to publish only inside the showing window", () => {
+      const contestant = {
+        ...shownTable,
+        results: [shownTable.results[0]],
+        winners: [0] as readonly number[],
+        yourSeatId: 1,
+        yourResult: shownTable.results[1],
+        canShow: true,
+      } satisfies PlayerView;
+
+      expect(revealWouldShow(contestant)).toBe(true);
+      expect(
+        revealWouldShow({ ...contestant, winners: null, results: [] }),
+      ).toBe(false);
+      expect(revealWouldShow({ ...contestant, canShow: false })).toBe(false);
+      expect(revealWouldShow(showdownViewFor(0))).toBe(false);
+    });
+
+    it("has no separate show control — the reveal gesture is the show", () => {
       const concealing: PlayerView = {
         ...shownTable,
         results: [shownTable.results[0]],
@@ -404,8 +422,8 @@ describe("Hand", () => {
       };
       const html = renderToStaticMarkup(<Hand view={concealing} seatId={1} />);
 
-      expect(html).toContain('data-testid="show-my-hand"');
-      expect(html).toContain("Show my hand");
+      expect(html).not.toContain('data-testid="show-my-hand"');
+      expect(html).toContain('aria-disabled="false"');
     });
 
     it("says why a show did not go through, on the screen that offered it", () => {
@@ -437,28 +455,6 @@ describe("Hand", () => {
 
       expect(html).toContain('data-testid="action-rejection"');
       expect(html).toContain("There&#x27;s no hand of yours to show.");
-    });
-
-    it("withholds Show my hand until the table's reveal", () => {
-      const resting: PlayerView = {
-        ...shownTable,
-        results: [],
-        winners: null,
-        yourSeatId: 1,
-        yourResult: shownTable.results[1],
-        canShow: true,
-      };
-      const html = renderToStaticMarkup(<Hand view={resting} seatId={1} />);
-
-      expect(html).not.toContain('data-testid="show-my-hand"');
-    });
-
-    it("drops Show my hand once the hand has been shown", () => {
-      const html = renderToStaticMarkup(
-        <Hand view={showdownViewFor(1)} seatId={1} />,
-      );
-
-      expect(html).not.toContain('data-testid="show-my-hand"');
     });
 
     it("never puts another seat's shown cards on a player's phone", () => {

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -32,23 +32,35 @@ export interface HandProps {
 
 const noAction = () => undefined;
 
-function cardActionsFrom(intent: ActionIntent | undefined): CardActions {
+function cardActionsFrom(
+  intent: ActionIntent | undefined,
+  showLegal: boolean,
+): CardActions {
   if (intent === undefined) {
     return {
       foldLegal: false,
       checkLegal: false,
+      showLegal: false,
       pending: false,
       fold: noAction,
       check: noAction,
+      show: noAction,
     };
   }
   return {
     foldLegal: intent.legalActions.includes("fold"),
     checkLegal: intent.legalActions.includes("check"),
+    showLegal,
     pending: intent.pendingAction !== null,
     fold: intent.fold,
     check: intent.check,
+    show: intent.show,
   };
+}
+
+/** At Showdown the reveal gesture publishes: see ADR-0008's amendment for #253. */
+export function revealWouldShow(view: PlayerView): boolean {
+  return view.phase === "showdown" && view.canShow && view.winners !== null;
 }
 
 type BannerTone = "turn" | "all-in" | "win" | "loss" | "idle" | "offline";
@@ -378,30 +390,6 @@ function HoleCardsRegion({
   );
 }
 
-function ShowMyHandButton({ onShow }: { readonly onShow: () => void }) {
-  return (
-    <button
-      type="button"
-      data-testid="show-my-hand"
-      onClick={onShow}
-      style={{
-        flex: "none",
-        height: "3.6em",
-        borderRadius: radius.control,
-        border: 0,
-        background: color.pillGradient,
-        color: color.pillInk,
-        boxShadow: shadow.pill,
-        fontFamily: font.body,
-        fontSize: fontSize.lg,
-        fontWeight: 700,
-      }}
-    >
-      Show my hand
-    </button>
-  );
-}
-
 export function Hand({
   view,
   seatId,
@@ -410,7 +398,7 @@ export function Hand({
   shotClockSeconds = 90,
   intent,
 }: HandProps) {
-  const actions = cardActionsFrom(intent);
+  const actions = cardActionsFrom(intent, revealWouldShow(view));
 
   if (view.phase === "no-hand") {
     return (
@@ -508,9 +496,6 @@ export function Hand({
             actions={actions}
             caption="You folded — cards are in the muck."
           />
-        )}
-        {view.canShow && view.winners !== null && (
-          <ShowMyHandButton onShow={intent?.show ?? noAction} />
         )}
         {intent?.rejection != null && (
           <RejectionNotice rejection={intent.rejection} />

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -15,6 +15,7 @@ import {
 } from "@table-top-poker/ui-shared";
 import { motion } from "motion/react";
 import type { CSSProperties } from "react";
+import { RejectionNotice } from "./actions/RejectionNotice.js";
 import type { ActionIntent } from "./actions/useActionIntent.js";
 import { HoleCardPair, type CardActions } from "./holecards/index.js";
 import { PositionBadge } from "./PositionBadge.js";
@@ -50,7 +51,7 @@ function cardActionsFrom(intent: ActionIntent | undefined): CardActions {
   };
 }
 
-type BannerTone = "turn" | "win" | "loss" | "idle" | "offline";
+type BannerTone = "turn" | "all-in" | "win" | "loss" | "idle" | "offline";
 
 interface Banner {
   readonly kicker: string;
@@ -75,6 +76,14 @@ const bannerToneStyle: Record<
     dot: color.accentBright,
     kicker: color.textBright,
     text: color.text,
+  },
+  "all-in": {
+    background:
+      "linear-gradient(120deg,rgba(229,68,60,.28),rgba(229,68,60,.10))",
+    border: color.accentBright,
+    dot: color.accentBright,
+    kicker: color.textBright,
+    text: color.textBright,
   },
   win: {
     background: color.winBackground,
@@ -110,6 +119,13 @@ type PlayerViewBetting = Extract<PlayerView, { phase: "betting" }>;
 
 function isDealtIn(view: PlayerViewBetting): boolean {
   return view.seats.some((s) => s.seatId === view.yourSeatId);
+}
+
+function isAllIn(view: PlayerView): boolean {
+  return (
+    view.phase === "betting" &&
+    (view.seats.find((s) => s.seatId === view.yourSeatId)?.allIn ?? false)
+  );
 }
 
 function seatLabel(seatId: number, seats: readonly SeatView[]): string {
@@ -198,6 +214,13 @@ function bannerFor(
       kicker: "Your turn",
       text: `You're to act — ${view.street}`,
       tone: "turn",
+    };
+  }
+  if (isAllIn(view)) {
+    return {
+      kicker: "All in",
+      text: "Your chips are in — the board runs out",
+      tone: "all-in",
     };
   }
   if (folded) {
@@ -320,11 +343,13 @@ const absentCaptionStyle: CSSProperties = {
 function HoleCardsRegion({
   cards,
   locked = false,
+  sealed = false,
   actions,
   caption,
 }: {
   readonly cards: readonly [CardType, CardType] | null;
   readonly locked?: boolean;
+  readonly sealed?: boolean;
   readonly actions: CardActions;
   readonly caption?: string;
 }) {
@@ -342,9 +367,38 @@ function HoleCardsRegion({
         textAlign: "center",
       }}
     >
-      <HoleCardPair cards={cards} locked={locked} actions={actions} />
+      <HoleCardPair
+        cards={cards}
+        locked={locked}
+        sealed={sealed}
+        actions={actions}
+      />
       {absent && <span style={absentCaptionStyle}>{caption}</span>}
     </div>
+  );
+}
+
+function ShowMyHandButton({ onShow }: { readonly onShow: () => void }) {
+  return (
+    <button
+      type="button"
+      data-testid="show-my-hand"
+      onClick={onShow}
+      style={{
+        flex: "none",
+        height: "3.6em",
+        borderRadius: radius.control,
+        border: 0,
+        background: color.pillGradient,
+        color: color.pillInk,
+        boxShadow: shadow.pill,
+        fontFamily: font.body,
+        fontSize: fontSize.lg,
+        fontWeight: 700,
+      }}
+    >
+      Show my hand
+    </button>
   );
 }
 
@@ -455,6 +509,12 @@ export function Hand({
             caption="You folded — cards are in the muck."
           />
         )}
+        {view.canShow && view.winners !== null && (
+          <ShowMyHandButton onShow={intent?.show ?? noAction} />
+        )}
+        {intent?.rejection != null && (
+          <RejectionNotice rejection={intent.rejection} />
+        )}
       </div>
     );
   }
@@ -479,7 +539,11 @@ export function Hand({
         shotClockSeconds={shotClockSeconds}
       />
       {view.yourHoleCards ? (
-        <HoleCardsRegion cards={view.yourHoleCards} actions={actions} />
+        <HoleCardsRegion
+          cards={view.yourHoleCards}
+          sealed={isAllIn(view)}
+          actions={actions}
+        />
       ) : (
         <HoleCardsRegion
           cards={null}

--- a/packages/player-client/src/actions/RejectionNotice.tsx
+++ b/packages/player-client/src/actions/RejectionNotice.tsx
@@ -1,0 +1,31 @@
+import { fontSize, radius } from "@table-top-poker/ui-shared";
+import type { ActionType } from "@table-top-poker/protocol";
+import { rejectionCopy } from "./rejectionCopy.js";
+import type { ActionRejection } from "../store/actionSlice.js";
+
+export interface RejectionNoticeProps {
+  readonly rejection: ActionRejection;
+  readonly attributedTo?: ActionType | "show" | null;
+}
+
+export function RejectionNotice({
+  rejection,
+  attributedTo = null,
+}: RejectionNoticeProps) {
+  return (
+    <div
+      data-testid="action-rejection"
+      data-rejected-action={attributedTo ?? ""}
+      style={{
+        padding: "0.7em 0.9em",
+        borderRadius: radius.control,
+        background: "rgba(232,139,125,.13)",
+        border: "1px solid rgba(232,139,125,.34)",
+        fontSize: fontSize.caption,
+        color: "#f0aa9d",
+      }}
+    >
+      {rejectionCopy(rejection.reason)}
+    </div>
+  );
+}

--- a/packages/player-client/src/actions/allIn.test.ts
+++ b/packages/player-client/src/actions/allIn.test.ts
@@ -1,30 +1,64 @@
 import { describe, expect, it } from "vitest";
-import { allInChoices, isAllInAction, pressAllIn } from "./allIn.js";
+import {
+  allInChoices,
+  isAllInAction,
+  otherSeatIsAllIn,
+  pressAllIn,
+} from "./allIn.js";
+
+const facingBet = ["fold", "call", "raise", "allInCall", "allInRaise"] as const;
+const noBet = ["fold", "check", "raise", "allInCall", "allInRaise"] as const;
 
 describe("allInChoices", () => {
-  it("forks into a call and a raise when facing a bet", () => {
-    expect(
-      allInChoices(["fold", "call", "raise", "allInCall", "allInRaise"]),
-    ).toEqual([
+  it("offers one wide all-in while nobody has shoved", () => {
+    expect(allInChoices([...facingBet], false)).toEqual([
+      { action: "allInRaise", label: "All in" },
+    ]);
+    expect(allInChoices([...noBet], false)).toEqual([
+      { action: "allInRaise", label: "All in" },
+    ]);
+  });
+
+  it("splits into a call and a raise once another seat is all in", () => {
+    expect(allInChoices([...facingBet], true)).toEqual([
       { action: "allInCall", label: "All-in call" },
       { action: "allInRaise", label: "All-in raise" },
     ]);
   });
 
-  it("offers one all-in when there is no bet to call", () => {
-    expect(
-      allInChoices(["fold", "check", "raise", "allInCall", "allInRaise"]),
-    ).toEqual([{ action: "allInRaise", label: "All in" }]);
+  it("drops the call arm when the shove has already been retired, leaving nothing to match", () => {
+    expect(allInChoices([...noBet], true)).toEqual([
+      { action: "allInRaise", label: "All-in raise" },
+    ]);
   });
 
   it("offers nothing when it is not the player's turn", () => {
-    expect(allInChoices([])).toEqual([]);
+    expect(allInChoices([], true)).toEqual([]);
   });
 
   it("drops a choice the engine has not made legal", () => {
-    expect(allInChoices(["fold", "call", "raise", "allInRaise"])).toEqual([
-      { action: "allInRaise", label: "All-in raise" },
-    ]);
+    expect(allInChoices(["fold", "call", "raise", "allInRaise"], true)).toEqual(
+      [{ action: "allInRaise", label: "All-in raise" }],
+    );
+  });
+});
+
+describe("otherSeatIsAllIn", () => {
+  const live = { seatId: 0, folded: false, allIn: false };
+  const shover = { seatId: 1, folded: false, allIn: true };
+  const mucked = { seatId: 2, folded: true, allIn: false };
+  const seats = [live, shover, mucked];
+
+  it("sees another seat's shove", () => {
+    expect(otherSeatIsAllIn(seats, 0)).toBe(true);
+  });
+
+  it("does not count the asking seat's own shove", () => {
+    expect(otherSeatIsAllIn(seats, 1)).toBe(false);
+  });
+
+  it("is false when nobody is all in", () => {
+    expect(otherSeatIsAllIn([live, mucked], 0)).toBe(false);
   });
 });
 

--- a/packages/player-client/src/actions/allIn.test.ts
+++ b/packages/player-client/src/actions/allIn.test.ts
@@ -26,9 +26,15 @@ describe("allInChoices", () => {
     ]);
   });
 
-  it("drops the call arm when the shove has already been retired, leaving nothing to match", () => {
-    expect(allInChoices([...noBet], true)).toEqual([
-      { action: "allInRaise", label: "All-in raise" },
+  it("drops the call arm when the engine offers no all-in call to make", () => {
+    expect(
+      allInChoices(["fold", "check", "raise", "allInRaise"], true),
+    ).toEqual([{ action: "allInRaise", label: "All-in raise" }]);
+  });
+
+  it("drops the raise arm once nobody is left to answer a raise", () => {
+    expect(allInChoices(["fold", "call", "allInCall"], true)).toEqual([
+      { action: "allInCall", label: "All-in call" },
     ]);
   });
 

--- a/packages/player-client/src/actions/allIn.test.ts
+++ b/packages/player-client/src/actions/allIn.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { allInChoices, isAllInAction, pressAllIn } from "./allIn.js";
+
+describe("allInChoices", () => {
+  it("forks into a call and a raise when facing a bet", () => {
+    expect(
+      allInChoices(["fold", "call", "raise", "allInCall", "allInRaise"]),
+    ).toEqual([
+      { action: "allInCall", label: "All-in call" },
+      { action: "allInRaise", label: "All-in raise" },
+    ]);
+  });
+
+  it("offers one all-in when there is no bet to call", () => {
+    expect(
+      allInChoices(["fold", "check", "raise", "allInCall", "allInRaise"]),
+    ).toEqual([{ action: "allInRaise", label: "All in" }]);
+  });
+
+  it("offers nothing when it is not the player's turn", () => {
+    expect(allInChoices([])).toEqual([]);
+  });
+
+  it("drops a choice the engine has not made legal", () => {
+    expect(allInChoices(["fold", "call", "raise", "allInRaise"])).toEqual([
+      { action: "allInRaise", label: "All-in raise" },
+    ]);
+  });
+});
+
+describe("pressAllIn", () => {
+  it("arms on the first press and sends nothing", () => {
+    expect(pressAllIn(null, "allInCall")).toEqual({
+      armed: "allInCall",
+      send: null,
+    });
+  });
+
+  it("sends on the second press of the armed choice", () => {
+    expect(pressAllIn("allInCall", "allInCall")).toEqual({
+      armed: null,
+      send: "allInCall",
+    });
+  });
+
+  it("moves the arming across when the other choice is pressed", () => {
+    expect(pressAllIn("allInCall", "allInRaise")).toEqual({
+      armed: "allInRaise",
+      send: null,
+    });
+  });
+});
+
+describe("isAllInAction", () => {
+  it("recognises the two declared all-ins", () => {
+    expect(isAllInAction("allInCall")).toBe(true);
+    expect(isAllInAction("allInRaise")).toBe(true);
+  });
+
+  it("rejects the ordinary actions and an unattributed rejection", () => {
+    expect(isAllInAction("raise")).toBe(false);
+    expect(isAllInAction(null)).toBe(false);
+  });
+});

--- a/packages/player-client/src/actions/allIn.ts
+++ b/packages/player-client/src/actions/allIn.ts
@@ -1,0 +1,44 @@
+import type { ActionType } from "@table-top-poker/protocol";
+
+export type AllInAction = "allInCall" | "allInRaise";
+
+export function isAllInAction(
+  action: ActionType | null,
+): action is AllInAction {
+  return action === "allInCall" || action === "allInRaise";
+}
+
+export interface AllInChoice {
+  readonly action: AllInAction;
+  readonly label: string;
+}
+
+const FACING_BET: readonly AllInChoice[] = [
+  { action: "allInCall", label: "All-in call" },
+  { action: "allInRaise", label: "All-in raise" },
+];
+
+const UNOPPOSED: readonly AllInChoice[] = [
+  { action: "allInRaise", label: "All in" },
+];
+
+export function allInChoices(
+  legalActions: readonly ActionType[],
+): readonly AllInChoice[] {
+  const offered = legalActions.includes("call") ? FACING_BET : UNOPPOSED;
+  return offered.filter((choice) => legalActions.includes(choice.action));
+}
+
+export interface AllInPress {
+  readonly armed: AllInAction | null;
+  readonly send: AllInAction | null;
+}
+
+export function pressAllIn(
+  armed: AllInAction | null,
+  pressed: AllInAction,
+): AllInPress {
+  return armed === pressed
+    ? { armed: null, send: pressed }
+    : { armed: pressed, send: null };
+}

--- a/packages/player-client/src/actions/allIn.ts
+++ b/packages/player-client/src/actions/allIn.ts
@@ -1,4 +1,4 @@
-import type { ActionType } from "@table-top-poker/protocol";
+import type { ActionType, SeatSnapshot } from "@table-top-poker/protocol";
 
 export type AllInAction = "allInCall" | "allInRaise";
 
@@ -13,20 +13,40 @@ export interface AllInChoice {
   readonly label: string;
 }
 
-const FACING_BET: readonly AllInChoice[] = [
+const SPLIT: readonly AllInChoice[] = [
   { action: "allInCall", label: "All-in call" },
   { action: "allInRaise", label: "All-in raise" },
 ];
 
-const UNOPPOSED: readonly AllInChoice[] = [
+const WHOLE: readonly AllInChoice[] = [
   { action: "allInRaise", label: "All in" },
 ];
 
+export function otherSeatIsAllIn(
+  seats: readonly SeatSnapshot[],
+  yourSeatId: number,
+): boolean {
+  return seats.some((seat) => seat.seatId !== yourSeatId && seat.allIn);
+}
+
+/**
+ * An all-in call only means something against chips already in front of you,
+ * so the split arm needs a live bet as well as a shove to have happened.
+ */
+function offerable(
+  action: AllInAction,
+  legalActions: readonly ActionType[],
+): boolean {
+  if (!legalActions.includes(action)) return false;
+  return action === "allInCall" ? legalActions.includes("call") : true;
+}
+
 export function allInChoices(
   legalActions: readonly ActionType[],
+  facingAllIn: boolean,
 ): readonly AllInChoice[] {
-  const offered = legalActions.includes("call") ? FACING_BET : UNOPPOSED;
-  return offered.filter((choice) => legalActions.includes(choice.action));
+  const offered = facingAllIn ? SPLIT : WHOLE;
+  return offered.filter((choice) => offerable(choice.action, legalActions));
 }
 
 export interface AllInPress {

--- a/packages/player-client/src/actions/allIn.ts
+++ b/packages/player-client/src/actions/allIn.ts
@@ -29,24 +29,12 @@ export function otherSeatIsAllIn(
   return seats.some((seat) => seat.seatId !== yourSeatId && seat.allIn);
 }
 
-/**
- * An all-in call only means something against chips already in front of you,
- * so the split arm needs a live bet as well as a shove to have happened.
- */
-function offerable(
-  action: AllInAction,
-  legalActions: readonly ActionType[],
-): boolean {
-  if (!legalActions.includes(action)) return false;
-  return action === "allInCall" ? legalActions.includes("call") : true;
-}
-
 export function allInChoices(
   legalActions: readonly ActionType[],
   facingAllIn: boolean,
 ): readonly AllInChoice[] {
   const offered = facingAllIn ? SPLIT : WHOLE;
-  return offered.filter((choice) => offerable(choice.action, legalActions));
+  return offered.filter((choice) => legalActions.includes(choice.action));
 }
 
 export interface AllInPress {

--- a/packages/player-client/src/actions/legalActionsFromView.test.ts
+++ b/packages/player-client/src/actions/legalActionsFromView.test.ts
@@ -23,7 +23,7 @@ describe("legalActionsFromView", () => {
       street: "preflop",
       board: [],
       toAct: [0],
-      seats: [{ seatId: 0, folded: false }],
+      seats: [{ seatId: 0, folded: false, allIn: false }],
       yourSeatId: 0,
       yourHoleCards: null,
       legalActions: ["fold", "check", "raise"],

--- a/packages/player-client/src/actions/useActionIntent.ts
+++ b/packages/player-client/src/actions/useActionIntent.ts
@@ -1,6 +1,7 @@
 import type { ActionType, ClientCommand } from "@table-top-poker/protocol";
 import { useCallback } from "react";
 import { usePlayerStore } from "../store/store.js";
+import type { AllInAction } from "./allIn.js";
 import type { ActionRejection } from "../store/actionSlice.js";
 import { legalActionsFromView } from "./legalActionsFromView.js";
 
@@ -12,6 +13,8 @@ export interface ActionIntent {
   readonly check: () => void;
   readonly call: () => void;
   readonly raise: () => void;
+  readonly allIn: (action: AllInAction) => void;
+  readonly show: () => void;
 }
 
 type SendableAction = Extract<ClientCommand["type"], ActionType>;
@@ -58,6 +61,12 @@ export function useActionIntent(
     },
     raise: () => {
       act("raise");
+    },
+    allIn: (action: AllInAction) => {
+      act(action);
+    },
+    show: () => {
+      send({ type: "show" });
     },
   };
 }

--- a/packages/player-client/src/holecards/HoleCardPair.test.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.test.tsx
@@ -15,9 +15,11 @@ import type { CardActions } from "./ports.js";
 const actions: CardActions = {
   foldLegal: true,
   checkLegal: true,
+  showLegal: false,
   pending: false,
   fold: () => undefined,
   check: () => undefined,
+  show: () => undefined,
 };
 
 const queenJack: readonly [Card, Card] = [

--- a/packages/player-client/src/holecards/HoleCardPair.test.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.test.tsx
@@ -28,7 +28,12 @@ const queenJack: readonly [Card, Card] = [
 describe("HoleCardPair", () => {
   it("deals in face-down, with no rank or suit anywhere in the document", () => {
     const html = renderToStaticMarkup(
-      <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
+      <HoleCardPair
+        cards={queenJack}
+        locked={false}
+        sealed={false}
+        actions={actions}
+      />,
     );
 
     expect(html).toMatch(/data-testid="hole-cards"/);
@@ -39,7 +44,12 @@ describe("HoleCardPair", () => {
 
   it("renders as a real focusable button with an accessible name", () => {
     const html = renderToStaticMarkup(
-      <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
+      <HoleCardPair
+        cards={queenJack}
+        locked={false}
+        sealed={false}
+        actions={actions}
+      />,
     );
 
     expect(html).toMatch(/<button [^>]*type="button"/);
@@ -50,7 +60,12 @@ describe("HoleCardPair", () => {
 
   it("names the cards for a screen reader once they are revealed", () => {
     const html = renderToStaticMarkup(
-      <HoleCardPair cards={queenJack} locked actions={actions} />,
+      <HoleCardPair
+        cards={queenJack}
+        locked
+        sealed={false}
+        actions={actions}
+      />,
     );
 
     expect(html).toContain(
@@ -60,7 +75,12 @@ describe("HoleCardPair", () => {
 
   it("renders a locked pair face-up and inert", () => {
     const html = renderToStaticMarkup(
-      <HoleCardPair cards={queenJack} locked actions={actions} />,
+      <HoleCardPair
+        cards={queenJack}
+        locked
+        sealed={false}
+        actions={actions}
+      />,
     );
 
     expect(html).toContain('data-presentation="Revealed"');
@@ -73,7 +93,12 @@ describe("HoleCardPair", () => {
 
   it("renders the Absent presentation and no card pair for a seat holding nothing", () => {
     const html = renderToStaticMarkup(
-      <HoleCardPair cards={null} locked={false} actions={actions} />,
+      <HoleCardPair
+        cards={null}
+        locked={false}
+        sealed={false}
+        actions={actions}
+      />,
     );
 
     expect(html).toMatch(/data-testid="no-hole-cards"/);
@@ -84,7 +109,12 @@ describe("HoleCardPair", () => {
 
   it("carries the bend affordance on both cards", () => {
     const html = renderToStaticMarkup(
-      <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
+      <HoleCardPair
+        cards={queenJack}
+        locked={false}
+        sealed={false}
+        actions={actions}
+      />,
     );
 
     expect((html.match(/data-bend-zone="true"/g) ?? []).length).toBe(2);
@@ -92,7 +122,12 @@ describe("HoleCardPair", () => {
 
   it("does not offer the bend affordance on a locked pair", () => {
     const html = renderToStaticMarkup(
-      <HoleCardPair cards={queenJack} locked actions={actions} />,
+      <HoleCardPair
+        cards={queenJack}
+        locked
+        sealed={false}
+        actions={actions}
+      />,
     );
 
     expect(html).not.toContain("data-bend-zone");
@@ -100,7 +135,12 @@ describe("HoleCardPair", () => {
 
   it("takes the whole gesture from the browser, so a drag is never a pan and a double-tap never a zoom", () => {
     const html = renderToStaticMarkup(
-      <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
+      <HoleCardPair
+        cards={queenJack}
+        locked={false}
+        sealed={false}
+        actions={actions}
+      />,
     );
 
     expect(html).toContain("touch-action:none");
@@ -111,7 +151,12 @@ describe("HoleCardPair", () => {
 
   it("renders no hint while the pair is settled", () => {
     const html = renderToStaticMarkup(
-      <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
+      <HoleCardPair
+        cards={queenJack}
+        locked={false}
+        sealed={false}
+        actions={actions}
+      />,
     );
 
     expect(html).not.toContain('data-testid="hole-cards-hint"');
@@ -119,7 +164,12 @@ describe("HoleCardPair", () => {
 
   it("stamps no Check confirmation over a pair that has not just checked", () => {
     const html = renderToStaticMarkup(
-      <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
+      <HoleCardPair
+        cards={queenJack}
+        locked={false}
+        sealed={false}
+        actions={actions}
+      />,
     );
 
     expect(html).not.toContain('data-testid="check-stamp"');
@@ -128,7 +178,12 @@ describe("HoleCardPair", () => {
 
   it("mounts the live region empty, before there is any news to put in it", () => {
     const html = renderToStaticMarkup(
-      <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
+      <HoleCardPair
+        cards={queenJack}
+        locked={false}
+        sealed={false}
+        actions={actions}
+      />,
     );
 
     expect(html).toMatch(/<span role="status"[^>]*><\/span>/);
@@ -193,7 +248,12 @@ describe("HoleCardPair", () => {
 
   it("names the corner the bend affordance is actually drawn in", () => {
     const html = renderToStaticMarkup(
-      <HoleCardPair cards={queenJack} locked={false} actions={actions} />,
+      <HoleCardPair
+        cards={queenJack}
+        locked={false}
+        sealed={false}
+        actions={actions}
+      />,
     );
     const zone = /<span data-bend-zone="true"[^>]*style="([^"]*)"/.exec(html);
     const zoneStyle = zone?.[1];

--- a/packages/player-client/src/holecards/HoleCardPair.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.tsx
@@ -14,6 +14,8 @@ import { useHoleCards } from "./useHoleCards.js";
 export interface HoleCardPairProps {
   readonly cards: readonly [CardType, CardType] | null;
   readonly locked: boolean;
+  /** All-in: inert, but still face-down until the table's Reveal. */
+  readonly sealed: boolean;
   readonly actions: CardActions;
 }
 

--- a/packages/player-client/src/holecards/cardState.test.ts
+++ b/packages/player-client/src/holecards/cardState.test.ts
@@ -25,27 +25,33 @@ function lockedState(presentation: Presentation): CardState {
 
 describe("initialCardState", () => {
   it("starts Absent when the seat holds no cards", () => {
-    expect(initialCardState({ hasCards: false, locked: false })).toEqual(
-      state("Absent"),
-    );
+    expect(
+      initialCardState({ hasCards: false, locked: false, sealed: false }),
+    ).toEqual(state("Absent"));
   });
 
   it("starts FaceDown when cards are already in hand on mount", () => {
-    expect(initialCardState({ hasCards: true, locked: false })).toEqual(
-      state("FaceDown"),
-    );
+    expect(
+      initialCardState({ hasCards: true, locked: false, sealed: false }),
+    ).toEqual(state("FaceDown"));
+  });
+
+  it("starts FaceDown and inert when mounting into an all-in seat", () => {
+    expect(
+      initialCardState({ hasCards: true, locked: false, sealed: true }),
+    ).toEqual(lockedState("FaceDown"));
   });
 
   it("starts Revealed and inert when mounting into a locked (showdown) pair", () => {
-    expect(initialCardState({ hasCards: true, locked: true })).toEqual(
-      lockedState("Revealed"),
-    );
+    expect(
+      initialCardState({ hasCards: true, locked: true, sealed: false }),
+    ).toEqual(lockedState("Revealed"));
   });
 
   it("stays Absent when locked with no cards", () => {
-    expect(initialCardState({ hasCards: false, locked: true })).toEqual(
-      state("Absent"),
-    );
+    expect(
+      initialCardState({ hasCards: false, locked: true, sealed: false }),
+    ).toEqual(state("Absent"));
   });
 });
 
@@ -226,6 +232,37 @@ describe("reduce", () => {
       expect(reduce(bending, { type: "SHOWDOWN_REVEAL" })).toEqual(
         lockedState("Turning"),
       );
+    });
+  });
+
+  describe("SEALED", () => {
+    it("turns the pair face-down and inert when the seat goes all in", () => {
+      for (const presentation of ["FaceDown", "Peeking", "Revealed"] as const) {
+        expect(reduce(state(presentation), { type: "SEALED" })).toEqual(
+          lockedState("FaceDown"),
+        );
+      }
+    });
+
+    it("clears any gesture the player still had a finger on", () => {
+      expect(reduce(state("Peeking", "Bending"), { type: "SEALED" })).toEqual(
+        lockedState("FaceDown"),
+      );
+    });
+
+    it("seals nothing for a seat holding no cards", () => {
+      expect(reduce(state("Absent"), { type: "SEALED" })).toEqual(
+        state("Absent"),
+      );
+      expect(reduce(state("Leaving"), { type: "SEALED" })).toEqual(
+        state("Leaving"),
+      );
+    });
+
+    it("still turns over at the table's reveal", () => {
+      expect(
+        reduce(lockedState("FaceDown"), { type: "SHOWDOWN_REVEAL" }),
+      ).toEqual(lockedState("Turning"));
     });
   });
 

--- a/packages/player-client/src/holecards/cardState.test.ts
+++ b/packages/player-client/src/holecards/cardState.test.ts
@@ -3,6 +3,7 @@ import {
   initialCardState,
   reduce,
   releaseCommitsFold,
+  revealPublishes,
   type CardEvent,
   type CardState,
   type Presentation,
@@ -716,5 +717,23 @@ describe("reduce", () => {
         reduce(lockedState("Revealed"), { type: "DOUBLE_TAPPED" }),
       ).toEqual(lockedState("Revealed"));
     });
+  });
+});
+
+describe("revealPublishes", () => {
+  it("publishes the committed flip face-up while the window is open", () => {
+    expect(revealPublishes("FaceDown", "Turning", true)).toBe(true);
+    expect(revealPublishes("Peeking", "Turning", true)).toBe(true);
+  });
+
+  it("keeps the reveal local while the window is shut", () => {
+    expect(revealPublishes("FaceDown", "Turning", false)).toBe(false);
+  });
+
+  it("does not publish a peek, a hide, or a flip already in flight", () => {
+    expect(revealPublishes("FaceDown", "Peeking", true)).toBe(false);
+    expect(revealPublishes("Revealed", "FaceDown", true)).toBe(false);
+    expect(revealPublishes("Turning", "Turning", true)).toBe(false);
+    expect(revealPublishes("Turning", "Revealed", true)).toBe(false);
   });
 });

--- a/packages/player-client/src/holecards/cardState.ts
+++ b/packages/player-client/src/holecards/cardState.ts
@@ -74,6 +74,18 @@ function settled(state: CardState): CardState {
   };
 }
 
+/**
+ * A committed flip face-up is the Showdown show (ADR-0008 amendment, #253) —
+ * the peek is not, and neither is a pair already face-up when the window opened.
+ */
+export function revealPublishes(
+  from: Presentation,
+  to: Presentation,
+  showLegal: boolean,
+): boolean {
+  return showLegal && from !== "Turning" && to === "Turning";
+}
+
 export function releaseCommitsFold(state: CardState): boolean {
   return state.recognizer === "FoldDragging" && state.armed;
 }

--- a/packages/player-client/src/holecards/cardState.ts
+++ b/packages/player-client/src/holecards/cardState.ts
@@ -29,6 +29,7 @@ export type CardEvent =
   | { readonly type: "TAPPED" }
   | { readonly type: "DOUBLE_TAPPED" }
   | { readonly type: "PENDING_RESOLVED"; readonly hasCards: boolean }
+  | { readonly type: "SEALED" }
   | { readonly type: "SHOWDOWN_REVEAL" };
 
 function idle(presentation: Presentation): CardState {
@@ -39,6 +40,7 @@ function survivesLock(event: CardEvent): boolean {
   switch (event.type) {
     case "DEALT":
     case "CARDS_GONE":
+    case "SEALED":
     case "SHOWDOWN_REVEAL":
     case "TURN_FINISHED":
       return true;
@@ -50,12 +52,15 @@ function survivesLock(event: CardEvent): boolean {
 export function initialCardState({
   hasCards,
   locked,
+  sealed,
 }: {
   readonly hasCards: boolean;
   readonly locked: boolean;
+  readonly sealed: boolean;
 }): CardState {
   if (!hasCards) return idle("Absent");
   if (locked) return { ...idle("Revealed"), locked: true };
+  if (sealed) return { ...idle("FaceDown"), locked: true };
   return idle("FaceDown");
 }
 
@@ -160,6 +165,12 @@ export function reduce(state: CardState, event: CardEvent): CardState {
     case "PENDING_RESOLVED":
       if (state.presentation !== "Leaving") return state;
       return idle(event.hasCards ? "FaceDown" : "Absent");
+
+    case "SEALED":
+      if (state.presentation === "Absent" || state.presentation === "Leaving") {
+        return state;
+      }
+      return { ...idle("FaceDown"), locked: true };
 
     case "SHOWDOWN_REVEAL":
       if (state.presentation === "Absent" || state.presentation === "Leaving") {

--- a/packages/player-client/src/holecards/ports.ts
+++ b/packages/player-client/src/holecards/ports.ts
@@ -1,7 +1,10 @@
 export interface CardActions {
   readonly foldLegal: boolean;
   readonly checkLegal: boolean;
+  /** The Showdown showing window is open and this Seat has not shown yet. */
+  readonly showLegal: boolean;
   readonly pending: boolean;
   readonly fold: () => void;
   readonly check: () => void;
+  readonly show: () => void;
 }

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -13,6 +13,7 @@ import {
 import {
   initialCardState,
   reduce,
+  revealPublishes,
   type CardEvent,
   type CardState,
 } from "./cardState.js";
@@ -161,6 +162,9 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     }
   }, [state.presentation, bend]);
 
+  const latestActions = useRef(props.actions);
+  latestActions.current = props.actions;
+
   const prevPresentation = useRef(state.presentation);
   useEffect(() => {
     const from = prevPresentation.current;
@@ -168,6 +172,9 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     prevPresentation.current = to;
     if (to === "Turning" || (from === "Revealed" && to === "FaceDown")) {
       playRevealFlip();
+    }
+    if (revealPublishes(from, to, latestActions.current.showLegal)) {
+      latestActions.current.show();
     }
   }, [state.presentation]);
 

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -98,6 +98,7 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
     initialCardState({
       hasCards: initial.cards !== null,
       locked: initial.locked,
+      sealed: initial.sealed,
     }),
   );
 

--- a/packages/player-client/src/holecards/viewEvents.test.ts
+++ b/packages/player-client/src/holecards/viewEvents.test.ts
@@ -8,9 +8,11 @@ import { eventsForPropChange, eventsForVisibility } from "./viewEvents.js";
 const actions: CardActions = {
   foldLegal: false,
   checkLegal: false,
+  showLegal: false,
   pending: false,
   fold: () => undefined,
   check: () => undefined,
+  show: () => undefined,
 };
 
 const queenJack: readonly [Card, Card] = [
@@ -275,6 +277,35 @@ describe("eventsForPropChange", () => {
           props({ cards: queenJack, sealed: true }),
           props({ cards: queenJack }),
           faceDown,
+        ),
+      ).toEqual([]);
+    });
+  });
+
+  describe("the showing window opening", () => {
+    const showable: CardActions = { ...actions, showLegal: true };
+
+    it("returns the pair face-down, so the reveal that publishes is deliberate", () => {
+      expect(
+        eventsForPropChange(
+          props({ cards: queenJack }),
+          props({ cards: queenJack, actions: showable }),
+          revealed,
+        ),
+      ).toEqual([{ type: "RESET" }]);
+    });
+
+    it("produces nothing while the window is unchanged", () => {
+      const open = props({ cards: queenJack, actions: showable });
+      expect(eventsForPropChange(open, { ...open }, revealed)).toEqual([]);
+    });
+
+    it("produces nothing when the window closes", () => {
+      expect(
+        eventsForPropChange(
+          props({ cards: queenJack, actions: showable }),
+          props({ cards: queenJack }),
+          revealed,
         ),
       ).toEqual([]);
     });

--- a/packages/player-client/src/holecards/viewEvents.test.ts
+++ b/packages/player-client/src/holecards/viewEvents.test.ts
@@ -19,7 +19,7 @@ const queenJack: readonly [Card, Card] = [
 ];
 
 function props(overrides: Partial<HoleCardPairProps> = {}): HoleCardPairProps {
-  return { cards: null, locked: false, actions, ...overrides };
+  return { cards: null, locked: false, sealed: false, actions, ...overrides };
 }
 
 const faceDown: CardState = {
@@ -246,6 +246,35 @@ describe("eventsForPropChange", () => {
           props({ cards: queenJack }),
           props({ cards: queenJack, actions: pending }),
           leaving,
+        ),
+      ).toEqual([]);
+    });
+  });
+
+  describe("all in", () => {
+    it("seals when sealed goes false → true", () => {
+      expect(
+        eventsForPropChange(
+          props({ cards: queenJack }),
+          props({ cards: queenJack, sealed: true }),
+          faceDown,
+        ),
+      ).toEqual([{ type: "SEALED" }]);
+    });
+
+    it("produces nothing while sealed is unchanged", () => {
+      const stillSealed = props({ cards: queenJack, sealed: true });
+      expect(
+        eventsForPropChange(stillSealed, { ...stillSealed }, faceDown),
+      ).toEqual([]);
+    });
+
+    it("produces nothing when a seal is released — the next deal reopens it", () => {
+      expect(
+        eventsForPropChange(
+          props({ cards: queenJack, sealed: true }),
+          props({ cards: queenJack }),
+          faceDown,
         ),
       ).toEqual([]);
     });

--- a/packages/player-client/src/holecards/viewEvents.ts
+++ b/packages/player-client/src/holecards/viewEvents.ts
@@ -42,6 +42,10 @@ export function eventsForPropChange(
     events.push({ type: "FOLD_DISARMED" });
   }
 
+  if (!prev.actions.showLegal && next.actions.showLegal) {
+    events.push({ type: "RESET" });
+  }
+
   if (prev.actions.pending && !next.actions.pending) {
     events.push({ type: "PENDING_RESOLVED", hasCards: next.cards !== null });
   }

--- a/packages/player-client/src/holecards/viewEvents.ts
+++ b/packages/player-client/src/holecards/viewEvents.ts
@@ -28,6 +28,8 @@ export function eventsForPropChange(
   } else {
     if (!samePair(prev.cards, next.cards)) events.push({ type: "DEALT" });
 
+    if (!prev.sealed && next.sealed) events.push({ type: "SEALED" });
+
     if (!prev.locked && next.locked) events.push({ type: "SHOWDOWN_REVEAL" });
   }
 

--- a/packages/protocol/src/command-schema.test.ts
+++ b/packages/protocol/src/command-schema.test.ts
@@ -8,7 +8,11 @@ describe("ClientCommandSchema", () => {
     "check",
     "call",
     "raise",
+    "allInCall",
+    "allInRaise",
     "nextHand",
+    "reveal",
+    "show",
     "sitOut",
     "sitIn",
   ])("accepts a bare %s command", (type) => {

--- a/packages/protocol/src/command-schema.ts
+++ b/packages/protocol/src/command-schema.ts
@@ -6,6 +6,8 @@ export const ClientCommandSchema = z.discriminatedUnion("type", [
   z.strictObject({ type: z.literal("check") }),
   z.strictObject({ type: z.literal("call") }),
   z.strictObject({ type: z.literal("raise") }),
+  z.strictObject({ type: z.literal("allInCall") }),
+  z.strictObject({ type: z.literal("allInRaise") }),
   z.strictObject({ type: z.literal("nextHand") }),
   z.strictObject({ type: z.literal("reveal") }),
   z.strictObject({ type: z.literal("show") }),

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -1035,6 +1035,28 @@ describe("RoomStore", () => {
         expect(room.engine?.hand?.status).toBe("complete");
       });
 
+      it("frees an all-in seat's claim, which no fold can release", () => {
+        const store = new RoomStore();
+        const room = roomWithClaimedSeats(store, 3);
+        commitDispatch(store, room.code, "table", "startHand");
+        const shover = store.currentActor(room.code);
+        if (shover === undefined) throw new Error("expected a current actor");
+        commitDispatch(store, room.code, shover, "allInRaise");
+        if (room.engine?.hand?.status !== "betting") {
+          throw new Error("expected the hand to still be live");
+        }
+        expect(room.engine.hand.players.get(shover)?.allIn).toBe(true);
+
+        const result = commitEviction(store, room.code, shover);
+
+        expect(result.transaction).toBeUndefined();
+        expect(room.seats[shover]).toMatchObject({
+          claimed: false,
+          token: null,
+        });
+        expect(room.engine.hand.players.get(shover)?.folded).toBe(false);
+      });
+
       it("frees a claimed seat via evictSeat regardless of connection status", () => {
         const store = new RoomStore();
         const room = roomWithClaimedSeats(store, 3);

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -1312,6 +1312,32 @@ describe("RoomStore", () => {
       });
     });
 
+    it("stamps an all-in raise with the seat that declared it", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, [0, 1]);
+      commitDispatch(store, room.code, "table", "startHand");
+      const actor = store.currentActor(room.code);
+      if (actor === undefined) throw new Error("expected a current actor");
+
+      const declared = commitDispatch(store, room.code, actor, "allInRaise");
+
+      if (!("steps" in declared)) throw new Error("expected a transaction");
+      expect(declared.command).toEqual({ type: "allInRaise", seatId: actor });
+      expect(declared.steps.map((step) => step.event.type)).toContain(
+        "ActionTaken",
+      );
+    });
+
+    it("refuses an all-in call from the table", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, [0, 1]);
+      commitDispatch(store, room.code, "table", "startHand");
+
+      expect(store.dispatch(room.code, "table", "allInCall")).toEqual({
+        error: "not-permitted",
+      });
+    });
+
     it("takes reveal from the table and stamps a seat on it", () => {
       const store = new RoomStore();
       const room = roomWithClaimedSeats(store, [0, 1]);

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -3,6 +3,7 @@ import { handStartContextFor } from "@table-top-poker/recording";
 import type { RoomOperation } from "@table-top-poker/recording";
 import {
   apply,
+  canStillAct,
   createInitialState,
   DEFAULT_SEAT_COUNT,
   DEFAULT_SHOT_CLOCK,
@@ -540,7 +541,7 @@ export class RoomStore {
       hand?.status === "betting" &&
       hand.ring.includes(seatId) &&
       player !== undefined &&
-      !player.folded
+      canStillAct(player)
     ) {
       const transaction = this.#stageSeatRelease(room, seatId, "evict");
       return transaction === undefined ? {} : { transaction };

--- a/packages/table-client/src/App.review.test.tsx
+++ b/packages/table-client/src/App.review.test.tsx
@@ -80,8 +80,8 @@ const liveHand: TableView = {
   board: [],
   toAct: [1],
   seats: [
-    { seatId: 0, folded: false },
-    { seatId: 1, folded: false },
+    { seatId: 0, folded: false, allIn: false },
+    { seatId: 1, folded: false, allIn: false },
   ],
 };
 

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -42,8 +42,8 @@ const liveHand: TableView = {
   board: [],
   toAct: [1],
   seats: [
-    { seatId: 0, folded: false },
-    { seatId: 1, folded: false },
+    { seatId: 0, folded: false, allIn: false },
+    { seatId: 1, folded: false, allIn: false },
   ],
 };
 

--- a/packages/table-client/src/Board.test.tsx
+++ b/packages/table-client/src/Board.test.tsx
@@ -27,8 +27,8 @@ describe("Board", () => {
       ],
       toAct: [1],
       seats: [
-        { seatId: 0, folded: false },
-        { seatId: 1, folded: false },
+        { seatId: 0, folded: false, allIn: false },
+        { seatId: 1, folded: false, allIn: false },
       ],
     };
     const html = renderToStaticMarkup(<Board view={view} />);
@@ -155,8 +155,8 @@ describe("Board", () => {
       board,
       toAct: [1],
       seats: [
-        { seatId: 0, folded: false },
-        { seatId: 1, folded: false },
+        { seatId: 0, folded: false, allIn: false },
+        { seatId: 1, folded: false, allIn: false },
       ],
     };
     const showdown: TableView = {

--- a/packages/table-client/src/HandPicker.test.tsx
+++ b/packages/table-client/src/HandPicker.test.tsx
@@ -161,6 +161,29 @@ describe("HandPicker", () => {
     expect(html).toContain("Seat 1 wins — Pair of aces");
   });
 
+  it("says the hand is awaiting its reveal rather than naming nobody", () => {
+    const resting: HandSummary = {
+      ...showdown,
+      outcome: {
+        kind: "showdown",
+        contestants: [0, 1],
+        winners: [],
+        reveals: [],
+      },
+    };
+    const html = renderToStaticMarkup(
+      <HandPicker
+        summaries={[resting]}
+        seats={[seat(0), seat(1)]}
+        onSelectHand={noop}
+        onClose={noop}
+      />,
+    );
+
+    expect(html).toContain("Waiting on the reveal");
+    expect(html).not.toMatch(/>\s*wins/);
+  });
+
   it("shows an empty state when no hands have completed", () => {
     const html = renderToStaticMarkup(
       <HandPicker

--- a/packages/table-client/src/HandPicker.tsx
+++ b/packages/table-client/src/HandPicker.tsx
@@ -85,6 +85,7 @@ function outcomeText(hand: HandSummary, seats: readonly SeatView[]): string {
   if (outcome.kind === "folded-out") {
     return `${seatLabel(outcome.winner, seats)} wins — everyone folded`;
   }
+  if (outcome.winners.length === 0) return "Waiting on the reveal";
   const { names, verb, description } = showdownVerdict(
     outcome.winners,
     outcome.reveals,

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -965,7 +965,7 @@ describe("Seats at showdown", () => {
     expect(html).not.toContain('data-testid="seat-pod-2-showdown-badges"');
   });
 
-  it("names a winner who was never compelled to show", () => {
+  it("withholds the verdict from a winner who has not shown — the cards carry it", () => {
     const html = renderToStaticMarkup(
       <Seats
         seats={seats}
@@ -981,9 +981,26 @@ describe("Seats at showdown", () => {
     expect(html).toMatch(
       /data-testid="seat-pod-1-showdown"[^>]*data-shown="false"/,
     );
+    expect(html).not.toContain("wins");
+    expect(html).not.toContain('data-testid="seat-pod-1-showdown-verdict"');
+  });
+
+  it("names the winner as soon as they show", () => {
+    const html = renderToStaticMarkup(
+      <Seats
+        seats={seats}
+        view={{
+          ...board,
+          contestants: [0, 1],
+          winners: [1],
+          results: [shown(0, 10, "Ace high"), shown(1, 30, "Pair of Aces")],
+        }}
+      />,
+    );
+
     expect(html).toContain("wins");
     expect(html).toContain('data-testid="seat-pod-1-showdown-verdict"');
-    expect(html).not.toContain("Pair of Aces");
+    expect(html).not.toContain('data-testid="seat-pod-0-showdown-verdict"');
   });
 
   it("never spells out the hand a seat made — the cards are the result", () => {
@@ -1082,7 +1099,11 @@ describe("Seats at showdown", () => {
           ...board,
           contestants: [0, 1, 2],
           winners: [2],
-          results: [shown(0, 30, "Pair of Aces"), shown(1, 10, "Ace high")],
+          results: [
+            shown(0, 30, "Pair of Aces"),
+            shown(1, 10, "Ace high"),
+            shown(2, 40, "Two pair"),
+          ],
         }}
       />,
     );

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -156,8 +156,8 @@ describe("Seats", () => {
       board: [],
       toAct: [0],
       seats: [
-        { seatId: 0, folded: false },
-        { seatId: 1, folded: false },
+        { seatId: 0, folded: false, allIn: false },
+        { seatId: 1, folded: false, allIn: false },
       ],
     };
     const html = renderToStaticMarkup(
@@ -192,7 +192,7 @@ describe("Seats", () => {
       street: "flop",
       board: [],
       toAct: [0],
-      seats: [{ seatId: 0, folded: false }],
+      seats: [{ seatId: 0, folded: false, allIn: false }],
     };
     const html = renderToStaticMarkup(
       <Seats
@@ -242,8 +242,8 @@ describe("Seats", () => {
       board: [],
       toAct: [1],
       seats: [
-        { seatId: 0, folded: false },
-        { seatId: 1, folded: false },
+        { seatId: 0, folded: false, allIn: false },
+        { seatId: 1, folded: false, allIn: false },
       ],
     };
     const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
@@ -289,8 +289,8 @@ describe("Seats", () => {
       board: [],
       toAct: [0],
       seats: [
-        { seatId: 0, folded: false },
-        { seatId: 1, folded: true },
+        { seatId: 0, folded: false, allIn: false },
+        { seatId: 1, folded: true, allIn: false },
       ],
     };
     const html = renderToStaticMarkup(
@@ -496,9 +496,9 @@ describe("Seats", () => {
       board: [],
       toAct: [3],
       seats: [
-        { seatId: 0, folded: false },
-        { seatId: 1, folded: false },
-        { seatId: 3, folded: false },
+        { seatId: 0, folded: false, allIn: false },
+        { seatId: 1, folded: false, allIn: false },
+        { seatId: 3, folded: false, allIn: false },
       ],
     };
     const html = renderToStaticMarkup(
@@ -529,8 +529,8 @@ describe("Seats", () => {
       board: [],
       toAct: [1],
       seats: [
-        { seatId: 0, folded: false },
-        { seatId: 1, folded: false },
+        { seatId: 0, folded: false, allIn: false },
+        { seatId: 1, folded: false, allIn: false },
       ],
     };
     const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
@@ -596,8 +596,8 @@ describe("Seats", () => {
       board: [],
       toAct: [0],
       seats: [
-        { seatId: 0, folded: false },
-        { seatId: 2, folded: true },
+        { seatId: 0, folded: false, allIn: false },
+        { seatId: 2, folded: true, allIn: false },
       ],
     };
     const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);
@@ -654,9 +654,9 @@ const threeHanded: Extract<TableView, { phase: "betting" }> = {
   board: [],
   toAct: [0],
   seats: [
-    { seatId: 3, folded: false },
-    { seatId: 0, folded: false },
-    { seatId: 1, folded: false },
+    { seatId: 3, folded: false, allIn: false },
+    { seatId: 0, folded: false, allIn: false },
+    { seatId: 1, folded: false, allIn: false },
   ],
 };
 
@@ -723,8 +723,8 @@ describe("Seats: position markers", () => {
         board: [],
         toAct: [0],
         seats: [
-          { seatId: 0, folded: false },
-          { seatId: 1, folded: false },
+          { seatId: 0, folded: false, allIn: false },
+          { seatId: 1, folded: false, allIn: false },
         ],
       } satisfies TableView,
     ],
@@ -1163,8 +1163,8 @@ describe("Seats to-act glow", () => {
       board: [],
       toAct: [1],
       seats: [
-        { seatId: 0, folded: false },
-        { seatId: 1, folded: false },
+        { seatId: 0, folded: false, allIn: false },
+        { seatId: 1, folded: false, allIn: false },
       ],
     };
     const html = renderToStaticMarkup(<Seats seats={seats} view={view} />);

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -105,7 +105,7 @@ function showdownSeats(view: TableView | null): Map<SeatId, ShowdownSeat> {
   for (const seatId of view.contestants) {
     bySeat.set(seatId, {
       hand: shown.get(seatId) ?? null,
-      isWinner: winners.includes(seatId),
+      isWinner: winners.includes(seatId) && shown.has(seatId),
       splitting: winners.length > 1,
     });
   }
@@ -113,7 +113,8 @@ function showdownSeats(view: TableView | null): Map<SeatId, ShowdownSeat> {
 }
 /**
  * The Hand a Seat made is never spelled out and never placed — the cards are
- * the result and the room reads them. Only the outcome is the engine's to say.
+ * the result and the room reads them. Only the outcome is the engine's to say,
+ * and only once the Seat's cards are public to say it over (#253).
  */
 function outcomeOf(showdown: ShowdownSeat): string | null {
   if (!showdown.isWinner) return null;

--- a/packages/table-client/src/replay/HandReview.test.tsx
+++ b/packages/table-client/src/replay/HandReview.test.tsx
@@ -72,9 +72,9 @@ function bettingView(board: readonly Card[]): TableView {
     board,
     toAct: [1],
     seats: [
-      { seatId: 0, folded: false },
-      { seatId: 1, folded: false },
-      { seatId: 2, folded: false },
+      { seatId: 0, folded: false, allIn: false },
+      { seatId: 1, folded: false, allIn: false },
+      { seatId: 2, folded: false, allIn: false },
     ],
   };
 }

--- a/packages/table-client/src/replay/ReplayStage.test.tsx
+++ b/packages/table-client/src/replay/ReplayStage.test.tsx
@@ -28,7 +28,11 @@ const view: TableView = {
     { rank: "2", suit: "clubs" },
   ],
   toAct: [1],
-  seats: seats.map((seat) => ({ seatId: seat.id, folded: false })),
+  seats: seats.map((seat) => ({
+    seatId: seat.id,
+    folded: false,
+    allIn: false,
+  })),
 };
 
 describe("ReplayStage", () => {

--- a/packages/ui-shared/src/positionMarker.test.ts
+++ b/packages/ui-shared/src/positionMarker.test.ts
@@ -17,9 +17,9 @@ const bettingTable: TableView = {
   board: [],
   toAct: [3],
   seats: [
-    { seatId: 0, folded: false },
-    { seatId: 1, folded: false },
-    { seatId: 2, folded: false },
+    { seatId: 0, folded: false, allIn: false },
+    { seatId: 1, folded: false, allIn: false },
+    { seatId: 2, folded: false, allIn: false },
   ],
 };
 

--- a/packages/ui-shared/src/sound/engine.test.ts
+++ b/packages/ui-shared/src/sound/engine.test.ts
@@ -76,7 +76,7 @@ const bettingView = (myTurn: boolean): PlayerView => ({
   street: "preflop",
   board: [],
   toAct: myTurn ? [0] : [1],
-  seats: [{ seatId: 0, folded: false }],
+  seats: [{ seatId: 0, folded: false, allIn: false }],
   yourSeatId: 0,
   yourHoleCards: pair(),
   legalActions: myTurn ? ["fold", "check"] : [],
@@ -100,6 +100,7 @@ const tableBettingView = (dealtSeatCount: number): TableView => ({
   seats: Array.from({ length: dealtSeatCount }, (_, seatId) => ({
     seatId,
     folded: false,
+    allIn: false,
   })),
   button: 0,
   smallBlind: 0,


### PR DESCRIPTION
Closes #253. Branches from and targets `showdown-v2`.

The Player-device half of [ADR-0007](https://github.com/ewanhardingham/table-top-poker/blob/showdown-v2/docs/adr/0007-all-in-as-declared-actions-without-chip-values.md) and [ADR-0008](https://github.com/ewanhardingham/table-top-poker/blob/showdown-v2/docs/adr/0008-showdown-visibility-is-engine-state.md), plus four fixes to the engine and server work those ADRs landed.

## All-in

The Player is the only party who knows their own stack, so the declaration is made on the phone. The Action bar carries **one wide "All in"** until another Seat is all in, at which point it splits into **"All-in call"** and **"All-in raise"** — the fork only means something against chips already committed. Both take a **confirm press**: they are irreversible and self-excluding, the standard the Hole-card fold gesture already sets. Any change in `legalActions` disarms them.

Once all in, the Action bar goes away, an **ALL IN** banner explains where it went, and the Hole cards are **sealed** — still in hand, inert, and still face-down, because an all-in Hand stays private until the table's Reveal. `SEALED` is a second way into the Hole-card lifecycle's `locked`, distinct from `SHOWDOWN_REVEAL`, which turns a sealed pair over when the Reveal lands.

## Showing at Showdown

There is **no separate show control**. Inside the showing window the ordinary reveal gesture *is* the `show`: a committed flip face-up publishes the Hand and locks it face-up. A player who turns their own cards over has, in the room, shown their hand; answering that by keeping the cards private and asking for a second press argues with what they just did.

Three things keep that safe. A *peek* never reaches `Turning`, so it cannot publish. Outside the window `showLegal` is false, so reveal stays as local as it has always been. And opening the window returns the pair **face-down**, so the reveal that publishes is always an act taken with the window already open — that reset is load-bearing, not tidiness.

A phone never shows another Seat's Hole cards. On the table, the **`wins` badge now waits for the cards**: it was derived from `winners` alone, so a winner never compelled to show wore it over two face-down cards.

## Fixes to the engine and server substrate

Found by a review of the branch; each was pre-existing on `showdown-v2`.

- **An all-in Seat could never be evicted, and its claim leaked.** `evictSeat` routed on `!folded`, so an all-in Seat took the fold branch, got the engine's (correct) rejection, and returned without freeing anything — the player was disconnected and told they had left while the seat stayed claimed for the rest of the session. Now routes on `canStillAct`.
- **`legalActions` advertised actions that do nothing.** It knew the street but not the Seats, so it offered `allInCall` with no bet to match and both raises into a table already all in. It now reads `players`.
- **`show` did not require the table's Reveal**, so a Hand could be published out of order with the compulsory set. Now rejects `not-at-showdown`.
- **The Hand picker named nobody** — " wins" during the resting window. Now reads "Waiting on the reveal".

## Docs

`CONTEXT.md` (All in, Hole-card reveal, Showdown show), a refinement note on ADR-0007's `legalActions` consequence, two amendments to ADR-0008 — the reveal-gesture reversal is written up as reversing that ADR's own "separate, explicit button" consequence — and the Hole-card design notes.

## Verification

Full suite (1282), typecheck and lint green locally. Two engine tests that asserted behaviour the fixes correct were rewritten rather than deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nyg8H7osWtxHAYdJ4ceA1A
