### PR TITLE
feat(showdown): show or muck in turn, on a clock

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -301,17 +301,25 @@ left open can never swallow the Board.
 
 **Scrub**:
 The table's replay transport: a timeline the width of the felt, ticked once
-per Replay position and chaptered by Street, draggable to any position.
+per Replay position and chaptered by Segment, draggable to any position.
 Autoplay is a secondary toggle, not the primary mode.
 _Avoid_: Calling it playback — getting to a moment is the point, not
 watching the Hand through.
 
+**Segment**:
+The stretch of a Hand a replay position belongs to: one of the four Streets,
+or Showdown. Showdown is not a Street — no betting round opens there — but it
+is a place a viewer wants to jump to, so the Scrub treats it as one more
+Segment after the River.
+
 **Chapter**:
-A Street's landmark on the Scrub, seeking to the position that Street opens
+A Segment's landmark on the Scrub, seeking to the position that Segment opens
 on. For every Street after preflop that is its `BoardDealt`, not its
 `StreetStarted`: the engine's cascade emits `StreetClosed → BoardDealt →
 StreetStarted`, so anchoring on the Street start lands after the cards
-appeared and the viewer never sees them arrive. Chapters are the navigation
+appeared and the viewer never sees them arrive. Showdown anchors on
+`ShowdownReached`, where the contestants are named. A folded-out Hand reaches
+no Showdown and so offers no such Chapter. Chapters are the navigation
 contract; the per-position ticks beside them are a visual affordance that
 may collapse on an unusually long Hand.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -87,9 +87,8 @@ Turning a Player's own Hole cards persistently face-up on their own Device.
 Local presentation for the whole Hand: it does not change poker visibility or
 server state. The one exception is the Showdown showing window, where the same
 gesture *is* the *Showdown show* and publishes the Hand to the room (#253).
-The window opens the Player's cards face-down for exactly this reason, so the
-reveal that publishes is always a deliberate one. Distinct from the table's
-*Reveal*, which turns the compulsory Hands over for the whole room.
+Every contestant's pair opens the window face-down for exactly this reason, so
+the reveal that publishes is always a deliberate one.
 
 **Hole-card peek**:
 Temporarily lifting a corner of a Player's own Hole cards to read them, closing
@@ -134,7 +133,7 @@ offers one wide "All in" while no Seat has shoved and splits it into
 "All-in call" and "All-in raise" once another Seat is all in, showing whichever
 arms are legal. Both take a confirm press, and once the Seat is all in its
 Action bar goes away and its Hole cards are *sealed* — held, inert, and still
-face-down until the table's Reveal.
+face-down until the showing window opens, which tables them at once.
 _Avoid_: Treating all-in as a folded Seat — an all-in Seat is live, keeps its
 claim on the pot, and is revealed at Showdown. Side pots stay a
 physical-chips problem the humans settle at the table.
@@ -175,8 +174,8 @@ reversal.
 **Showdown**:
 The state where the Hands still live after River closes are ranked, the
 winner(s) declared, and ties reported as splits. Skipped entirely when a Hand
-ends early by fold-out. Reaching it does not publish anything: the Hand rests
-until the table reveals (ADR-0008).
+ends early by fold-out. River close opens the showing window by itself; the
+Hand rests until every contestant has shown or mucked (ADR-0009).
 
 **Contestant**:
 A Seat that reached Showdown, shown or not. Every view names the contestants;
@@ -184,18 +183,45 @@ only a Seat that has shown appears in `results`, so holding a `RevealedResult`
 is proof the cards are public.
 
 **Showdown show**:
-Publishing a contestant's Hole cards to the whole room, irreversibly. Two
-Commands produce it. The table's `reveal` turns over the compulsory set — the
-River's last aggressor plus every all-in Seat, or the winning Seat when that
-set is empty — and publishes the winners. Every other contestant may then
-`show`, in any order, on their own Device, by revealing their Hole cards with
-the ordinary reveal gesture while the window is open — there is no separate
-control. Both are idempotent: a second press changes nothing and is not an
-error. A Seat's verdict is withheld from the table until that Seat's cards are
-public, so `wins` never sits over two face-down cards. The window closes when the table deals
-the next Hand, which mucks whatever was not shown.
+Publishing a contestant's Hole cards to the whole room, irreversibly, with the
+`show` Command. A Player sends it by revealing their Hole cards with the
+ordinary reveal gesture on their own Device — there is no separate control —
+and only on their turn at the head of the *Showing order*. Every all-in
+contestant is shown by the engine as the window opens: their Hands were decided
+streets ago and they have no decision to make. A Seat's verdict is withheld
+from the table until that Seat's cards are public, so `wins` never sits over
+two face-down cards.
 _Avoid_: Confusing a show with *Hole-card reveal*, which stays local to one
 Device and can be undone.
+
+**Muck**:
+Declining to show at Showdown, with the `muck` Command — the same upward
+fold-drag that folds during betting. Mucking forfeits: winners are computed
+over shown Hands only, so a mucked winning Hand takes nothing. Barred while no
+Hand is yet face-up, since a Pot must never be settled with nothing tabled; the
+first Hand face-up discharges that compulsion for everyone left, including a
+Seat holding the best Hand. A mucked Seat is carried separately from an unshown
+one: *declined* and *not shown yet* are different states and the table tells
+them apart.
+_Avoid_: Reading a Muck as a fold — a mucked contestant reached Showdown, and
+its Seat is still in `contestants`.
+
+**Showing order**:
+The queue of contestants owing a show or a muck, head first. Set as the window
+opens: the River's last aggressor first, or the first live Seat left of the
+Button when the River checked through, then clockwise. All-in contestants never
+queue. Only the head may show or muck; anyone else is rejected. The window
+closes when the queue empties, which is when the winners are published and when
+`nextHand` and `startHand` stop being rejected.
+
+**Showdown clock**:
+The per-Room House rule bounding each turn in the *Showing order*, in seconds
+and defaulting to 30. Unlike the *Shot clock* it cannot be turned off: with
+showing ordered, one locked phone blocks every Player behind it. It reuses the
+Shot clock's scheduler and `turnEndsAt`. Expiry mucks the head — or shows them
+where they are compelled, which is the one place cards are turned over on a
+Player's behalf. The engine holds no clock: an expiry is an ordinary Command the
+server issues, so it lands in the recording and replays as an ordinary act.
 
 **Pot**:
 The physical chips in the middle of the table — a spoken/table term only.
@@ -363,13 +389,12 @@ Seats dealt in, which folding never reduces.
    RIVER (a Street)      — 1 board card dealt, betting round
         │ street closes (last-aggressor logic)
         ▼
-   SHOWDOWN               — contestants named, nothing published;
-        │                   the table's Reveal turns over the
-        │                   compulsory Hands and declares winners
+   SHOWDOWN               — contestants named, all-in Hands tabled,
+        │                   the rest queued to show or muck in turn
         ▼
-   HAND_COMPLETE           — shown hands rest on the table while any
-        │                    other contestant may still show; a
-        │                    "Next hand" button appears
+   HAND_COMPLETE           — the showing window runs on a clock; winners
+        │                    are published once the queue empties, and
+        │                    only then does "Next hand" appear
         ▼
 [Room: seated, awaiting hand]  (button rotates)
 ```

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -321,6 +321,8 @@ the live "To act" pill uses. Folded back out of the Event stream: the table
 view's Seats carry only `folded`, so the view at a position cannot supply
 them. Cleared at each new Street, on the same boundary a Chapter anchors to —
 once the Turn is out, "Seat 4 called" is about a Street nobody is looking at.
+Cleared again when the betting ends, at Showdown or a fold-out: the reveals
+and the verdict are what the felt is saying then.
 Raise is orange rather than accent red, which belongs to the clock, and Call
 is the one cool fill on an otherwise warm felt.
 _Avoid_: Showing one beside a "To act" pill. They share a slot, and the

--- a/docs/adr/0008-showdown-visibility-is-engine-state.md
+++ b/docs/adr/0008-showdown-visibility-is-engine-state.md
@@ -2,7 +2,15 @@
 
 ## Status
 
-Accepted. Depends on [ADR-0007](0007-all-in-as-declared-actions-without-chip-values.md)
+Superseded by [ADR-0009](0009-showing-in-turn-on-a-clock.md), which replaces
+the Decision section below: the window now opens at river close rather than on
+a table press, the `reveal` command is deleted, showing happens in queue order
+against a clock, and a contestant may muck. What stands is this ADR's thesis —
+that showdown visibility is engine state — and the reasoning in its Context for
+why. The text is left otherwise intact as the record of that, and of the
+`ShowdownOverlay`'s removal in #258.
+
+Previously: accepted. Depends on [ADR-0007](0007-all-in-as-declared-actions-without-chip-values.md)
 for the all-in actions this decision compels to show. The rank badge in
 "Showdown happens on the table, not over it" was dropped while building it, the
 player's separate show button was dropped in favour of the reveal gesture, the

--- a/docs/adr/0009-showing-in-turn-on-a-clock.md
+++ b/docs/adr/0009-showing-in-turn-on-a-clock.md
@@ -1,0 +1,108 @@
+# 0009 — Showing at showdown happens in turn, on a clock
+
+## Status
+
+Accepted. Supersedes the Decision section of
+[ADR-0008](0008-showdown-visibility-is-engine-state.md), whose thesis — that
+showdown visibility is engine state — this decision keeps and builds on.
+Depends on [ADR-0007](0007-all-in-as-declared-actions-without-chip-values.md)
+for the all-in actions it tables at the window's opening.
+
+## Context
+
+ADR-0008 made showing engine state, but modelled the act as a table press: the
+table's `reveal` turned over a compulsory set and published the winners, after
+which any contestant could `show`, in any order, for as long as the room left
+the hand up. That is not what a room does. A real showdown rests, and each
+contestant in turn either tables their cards or mucks them; nobody at the table
+presses anything to start it.
+
+Three things followed from the press. Nobody could muck, so a losing hand had
+no way to decline — the concept did not exist in the engine at all. Order did
+not exist either, so the room had no answer to "whose turn is it", and the
+device could not tell a player when to act. And the compulsory set was computed
+at the press, which made the winning seat compelled where the river checked
+through: the table would announce, before any card was turned, which seat held
+the best hand.
+
+The `reveal` press also had nothing left to do. Its two jobs — opening the
+window and publishing the winners — both belong to the hand's own progress:
+river close is the opening, and the queue emptying is the publication.
+
+## Decision
+
+**The window opens by itself, and the `reveal` command is deleted.** River close
+opens it. Every contestant's hole-card pair resets face-down as it opens, so the
+flip that publishes (ADR-0008's amendment for #253) is always a deliberate act
+taken with the window already open.
+
+**All-in contestants are tabled by the engine at that instant.** Their hands
+were decided streets ago and they have no decision to make. Every other
+contestant enters a queue, ordered: the river's last aggressor first; if the
+river checked through and there is no aggressor, the first live seat left of the
+button; then clockwise. If every contestant is all-in the queue is empty at the
+opening and the winners publish immediately.
+
+**Two acts, gated to the head of the queue.** A committed peel face-up is the
+`show`. The same upward fold-drag that folds during betting is the new `muck`.
+Anything from any other seat is rejected. The bend-to-peek stays live for every
+contestant throughout: the wait before your turn is exactly when someone wants a
+last look at what they are about to muck.
+
+**Compulsion is a property of the window, not of a seat.** Until some hand is
+face-up, the head of the queue cannot muck. The first hand face-up discharges
+it, and every remaining contestant may then muck freely — including one holding
+the winning hand who has misread the board. This is the departure from ADR-0008
+noted above: the compelled seat is the first-to-act left of the button, never
+the winning seat.
+
+**Winners are the best shown hand.** Mucking forfeits, full stop. Winners are
+computed over `results` only, and published only once every contestant has
+shown or mucked. `nextHand` and `startHand` are rejected while the queue is
+unresolved, in the engine rather than by greying out a control, because
+ADR-0008's thesis is that showdown visibility is engine state.
+
+**The window runs on a clock, and the engine keeps no notion of time.** A new
+per-room house rule sits beside the shot clock: seconds configurable, default
+30, and `enabled` fixed true. The clock is load-bearing, not a preference — with
+ordering enforced, one locked phone blocks every player behind it, and eviction
+does not reach a complete hand. A house rule whose "off" position can wedge the
+room is a bug with a toggle. It reuses the action clock's scheduler, its
+`turnEndsAt` broadcast, and the shot-clock component. Expiry is the server
+issuing an ordinary command, which lands in the recording and re-runs under
+Replay as an ordinary act: it mucks the head of the queue, unless they are
+compelled, in which case it shows them. That is the one place cards are turned
+over on a player's behalf, and it is the place a pot would otherwise be settled
+with nothing tabled.
+
+## Consequences
+
+- `ShowdownCompleteHandState` gains `queue` and `mucked`; the views carry both,
+  so "not shown yet" and "declined" are distinct states the table can tell
+  apart. `HandEvent` gains `HoleCardsMucked`, `RejectionReason` gains
+  `showdown-unresolved`, and `ENGINE_LOG_VERSION` moves to 6. Fixtures are
+  regenerated.
+- A bot in the queue would wedge the room, so it resolves on its turn after the
+  usual bot action delay — not instantly, which would make the queue jump in a
+  way the room cannot follow — showing if compelled, otherwise rolling show or
+  muck weighted heavily toward showing.
+- The player's device carries a persistent turn prompt, *"Show your hand, or drag
+  up to muck"*, or *"Show your hand"* with no muck line when compelled: offering
+  an option that will be rejected is worse than not offering it. This is not the
+  `coaching.ts` one-shot teaching system; an experienced player still needs to
+  be told whose turn it is.
+- The table reuses the betting turn's active-seat treatment for the head of the
+  queue rather than inventing a showdown-only highlight. The clock shows as a
+  ring on the player's own cards, where the person about to lose their hand is
+  looking, and only in its closing seconds on the table's active seat plate, so
+  the room gets the "clock's running" beat without a permanent timer on screen.
+- A muck reuses the existing fly-to-muck animation and the existing fold sound;
+  a show reuses the card-flip sound. No new cues — showdown is tense because the
+  room is silent and waiting.
+- A muck is its own Replay beat, captioned "Seat N mucks". An auto-muck from
+  clock expiry is captioned identically: the recording says what occurred at the
+  table, not why, and "timed out" is a fact about the room rather than about the
+  hand.
+- If an untimed showdown is ever wanted, it arrives together with an extension
+  of eviction into the showdown window as the manual out — not as an "off"
+  position on this house rule.

--- a/docs/design/holecards.md
+++ b/docs/design/holecards.md
@@ -57,17 +57,24 @@ no simulated pointer.
   - `SHOWDOWN_REVEAL` — showdown reached with this seat still live (story 48):
     inert and face-**up**.
   - `SEALED` — the seat declared all in (issue #253): inert and face-**down**,
-    because an all-in Hand is still private until the table's Reveal. It clears
-    the fold gesture with it, which is the point: an all-in Seat cannot fold.
+    because an all-in Hand is still private until the showing window opens. It
+    clears the fold gesture with it, which is the point: an all-in Seat cannot
+    fold.
 
 `revealPublishes(from, to, showLegal)` is the other predicate the hook reads off
 the lifecycle, alongside `releaseCommitsFold`. Inside the Showdown showing
 window a committed flip face-up **is** the `show` (ADR-0008's #253 amendment):
-entering `Turning` publishes the Hand. A peek does not — it never reaches
-`Turning` — and neither does a pair already face-up when the window opened,
-because `showLegal` rising emits `RESET` and puts it face-down first. That reset
-is the whole safeguard against publishing by accident, so it is load-bearing,
-not tidiness.
+entering `Turning` publishes the Hand, and only on this Seat's turn at the head
+of the queue (ADR-0009). A peek does not — it never reaches `Turning` — and
+neither does a pair already face-up when the window opened, because
+`showdownOpen` rising emits `RESET` for every contestant and puts it face-down
+first. That reset is the whole safeguard against publishing by accident, so it
+is load-bearing, not tidiness.
+
+`muckLegal` arms the same upward drag that folds during betting, and
+`planFinish` sends `muck` in place of `fold` when only it is legal. The two are
+never both legal — betting and Showdown do not overlap — so a single armed drag
+has exactly one meaning at any moment.
 
 `CardState`/`CardEvent` are intentionally **complete**: every event name the
 phase needs is declared even where an arm does not yet answer it, so later
@@ -215,7 +222,7 @@ The order encodes the two sequences that cost money:
   the `fold` send, so the pair is already flying to the muck when the Action
   goes and the departure is the player's own answer, not the server's (§7).
 
-Legality (`foldLegal`/`checkLegal`/`pending`) is for **arming and rendering
+Legality (`foldLegal`/`checkLegal`/`muckLegal`/`pending`) is for **arming and rendering
 only**. `canAct` inside `intent.fold`/`intent.check` stays the single gate on
 whether an Action is sent, so a stale flag can at worst arm a gesture `canAct`
 then refuses — never send one. `planFinish` re-samples fold legality (and

--- a/packages/engine/src/all-in.test.ts
+++ b/packages/engine/src/all-in.test.ts
@@ -176,6 +176,8 @@ describe("all-in and the automatic run-out", () => {
       "BoardDealt",
       "BoardDealt",
       "ShowdownReached",
+      "HoleCardsShown",
+      "HoleCardsShown",
       "HandComplete",
     ]);
   });
@@ -192,6 +194,8 @@ describe("all-in and the automatic run-out", () => {
     );
 
     const final = showdown(playAll(state, [{ type: "allInCall", seatId: 1 }]));
+    expect(final.queue).toEqual([]);
+    expect(final.winners).not.toBeNull();
     expect(final.board).toHaveLength(5);
     expect(final.contestants.map((contestant) => contestant.seatId)).toEqual([
       1, 0,
@@ -248,6 +252,7 @@ describe("all-in and fold-out", () => {
       "StreetClosed",
       "BoardDealt",
       "ShowdownReached",
+      "HoleCardsShown",
       "HandComplete",
     ]);
 

--- a/packages/engine/src/apply.ts
+++ b/packages/engine/src/apply.ts
@@ -7,6 +7,7 @@ import {
   reopensBetting,
   requeueAfterRaise,
   rotateFromButton,
+  showingOrder,
   smallBlindSeat,
 } from "./table.js";
 import type {
@@ -180,6 +181,8 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
           contestants,
           lastAggressor: hand.lastAggressor,
           results: [],
+          queue: showingOrder(hand.ring, contestants, hand.lastAggressor),
+          mucked: [],
           winners: null,
         },
       };
@@ -192,7 +195,24 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
       }
       return {
         ...state,
-        hand: { ...hand, results: [...hand.results, event.result] },
+        hand: {
+          ...hand,
+          results: [...hand.results, event.result],
+          queue: hand.queue.filter((seat) => seat !== event.result.seatId),
+        },
+      };
+    }
+
+    case "HoleCardsMucked": {
+      const hand = asAwaitingShowdown(state);
+      if (hand.mucked.includes(event.seatId)) return state;
+      return {
+        ...state,
+        hand: {
+          ...hand,
+          mucked: [...hand.mucked, event.seatId],
+          queue: hand.queue.filter((seat) => seat !== event.seatId),
+        },
       };
     }
 

--- a/packages/engine/src/decide.ts
+++ b/packages/engine/src/decide.ts
@@ -54,6 +54,9 @@ export function decide(
       if (state.hand?.status !== "complete") {
         return reject("stale-next-hand", command);
       }
+      if (awaitingShowdown(state)?.winners === null) {
+        return reject("showdown-unresolved", command);
+      }
       return beginHand(state, command.seed);
     }
 
@@ -68,11 +71,11 @@ export function decide(
     case "evict":
       return decideEviction(state, command);
 
-    case "reveal":
-      return decideReveal(state, command);
-
     case "show":
       return decideShow(state, command);
+
+    case "muck":
+      return decideMuck(state, command);
   }
 }
 
@@ -85,60 +88,59 @@ function awaitingShowdown(
 }
 
 /**
- * The river's last aggressor and every all-in Seat, or the winning Seat when
- * that set is empty — see ADR-0008.
+ * The showing window's gate: only its head may act, and only while it is open
+ * — see ADR-0009.
  */
-function compelledToShow(
-  hand: ShowdownCompleteHandState,
-  results: readonly RevealedResult[],
-): readonly SeatId[] {
-  const compelled = hand.contestants
-    .filter(
-      (contestant) =>
-        contestant.allIn || contestant.seatId === hand.lastAggressor,
-    )
-    .map((contestant) => contestant.seatId);
-  return compelled.length > 0 ? compelled : winnersOf(results);
+function headOfQueue(
+  state: EngineState,
+  command: Extract<Command, { type: "show" | "muck" }>,
+): ShowdownCompleteHandState | Rejection {
+  const hand = awaitingShowdown(state);
+  const head = hand?.winners === null ? hand.queue[0] : undefined;
+  if (hand === null || head === undefined) {
+    return reject("not-at-showdown", command);
+  }
+  if (head !== command.seatId) return reject("not-your-turn", command);
+  return hand;
 }
 
-function decideReveal(
-  state: EngineState,
-  command: Extract<Command, { type: "reveal" }>,
-): HandEvent[] | Rejection {
-  const hand = awaitingShowdown(state);
-  if (hand === null) return reject("not-at-showdown", command);
-  if (hand.winners !== null) return [];
-
-  const results = hand.contestants.map((contestant) =>
-    revealedResultFor(hand.board, contestant),
-  );
-  const compelled = new Set(compelledToShow(hand, results));
-  const shows: HandEvent[] = results
-    .filter((result) => compelled.has(result.seatId))
-    .map((result) => ({ type: "HoleCardsShown", result }));
-
-  return [...shows, { type: "WinnersDeclared", winners: winnersOf(results) }];
+/** The last contestant to resolve publishes the winners over the shown hands. */
+function closingWinners(
+  hand: ShowdownCompleteHandState,
+  shown: RevealedResult | null,
+): HandEvent[] {
+  if (hand.queue.length > 1) return [];
+  const results = shown === null ? hand.results : [...hand.results, shown];
+  return [{ type: "WinnersDeclared", winners: winnersOf(results) }];
 }
 
 function decideShow(
   state: EngineState,
   command: Extract<Command, { type: "show" }>,
 ): HandEvent[] | Rejection {
-  const hand = awaitingShowdown(state);
-  if (hand === null) return reject("not-at-showdown", command);
-  if (hand.winners === null) return reject("not-at-showdown", command);
+  const hand = headOfQueue(state, command);
+  if ("type" in hand) return hand;
 
-  const contestant = hand.contestants.find(
-    (candidate) => candidate.seatId === command.seatId,
+  const contestant = must(
+    hand.contestants.find((candidate) => candidate.seatId === command.seatId),
+    "the head of the showing queue is always a contestant",
   );
-  if (contestant === undefined) return reject("not-at-showdown", command);
-  if (hand.results.some((shown) => shown.seatId === command.seatId)) return [];
+  const result = revealedResultFor(hand.board, contestant);
+  return [{ type: "HoleCardsShown", result }, ...closingWinners(hand, result)];
+}
+
+/** Mucking is barred until some hand is face-up: see Compulsion in ADR-0009. */
+function decideMuck(
+  state: EngineState,
+  command: Extract<Command, { type: "muck" }>,
+): HandEvent[] | Rejection {
+  const hand = headOfQueue(state, command);
+  if ("type" in hand) return hand;
+  if (hand.results.length === 0) return reject("action-not-legal", command);
 
   return [
-    {
-      type: "HoleCardsShown",
-      result: revealedResultFor(hand.board, contestant),
-    },
+    { type: "HoleCardsMucked", seatId: command.seatId },
+    ...closingWinners(hand, null),
   ];
 }
 
@@ -336,6 +338,7 @@ function runOut(
   return finishAtShowdown(current, events);
 }
 
+/** The window opens with every all-in contestant already tabled — ADR-0009. */
 function finishAtShowdown(
   scratch: EngineState,
   events: HandEvent[],
@@ -345,9 +348,34 @@ function finishAtShowdown(
     contestants: liveSeats(asBetting(scratch)),
   };
   events.push(showdownReached);
-  const afterShowdown = apply(scratch, showdownReached);
+  let current = apply(scratch, showdownReached);
+
+  const opened = asShowdown(current);
+  for (const contestant of opened.contestants.filter((c) => c.allIn)) {
+    const shown: HandEvent = {
+      type: "HoleCardsShown",
+      result: revealedResultFor(opened.board, contestant),
+    };
+    events.push(shown);
+    current = apply(current, shown);
+  }
+
+  const settled = asShowdown(current);
+  if (settled.queue.length === 0) {
+    const declared: HandEvent = {
+      type: "WinnersDeclared",
+      winners: winnersOf(settled.results),
+    };
+    events.push(declared);
+    current = apply(current, declared);
+  }
+
   const handComplete: HandEvent = { type: "HandComplete" };
   events.push(handComplete);
-  apply(afterShowdown, handComplete);
+  apply(current, handComplete);
   return events;
+}
+
+function asShowdown(state: EngineState): ShowdownCompleteHandState {
+  return must(awaitingShowdown(state), "expected a hand at showdown");
 }

--- a/packages/engine/src/decide.ts
+++ b/packages/engine/src/decide.ts
@@ -44,6 +44,9 @@ export function decide(
 ): HandEvent[] | Rejection {
   switch (command.type) {
     case "startHand": {
+      if (awaitingShowdown(state)?.winners === null) {
+        return reject("showdown-unresolved", command);
+      }
       if (state.hand !== null) {
         return reject("hand-already-in-progress", command);
       }
@@ -51,11 +54,11 @@ export function decide(
     }
 
     case "nextHand": {
-      if (state.hand?.status !== "complete") {
-        return reject("stale-next-hand", command);
-      }
       if (awaitingShowdown(state)?.winners === null) {
         return reject("showdown-unresolved", command);
+      }
+      if (state.hand?.status !== "complete") {
+        return reject("stale-next-hand", command);
       }
       return beginHand(state, command.seed);
     }
@@ -87,10 +90,7 @@ function awaitingShowdown(
   return hand;
 }
 
-/**
- * The showing window's gate: only its head may act, and only while it is open
- * — see ADR-0009.
- */
+/** The showing window's gate — see Showing order in `CONTEXT.md`. */
 function headOfQueue(
   state: EngineState,
   command: Extract<Command, { type: "show" | "muck" }>,
@@ -129,7 +129,6 @@ function decideShow(
   return [{ type: "HoleCardsShown", result }, ...closingWinners(hand, result)];
 }
 
-/** Mucking is barred until some hand is face-up: see Compulsion in ADR-0009. */
 function decideMuck(
   state: EngineState,
   command: Extract<Command, { type: "muck" }>,
@@ -338,7 +337,6 @@ function runOut(
   return finishAtShowdown(current, events);
 }
 
-/** The window opens with every all-in contestant already tabled — ADR-0009. */
 function finishAtShowdown(
   scratch: EngineState,
   events: HandEvent[],

--- a/packages/engine/src/showdown.test.ts
+++ b/packages/engine/src/showdown.test.ts
@@ -4,6 +4,7 @@ import { decide } from "./decide.js";
 import { createInitialState } from "./room.js";
 import { play, playAll } from "./test-utils.js";
 import type { Command, EngineState, HandEvent, SeatId } from "./types.js";
+import { must } from "./util.js";
 import { view } from "./view.js";
 
 function playAndCollect(state: EngineState, commands: Command[]): HandEvent[] {
@@ -39,6 +40,12 @@ const raisedOnTheRiver: Command[] = [
   { type: "call", seatId: 1 },
 ];
 
+const bothAllInPreflop: Command[] = [
+  { type: "call", seatId: 0 },
+  { type: "allInRaise", seatId: 1 },
+  { type: "allInCall", seatId: 0 },
+];
+
 function headsUpAt(commands: Command[], seed = "s0"): EngineState {
   return playAll(createInitialState([0, 1]), [
     { type: "startHand", seatId: 0, seed },
@@ -52,10 +59,6 @@ function showdownState(state: EngineState) {
     throw new Error("expected a hand at showdown");
   }
   return hand;
-}
-
-function reveal(state: EngineState): EngineState {
-  return playAll(state, [{ type: "reveal", seatId: 0 }]);
 }
 
 function shownSeats(state: EngineState): SeatId[] {
@@ -102,7 +105,7 @@ describe("ShowdownReached", () => {
   });
 });
 
-describe("the hand rests before it resolves", () => {
+describe("the window opens at river close", () => {
   it("carries no hole cards, results or winners in any view", () => {
     const state = headsUpAt(checkedThroughToRiver);
 
@@ -110,144 +113,224 @@ describe("the hand rests before it resolves", () => {
     if (table.phase !== "showdown") throw new Error("expected showdown");
     expect(table.contestants).toEqual([1, 0]);
     expect(table.results).toEqual([]);
+    expect(table.mucked).toEqual([]);
     expect(table.winners).toBeNull();
     expect(JSON.stringify(table)).not.toContain("holeCards");
   });
 
-  it("still tells a player their own hand and that they may show", () => {
-    const player = view(headsUpAt(checkedThroughToRiver), 0);
-    if (player.phase !== "showdown") throw new Error("expected showdown");
-    expect(player.yourResult?.holeCards).toHaveLength(2);
-    expect(player.canShow).toBe(true);
+  it("queues the river's last aggressor first, then clockwise", () => {
+    expect(showdownState(headsUpAt(raisedOnTheRiver)).queue).toEqual([0, 1]);
   });
-});
 
-describe("reveal turns over exactly the compulsory set", () => {
-  it("compels the river's last aggressor", () => {
-    const state = reveal(headsUpAt(raisedOnTheRiver));
-    expect(shownSeats(state)).toEqual([0]);
-    expect(showdownState(state).winners).not.toBeNull();
+  it("queues from the first live seat left of the button with no aggressor", () => {
+    expect(showdownState(headsUpAt(checkedThroughToRiver)).queue).toEqual([
+      1, 0,
+    ]);
   });
 
   it("forgets an aggressor from an earlier street", () => {
-    const state = reveal(
-      headsUpAt([
-        { type: "call", seatId: 0 },
-        { type: "check", seatId: 1 },
-        { type: "check", seatId: 1 },
-        { type: "raise", seatId: 0 },
-        { type: "call", seatId: 1 },
-        { type: "check", seatId: 1 },
-        { type: "check", seatId: 0 },
-        { type: "check", seatId: 1 },
-        { type: "check", seatId: 0 },
-      ]),
-    );
-    expect(shownSeats(state)).toEqual(showdownState(state).winners);
+    const state = headsUpAt([
+      { type: "call", seatId: 0 },
+      { type: "check", seatId: 1 },
+      { type: "check", seatId: 1 },
+      { type: "raise", seatId: 0 },
+      { type: "call", seatId: 1 },
+      { type: "check", seatId: 1 },
+      { type: "check", seatId: 0 },
+      { type: "check", seatId: 1 },
+      { type: "check", seatId: 0 },
+    ]);
+    expect(showdownState(state).queue).toEqual([1, 0]);
   });
 
-  it("compels the winning seat when the river was checked through", () => {
-    const state = reveal(headsUpAt(checkedThroughToRiver));
-    const hand = showdownState(state);
-    expect(hand.winners).not.toBeNull();
-    expect(shownSeats(state)).toEqual(hand.winners);
+  it("tells a player it is their turn, and that they cannot yet muck", () => {
+    const player = view(headsUpAt(raisedOnTheRiver), 0);
+    if (player.phase !== "showdown") throw new Error("expected showdown");
+    expect(player.yourResult?.holeCards).toHaveLength(2);
+    expect(player.canShow).toBe(true);
+    expect(player.canMuck).toBe(false);
   });
 
-  it("compels every all-in seat", () => {
-    const state = reveal(
-      headsUpAt([
-        { type: "call", seatId: 0 },
-        { type: "allInRaise", seatId: 1 },
-        { type: "call", seatId: 0 },
-      ]),
-    );
-    expect(shownSeats(state)).toContain(1);
-  });
-
-  it("publishes winners over every contestant, shown or not", () => {
-    const state = reveal(headsUpAt(raisedOnTheRiver));
-    const hand = showdownState(state);
-    const ranked = [...hand.contestants].map((contestant) => contestant.seatId);
-    expect(hand.winners?.every((seat) => ranked.includes(seat))).toBe(true);
-  });
-
-  it("is an idempotent no-op when pressed again", () => {
-    const revealed = reveal(headsUpAt(raisedOnTheRiver));
-    const outcome = play(revealed, { type: "reveal", seatId: 0 });
-    if ("rejection" in outcome) throw new Error("expected a no-op");
-    expect(outcome.events).toEqual([]);
-  });
-
-  it("is rejected before the river closes", () => {
-    const state = headsUpAt([{ type: "call", seatId: 0 }]);
-    const outcome = play(state, { type: "reveal", seatId: 0 });
-    if (!("rejection" in outcome)) throw new Error("expected a rejection");
-    expect(outcome.rejection.reason).toBe("not-at-showdown");
+  it("leaves a contestant behind the head unable to act", () => {
+    const player = view(headsUpAt(raisedOnTheRiver), 1);
+    if (player.phase !== "showdown") throw new Error("expected showdown");
+    expect(player.canShow).toBe(false);
+    expect(player.canMuck).toBe(false);
   });
 });
 
-describe("show", () => {
-  it("lets any other contestant turn over, in any order", () => {
-    const revealed = reveal(headsUpAt(raisedOnTheRiver));
-    expect(shownSeats(revealed)).toEqual([0]);
-    const shown = playAll(revealed, [{ type: "show", seatId: 1 }]);
-    expect(shownSeats(shown)).toEqual([0, 1]);
+describe("all-in contestants are tabled as the window opens", () => {
+  it("shows them without queueing them, and publishes winners at once", () => {
+    const state = headsUpAt(bothAllInPreflop);
+    const hand = showdownState(state);
+    expect(hand.queue).toEqual([]);
+    expect([...shownSeats(state)].sort()).toEqual([0, 1]);
+    expect(hand.winners).not.toBeNull();
   });
 
-  it("cannot conceal a hand once shown", () => {
-    const shown = playAll(reveal(headsUpAt(raisedOnTheRiver)), [
-      { type: "show", seatId: 1 },
-    ]);
-    const outcome = play(shown, { type: "show", seatId: 1 });
-    if ("rejection" in outcome) throw new Error("expected a no-op");
-    expect(outcome.events).toEqual([]);
-    expect(shownSeats(shown)).toEqual([0, 1]);
-  });
-
-  it("is rejected from a seat that folded", () => {
+  it("frees the rest to muck when the last aggressor was all-in", () => {
     const state = playAll(createInitialState([0, 1, 2]), [
       { type: "startHand", seatId: 0, seed: "seed-1" },
       { type: "call", seatId: 0 },
       { type: "call", seatId: 1 },
-      { type: "raise", seatId: 2 },
-      { type: "call", seatId: 0 },
-      { type: "call", seatId: 1 },
+      { type: "check", seatId: 2 },
       { type: "check", seatId: 1 },
       { type: "check", seatId: 2 },
       { type: "check", seatId: 0 },
-      { type: "fold", seatId: 1 },
+      { type: "check", seatId: 1 },
       { type: "check", seatId: 2 },
       { type: "check", seatId: 0 },
-      { type: "check", seatId: 2 },
-      { type: "raise", seatId: 0 },
-      { type: "call", seatId: 2 },
+      { type: "check", seatId: 1 },
+      { type: "allInRaise", seatId: 2 },
+      { type: "call", seatId: 0 },
+      { type: "call", seatId: 1 },
     ]);
-    const outcome = play(state, { type: "show", seatId: 1 });
+    const hand = showdownState(state);
+    expect(shownSeats(state)).toEqual([2]);
+    expect(hand.queue).not.toContain(2);
+    const player = view(state, must(hand.queue[0]));
+    if (player.phase !== "showdown") throw new Error("expected showdown");
+    expect(player.canMuck).toBe(true);
+  });
+});
+
+describe("show", () => {
+  it("publishes the head's hand and passes the turn on", () => {
+    const shown = playAll(headsUpAt(raisedOnTheRiver), [
+      { type: "show", seatId: 0 },
+    ]);
+    expect(shownSeats(shown)).toEqual([0]);
+    expect(showdownState(shown).queue).toEqual([1]);
+    expect(showdownState(shown).winners).toBeNull();
+  });
+
+  it("declares winners once the last contestant resolves", () => {
+    const shown = playAll(headsUpAt(raisedOnTheRiver), [
+      { type: "show", seatId: 0 },
+      { type: "show", seatId: 1 },
+    ]);
+    const hand = showdownState(shown);
+    expect(shownSeats(shown)).toEqual([0, 1]);
+    expect(hand.winners).not.toBeNull();
+  });
+
+  it("is rejected from a seat that is not the head of the queue", () => {
+    const outcome = play(headsUpAt(raisedOnTheRiver), {
+      type: "show",
+      seatId: 1,
+    });
+    if (!("rejection" in outcome)) throw new Error("expected a rejection");
+    expect(outcome.rejection.reason).toBe("not-your-turn");
+  });
+
+  it("is rejected from a seat that folded", () => {
+    const outcome = play(headsUpAt(raisedOnTheRiver), {
+      type: "show",
+      seatId: 2,
+    });
+    if (!("rejection" in outcome)) throw new Error("expected a rejection");
+    expect(outcome.rejection.reason).toBe("not-your-turn");
+  });
+
+  it("is rejected before the river closes", () => {
+    const outcome = play(headsUpAt([{ type: "call", seatId: 0 }]), {
+      type: "show",
+      seatId: 0,
+    });
     if (!("rejection" in outcome)) throw new Error("expected a rejection");
     expect(outcome.rejection.reason).toBe("not-at-showdown");
   });
 
-  it("is rejected before the table has revealed — the hand rests first", () => {
-    const resting = headsUpAt(raisedOnTheRiver);
-    const outcome = play(resting, { type: "show", seatId: 1 });
+  it("is rejected once the window has closed", () => {
+    const closed = playAll(headsUpAt(raisedOnTheRiver), [
+      { type: "show", seatId: 0 },
+      { type: "show", seatId: 1 },
+    ]);
+    const outcome = play(closed, { type: "show", seatId: 1 });
     if (!("rejection" in outcome)) throw new Error("expected a rejection");
     expect(outcome.rejection.reason).toBe("not-at-showdown");
-    expect(shownSeats(resting)).toEqual([]);
+  });
+});
+
+describe("muck", () => {
+  it("is refused from the head while no hand is face-up", () => {
+    const outcome = play(headsUpAt(raisedOnTheRiver), {
+      type: "muck",
+      seatId: 0,
+    });
+    if (!("rejection" in outcome)) throw new Error("expected a rejection");
+    expect(outcome.rejection.reason).toBe("action-not-legal");
   });
 
-  it("is rejected once the hand has closed", () => {
-    const next = playAll(reveal(headsUpAt(raisedOnTheRiver)), [
+  it("is allowed once the first hand is face-up, and forfeits the pot", () => {
+    const shown = playAll(headsUpAt(raisedOnTheRiver), [
+      { type: "show", seatId: 0 },
+    ]);
+    const mucked = playAll(shown, [{ type: "muck", seatId: 1 }]);
+    const hand = showdownState(mucked);
+    expect(hand.mucked).toEqual([1]);
+    expect(hand.queue).toEqual([]);
+    expect(hand.winners).toEqual([0]);
+  });
+
+  it("is rejected from a seat that is not the head of the queue", () => {
+    const shown = playAll(headsUpAt(checkedThroughToRiver), [
+      { type: "show", seatId: 1 },
+    ]);
+    const outcome = play(shown, { type: "muck", seatId: 1 });
+    if (!("rejection" in outcome)) throw new Error("expected a rejection");
+    expect(outcome.rejection.reason).toBe("not-your-turn");
+  });
+
+  it("takes a mucked hand out of the player's own view", () => {
+    const mucked = playAll(headsUpAt(raisedOnTheRiver), [
+      { type: "show", seatId: 0 },
+      { type: "muck", seatId: 1 },
+    ]);
+    const player = view(mucked, 1);
+    if (player.phase !== "showdown") throw new Error("expected showdown");
+    expect(player.yourResult).toBeNull();
+    expect(player.mucked).toEqual([1]);
+  });
+});
+
+describe("winners are the best shown hand", () => {
+  it("hands the pot to a losing hand that tabled when the best hand mucked", () => {
+    const shown = playAll(headsUpAt(checkedThroughToRiver), [
+      { type: "show", seatId: 1 },
+    ]);
+    const only = shownSeats(shown);
+    const closed = playAll(shown, [{ type: "muck", seatId: 0 }]);
+    expect(showdownState(closed).winners).toEqual(only);
+  });
+});
+
+describe("the window holds the next hand", () => {
+  it("rejects nextHand while the queue is unresolved", () => {
+    const outcome = play(headsUpAt(raisedOnTheRiver), {
+      type: "nextHand",
+      seatId: 0,
+      seed: "s1",
+    });
+    if (!("rejection" in outcome)) throw new Error("expected a rejection");
+    expect(outcome.rejection.reason).toBe("showdown-unresolved");
+  });
+
+  it("deals once every contestant has shown or mucked", () => {
+    const closed = playAll(headsUpAt(raisedOnTheRiver), [
+      { type: "show", seatId: 0 },
+      { type: "muck", seatId: 1 },
       { type: "nextHand", seatId: 0, seed: "s1" },
     ]);
-    const outcome = play(next, { type: "show", seatId: 1 });
-    if (!("rejection" in outcome)) throw new Error("expected a rejection");
-    expect(outcome.rejection.reason).toBe("not-at-showdown");
+    expect(closed.hand?.status).toBe("betting");
   });
 });
 
 describe("an unshown seat leaks nothing derived from its cards", () => {
   it("appears in contestants and nowhere else, for the table or a rival", () => {
-    const state = reveal(headsUpAt(raisedOnTheRiver));
+    const state = playAll(headsUpAt(raisedOnTheRiver), [
+      { type: "show", seatId: 0 },
+    ]);
     const concealed = showdownState(state).contestants.find(
       (contestant) => !shownSeats(state).includes(contestant.seatId),
     );
@@ -266,23 +349,13 @@ describe("an unshown seat leaks nothing derived from its cards", () => {
   });
 });
 
-describe("the next hand closes the window", () => {
-  it("mucks whatever was not shown", () => {
-    const next = playAll(reveal(headsUpAt(raisedOnTheRiver)), [
-      { type: "nextHand", seatId: 0, seed: "s1" },
-    ]);
-    expect(next.hand?.status).toBe("betting");
-    const table = view(next, "table");
-    expect(table.phase).toBe("betting");
-  });
-});
-
 describe("replay reproduces exactly who showed", () => {
-  it("keeps a concealed hand concealed when the events are folded again", () => {
+  it("keeps a mucked hand mucked when the events are folded again", () => {
     const commands: Command[] = [
       { type: "startHand", seatId: 0, seed: "s0" },
       ...raisedOnTheRiver,
-      { type: "reveal", seatId: 0 },
+      { type: "show", seatId: 0 },
+      { type: "muck", seatId: 1 },
     ];
     const events = playAndCollect(createInitialState([0, 1]), commands);
 
@@ -290,6 +363,7 @@ describe("replay reproduces exactly who showed", () => {
     for (const event of events) replayed = apply(replayed, event);
 
     expect(shownSeats(replayed)).toEqual([0]);
+    expect(showdownState(replayed).mucked).toEqual([1]);
     expect(showdownState(replayed).winners).toEqual(
       showdownState(playAll(createInitialState([0, 1]), commands)).winners,
     );

--- a/packages/engine/src/showdown.test.ts
+++ b/packages/engine/src/showdown.test.ts
@@ -316,6 +316,16 @@ describe("the window holds the next hand", () => {
     expect(outcome.rejection.reason).toBe("showdown-unresolved");
   });
 
+  it("rejects startHand with the same reason the table surfaces", () => {
+    const outcome = play(headsUpAt(raisedOnTheRiver), {
+      type: "startHand",
+      seatId: 0,
+      seed: "s1",
+    });
+    if (!("rejection" in outcome)) throw new Error("expected a rejection");
+    expect(outcome.rejection.reason).toBe("showdown-unresolved");
+  });
+
   it("deals once every contestant has shown or mucked", () => {
     const closed = playAll(headsUpAt(raisedOnTheRiver), [
       { type: "show", seatId: 0 },

--- a/packages/engine/src/table.test.ts
+++ b/packages/engine/src/table.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createInitialState } from "./room.js";
-import { legalActions } from "./table.js";
+import { legalActions, showingOrder } from "./table.js";
 import { playAll } from "./test-utils.js";
 import { must } from "./util.js";
 
@@ -80,5 +80,41 @@ describe("legalActions", () => {
       "call",
       "allInCall",
     ]);
+  });
+});
+
+describe("showingOrder", () => {
+  const contestants = (
+    seats: readonly number[],
+    allIn: readonly number[] = [],
+  ) => seats.map((seatId) => ({ seatId, allIn: allIn.includes(seatId) }));
+
+  // Button 0, so the ring runs 1, 2, 3, 0 — clockwise from its left.
+  const ring = [1, 2, 3, 0];
+
+  it("starts at the river's last aggressor and runs clockwise, wrapping", () => {
+    expect(showingOrder(ring, contestants([0, 1, 2, 3]), 3)).toEqual([
+      3, 0, 1, 2,
+    ]);
+  });
+
+  it("starts left of the button when the river checked through", () => {
+    expect(showingOrder(ring, contestants([0, 1, 2, 3]), null)).toEqual([
+      1, 2, 3, 0,
+    ]);
+  });
+
+  it("skips a folded seat while keeping the rest in order", () => {
+    expect(showingOrder(ring, contestants([0, 2, 3]), null)).toEqual([2, 3, 0]);
+  });
+
+  it("leaves all-in seats out, and falls back when the aggressor is one", () => {
+    expect(showingOrder(ring, contestants([0, 1, 2, 3], [3]), 3)).toEqual([
+      1, 2, 0,
+    ]);
+  });
+
+  it("empties when every contestant is all-in", () => {
+    expect(showingOrder(ring, contestants([0, 1], [0, 1]), 1)).toEqual([]);
   });
 });

--- a/packages/engine/src/table.ts
+++ b/packages/engine/src/table.ts
@@ -183,3 +183,25 @@ export function dealCommunityCards(
   const start = numSeats * 2 + boardLenSoFar;
   return deck.slice(start, start + count);
 }
+
+/**
+ * The order contestants are asked to show or muck: the river's last aggressor
+ * first, else the first live seat left of the button, then clockwise. All-in
+ * contestants are tabled as the window opens and never queue — see ADR-0009.
+ */
+export function showingOrder(
+  ring: readonly SeatId[],
+  contestants: readonly { seatId: SeatId; allIn: boolean }[],
+  lastAggressor: SeatId | null,
+): SeatId[] {
+  const queued = new Set(
+    contestants.filter((c) => !c.allIn).map((c) => c.seatId),
+  );
+  const start =
+    lastAggressor !== null && queued.has(lastAggressor)
+      ? ring.indexOf(lastAggressor)
+      : 0;
+  return [...ring.slice(start), ...ring.slice(0, start)].filter((seat) =>
+    queued.has(seat),
+  );
+}

--- a/packages/engine/src/table.ts
+++ b/packages/engine/src/table.ts
@@ -184,11 +184,7 @@ export function dealCommunityCards(
   return deck.slice(start, start + count);
 }
 
-/**
- * The order contestants are asked to show or muck: the river's last aggressor
- * first, else the first live seat left of the button, then clockwise. All-in
- * contestants are tabled as the window opens and never queue — see ADR-0009.
- */
+/** See Showing order in `CONTEXT.md`. */
 export function showingOrder(
   ring: readonly SeatId[],
   contestants: readonly { seatId: SeatId; allIn: boolean }[],

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -115,7 +115,7 @@ export interface ShowdownCompleteHandState extends HandPositions {
   readonly contestants: readonly Contestant[];
   readonly lastAggressor: SeatId | null;
   readonly results: readonly RevealedResult[];
-  /** Contestants still owing a show or a muck, head first — see ADR-0009. */
+  /** See Showing order in `CONTEXT.md`. */
   readonly queue: readonly SeatId[];
   readonly mucked: readonly SeatId[];
   readonly winners: readonly SeatId[] | null;

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -22,8 +22,8 @@ export type Command =
   | { type: ActionType; seatId: SeatId }
   | { type: "evict"; seatId: SeatId }
   | { type: "nextHand"; seatId: SeatId; seed: string }
-  | { type: "reveal"; seatId: SeatId }
-  | { type: "show"; seatId: SeatId };
+  | { type: "show"; seatId: SeatId }
+  | { type: "muck"; seatId: SeatId };
 
 export type HandEvent =
   | { type: "HandStarted"; seed: string; button: SeatId }
@@ -38,6 +38,7 @@ export type HandEvent =
   | { type: "HandFoldedOut"; winner: SeatId }
   | { type: "ShowdownReached"; contestants: SeatId[] }
   | { type: "HoleCardsShown"; result: RevealedResult }
+  | { type: "HoleCardsMucked"; seatId: SeatId }
   | { type: "WinnersDeclared"; winners: SeatId[] }
   | { type: "HandComplete" };
 
@@ -47,7 +48,8 @@ export type RejectionReason =
   | "hand-not-in-progress"
   | "hand-already-in-progress"
   | "stale-next-hand"
-  | "not-at-showdown";
+  | "not-at-showdown"
+  | "showdown-unresolved";
 
 export interface Rejection {
   readonly type: "Rejection";
@@ -113,6 +115,9 @@ export interface ShowdownCompleteHandState extends HandPositions {
   readonly contestants: readonly Contestant[];
   readonly lastAggressor: SeatId | null;
   readonly results: readonly RevealedResult[];
+  /** Contestants still owing a show or a muck, head first — see ADR-0009. */
+  readonly queue: readonly SeatId[];
+  readonly mucked: readonly SeatId[];
   readonly winners: readonly SeatId[] | null;
 }
 

--- a/packages/engine/src/version.test.ts
+++ b/packages/engine/src/version.test.ts
@@ -7,7 +7,7 @@ describe("ENGINE_LOG_VERSION", () => {
     expect(ENGINE_LOG_VERSION).toBeGreaterThan(0);
   });
 
-  it("uses the next version for showdown visibility as engine state", () => {
-    expect(ENGINE_LOG_VERSION).toBe(5);
+  it("uses the next version for showing in turn, with mucking", () => {
+    expect(ENGINE_LOG_VERSION).toBe(6);
   });
 });

--- a/packages/engine/src/version.ts
+++ b/packages/engine/src/version.ts
@@ -1,1 +1,1 @@
-export const ENGINE_LOG_VERSION = 5;
+export const ENGINE_LOG_VERSION = 6;

--- a/packages/engine/src/view.test.ts
+++ b/packages/engine/src/view.test.ts
@@ -254,9 +254,11 @@ function assertNoLeak(
 ): void {
   const shown = new Set<SeatId>();
   const contestants = new Set<SeatId>();
+  const mucked = new Set<SeatId>();
   if (state.hand?.status === "complete" && state.hand.reason === "showdown") {
     for (const result of state.hand.results) shown.add(result.seatId);
     for (const c of state.hand.contestants) contestants.add(c.seatId);
+    for (const seatId of state.hand.mucked) mucked.add(seatId);
   }
 
   const viewers: (SeatId | "table")[] = [...seats, "table"];
@@ -271,7 +273,7 @@ function assertNoLeak(
         v === seatId &&
         (state.hand?.status === "betting"
           ? !must(state.hand.players.get(seatId)).folded
-          : contestants.has(seatId));
+          : contestants.has(seatId) && !mucked.has(seatId));
 
       for (const card of cards) {
         const present = cardKeys.has(`${card.rank}${card.suit}`);
@@ -329,8 +331,8 @@ describe("property: view never leaks a hole card it isn't entitled to", () => {
           }
 
           for (const command of [
-            { type: "reveal", seatId: firstPlayer },
             ...seats.map((seatId) => ({ type: "show", seatId }) as const),
+            ...seats.map((seatId) => ({ type: "muck", seatId }) as const),
           ] as const) {
             const result = decide(state, command);
             if (!Array.isArray(result)) continue;

--- a/packages/engine/src/view.ts
+++ b/packages/engine/src/view.ts
@@ -34,9 +34,9 @@ export interface ShowdownView extends HandPositions {
   readonly contestants: readonly SeatId[];
   /** Shown Seats only, in the order they were turned over. */
   readonly results: readonly RevealedResult[];
-  /** Contestants still owing a show or a muck, head first — see ADR-0009. */
+  /** See Showing order in `CONTEXT.md`. */
   readonly queue: readonly SeatId[];
-  /** Declined: distinct from a contestant who has simply not shown yet. */
+  /** Declined — distinct from a contestant who has simply not shown yet. */
   readonly mucked: readonly SeatId[];
   /** Null until the queue empties: the Hand rests before it resolves. */
   readonly winners: readonly SeatId[] | null;
@@ -45,7 +45,6 @@ export interface ShowdownView extends HandPositions {
 export interface PlayerShowdownView extends ShowdownView {
   readonly yourSeatId: SeatId;
   readonly yourResult: RevealedResult | null;
-  /** It is your turn in the showing window. */
   readonly canShow: boolean;
   /** Your turn, and some hand is already face-up to discharge the compulsion. */
   readonly canMuck: boolean;

--- a/packages/engine/src/view.ts
+++ b/packages/engine/src/view.ts
@@ -28,19 +28,27 @@ interface FoldedOutView extends HandPositions {
 
 export interface ShowdownView extends HandPositions {
   readonly phase: "showdown";
+  readonly turnEndsAt: number | null;
   readonly board: readonly Card[];
   /** Every Seat that reached showdown, shown or not — see ADR-0008. */
   readonly contestants: readonly SeatId[];
   /** Shown Seats only, in the order they were turned over. */
   readonly results: readonly RevealedResult[];
-  /** Null until the table reveals: the Hand rests before it resolves. */
+  /** Contestants still owing a show or a muck, head first — see ADR-0009. */
+  readonly queue: readonly SeatId[];
+  /** Declined: distinct from a contestant who has simply not shown yet. */
+  readonly mucked: readonly SeatId[];
+  /** Null until the queue empties: the Hand rests before it resolves. */
   readonly winners: readonly SeatId[] | null;
 }
 
 export interface PlayerShowdownView extends ShowdownView {
   readonly yourSeatId: SeatId;
   readonly yourResult: RevealedResult | null;
+  /** It is your turn in the showing window. */
   readonly canShow: boolean;
+  /** Your turn, and some hand is already face-up to discharge the compulsion. */
+  readonly canMuck: boolean;
 }
 
 export interface PlayerViewBetting extends HandPositions {
@@ -109,6 +117,7 @@ export function view(
   if (hand.status === "complete") {
     const showdownView: ShowdownView = {
       phase: "showdown",
+      turnEndsAt,
       button: hand.button,
       smallBlind: hand.smallBlind,
       bigBlind: hand.bigBlind,
@@ -116,6 +125,8 @@ export function view(
       board: hand.board,
       contestants: hand.contestants.map((contestant) => contestant.seatId),
       results: hand.results,
+      queue: hand.queue,
+      mucked: hand.mucked,
       winners: hand.winners,
     };
     if (seatId === "table") return showdownView;
@@ -123,14 +134,16 @@ export function view(
     const yours = hand.contestants.find(
       (contestant) => contestant.seatId === seatId,
     );
+    const canShow = hand.winners === null && hand.queue[0] === seatId;
     return {
       ...showdownView,
       yourSeatId: seatId,
       yourResult:
-        yours === undefined ? null : revealedResultFor(hand.board, yours),
-      canShow:
-        yours !== undefined &&
-        !hand.results.some((shown) => shown.seatId === seatId),
+        yours === undefined || hand.mucked.includes(seatId)
+          ? null
+          : revealedResultFor(hand.board, yours),
+      canShow,
+      canMuck: canShow && hand.results.length > 0,
     };
   }
 

--- a/packages/harness/fixtures/hand-1.commands.jsonl
+++ b/packages/harness/fixtures/hand-1.commands.jsonl
@@ -13,5 +13,5 @@
 {"type":"check","seatId":2}
 {"type":"raise","seatId":0}
 {"type":"call","seatId":2}
-{"type":"reveal","seatId":0}
-{"type":"show","seatId":2}
+{"type":"show","seatId":0}
+{"type":"muck","seatId":2}

--- a/packages/harness/fixtures/hand-1.expected.jsonl
+++ b/packages/harness/fixtures/hand-1.expected.jsonl
@@ -28,5 +28,5 @@
 {"type":"ShowdownReached","contestants":[2,0]}
 {"type":"HandComplete"}
 {"type":"HoleCardsShown","result":{"seatId":0,"holeCards":[{"rank":"J","suit":"clubs"},{"rank":"7","suit":"hearts"}],"rank":3594375,"bestHand":[{"rank":"J","suit":"clubs"},{"rank":"10","suit":"hearts"},{"rank":"9","suit":"clubs"},{"rank":"8","suit":"clubs"},{"rank":"7","suit":"hearts"}],"description":"Straight, jack high"}}
+{"type":"HoleCardsMucked","seatId":2}
 {"type":"WinnersDeclared","winners":[0]}
-{"type":"HoleCardsShown","result":{"seatId":2,"holeCards":[{"rank":"9","suit":"spades"},{"rank":"2","suit":"clubs"}],"rank":1250655,"bestHand":[{"rank":"9","suit":"spades"},{"rank":"9","suit":"clubs"},{"rank":"10","suit":"hearts"},{"rank":"8","suit":"clubs"},{"rank":"7","suit":"diamonds"}],"description":"Pair of nines"}}

--- a/packages/harness/src/fixtures.test.ts
+++ b/packages/harness/src/fixtures.test.ts
@@ -54,7 +54,7 @@ describe("hand-1 fixture: replay through the engine", () => {
     let state = createInitialState([0, 1, 2]);
     for (const event of events) state = apply(state, event);
 
-    expect(ENGINE_LOG_VERSION).toBe(5);
+    expect(ENGINE_LOG_VERSION).toBe(6);
     if (state.hand?.status !== "complete") throw new Error("expected complete");
     expect(state.hand.button).toBe(0);
     expect(state.hand.smallBlind).toBe(1);

--- a/packages/player-client/src/App.tsx
+++ b/packages/player-client/src/App.tsx
@@ -33,6 +33,9 @@ export function App() {
   const connectionStatus = usePlayerStore((state) => state.connectionStatus);
   const hasEverConnected = usePlayerStore((state) => state.hasEverConnected);
   const shotClockSettings = usePlayerStore((state) => state.shotClockSettings);
+  const showdownClockSettings = usePlayerStore(
+    (state) => state.showdownClockSettings,
+  );
   const handView = usePlayerStore((state) => state.handView);
   const setRoomView = usePlayerStore((state) => state.setRoomView);
   const setJoinError = usePlayerStore((state) => state.setJoinError);
@@ -240,6 +243,7 @@ export function App() {
             seats={seats}
             connectionStatus={connectionStatus}
             shotClockSeconds={shotClockSettings.seconds}
+            showdownClockSeconds={showdownClockSettings.seconds}
             intent={intent}
           />
         )}

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -2,7 +2,7 @@ import type { PlayerView } from "@table-top-poker/protocol";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { Hand, revealWouldShow } from "./Hand.js";
+import { Hand, showdownPrompt, showdownTurn } from "./Hand.js";
 
 describe("Hand", () => {
   it("shows a waiting state before any hand has started", () => {
@@ -294,6 +294,9 @@ describe("Hand", () => {
   describe("showdown", () => {
     const shownTable = {
       phase: "showdown",
+      turnEndsAt: null,
+      queue: [],
+      mucked: [],
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -351,6 +354,7 @@ describe("Hand", () => {
         yourSeatId: seatId,
         yourResult,
         canShow: false,
+        canMuck: false,
       };
     }
 
@@ -385,6 +389,7 @@ describe("Hand", () => {
         yourSeatId: 1,
         yourResult: shownTable.results[1],
         canShow: true,
+        canMuck: false,
       };
       const html = renderToStaticMarkup(<Hand view={concealing} seatId={1} />);
 
@@ -393,22 +398,54 @@ describe("Hand", () => {
       expect(html).toContain('aria-disabled="false"');
     });
 
-    it("arms the reveal to publish only inside the showing window", () => {
+    it("arms the reveal to publish only on your turn in an open window", () => {
       const contestant = {
         ...shownTable,
         results: [shownTable.results[0]],
-        winners: [0] as readonly number[],
+        winners: null,
+        queue: [1] as readonly number[],
         yourSeatId: 1,
         yourResult: shownTable.results[1],
         canShow: true,
+        canMuck: true,
       } satisfies PlayerView;
 
-      expect(revealWouldShow(contestant)).toBe(true);
+      expect(showdownTurn(contestant)).toEqual({
+        showdownOpen: true,
+        showLegal: true,
+        muckLegal: true,
+      });
+      expect(showdownTurn({ ...contestant, winners: [0] }).showLegal).toBe(
+        false,
+      );
+      expect(showdownTurn({ ...contestant, canShow: false }).showLegal).toBe(
+        false,
+      );
+      expect(showdownTurn(showdownViewFor(0)).showdownOpen).toBe(false);
+    });
+
+    it("drops the muck line from the prompt while the compulsion stands", () => {
       expect(
-        revealWouldShow({ ...contestant, winners: null, results: [] }),
-      ).toBe(false);
-      expect(revealWouldShow({ ...contestant, canShow: false })).toBe(false);
-      expect(revealWouldShow(showdownViewFor(0))).toBe(false);
+        showdownPrompt({
+          showdownOpen: true,
+          showLegal: true,
+          muckLegal: true,
+        }),
+      ).toBe("Show your hand, or drag up to muck");
+      expect(
+        showdownPrompt({
+          showdownOpen: true,
+          showLegal: true,
+          muckLegal: false,
+        }),
+      ).toBe("Show your hand");
+      expect(
+        showdownPrompt({
+          showdownOpen: true,
+          showLegal: false,
+          muckLegal: false,
+        }),
+      ).toBeNull();
     });
 
     it("has no separate show control — the reveal gesture is the show", () => {
@@ -419,6 +456,7 @@ describe("Hand", () => {
         yourSeatId: 1,
         yourResult: shownTable.results[1],
         canShow: true,
+        canMuck: false,
       };
       const html = renderToStaticMarkup(<Hand view={concealing} seatId={1} />);
 
@@ -434,6 +472,7 @@ describe("Hand", () => {
         yourSeatId: 1,
         yourResult: shownTable.results[1],
         canShow: true,
+        canMuck: false,
       };
       const html = renderToStaticMarkup(
         <Hand
@@ -449,6 +488,7 @@ describe("Hand", () => {
             raise: () => undefined,
             allIn: () => undefined,
             show: () => undefined,
+            muck: () => undefined,
           }}
         />,
       );
@@ -599,6 +639,9 @@ describe("Hand", () => {
         "showdown",
         {
           phase: "showdown",
+          turnEndsAt: null,
+          queue: [],
+          mucked: [],
           button: 0,
           smallBlind: 1,
           bigBlind: 2,
@@ -610,6 +653,7 @@ describe("Hand", () => {
           yourSeatId: 0,
           yourResult: null,
           canShow: true,
+          canMuck: false,
         },
       ],
       [
@@ -671,5 +715,93 @@ describe("Hand", () => {
 
       expect(html).toContain("opacity:1");
     });
+  });
+});
+
+describe("Hand in the showing window", () => {
+  const yourResult = {
+    seatId: 1,
+    rank: 2,
+    description: "Pair of Kings",
+    holeCards: [
+      { rank: "K", suit: "clubs" },
+      { rank: "4", suit: "hearts" },
+    ],
+    bestHand: [
+      { rank: "K", suit: "hearts" },
+      { rank: "K", suit: "clubs" },
+      { rank: "A", suit: "spades" },
+      { rank: "9", suit: "diamonds" },
+      { rank: "4", suit: "spades" },
+    ],
+  } as const;
+
+  const yourTurn: PlayerView = {
+    phase: "showdown",
+    turnEndsAt: Date.now() + 4000,
+    button: 0,
+    smallBlind: 1,
+    bigBlind: 0,
+    dealtSeatCount: 2,
+    board: [],
+    contestants: [0, 1],
+    results: [],
+    queue: [1, 0],
+    mucked: [],
+    winners: null,
+    yourSeatId: 1,
+    yourResult,
+    canShow: true,
+    canMuck: false,
+  };
+
+  it("prompts without the muck line while the compulsion stands", () => {
+    const html = renderToStaticMarkup(<Hand view={yourTurn} seatId={1} />);
+
+    expect(html).toMatch(/data-testid="turn-banner"[^>]*data-tone="turn"/);
+    expect(html).toContain("Show your hand");
+    expect(html).not.toContain("drag up to muck");
+  });
+
+  it("offers the muck once some hand is face-up", () => {
+    const html = renderToStaticMarkup(
+      <Hand view={{ ...yourTurn, canMuck: true }} seatId={1} />,
+    );
+
+    expect(html).toContain("Show your hand, or drag up to muck");
+  });
+
+  it("rings the clock on the player's own cards while it is their turn", () => {
+    const html = renderToStaticMarkup(<Hand view={yourTurn} seatId={1} />);
+
+    expect(html).toContain('data-testid="showdown-shot-clock"');
+  });
+
+  it("carries no clock and no prompt behind the head of the queue", () => {
+    const waiting: PlayerView = {
+      ...yourTurn,
+      queue: [0, 1],
+      canShow: false,
+      canMuck: false,
+    };
+    const html = renderToStaticMarkup(<Hand view={waiting} seatId={1} />);
+
+    expect(html).not.toContain('data-testid="showdown-shot-clock"');
+    expect(html).not.toContain("Show your hand");
+    expect(html).toContain("Waiting on");
+  });
+
+  it("says the cards are mucked once this seat has declined", () => {
+    const mucked: PlayerView = {
+      ...yourTurn,
+      queue: [0],
+      mucked: [1],
+      yourResult: null,
+      canShow: false,
+      canMuck: false,
+    };
+    const html = renderToStaticMarkup(<Hand view={mucked} seatId={1} />);
+
+    expect(html).toContain("You mucked");
   });
 });

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -777,6 +777,16 @@ describe("Hand in the showing window", () => {
     expect(html).toContain('data-testid="showdown-shot-clock"');
   });
 
+  it("sizes the ring by the room's showdown clock, not a default", () => {
+    const html = renderToStaticMarkup(
+      <Hand view={yourTurn} seatId={1} showdownClockSeconds={10} />,
+    );
+
+    // 4s left of 10 leaves the ring past the amber turn, not near-full.
+    expect(html).toContain('data-testid="showdown-shot-clock"');
+    expect(html).toContain("4");
+  });
+
   it("carries no clock and no prompt behind the head of the queue", () => {
     const waiting: PlayerView = {
       ...yourTurn,

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -771,10 +771,10 @@ describe("Hand in the showing window", () => {
     expect(html).toContain("Show your hand, or drag up to muck");
   });
 
-  it("rings the clock on the player's own cards while it is their turn", () => {
+  it("rings the clock in the turn banner while it is their turn", () => {
     const html = renderToStaticMarkup(<Hand view={yourTurn} seatId={1} />);
 
-    expect(html).toContain('data-testid="showdown-shot-clock"');
+    expect(html).toContain('data-testid="turn-banner-shot-clock"');
   });
 
   it("sizes the ring by the room's showdown clock, not a default", () => {
@@ -783,7 +783,7 @@ describe("Hand in the showing window", () => {
     );
 
     // 4s left of 10 leaves the ring past the amber turn, not near-full.
-    expect(html).toContain('data-testid="showdown-shot-clock"');
+    expect(html).toContain('data-testid="turn-banner-shot-clock"');
     expect(html).toContain("4");
   });
 
@@ -796,7 +796,7 @@ describe("Hand in the showing window", () => {
     };
     const html = renderToStaticMarkup(<Hand view={waiting} seatId={1} />);
 
-    expect(html).not.toContain('data-testid="showdown-shot-clock"');
+    expect(html).not.toContain('data-testid="turn-banner-shot-clock"');
     expect(html).not.toContain("Show your hand");
     expect(html).toContain("Waiting on");
   });

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -27,40 +27,69 @@ export interface HandProps {
   readonly seats?: readonly SeatView[];
   readonly connectionStatus?: ConnectionStatus;
   readonly shotClockSeconds?: number;
+  readonly showdownClockSeconds?: number;
   readonly intent?: ActionIntent;
 }
 
 const noAction = () => undefined;
 
+interface ShowdownTurn {
+  readonly showdownOpen: boolean;
+  readonly showLegal: boolean;
+  readonly muckLegal: boolean;
+}
+
+/** At Showdown the reveal gesture publishes: see ADR-0008's amendment for #253. */
+export function showdownTurn(view: PlayerView): ShowdownTurn {
+  if (view.phase !== "showdown" || view.winners !== null) {
+    return { showdownOpen: false, showLegal: false, muckLegal: false };
+  }
+  return {
+    showdownOpen: true,
+    showLegal: view.canShow,
+    muckLegal: view.canMuck,
+  };
+}
+
 function cardActionsFrom(
   intent: ActionIntent | undefined,
-  showLegal: boolean,
+  turn: ShowdownTurn,
 ): CardActions {
   if (intent === undefined) {
     return {
       foldLegal: false,
       checkLegal: false,
-      showLegal: false,
+      ...turn,
       pending: false,
       fold: noAction,
       check: noAction,
       show: noAction,
+      muck: noAction,
     };
   }
   return {
     foldLegal: intent.legalActions.includes("fold"),
     checkLegal: intent.legalActions.includes("check"),
-    showLegal,
+    ...turn,
     pending: intent.pendingAction !== null,
     fold: intent.fold,
     check: intent.check,
     show: intent.show,
+    muck: intent.muck,
   };
 }
 
-/** At Showdown the reveal gesture publishes: see ADR-0008's amendment for #253. */
-export function revealWouldShow(view: PlayerView): boolean {
-  return view.phase === "showdown" && view.canShow && view.winners !== null;
+/**
+ * A persistent prompt, not `coaching.ts`'s one-shot teaching: an experienced
+ * player still needs to be told whose turn it is. The muck line is left off
+ * when compelled — offering an option that will be rejected is worse than not
+ * offering it (ADR-0009).
+ */
+export function showdownPrompt(turn: ShowdownTurn): string | null {
+  if (!turn.showLegal) return null;
+  return turn.muckLegal
+    ? "Show your hand, or drag up to muck"
+    : "Show your hand";
 }
 
 type BannerTone = "turn" | "all-in" | "win" | "loss" | "idle" | "offline";
@@ -168,9 +197,17 @@ function bannerFor(
   if (view.phase === "showdown") {
     const winners = view.winners;
     if (winners === null) {
+      const prompt = showdownPrompt(showdownTurn(view));
+      if (prompt !== null) {
+        return { kicker: "Your turn", text: prompt, tone: "turn" };
+      }
+      const waitingOn = view.queue[0];
       return {
         kicker: "Showdown",
-        text: "Waiting for the table to turn the hands over",
+        text:
+          waitingOn === undefined
+            ? "Waiting for the hands to be turned over"
+            : `Waiting on ${seatLabel(waitingOn, seats)}`,
         tone: "idle",
       };
     }
@@ -358,12 +395,17 @@ function HoleCardsRegion({
   sealed = false,
   actions,
   caption,
+  clock,
 }: {
   readonly cards: readonly [CardType, CardType] | null;
   readonly locked?: boolean;
   readonly sealed?: boolean;
   readonly actions: CardActions;
   readonly caption?: string;
+  readonly clock?: {
+    readonly turnEndsAt: number | null;
+    readonly durationSeconds: number;
+  };
 }) {
   const absent = cards === null;
   return (
@@ -379,6 +421,14 @@ function HoleCardsRegion({
         textAlign: "center",
       }}
     >
+      {clock && clock.turnEndsAt !== null ? (
+        <ShotClock
+          turnEndsAt={clock.turnEndsAt}
+          durationSeconds={clock.durationSeconds}
+          variant="ring"
+          testId="showdown-shot-clock"
+        />
+      ) : null}
       <HoleCardPair
         cards={cards}
         locked={locked}
@@ -396,9 +446,11 @@ export function Hand({
   seats = [],
   connectionStatus = "connected",
   shotClockSeconds = 90,
+  showdownClockSeconds = 30,
   intent,
 }: HandProps) {
-  const actions = cardActionsFrom(intent, revealWouldShow(view));
+  const turn = showdownTurn(view);
+  const actions = cardActionsFrom(intent, turn);
 
   if (view.phase === "no-hand") {
     return (
@@ -489,12 +541,20 @@ export function Hand({
             cards={myResult.holeCards}
             locked={iHaveShown}
             actions={actions}
+            clock={{
+              turnEndsAt: turn.showLegal ? view.turnEndsAt : null,
+              durationSeconds: showdownClockSeconds,
+            }}
           />
         ) : (
           <HoleCardsRegion
             cards={null}
             actions={actions}
-            caption="You folded — cards are in the muck."
+            caption={
+              view.mucked.includes(seatId)
+                ? "You mucked — cards are in the muck."
+                : "You folded — cards are in the muck."
+            }
           />
         )}
         {intent?.rejection != null && (

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -79,12 +79,7 @@ function cardActionsFrom(
   };
 }
 
-/**
- * A persistent prompt, not `coaching.ts`'s one-shot teaching: an experienced
- * player still needs to be told whose turn it is. The muck line is left off
- * when compelled — offering an option that will be rejected is worse than not
- * offering it (ADR-0009).
- */
+/** A persistent prompt, not `coaching.ts`'s one-shot teaching — see ADR-0009. */
 export function showdownPrompt(turn: ShowdownTurn): string | null {
   if (!turn.showLegal) return null;
   return turn.muckLegal

--- a/packages/player-client/src/Hand.tsx
+++ b/packages/player-client/src/Hand.tsx
@@ -390,17 +390,12 @@ function HoleCardsRegion({
   sealed = false,
   actions,
   caption,
-  clock,
 }: {
   readonly cards: readonly [CardType, CardType] | null;
   readonly locked?: boolean;
   readonly sealed?: boolean;
   readonly actions: CardActions;
   readonly caption?: string;
-  readonly clock?: {
-    readonly turnEndsAt: number | null;
-    readonly durationSeconds: number;
-  };
 }) {
   const absent = cards === null;
   return (
@@ -416,14 +411,6 @@ function HoleCardsRegion({
         textAlign: "center",
       }}
     >
-      {clock && clock.turnEndsAt !== null ? (
-        <ShotClock
-          turnEndsAt={clock.turnEndsAt}
-          durationSeconds={clock.durationSeconds}
-          variant="ring"
-          testId="showdown-shot-clock"
-        />
-      ) : null}
       <HoleCardPair
         cards={cards}
         locked={locked}
@@ -528,18 +515,14 @@ export function Hand({
         <TurnBanner
           banner={bannerFor(view, connectionStatus, seatId, seats)}
           marker={positionMarkerFor(seatId, view)}
-          turnEndsAt={null}
-          shotClockSeconds={shotClockSeconds}
+          turnEndsAt={turn.showLegal ? view.turnEndsAt : null}
+          shotClockSeconds={showdownClockSeconds}
         />
         {myResult ? (
           <HoleCardsRegion
             cards={myResult.holeCards}
             locked={iHaveShown}
             actions={actions}
-            clock={{
-              turnEndsAt: turn.showLegal ? view.turnEndsAt : null,
-              durationSeconds: showdownClockSeconds,
-            }}
           />
         ) : (
           <HoleCardsRegion

--- a/packages/player-client/src/actions/rejectionCopy.ts
+++ b/packages/player-client/src/actions/rejectionCopy.ts
@@ -19,6 +19,8 @@ export function rejectionCopy(
       return "That hand has already moved on.";
     case "not-at-showdown":
       return "There's no hand of yours to show.";
+    case "showdown-unresolved":
+      return "The hands are still being turned over.";
     case "invalid-command":
       return "That didn't go through — try again.";
     case "room-not-found":

--- a/packages/player-client/src/actions/useActionIntent.ts
+++ b/packages/player-client/src/actions/useActionIntent.ts
@@ -15,6 +15,7 @@ export interface ActionIntent {
   readonly raise: () => void;
   readonly allIn: (action: AllInAction) => void;
   readonly show: () => void;
+  readonly muck: () => void;
 }
 
 type SendableAction = Extract<ClientCommand["type"], ActionType>;
@@ -67,6 +68,9 @@ export function useActionIntent(
     },
     show: () => {
       send({ type: "show" });
+    },
+    muck: () => {
+      send({ type: "muck" });
     },
   };
 }

--- a/packages/player-client/src/holecards/HoleCardPair.test.tsx
+++ b/packages/player-client/src/holecards/HoleCardPair.test.tsx
@@ -15,9 +15,12 @@ import type { CardActions } from "./ports.js";
 const actions: CardActions = {
   foldLegal: true,
   checkLegal: true,
+  showdownOpen: false,
   showLegal: false,
+  muckLegal: false,
   pending: false,
   fold: () => undefined,
+  muck: () => undefined,
   check: () => undefined,
   show: () => undefined,
 };

--- a/packages/player-client/src/holecards/finishPlan.test.ts
+++ b/packages/player-client/src/holecards/finishPlan.test.ts
@@ -26,9 +26,15 @@ const armedFold = session({
 
 const tap = session({ classification: null });
 
-const open: Pick<CardActions, "foldLegal" | "checkLegal" | "pending"> = {
+type PlanActions = Pick<
+  CardActions,
+  "foldLegal" | "checkLegal" | "muckLegal" | "pending"
+>;
+
+const open: PlanActions = {
   foldLegal: true,
   checkLegal: true,
+  muckLegal: false,
   pending: false,
 };
 
@@ -241,5 +247,41 @@ describe("planFinish — the tap window closes on any non-tap ending (§5)", () 
     });
 
     expect(plan.nextTapWindow).toBeNull();
+  });
+});
+
+describe("planFinish — Muck", () => {
+  const showdown: PlanActions = {
+    foldLegal: false,
+    checkLegal: false,
+    muckLegal: true,
+    pending: false,
+  };
+
+  it("sends a muck for the same armed upward drag that folds", () => {
+    const plan = planFinish({
+      end: endGesture(armedFold, { cancelled: false }),
+      actions: showdown,
+      presentation: "FaceDown",
+      tapWindow: null,
+      now: 1000,
+    });
+
+    expect(sent(plan.effects)).toEqual(["muck"]);
+    expect(plan.leaving).toEqual({ faceUp: false });
+  });
+
+  it("disarms rather than mucking while the compulsion stands", () => {
+    const plan = planFinish({
+      end: endGesture(armedFold, { cancelled: false }),
+      actions: { ...showdown, muckLegal: false },
+      presentation: "FaceDown",
+      tapWindow: null,
+      now: 1000,
+    });
+
+    expect(sent(plan.effects)).toEqual([]);
+    expect(dispatched(plan.effects)).toContain("FOLD_DISARMED");
+    expect(plan.leaving).toBeNull();
   });
 });

--- a/packages/player-client/src/holecards/finishPlan.ts
+++ b/packages/player-client/src/holecards/finishPlan.ts
@@ -5,7 +5,7 @@ import { confirmsCheck, tapLanded, type TapWindow } from "./taps.js";
 
 export type FinishEffect =
   | { readonly kind: "dispatch"; readonly event: CardEvent }
-  | { readonly kind: "send"; readonly action: "check" | "fold" };
+  | { readonly kind: "send"; readonly action: "check" | "fold" | "muck" };
 
 export interface FinishPlan {
   readonly effects: readonly FinishEffect[];
@@ -16,7 +16,10 @@ export interface FinishPlan {
 
 export interface FinishInputs {
   readonly end: GestureEnd;
-  readonly actions: Pick<CardActions, "foldLegal" | "checkLegal" | "pending">;
+  readonly actions: Pick<
+    CardActions,
+    "foldLegal" | "checkLegal" | "muckLegal" | "pending"
+  >;
   readonly presentation: Presentation;
   readonly tapWindow: TapWindow;
   readonly now: number;
@@ -26,7 +29,8 @@ export function planFinish(inputs: FinishInputs): FinishPlan {
   const { end, actions, presentation, tapWindow, now } = inputs;
   const { events, commitsFold } = end;
 
-  const commits = commitsFold && actions.foldLegal && !actions.pending;
+  const commits =
+    commitsFold && (actions.foldLegal || actions.muckLegal) && !actions.pending;
 
   const effects: FinishEffect[] = [];
   let nextTapWindow: TapWindow = tapWindow;
@@ -60,7 +64,12 @@ export function planFinish(inputs: FinishInputs): FinishPlan {
   }
   if (!tapped) nextTapWindow = null;
 
-  if (commits) effects.push({ kind: "send", action: "fold" });
+  if (commits) {
+    effects.push({
+      kind: "send",
+      action: actions.foldLegal ? "fold" : "muck",
+    });
+  }
 
   return { effects, nextTapWindow, confirmCheck, leaving };
 }

--- a/packages/player-client/src/holecards/ports.ts
+++ b/packages/player-client/src/holecards/ports.ts
@@ -1,7 +1,7 @@
 export interface CardActions {
   readonly foldLegal: boolean;
   readonly checkLegal: boolean;
-  /** The Showdown showing window is open, whosever turn it is — see ADR-0009. */
+  /** The showing window is open, whosever turn it is. */
   readonly showdownOpen: boolean;
   /** It is this Seat's turn in the showing window. */
   readonly showLegal: boolean;

--- a/packages/player-client/src/holecards/ports.ts
+++ b/packages/player-client/src/holecards/ports.ts
@@ -1,10 +1,15 @@
 export interface CardActions {
   readonly foldLegal: boolean;
   readonly checkLegal: boolean;
-  /** The Showdown showing window is open and this Seat has not shown yet. */
+  /** The Showdown showing window is open, whosever turn it is — see ADR-0009. */
+  readonly showdownOpen: boolean;
+  /** It is this Seat's turn in the showing window. */
   readonly showLegal: boolean;
+  /** Its turn, and some hand is already face-up to discharge the compulsion. */
+  readonly muckLegal: boolean;
   readonly pending: boolean;
   readonly fold: () => void;
   readonly check: () => void;
   readonly show: () => void;
+  readonly muck: () => void;
 }

--- a/packages/player-client/src/holecards/useHoleCards.ts
+++ b/packages/player-client/src/holecards/useHoleCards.ts
@@ -319,6 +319,8 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
         dispatchFromPointer(effect.event);
       } else if (effect.action === "check") {
         props.actions.check();
+      } else if (effect.action === "muck") {
+        props.actions.muck();
       } else {
         props.actions.fold();
       }
@@ -364,7 +366,7 @@ export function useHoleCards(props: HoleCardPairProps): HoleCards {
         active,
         { x: event.clientX, y: event.clientY },
         {
-          foldLegal: props.actions.foldLegal,
+          foldLegal: props.actions.foldLegal || props.actions.muckLegal,
           foldThresholdPx: foldThreshold(window.innerHeight),
         },
       );

--- a/packages/player-client/src/holecards/viewEvents.test.ts
+++ b/packages/player-client/src/holecards/viewEvents.test.ts
@@ -8,8 +8,11 @@ import { eventsForPropChange, eventsForVisibility } from "./viewEvents.js";
 const actions: CardActions = {
   foldLegal: false,
   checkLegal: false,
+  showdownOpen: false,
   showLegal: false,
+  muckLegal: false,
   pending: false,
+  muck: () => undefined,
   fold: () => undefined,
   check: () => undefined,
   show: () => undefined,
@@ -283,27 +286,37 @@ describe("eventsForPropChange", () => {
   });
 
   describe("the showing window opening", () => {
-    const showable: CardActions = { ...actions, showLegal: true };
+    const open: CardActions = { ...actions, showdownOpen: true };
 
-    it("returns the pair face-down, so the reveal that publishes is deliberate", () => {
+    it("returns every contestant's pair face-down as the window opens", () => {
       expect(
         eventsForPropChange(
           props({ cards: queenJack }),
-          props({ cards: queenJack, actions: showable }),
+          props({ cards: queenJack, actions: open }),
           revealed,
         ),
       ).toEqual([{ type: "RESET" }]);
     });
 
+    it("does not reset again when the turn merely reaches this seat", () => {
+      expect(
+        eventsForPropChange(
+          props({ cards: queenJack, actions: open }),
+          props({ cards: queenJack, actions: { ...open, showLegal: true } }),
+          revealed,
+        ),
+      ).toEqual([]);
+    });
+
     it("produces nothing while the window is unchanged", () => {
-      const open = props({ cards: queenJack, actions: showable });
-      expect(eventsForPropChange(open, { ...open }, revealed)).toEqual([]);
+      const during = props({ cards: queenJack, actions: open });
+      expect(eventsForPropChange(during, { ...during }, revealed)).toEqual([]);
     });
 
     it("produces nothing when the window closes", () => {
       expect(
         eventsForPropChange(
-          props({ cards: queenJack, actions: showable }),
+          props({ cards: queenJack, actions: open }),
           props({ cards: queenJack }),
           revealed,
         ),

--- a/packages/player-client/src/holecards/viewEvents.ts
+++ b/packages/player-client/src/holecards/viewEvents.ts
@@ -33,16 +33,18 @@ export function eventsForPropChange(
     if (!prev.locked && next.locked) events.push({ type: "SHOWDOWN_REVEAL" });
   }
 
+  const couldCommit = (actions: HoleCardPairProps["actions"]) =>
+    actions.foldLegal || actions.muckLegal;
   if (
     next.cards !== null &&
-    prev.actions.foldLegal &&
-    !next.actions.foldLegal &&
+    couldCommit(prev.actions) &&
+    !couldCommit(next.actions) &&
     state.recognizer === "FoldDragging"
   ) {
     events.push({ type: "FOLD_DISARMED" });
   }
 
-  if (!prev.actions.showLegal && next.actions.showLegal) {
+  if (!prev.actions.showdownOpen && next.actions.showdownOpen) {
     events.push({ type: "RESET" });
   }
 

--- a/packages/player-client/src/store/roomSlice.ts
+++ b/packages/player-client/src/store/roomSlice.ts
@@ -1,8 +1,10 @@
 import {
   DEFAULT_SHOT_CLOCK,
+  DEFAULT_SHOWDOWN_CLOCK,
   type RoomView,
   type SeatView,
   type ShotClockSettings,
+  type ShowdownClockSettings,
 } from "@table-top-poker/protocol";
 import type { StateCreator } from "zustand";
 
@@ -10,6 +12,7 @@ export interface RoomSlice {
   readonly roomCode: string | null;
   readonly seats: readonly SeatView[];
   readonly shotClockSettings: ShotClockSettings;
+  readonly showdownClockSettings: ShowdownClockSettings;
   readonly joinError: string | null;
   readonly setRoomView: (view: RoomView) => void;
   readonly setJoinError: (message: string | null) => void;
@@ -20,12 +23,14 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
   roomCode: null,
   seats: [],
   shotClockSettings: DEFAULT_SHOT_CLOCK,
+  showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
   joinError: null,
   setRoomView: (view) => {
     set({
       roomCode: view.code,
       seats: view.seats,
       shotClockSettings: view.shotClockSettings,
+      showdownClockSettings: view.showdownClockSettings,
       joinError: null,
     });
   },
@@ -37,6 +42,7 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
       roomCode: null,
       seats: [],
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
       joinError: null,
     });
   },

--- a/packages/player-client/src/store/store.test.ts
+++ b/packages/player-client/src/store/store.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SHOT_CLOCK,
+  DEFAULT_SHOWDOWN_CLOCK,
   DEFAULT_SOUND_SETTINGS,
 } from "@table-top-poker/protocol";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -75,6 +76,7 @@ describe("usePlayerStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
       seats: [
         {
           id: 0,
@@ -100,6 +102,7 @@ describe("usePlayerStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
       seats: [
         {
           id: 0,
@@ -135,6 +138,7 @@ describe("usePlayerStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
       seats: [
         {
           id: 0,
@@ -165,6 +169,7 @@ describe("usePlayerStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
       seats: [
         {
           id: 0,
@@ -198,6 +203,7 @@ describe("usePlayerStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
       seats: [
         {
           id: 0,

--- a/packages/protocol/src/command-schema.test.ts
+++ b/packages/protocol/src/command-schema.test.ts
@@ -11,8 +11,8 @@ describe("ClientCommandSchema", () => {
     "allInCall",
     "allInRaise",
     "nextHand",
-    "reveal",
     "show",
+    "muck",
     "sitOut",
     "sitIn",
   ])("accepts a bare %s command", (type) => {
@@ -23,6 +23,12 @@ describe("ClientCommandSchema", () => {
   it("rejects an unknown command type", () => {
     const result = ClientCommandSchema.safeParse({ type: "advance" });
     expect(result.success).toBe(false);
+  });
+
+  it("no longer accepts the table's deleted reveal command", () => {
+    expect(ClientCommandSchema.safeParse({ type: "reveal" }).success).toBe(
+      false,
+    );
   });
 
   it("rejects a client-supplied seatId or seed", () => {

--- a/packages/protocol/src/command-schema.ts
+++ b/packages/protocol/src/command-schema.ts
@@ -9,8 +9,8 @@ export const ClientCommandSchema = z.discriminatedUnion("type", [
   z.strictObject({ type: z.literal("allInCall") }),
   z.strictObject({ type: z.literal("allInRaise") }),
   z.strictObject({ type: z.literal("nextHand") }),
-  z.strictObject({ type: z.literal("reveal") }),
   z.strictObject({ type: z.literal("show") }),
+  z.strictObject({ type: z.literal("muck") }),
   z.strictObject({ type: z.literal("sitOut") }),
   z.strictObject({ type: z.literal("sitIn") }),
 ]);

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -106,6 +106,38 @@ export type ChangeShotClockRequest = z.infer<
   typeof ChangeShotClockRequestSchema
 >;
 
+export const MIN_SHOWDOWN_CLOCK_SECONDS = 5;
+export const MAX_SHOWDOWN_CLOCK_SECONDS = 600;
+
+/**
+ * `enabled` is fixed true: with showing ordered, one locked phone blocks every
+ * player behind it, so the clock is load-bearing rather than a preference —
+ * see ADR-0009.
+ */
+export interface ShowdownClockSettings {
+  readonly enabled: true;
+  readonly seconds: number;
+}
+
+export const DEFAULT_SHOWDOWN_CLOCK: ShowdownClockSettings = {
+  enabled: true,
+  seconds: 30,
+};
+
+export const ShowdownClockSettingsSchema = z.strictObject({
+  enabled: z.literal(true),
+  seconds: z
+    .int()
+    .min(MIN_SHOWDOWN_CLOCK_SECONDS)
+    .max(MAX_SHOWDOWN_CLOCK_SECONDS),
+});
+
+export const ChangeShowdownClockRequestSchema = ShowdownClockSettingsSchema;
+
+export type ChangeShowdownClockRequest = z.infer<
+  typeof ChangeShowdownClockRequestSchema
+>;
+
 export type HandStateSource = EngineState | PlayerView | TableView | null;
 
 export function isHandLive(source: HandStateSource): boolean {
@@ -163,6 +195,7 @@ export interface RoomView {
   readonly pendingShotClock: ShotClockSettings | null;
   readonly soundSettings: SoundSettings;
   readonly shotClockSettings: ShotClockSettings;
+  readonly showdownClockSettings: ShowdownClockSettings;
 }
 
 export interface RoomViewMessage {

--- a/packages/protocol/src/room.ts
+++ b/packages/protocol/src/room.ts
@@ -109,11 +109,7 @@ export type ChangeShotClockRequest = z.infer<
 export const MIN_SHOWDOWN_CLOCK_SECONDS = 5;
 export const MAX_SHOWDOWN_CLOCK_SECONDS = 600;
 
-/**
- * `enabled` is fixed true: with showing ordered, one locked phone blocks every
- * player behind it, so the clock is load-bearing rather than a preference —
- * see ADR-0009.
- */
+/** `enabled` is fixed true — see Showdown clock in `CONTEXT.md`. */
 export interface ShowdownClockSettings {
   readonly enabled: true;
   readonly seconds: number;

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_SEAT_COUNT,
   DEFAULT_SHOT_CLOCK,
+  DEFAULT_SHOWDOWN_CLOCK,
   ENGINE_LOG_VERSION,
   legalActions,
   DEFAULT_SOUND_SETTINGS,
@@ -201,6 +202,7 @@ describe("rooms HTTP routes", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
       seats: unclaimedSeats(),
     });
   });
@@ -1272,6 +1274,7 @@ describe("WebSocket upgrade", () => {
         pendingShotClock: null,
         soundSettings: DEFAULT_SOUND_SETTINGS,
         shotClockSettings: DEFAULT_SHOT_CLOCK,
+        showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
         seats: unclaimedSeats(),
       },
     });
@@ -2112,6 +2115,172 @@ describe("room recording", () => {
       seat0.close();
       seat1.close();
       await app.close();
+    }
+  });
+});
+
+describe("showdown clock", () => {
+  const SHOWDOWN_CLOCK_MS = 200;
+  let app: FastifyInstance;
+  let rooms: RoomStore;
+  let port: number;
+
+  beforeEach(async () => {
+    rooms = new RoomStore();
+    app = await buildApp({
+      rooms,
+      recordings: testRecordings(),
+      showdownClockMs: SHOWDOWN_CLOCK_MS,
+    });
+    await app.listen({ port: 0, host: "127.0.0.1" });
+    const address = app.server.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("expected a bound TCP address");
+    }
+    port = address.port;
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  function connect(query: string): {
+    socket: WebSocket;
+    messages: ServerMessage[];
+  } {
+    const socket = new WebSocket(`ws://127.0.0.1:${String(port)}/ws?${query}`);
+    const messages: ServerMessage[] = [];
+    socket.on("message", (data: Buffer) => {
+      messages.push(JSON.parse(data.toString()) as ServerMessage);
+    });
+    return { socket, messages };
+  }
+
+  async function opened(socket: WebSocket): Promise<void> {
+    if (socket.readyState === WebSocket.OPEN) return;
+    await new Promise<void>((resolve, reject) => {
+      socket.on("open", resolve);
+      socket.on("error", reject);
+    });
+  }
+
+  async function settle(ms = 10): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  async function headsUpAtShowdown(): Promise<{
+    room: ReturnType<RoomStore["create"]>;
+    table: { socket: WebSocket; messages: ServerMessage[] };
+    seats: Map<number, WebSocket>;
+  }> {
+    const room = rooms.create(2);
+    const table = connect(`room=${room.code}&role=table`);
+    await opened(table.socket);
+    const seats = new Map<number, WebSocket>();
+    for (const seatId of [0, 1]) {
+      const claim = rooms.claimSeat(room.code, seatId, `P${String(seatId)}`);
+      if (!("seat" in claim)) throw new Error("expected a claimed seat");
+      const conn = connect(
+        `room=${room.code}&seat=${String(seatId)}&token=${claim.seat.token ?? ""}`,
+      );
+      await opened(conn.socket);
+      seats.set(seatId, conn.socket);
+    }
+    await settle();
+
+    table.socket.send(JSON.stringify({ type: "startHand" }));
+    await settle();
+
+    for (let step = 0; step < 16; step++) {
+      const actor = rooms.currentActor(room.code);
+      if (actor === undefined) break;
+      const socket = seats.get(actor);
+      if (socket === undefined) throw new Error("expected the actor's socket");
+      socket.send(JSON.stringify({ type: "call" }));
+      await settle();
+      if (rooms.currentActor(room.code) === actor) {
+        socket.send(JSON.stringify({ type: "check" }));
+        await settle();
+      }
+    }
+    if (rooms.showdownActor(room.code) === undefined) {
+      throw new Error("hand never reached an open showing window");
+    }
+    return { room, table, seats };
+  }
+
+  function showdownEvents(messages: ServerMessage[]) {
+    return messages
+      .filter((m) => m.type === "hand-update")
+      .map((m) => m.event)
+      .filter(
+        (e) => e.type === "HoleCardsShown" || e.type === "HoleCardsMucked",
+      );
+  }
+
+  it("shows a compelled head when the clock elapses, then mucks the rest", async () => {
+    const { room, table, seats } = await headsUpAtShowdown();
+    try {
+      const head = rooms.showdownActor(room.code);
+      expect(rooms.showdownCompelled(room.code)).toBe(true);
+
+      await settle(SHOWDOWN_CLOCK_MS + 60);
+      expect(showdownEvents(table.messages)).toEqual([
+        expect.objectContaining({ type: "HoleCardsShown" }),
+      ]);
+      expect(rooms.showdownActor(room.code)).not.toBe(head);
+
+      await settle(SHOWDOWN_CLOCK_MS + 60);
+      expect(showdownEvents(table.messages)).toEqual([
+        expect.objectContaining({ type: "HoleCardsShown" }),
+        expect.objectContaining({ type: "HoleCardsMucked" }),
+      ]);
+      expect(rooms.showdownActor(room.code)).toBeUndefined();
+    } finally {
+      table.socket.close();
+      for (const socket of seats.values()) socket.close();
+    }
+  });
+
+  it("runs even though the shot clock is off — it cannot be disabled", async () => {
+    const { room, table, seats } = await headsUpAtShowdown();
+    try {
+      expect(room.shotClockSettings.enabled).toBe(false);
+      expect(room.turnEndsAt).toEqual(expect.any(Number));
+
+      const views = table.messages
+        .filter(
+          (
+            message,
+          ): message is Extract<ServerMessage, { type: "hand-update" }> =>
+            message.type === "hand-update" && message.view.phase === "showdown",
+        )
+        .map((message) => message.view);
+      expect(views.length).toBeGreaterThan(0);
+      expect(
+        views.every(
+          (view) => view.phase === "showdown" && view.turnEndsAt !== null,
+        ),
+      ).toBe(true);
+    } finally {
+      table.socket.close();
+      for (const socket of seats.values()) socket.close();
+    }
+  });
+
+  it("holds the next hand until the window closes", async () => {
+    const { room, table, seats } = await headsUpAtShowdown();
+    try {
+      table.socket.send(JSON.stringify({ type: "nextHand" }));
+      await settle();
+
+      expect(
+        table.messages.filter((m) => m.type === "command-rejected"),
+      ).toEqual([{ type: "command-rejected", reason: "showdown-unresolved" }]);
+      expect(rooms.showdownActor(room.code)).toBeDefined();
+    } finally {
+      table.socket.close();
+      for (const socket of seats.values()) socket.close();
     }
   });
 });

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -13,6 +13,7 @@ import {
   ReplayRequestSchema,
   summarise,
   view,
+  type ActionType,
   type CommandRejectedMessage,
   type HandEvent,
   type HandSummary,
@@ -118,6 +119,13 @@ interface WsRoute {
 
 type SocketIdentity = SeatId | "table" | "lobby";
 type ActionClockPolicy = "reschedule" | "preserve";
+type ClockPhase = "betting" | "showing";
+
+interface ClockedActor {
+  readonly seatId: SeatId;
+  readonly phase: ClockPhase;
+}
+
 type BotActionDelay = number | readonly [number, number];
 
 const DEFAULT_BOT_ACTION_DELAY_MS: readonly [number, number] = [250, 750];
@@ -666,24 +674,33 @@ export async function buildApp(
     return changed;
   }
 
-  function botSeatAt(code: string, actor: SeatId | undefined): boolean {
-    if (actor === undefined) return false;
-    const seat = rooms.get(code)?.seats[actor];
+  /** Whoever the Room is waiting on, and which clock is therefore running. */
+  function clockedActor(code: string): ClockedActor | undefined {
+    const betting = rooms.currentActor(code);
+    if (betting !== undefined) return { seatId: betting, phase: "betting" };
+    const showing = rooms.showdownActor(code);
+    return showing === undefined
+      ? undefined
+      : { seatId: showing, phase: "showing" };
+  }
+
+  function stillActing(code: string, actor: ClockedActor): boolean {
+    const current = clockedActor(code);
+    return current?.seatId === actor.seatId && current.phase === actor.phase;
+  }
+
+  function isBotSeat(code: string, seatId: SeatId): boolean {
+    const seat = rooms.get(code)?.seats[seatId];
     return seat?.claimed === true && seat.bot === true;
   }
 
-  /**
-   * A bot in the showing queue would otherwise wedge the room, so it resolves
-   * on its own turn — after the usual delay, never instantly (ADR-0009).
-   */
+  /** A bot in the showing queue would otherwise wedge the room — see ADR-0009. */
   function scheduleBotAction(code: string): void {
     clearBotActionTimer(code);
     if (!testMode) return;
 
-    const betting = rooms.currentActor(code);
-    const showing = rooms.showdownActor(code);
-    const actor = betting ?? showing;
-    if (!botSeatAt(code, actor) || actor === undefined) return;
+    const actor = clockedActor(code);
+    if (actor === undefined || !isBotSeat(code, actor.seatId)) return;
 
     const timer = setTimeout(
       () => {
@@ -691,15 +708,13 @@ export async function buildApp(
         enqueueDetached(code, async () => {
           if (roomRecordings.isPaused(code)) return;
           const currentRoom = rooms.get(code);
-          if (!currentRoom || !botSeatAt(code, actor)) return;
+          if (!currentRoom || !isBotSeat(code, actor.seatId)) return;
+          if (!stillActing(code, actor)) return;
 
-          const action =
-            betting === undefined
-              ? botShowdownAction(code, actor)
-              : botBettingAction(currentRoom, actor);
+          const action = botAction(currentRoom, actor);
           if (action === null) return;
 
-          const result = rooms.dispatch(code, actor, action);
+          const result = rooms.dispatch(code, actor.seatId, action);
           if (!("commit" in result)) {
             rescheduleActionClock(code);
             scheduleBotAction(code);
@@ -713,54 +728,43 @@ export async function buildApp(
     botActionTimers.set(code, timer);
   }
 
-  function botBettingAction(room: Room, actor: SeatId): SeatCommandType | null {
-    if (rooms.currentActor(room.code) !== actor) return null;
-    const engine = room.engine;
-    if (engine?.hand?.status !== "betting") return null;
-    const actorView = view(engine, actor);
-    if (actorView.phase !== "betting" || actorView.legalActions.length === 0) {
-      return null;
+  function botAction(room: Room, actor: ClockedActor): SeatCommandType | null {
+    if (actor.phase === "showing") {
+      return chooseShowdownAction(rooms.showdownCompelled(room.code), botRng);
     }
-    return chooseBotAction(actorView.legalActions, botRng);
+    const legal = bettingActionsFor(room, actor.seatId);
+    return legal.length === 0 ? null : chooseBotAction(legal, botRng);
   }
 
-  function botShowdownAction(
-    code: string,
-    actor: SeatId,
-  ): SeatCommandType | null {
-    if (rooms.showdownActor(code) !== actor) return null;
-    return chooseShowdownAction(rooms.showdownCompelled(code), botRng);
+  function bettingActionsFor(
+    room: Room,
+    seatId: SeatId,
+  ): readonly ActionType[] {
+    if (room.engine?.hand?.status !== "betting") return [];
+    const actorView = view(room.engine, seatId);
+    return actorView.phase === "betting" ? actorView.legalActions : [];
   }
 
   /**
-   * One scheduler for both clocks: the betting turn's, which the room may turn
-   * off, and the showing window's, which it may not — see ADR-0009. Expiry is
-   * an ordinary Command, so the engine keeps no notion of time.
+   * One scheduler for both clocks; only the betting one may be turned off.
+   * Expiry is an ordinary Command, so the engine keeps no notion of time.
    */
   function rescheduleActionClock(
     code: string,
     policy: ActionClockPolicy = "reschedule",
   ): void {
     const room = rooms.get(code);
-    if (room === undefined) {
+    const actor = room === undefined ? undefined : clockedActor(code);
+    if (
+      room === undefined ||
+      actor === undefined ||
+      (actor.phase === "betting" && !room.shotClockSettings.enabled)
+    ) {
       cancelActionClock(code);
       return;
     }
 
-    const betting = rooms.currentActor(code);
-    const showing = rooms.showdownActor(code);
-    const actor = betting ?? showing;
-    if (actor === undefined) {
-      cancelActionClock(code);
-      return;
-    }
-
-    if (betting !== undefined && !room.shotClockSettings.enabled) {
-      cancelActionClock(code);
-      return;
-    }
-
-    const fullInterval = clockIntervalMs(room, betting !== undefined);
+    const fullInterval = clockIntervalMs(room, actor.phase);
     const preserved = policy === "preserve" ? room.turnEndsAt : null;
     const timeoutMs =
       preserved === null
@@ -773,16 +777,16 @@ export async function buildApp(
         if (roomRecordings.isPaused(code)) return;
         const currentRoom = rooms.get(code);
         if (currentRoom?.revision !== scheduledAt) return;
-        if ((rooms.currentActor(code) ?? rooms.showdownActor(code)) !== actor) {
+        if (!stillActing(code, actor)) {
           rescheduleActionClock(code);
           return;
         }
 
-        const action =
-          betting === undefined
-            ? expiryShowdownAction(code)
-            : expiryBettingAction(currentRoom, actor);
-        const result = rooms.dispatch(code, actor, action);
+        const result = rooms.dispatch(
+          code,
+          actor.seatId,
+          expiryAction(currentRoom, actor),
+        );
         if ("commit" in result) {
           await publishDispatch(code, result);
           return;
@@ -792,31 +796,28 @@ export async function buildApp(
     });
   }
 
-  function clockIntervalMs(room: Room, betting: boolean): number {
-    if (betting) {
-      return options.actionClock === undefined &&
-        options.actionClockMs !== undefined
-        ? options.actionClockMs
-        : room.shotClockSettings.seconds * 1000;
-    }
-    return options.actionClock === undefined &&
-      options.showdownClockMs !== undefined
-      ? options.showdownClockMs
-      : room.showdownClockSettings.seconds * 1000;
+  function clockIntervalMs(room: Room, phase: ClockPhase): number {
+    const override =
+      options.actionClock !== undefined
+        ? undefined
+        : phase === "betting"
+          ? options.actionClockMs
+          : options.showdownClockMs;
+    const seconds =
+      phase === "betting"
+        ? room.shotClockSettings.seconds
+        : room.showdownClockSettings.seconds;
+    return override ?? seconds * 1000;
   }
 
-  function expiryBettingAction(room: Room, actor: SeatId): SeatCommandType {
-    const actorView =
-      room.engine === null ? undefined : view(room.engine, actor);
-    return actorView?.phase === "betting" &&
-      actorView.legalActions.includes("check")
+  /** A compelled head is shown: the one place cards are turned over for a player. */
+  function expiryAction(room: Room, actor: ClockedActor): SeatCommandType {
+    if (actor.phase === "showing") {
+      return rooms.showdownCompelled(room.code) ? "show" : "muck";
+    }
+    return bettingActionsFor(room, actor.seatId).includes("check")
       ? "check"
       : "fold";
-  }
-
-  /** The one place cards are turned over for a player: a compelled head shows. */
-  function expiryShowdownAction(code: string): SeatCommandType {
-    return rooms.showdownCompelled(code) ? "show" : "muck";
   }
 
   /** The one place the live path and a resuming Retry both settle through. */

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -4,6 +4,7 @@ import {
   AddBotsRequestSchema,
   ChangeSeatCountRequestSchema,
   ChangeShotClockRequestSchema,
+  ChangeShowdownClockRequestSchema,
   ChangeSoundSettingsRequestSchema,
   ClaimSeatRequestSchema,
   LeaveSeatRequestSchema,
@@ -33,6 +34,7 @@ import type { WebSocket } from "ws";
 import { ActionClock } from "./action-clock.js";
 import {
   chooseBotAction,
+  chooseShowdownAction,
   shouldSitIn,
   shouldSitOut,
   unitRandom,
@@ -49,6 +51,7 @@ import {
   type EvictSeatResult,
   type Room,
   RoomStore,
+  type SeatCommandType,
   toRoomView,
 } from "./rooms.js";
 import { RoomRecordings, type PausedRoom } from "./room-recordings.js";
@@ -79,6 +82,8 @@ export interface BuildAppOptions {
   readonly now?: () => Date;
   /** Overridable for tests only; production runs `ActionClock`'s 90s default. */
   readonly actionClockMs?: number;
+  /** Overridable for tests only; production reads the room's showdown clock. */
+  readonly showdownClockMs?: number;
   readonly actionClock?: ActionClock;
   readonly pingIntervalMs?: number;
   readonly missedPongLimit?: number;
@@ -661,15 +666,24 @@ export async function buildApp(
     return changed;
   }
 
+  function botSeatAt(code: string, actor: SeatId | undefined): boolean {
+    if (actor === undefined) return false;
+    const seat = rooms.get(code)?.seats[actor];
+    return seat?.claimed === true && seat.bot === true;
+  }
+
+  /**
+   * A bot in the showing queue would otherwise wedge the room, so it resolves
+   * on its own turn — after the usual delay, never instantly (ADR-0009).
+   */
   function scheduleBotAction(code: string): void {
     clearBotActionTimer(code);
     if (!testMode) return;
 
-    const room = rooms.get(code);
-    const actor = rooms.currentActor(code);
-    if (room === undefined || actor === undefined) return;
-    const seat = room.seats[actor];
-    if (!seat?.claimed || seat.bot !== true) return;
+    const betting = rooms.currentActor(code);
+    const showing = rooms.showdownActor(code);
+    const actor = betting ?? showing;
+    if (!botSeatAt(code, actor) || actor === undefined) return;
 
     const timer = setTimeout(
       () => {
@@ -677,21 +691,14 @@ export async function buildApp(
         enqueueDetached(code, async () => {
           if (roomRecordings.isPaused(code)) return;
           const currentRoom = rooms.get(code);
-          if (!currentRoom || rooms.currentActor(code) !== actor) return;
-          const currentSeat = currentRoom.seats[actor];
-          if (!currentSeat?.claimed || currentSeat.bot !== true) return;
-          const engine = currentRoom.engine;
-          if (engine?.hand?.status !== "betting") return;
+          if (!currentRoom || !botSeatAt(code, actor)) return;
 
-          const actorView = view(engine, actor);
-          if (
-            actorView.phase !== "betting" ||
-            actorView.legalActions.length === 0
-          ) {
-            return;
-          }
+          const action =
+            betting === undefined
+              ? botShowdownAction(code, actor)
+              : botBettingAction(currentRoom, actor);
+          if (action === null) return;
 
-          const action = chooseBotAction(actorView.legalActions, botRng);
           const result = rooms.dispatch(code, actor, action);
           if (!("commit" in result)) {
             rescheduleActionClock(code);
@@ -706,27 +713,54 @@ export async function buildApp(
     botActionTimers.set(code, timer);
   }
 
+  function botBettingAction(room: Room, actor: SeatId): SeatCommandType | null {
+    if (rooms.currentActor(room.code) !== actor) return null;
+    const engine = room.engine;
+    if (engine?.hand?.status !== "betting") return null;
+    const actorView = view(engine, actor);
+    if (actorView.phase !== "betting" || actorView.legalActions.length === 0) {
+      return null;
+    }
+    return chooseBotAction(actorView.legalActions, botRng);
+  }
+
+  function botShowdownAction(
+    code: string,
+    actor: SeatId,
+  ): SeatCommandType | null {
+    if (rooms.showdownActor(code) !== actor) return null;
+    return chooseShowdownAction(rooms.showdownCompelled(code), botRng);
+  }
+
+  /**
+   * One scheduler for both clocks: the betting turn's, which the room may turn
+   * off, and the showing window's, which it may not — see ADR-0009. Expiry is
+   * an ordinary Command, so the engine keeps no notion of time.
+   */
   function rescheduleActionClock(
     code: string,
     policy: ActionClockPolicy = "reschedule",
   ): void {
     const room = rooms.get(code);
-    const actor = rooms.currentActor(code);
-    if (room === undefined || actor === undefined) {
+    if (room === undefined) {
       cancelActionClock(code);
       return;
     }
 
-    const { enabled, seconds } = room.shotClockSettings;
-    if (!enabled) {
+    const betting = rooms.currentActor(code);
+    const showing = rooms.showdownActor(code);
+    const actor = betting ?? showing;
+    if (actor === undefined) {
       cancelActionClock(code);
       return;
     }
 
-    const fullInterval =
-      options.actionClock === undefined && options.actionClockMs !== undefined
-        ? options.actionClockMs
-        : seconds * 1000;
+    if (betting !== undefined && !room.shotClockSettings.enabled) {
+      cancelActionClock(code);
+      return;
+    }
+
+    const fullInterval = clockIntervalMs(room, betting !== undefined);
     const preserved = policy === "preserve" ? room.turnEndsAt : null;
     const timeoutMs =
       preserved === null
@@ -739,20 +773,15 @@ export async function buildApp(
         if (roomRecordings.isPaused(code)) return;
         const currentRoom = rooms.get(code);
         if (currentRoom?.revision !== scheduledAt) return;
-        if (rooms.currentActor(code) !== actor) {
+        if ((rooms.currentActor(code) ?? rooms.showdownActor(code)) !== actor) {
           rescheduleActionClock(code);
           return;
         }
 
-        const actorView =
-          currentRoom.engine === null
-            ? undefined
-            : view(currentRoom.engine, actor);
         const action =
-          actorView?.phase === "betting" &&
-          actorView.legalActions.includes("check")
-            ? "check"
-            : "fold";
+          betting === undefined
+            ? expiryShowdownAction(code)
+            : expiryBettingAction(currentRoom, actor);
         const result = rooms.dispatch(code, actor, action);
         if ("commit" in result) {
           await publishDispatch(code, result);
@@ -761,6 +790,33 @@ export async function buildApp(
         rescheduleActionClock(code);
       });
     });
+  }
+
+  function clockIntervalMs(room: Room, betting: boolean): number {
+    if (betting) {
+      return options.actionClock === undefined &&
+        options.actionClockMs !== undefined
+        ? options.actionClockMs
+        : room.shotClockSettings.seconds * 1000;
+    }
+    return options.actionClock === undefined &&
+      options.showdownClockMs !== undefined
+      ? options.showdownClockMs
+      : room.showdownClockSettings.seconds * 1000;
+  }
+
+  function expiryBettingAction(room: Room, actor: SeatId): SeatCommandType {
+    const actorView =
+      room.engine === null ? undefined : view(room.engine, actor);
+    return actorView?.phase === "betting" &&
+      actorView.legalActions.includes("check")
+      ? "check"
+      : "fold";
+  }
+
+  /** The one place cards are turned over for a player: a compelled head shows. */
+  function expiryShowdownAction(code: string): SeatCommandType {
+    return rooms.showdownCompelled(code) ? "show" : "muck";
   }
 
   /** The one place the live path and a resuming Retry both settle through. */
@@ -1004,6 +1060,32 @@ export async function buildApp(
     }
     return result;
   });
+
+  app.post<RoomCodeRoute>(
+    "/rooms/:code/showdown-clock",
+    async (request, reply) => {
+      const body = ChangeShowdownClockRequestSchema.safeParse(request.body);
+      if (!body.success) {
+        return reply.code(400).send({ error: "invalid-request-body" });
+      }
+      const room = findRoomOrReject(rooms, request.params.code, reply);
+      if (!room) return;
+      const result = await enqueue(room.code, () => {
+        const settings = rooms.changeShowdownClockSettings(
+          room.code,
+          body.data,
+        );
+        if (!("error" in settings)) broadcastRoomView(room.code);
+        return settings;
+      });
+      if ("error" in result) {
+        return reply
+          .code(result.error === "room-not-found" ? 404 : 400)
+          .send({ error: result.error });
+      }
+      return result;
+    },
+  );
 
   app.get<RoomCodeRoute>("/join/:code", (request, reply) => {
     const room = findRoomOrReject(rooms, request.params.code, reply);

--- a/packages/server/src/bot-driver.test.ts
+++ b/packages/server/src/bot-driver.test.ts
@@ -131,6 +131,47 @@ describe("bot driver", () => {
     );
   });
 
+  it("resolves an all-bot showing window rather than wedging the room", async () => {
+    const rooms = new RoomStore();
+    const room = rooms.create(3);
+    rooms.addBots(room, 3);
+
+    app = await buildApp({
+      recordings: testRecordings(),
+      rooms,
+      testMode: true,
+      // Never rolls a muck: the compelled head shows and the rest follow.
+      botRng: () => 0.1,
+      botActionDelayMs: 1,
+      pingIntervalMs: 100_000,
+      showdownClockMs: 100_000,
+    });
+    const running = await openTable(app, room.code);
+    socket = running.socket;
+
+    socket.send(JSON.stringify({ type: "startHand" }));
+    await waitFor(
+      () => rooms.get(room.code)?.engine?.hand?.status === "complete",
+      "hand never completed",
+    );
+
+    const hand = rooms.get(room.code)?.engine?.hand;
+    if (hand?.status !== "complete")
+      throw new Error("expected a complete hand");
+    expect(hand.reason).toBe("showdown");
+
+    await waitForMessage(
+      running,
+      (message) =>
+        message.type === "hand-update" &&
+        message.event.type === "WinnersDeclared",
+    );
+    expect(rooms.showdownActor(room.code)).toBeUndefined();
+    expect(running.messages).not.toContainEqual(
+      expect.objectContaining({ type: "command-rejected" }),
+    );
+  });
+
   it("keeps a two-seat floor, reports cadence over WS, and deals a waiting bot next hand", async () => {
     app = await buildApp({
       recordings: testRecordings(),

--- a/packages/server/src/bot-policy.test.ts
+++ b/packages/server/src/bot-policy.test.ts
@@ -2,6 +2,7 @@ import fc from "fast-check";
 import { describe, expect, it } from "vitest";
 import {
   chooseBotAction,
+  chooseShowdownAction,
   DEFAULT_BOT_ACTION_WEIGHTS,
   DEFAULT_SIT_IN_PROBABILITY,
   DEFAULT_SIT_OUT_PROBABILITY,
@@ -166,5 +167,16 @@ describe("sit-out/in rolls", () => {
   it("rejects probabilities outside the unit interval", () => {
     expect(() => shouldSitOut(() => 0, -0.01)).toThrow(RangeError);
     expect(() => shouldSitIn(() => 0, 1.01)).toThrow(RangeError);
+  });
+});
+
+describe("chooseShowdownAction", () => {
+  it("shows when compelled, whatever the roll says", () => {
+    expect(chooseShowdownAction(true, () => 0.99)).toBe("show");
+  });
+
+  it("leans heavily on showing when free to muck", () => {
+    expect(chooseShowdownAction(false, () => 0.5)).toBe("show");
+    expect(chooseShowdownAction(false, () => 0.99)).toBe("muck");
   });
 });

--- a/packages/server/src/bot-policy.ts
+++ b/packages/server/src/bot-policy.ts
@@ -63,6 +63,20 @@ export function chooseBotAction(
   throw new Error("chooseBotAction lost its supplied legal action");
 }
 
+export const DEFAULT_BOT_SHOW_PROBABILITY = 0.85;
+
+export type BotShowdownAction = "show" | "muck";
+
+/** Weighted heavily toward showing; a compelled head has no choice at all. */
+export function chooseShowdownAction(
+  compelled: boolean,
+  rng: BotRng = Math.random,
+  probability: number = DEFAULT_BOT_SHOW_PROBABILITY,
+): BotShowdownAction {
+  if (compelled) return "show";
+  return rollBelow(rng, probability) ? "show" : "muck";
+}
+
 function rollBelow(rng: BotRng, probability: number): boolean {
   assertProbability(probability);
   return unitRandom(rng) < probability;

--- a/packages/server/src/rooms.test.ts
+++ b/packages/server/src/rooms.test.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_SEAT_COUNT,
   DEFAULT_SHOT_CLOCK,
+  DEFAULT_SHOWDOWN_CLOCK,
   DEFAULT_SOUND_SETTINGS,
   MAX_DISPLAY_NAME_LENGTH,
   MAX_SEAT_COUNT,
@@ -1146,6 +1147,12 @@ describe("RoomStore", () => {
 
     const MAX_ACTIONS_TO_SHOWDOWN = 16;
 
+    function headOfQueue(store: RoomStore, code: string): SeatId {
+      const head = store.showdownActor(code);
+      if (head === undefined) throw new Error("expected a showdown actor");
+      return head;
+    }
+
     function stagedDispatch(
       store: RoomStore,
       code: string,
@@ -1345,43 +1352,51 @@ describe("RoomStore", () => {
       });
     });
 
-    it("takes reveal from the table and stamps a seat on it", () => {
+    it("refuses show and muck from the table", () => {
       const store = new RoomStore();
       const room = roomWithClaimedSeats(store, [0, 1]);
       playToShowdown(store, room.code);
 
-      const revealed = commitDispatch(store, room.code, "table", "reveal");
-
-      if (!("steps" in revealed)) throw new Error("expected a transaction");
-      expect(revealed.command).toEqual({ type: "reveal", seatId: 0 });
-      expect(revealed.steps.map((step) => step.event.type)).toContain(
-        "WinnersDeclared",
-      );
-    });
-
-    it("refuses reveal from a player and show from the table", () => {
-      const store = new RoomStore();
-      const room = roomWithClaimedSeats(store, [0, 1]);
-      playToShowdown(store, room.code);
-
-      expect(store.dispatch(room.code, 0, "reveal")).toEqual({
-        error: "not-permitted",
-      });
       expect(store.dispatch(room.code, "table", "show")).toEqual({
         error: "not-permitted",
       });
+      expect(store.dispatch(room.code, "table", "muck")).toEqual({
+        error: "not-permitted",
+      });
     });
 
-    it("shows a player's own hand on their own command", () => {
+    it("shows the head of the queue's own hand on their own command", () => {
       const store = new RoomStore();
       const room = roomWithClaimedSeats(store, [0, 1]);
       playToShowdown(store, room.code);
-      commitDispatch(store, room.code, "table", "reveal");
+      const head = store.showdownActor(room.code);
+      if (head === undefined) throw new Error("expected a showdown actor");
 
-      const shown = commitDispatch(store, room.code, 1, "show");
+      const shown = commitDispatch(store, room.code, head, "show");
 
       if (!("steps" in shown)) throw new Error("expected a transaction");
-      expect(shown.command).toEqual({ type: "show", seatId: 1 });
+      expect(shown.command).toEqual({ type: "show", seatId: head });
+    });
+
+    it("mucks the last contestant and publishes the winners", () => {
+      const store = new RoomStore();
+      const room = roomWithClaimedSeats(store, [0, 1]);
+      playToShowdown(store, room.code);
+      commitDispatch(store, room.code, headOfQueue(store, room.code), "show");
+
+      const mucked = commitDispatch(
+        store,
+        room.code,
+        headOfQueue(store, room.code),
+        "muck",
+      );
+
+      if (!("steps" in mucked)) throw new Error("expected a transaction");
+      expect(mucked.steps.map((step) => step.event.type)).toEqual([
+        "HoleCardsMucked",
+        "WinnersDeclared",
+      ]);
+      expect(store.showdownActor(room.code)).toBeUndefined();
     });
 
     it("has no operation for a refusal the engine never ruled on", () => {
@@ -1455,6 +1470,7 @@ describe("toRoomView", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
       seats: [
         {
           id: 0,
@@ -1556,6 +1572,56 @@ describe("changeShotClockSettings", () => {
 
     expect(
       store.changeShotClockSettings("ZZZZ", {
+        enabled: true,
+        seconds: 30,
+      }),
+    ).toEqual({ error: "room-not-found" });
+  });
+});
+
+describe("changeShowdownClockSettings", () => {
+  it("applies a new duration at once", () => {
+    const store = new RoomStore();
+    const room = store.create();
+    const settings = { enabled: true, seconds: 45 } as const;
+
+    expect(store.changeShowdownClockSettings(room.code, settings)).toEqual(
+      settings,
+    );
+    expect(toRoomView(room).showdownClockSettings).toEqual(settings);
+  });
+
+  it("refuses to turn the clock off — the room would wedge", () => {
+    const store = new RoomStore();
+    const room = store.create();
+
+    expect(
+      store.changeShowdownClockSettings(room.code, {
+        enabled: false,
+        seconds: 30,
+      } as unknown as { enabled: true; seconds: number }),
+    ).toEqual({ error: "invalid-showdown-clock" });
+    expect(room.showdownClockSettings).toEqual(DEFAULT_SHOWDOWN_CLOCK);
+  });
+
+  it("rejects an invalid duration without changing the room", () => {
+    const store = new RoomStore();
+    const room = store.create();
+
+    expect(
+      store.changeShowdownClockSettings(room.code, {
+        enabled: true,
+        seconds: 4,
+      }),
+    ).toEqual({ error: "invalid-showdown-clock" });
+    expect(room.showdownClockSettings).toEqual(DEFAULT_SHOWDOWN_CLOCK);
+  });
+
+  it("reports an unknown room", () => {
+    const store = new RoomStore();
+
+    expect(
+      store.changeShowdownClockSettings("ZZZZ", {
         enabled: true,
         seconds: 30,
       }),

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -30,6 +30,7 @@ import {
   type SeatCountChangeError,
   type SeatMove,
   type ShotClockSettings,
+  type ShowdownCompleteHandState,
   type ShowdownClockSettings,
   type SittingOutReason,
   type SoundSettings,
@@ -446,21 +447,22 @@ export class RoomStore {
     return hand.toAct[0];
   }
 
-  /** The head of the showing queue, while the window is open — see ADR-0009. */
+  /** The head of the showing queue, while the window is open. */
   showdownActor(code: string): SeatId | undefined {
-    const hand = this.#rooms.get(code)?.engine?.hand;
-    if (hand?.status !== "complete" || hand.reason !== "showdown") {
-      return undefined;
-    }
-    if (hand.winners !== null) return undefined;
-    return hand.queue[0];
+    const hand = this.#openShowdown(code);
+    return hand?.winners === null ? hand.queue[0] : undefined;
   }
 
   /** Whether the head of the showing queue is barred from mucking. */
   showdownCompelled(code: string): boolean {
+    return this.#openShowdown(code)?.results.length === 0;
+  }
+
+  #openShowdown(code: string): ShowdownCompleteHandState | undefined {
     const hand = this.#rooms.get(code)?.engine?.hand;
-    if (hand?.status !== "complete" || hand.reason !== "showdown") return false;
-    return hand.results.length === 0;
+    return hand?.status === "complete" && hand.reason === "showdown"
+      ? hand
+      : undefined;
   }
 
   end(code: string): void {

--- a/packages/server/src/rooms.ts
+++ b/packages/server/src/rooms.ts
@@ -7,12 +7,14 @@ import {
   createInitialState,
   DEFAULT_SEAT_COUNT,
   DEFAULT_SHOT_CLOCK,
+  DEFAULT_SHOWDOWN_CLOCK,
   DEFAULT_SOUND_SETTINGS,
   decide,
   MAX_SEAT_COUNT,
   MAX_DISPLAY_NAME_LENGTH,
   MIN_SEAT_COUNT,
   ShotClockSettingsSchema,
+  ShowdownClockSettingsSchema,
   SeatCountSchema,
   type ClientCommandType,
   type Command,
@@ -28,6 +30,7 @@ import {
   type SeatCountChangeError,
   type SeatMove,
   type ShotClockSettings,
+  type ShowdownClockSettings,
   type SittingOutReason,
   type SoundSettings,
 } from "@table-top-poker/protocol";
@@ -57,6 +60,7 @@ export interface Room {
   pendingShotClock: ShotClockSettings | null;
   soundSettings: SoundSettings;
   shotClockSettings: ShotClockSettings;
+  showdownClockSettings: ShowdownClockSettings;
 }
 
 /** Staged, not yet joinable: Room creation is transactional with recording creation. */
@@ -133,11 +137,7 @@ export type SeatCommandType = Exclude<ClientCommandType, "sitOut" | "sitIn">;
 const TABLE_ONLY_COMMANDS: ReadonlySet<SeatCommandType> = new Set([
   "startHand",
   "nextHand",
-  "reveal",
 ]);
-
-/** The table has no Seat of its own; a table-originated Command still needs one stamped. */
-const TABLE_SEAT_ID = 0;
 
 function makeSeats(seatCount: number): Seat[] {
   return Array.from({ length: seatCount }, (_, id) => ({
@@ -237,6 +237,8 @@ function remapCompletedEngineState(
         ...result,
         seatId: map(result.seatId),
       })),
+      queue: hand.queue.map(map),
+      mucked: hand.mucked.map(map),
       winners: hand.winners === null ? null : hand.winners.map(map),
     },
   };
@@ -408,6 +410,7 @@ export class RoomStore {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
     };
     return {
       room,
@@ -441,6 +444,23 @@ export class RoomStore {
     const hand = this.#rooms.get(code)?.engine?.hand;
     if (hand?.status !== "betting") return undefined;
     return hand.toAct[0];
+  }
+
+  /** The head of the showing queue, while the window is open — see ADR-0009. */
+  showdownActor(code: string): SeatId | undefined {
+    const hand = this.#rooms.get(code)?.engine?.hand;
+    if (hand?.status !== "complete" || hand.reason !== "showdown") {
+      return undefined;
+    }
+    if (hand.winners !== null) return undefined;
+    return hand.queue[0];
+  }
+
+  /** Whether the head of the showing queue is barred from mucking. */
+  showdownCompelled(code: string): boolean {
+    const hand = this.#rooms.get(code)?.engine?.hand;
+    if (hand?.status !== "complete" || hand.reason !== "showdown") return false;
+    return hand.results.length === 0;
   }
 
   end(code: string): void {
@@ -625,6 +645,20 @@ export class RoomStore {
     return parsed.data;
   }
 
+  changeShowdownClockSettings(
+    code: string,
+    settings: ShowdownClockSettings,
+  ):
+    | ShowdownClockSettings
+    | { error: "room-not-found" | "invalid-showdown-clock" } {
+    const room = this.#rooms.get(code);
+    if (!room) return { error: "room-not-found" };
+    const parsed = ShowdownClockSettingsSchema.safeParse(settings);
+    if (!parsed.success) return { error: "invalid-showdown-clock" };
+    room.showdownClockSettings = parsed.data;
+    return parsed.data;
+  }
+
   isSittingOut(code: string, seatId: SeatId): boolean {
     const room = this.#rooms.get(code);
     return room ? isSittingOut(room, seatId) : false;
@@ -804,7 +838,6 @@ export class RoomStore {
     if (type === "startHand" || type === "nextHand") {
       return { type, seatId: 0, seed: this.#generateSeed() };
     }
-    if (type === "reveal") return { type, seatId: TABLE_SEAT_ID };
     return { type, seatId: identity as SeatId };
   }
 }
@@ -816,6 +849,7 @@ export function toRoomView(room: Room): RoomView {
     pendingShotClock: room.pendingShotClock,
     soundSettings: room.soundSettings,
     shotClockSettings: room.shotClockSettings,
+    showdownClockSettings: room.showdownClockSettings,
     seats: room.seats.map((seat) => {
       const reason = sittingOutReason(room, seat.id);
       return {

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -58,6 +58,9 @@ const completeHand: TableView = {
 
 const showdownHand: TableView = {
   phase: "showdown",
+  turnEndsAt: null,
+  queue: [],
+  mucked: [],
   button: 0,
   smallBlind: 1,
   bigBlind: 2,
@@ -107,10 +110,11 @@ function enterRoom(
   };
 }
 
-const awaitingReveal: TableView = {
+const openWindow: TableView = {
   ...showdownHand,
   winners: null,
   results: [],
+  queue: [0, 1],
 };
 
 describe("App", () => {
@@ -215,18 +219,18 @@ describe("App", () => {
     expect(html).toContain('data-testid="next-hand-button"');
   });
 
-  it("puts Reveal where Next hand goes until the table has revealed", () => {
-    enterRoom(2, awaitingReveal);
-    const revealing = renderToStaticMarkup(<App />);
+  it("withholds Next hand while the showing window is open", () => {
+    enterRoom(2, openWindow);
+    const showing = renderToStaticMarkup(<App />);
 
-    expect(revealing).toContain('data-testid="reveal-button"');
-    expect(revealing).not.toContain('data-testid="next-hand-button"');
+    expect(showing).toContain('data-testid="showdown-in-progress-hint"');
+    expect(showing).not.toContain('data-testid="next-hand-button"');
 
     enterRoom(2, showdownHand);
-    const revealed = renderToStaticMarkup(<App />);
+    const closed = renderToStaticMarkup(<App />);
 
-    expect(revealed).not.toContain('data-testid="reveal-button"');
-    expect(revealed).toContain('data-testid="next-hand-button"');
+    expect(closed).not.toContain('data-testid="showdown-in-progress-hint"');
+    expect(closed).toContain('data-testid="next-hand-button"');
   });
 
   it("banners a fold-out ending", () => {

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -397,11 +397,7 @@ export function App() {
                 handComplete={handComplete}
                 canDealNextHand={enoughPlayers}
                 awaitingShowdown={awaitingShowdown}
-                rejectionHint={
-                  commandRejection === "showdown-unresolved"
-                    ? "The hands are still being turned over"
-                    : null
-                }
+                dealRejected={commandRejection === "showdown-unresolved"}
                 onStartHand={handleStartHand}
                 onNextHand={handleNextHand}
                 onEndSession={handleEndSession}

--- a/packages/table-client/src/App.tsx
+++ b/packages/table-client/src/App.tsx
@@ -5,6 +5,7 @@ import {
   isHandLive,
   MIN_SEAT_COUNT,
   type ShotClockSettings,
+  type ShowdownClockSettings,
   type SoundSettings,
 } from "@table-top-poker/protocol";
 import {
@@ -18,6 +19,7 @@ import { useCallback, useEffect, useState, type CSSProperties } from "react";
 import {
   changeSeatCount,
   changeShotClockSettings,
+  changeShowdownClockSettings,
   changeSoundSettings,
   createRoom,
   addBots,
@@ -90,6 +92,9 @@ export function App() {
   const pendingShotClock = useTableStore((state) => state.pendingShotClock);
   const soundSettings = useTableStore((state) => state.soundSettings);
   const shotClockSettings = useTableStore((state) => state.shotClockSettings);
+  const showdownClockSettings = useTableStore(
+    (state) => state.showdownClockSettings,
+  );
   const testMode = useTableStore((state) => state.testMode);
   const connectionStatus = useTableStore((state) => state.connectionStatus);
   const handView = useTableStore((state) => state.handView);
@@ -125,7 +130,8 @@ export function App() {
 
   const [handPickerOpen, setHandPickerOpen] = useState(false);
 
-  const awaitingReveal =
+  const commandRejection = useTableStore((state) => state.commandRejection);
+  const awaitingShowdown =
     handView?.phase === "showdown" && handView.winners === null;
   const handleSeatClick = useCallback((seatId: number) => {
     setMenuSeatId((current) => (current === seatId ? null : seatId));
@@ -208,6 +214,14 @@ export function App() {
     [roomCode],
   );
 
+  const handleChangeShowdownClockSettings = useCallback(
+    async (next: ShowdownClockSettings): Promise<void> => {
+      if (roomCode === null) return;
+      await changeShowdownClockSettings(roomCode, next);
+    },
+    [roomCode],
+  );
+
   const handleStartHand = useCallback(() => {
     void unlockAudio();
     send({ type: "startHand" });
@@ -216,10 +230,6 @@ export function App() {
   const handleNextHand = useCallback(() => {
     void unlockAudio();
     send({ type: "nextHand" });
-  }, [send]);
-
-  const handleReveal = useCallback(() => {
-    send({ type: "reveal" });
   }, [send]);
 
   const handleSelectHand = useCallback(
@@ -302,6 +312,7 @@ export function App() {
               seats={seats}
               view={handView}
               shotClockSeconds={shotClockSettings.seconds}
+              showdownClockSeconds={showdownClockSettings.seconds}
               onSeatClick={handleSeatClick}
             />
             {menuSeatId !== null && (
@@ -370,8 +381,10 @@ export function App() {
                 handInProgress={isHandLive(handView)}
                 soundSettings={soundSettings}
                 shotClockSettings={shotClockSettings}
+                showdownClockSettings={showdownClockSettings}
                 onApply={handleChangeSeatCount}
                 onApplyShotClock={handleChangeShotClockSettings}
+                onApplyShowdownClock={handleChangeShowdownClockSettings}
                 onChangeSoundSettings={handleChangeSoundSettings}
                 onClose={() => {
                   setSettingsOpen(false);
@@ -383,10 +396,14 @@ export function App() {
                 canStartHand={canStartHand}
                 handComplete={handComplete}
                 canDealNextHand={enoughPlayers}
-                awaitingReveal={awaitingReveal}
+                awaitingShowdown={awaitingShowdown}
+                rejectionHint={
+                  commandRejection === "showdown-unresolved"
+                    ? "The hands are still being turned over"
+                    : null
+                }
                 onStartHand={handleStartHand}
                 onNextHand={handleNextHand}
-                onReveal={handleReveal}
                 onEndSession={handleEndSession}
                 testMode={testMode}
                 onAddBot={handleAddBot}

--- a/packages/table-client/src/Board.test.tsx
+++ b/packages/table-client/src/Board.test.tsx
@@ -79,6 +79,9 @@ describe("Board", () => {
   it("shows only the community cards at showdown, suppressing the banner the overlay now owns", () => {
     const view: TableView = {
       phase: "showdown",
+      turnEndsAt: null,
+      queue: [],
+      mucked: [],
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -161,6 +164,9 @@ describe("Board", () => {
     };
     const showdown: TableView = {
       phase: "showdown",
+      turnEndsAt: null,
+      queue: [],
+      mucked: [],
       button: 0,
       smallBlind: 1,
       bigBlind: 2,

--- a/packages/table-client/src/HouseRulesSheet.test.tsx
+++ b/packages/table-client/src/HouseRulesSheet.test.tsx
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SHOT_CLOCK,
+  DEFAULT_SHOWDOWN_CLOCK,
   DEFAULT_SOUND_SETTINGS,
   type SeatView,
 } from "@table-top-poker/protocol";
@@ -86,6 +87,8 @@ const shotClockProps = {
   pendingShotClock: null,
   shotClockSettings: DEFAULT_SHOT_CLOCK,
   onApplyShotClock: noop,
+  showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
+  onApplyShowdownClock: noop,
 };
 
 function renderSheet(
@@ -275,11 +278,13 @@ describe("HouseRulesSheet", () => {
         pendingSeatCount={null}
         pendingShotClock={{ enabled: true, seconds: 30 }}
         shotClockSettings={DEFAULT_SHOT_CLOCK}
+        showdownClockSettings={DEFAULT_SHOWDOWN_CLOCK}
         seats={seats.slice(0, 4)}
         handInProgress
         soundSettings={DEFAULT_SOUND_SETTINGS}
         onApply={noop}
         onApplyShotClock={noop}
+        onApplyShowdownClock={noop}
         onChangeSoundSettings={noop}
         onClose={noop}
       />,
@@ -392,5 +397,15 @@ describe("HouseRulesSheet", () => {
     act(() => {
       renderer.unmount();
     });
+  });
+});
+
+describe("HouseRulesSheet showdown clock", () => {
+  it("offers seconds with no way to turn the clock off", () => {
+    const html = renderToStaticMarkup(renderSheet());
+
+    expect(html).toContain('data-testid="showdown-clock-settings"');
+    expect(html).toContain('data-testid="showdown-clock-seconds"');
+    expect(html).not.toContain('data-testid="showdown-clock-toggle"');
   });
 });

--- a/packages/table-client/src/HouseRulesSheet.tsx
+++ b/packages/table-client/src/HouseRulesSheet.tsx
@@ -1,11 +1,14 @@
 import {
   MAX_SEAT_COUNT,
   MAX_SHOT_CLOCK_SECONDS,
+  MAX_SHOWDOWN_CLOCK_SECONDS,
   MIN_SEAT_COUNT,
   MIN_SHOT_CLOCK_SECONDS,
+  MIN_SHOWDOWN_CLOCK_SECONDS,
   type SeatView,
   type SeatMove,
   type ShotClockSettings,
+  type ShowdownClockSettings,
   type SoundSettings,
 } from "@table-top-poker/protocol";
 import {
@@ -28,9 +31,13 @@ export interface HouseRulesSheetProps {
   readonly handInProgress: boolean;
   readonly soundSettings: SoundSettings;
   readonly shotClockSettings: ShotClockSettings;
+  readonly showdownClockSettings: ShowdownClockSettings;
   readonly onApply: (seatCount: number) => void | Promise<void>;
   readonly onApplyShotClock: (
     settings: ShotClockSettings,
+  ) => void | Promise<void>;
+  readonly onApplyShowdownClock: (
+    settings: ShowdownClockSettings,
   ) => void | Promise<void>;
   readonly onChangeSoundSettings: (next: SoundSettings) => void;
   readonly onClose: () => void;
@@ -79,20 +86,46 @@ export interface ShotClockSecondsDraft {
   readonly valid: boolean;
 }
 
-export function updateShotClockSecondsDraft(
+function updateSecondsDraft(
   draft: ShotClockSecondsDraft,
   input: string,
+  minimum: number,
+  maximum: number,
 ): ShotClockSecondsDraft {
   const seconds = Number(input);
   if (
     /^\d+$/.test(input) &&
     Number.isInteger(seconds) &&
-    seconds >= MIN_SHOT_CLOCK_SECONDS &&
-    seconds <= MAX_SHOT_CLOCK_SECONDS
+    seconds >= minimum &&
+    seconds <= maximum
   ) {
     return { input, seconds, valid: true };
   }
   return { ...draft, input, valid: false };
+}
+
+export function updateShotClockSecondsDraft(
+  draft: ShotClockSecondsDraft,
+  input: string,
+): ShotClockSecondsDraft {
+  return updateSecondsDraft(
+    draft,
+    input,
+    MIN_SHOT_CLOCK_SECONDS,
+    MAX_SHOT_CLOCK_SECONDS,
+  );
+}
+
+export function updateShowdownClockSecondsDraft(
+  draft: ShotClockSecondsDraft,
+  input: string,
+): ShotClockSecondsDraft {
+  return updateSecondsDraft(
+    draft,
+    input,
+    MIN_SHOWDOWN_CLOCK_SECONDS,
+    MAX_SHOWDOWN_CLOCK_SECONDS,
+  );
 }
 
 function Toggle({
@@ -181,8 +214,10 @@ export function HouseRulesSheet({
   handInProgress,
   soundSettings,
   shotClockSettings,
+  showdownClockSettings,
   onApply,
   onApplyShotClock,
+  onApplyShowdownClock,
   onChangeSoundSettings,
   onClose,
 }: HouseRulesSheetProps) {
@@ -205,6 +240,12 @@ export function HouseRulesSheet({
       String((pendingShotClock ?? shotClockSettings).seconds),
     ),
   );
+  const [showdownSecondsDraft, setShowdownSecondsDraft] = useState(() =>
+    updateShowdownClockSecondsDraft(
+      { input: "", seconds: showdownClockSettings.seconds, valid: true },
+      String(showdownClockSettings.seconds),
+    ),
+  );
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const shotClockChanged =
@@ -212,9 +253,14 @@ export function HouseRulesSheet({
       (pendingShotClock ?? shotClockSettings).enabled ||
     shotClockDraft.seconds !== (pendingShotClock ?? shotClockSettings).seconds;
   const shotClockIsQueued = pendingShotClock !== null || shotClockChanged;
+  const showdownClockChanged =
+    showdownSecondsDraft.valid &&
+    showdownSecondsDraft.seconds !== showdownClockSettings.seconds;
 
   async function applyHouseRules(): Promise<void> {
-    if (saving || !shotClockSecondsDraft.valid) return;
+    if (saving || !shotClockSecondsDraft.valid || !showdownSecondsDraft.valid) {
+      return;
+    }
     setSaving(true);
     setSaveError(null);
     try {
@@ -224,6 +270,16 @@ export function HouseRulesSheet({
       if (shotClockChanged) {
         writes.push(
           Promise.resolve().then(() => onApplyShotClock(shotClockDraft)),
+        );
+      }
+      if (showdownClockChanged) {
+        writes.push(
+          Promise.resolve().then(() =>
+            onApplyShowdownClock({
+              enabled: true,
+              seconds: showdownSecondsDraft.seconds,
+            }),
+          ),
         );
       }
       const results = await Promise.allSettled(writes);
@@ -574,6 +630,84 @@ export function HouseRulesSheet({
           </div>
 
           <div
+            data-testid="showdown-clock-settings"
+            style={{
+              paddingTop: 20,
+              display: "flex",
+              flexDirection: "column",
+              gap: 10,
+              borderTop: `1px solid ${color.mutedSurface}`,
+              marginTop: 20,
+            }}
+          >
+            <label
+              style={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+                gap: 20,
+                color: color.text,
+                fontSize: fontSize.lg,
+                fontWeight: 600,
+              }}
+            >
+              <span>Showdown clock</span>
+              <input
+                type="number"
+                min={MIN_SHOWDOWN_CLOCK_SECONDS}
+                max={MAX_SHOWDOWN_CLOCK_SECONDS}
+                step={1}
+                value={showdownSecondsDraft.input}
+                data-testid="showdown-clock-seconds"
+                aria-label="Showdown clock seconds"
+                disabled={saving}
+                onChange={(event) => {
+                  setShowdownSecondsDraft(
+                    updateShowdownClockSecondsDraft(
+                      showdownSecondsDraft,
+                      event.currentTarget.value,
+                    ),
+                  );
+                }}
+                style={{
+                  width: 92,
+                  padding: "9px 10px",
+                  borderRadius: 10,
+                  border: `1px solid ${color.border}`,
+                  background: color.controlFill,
+                  color: color.textBright,
+                  fontFamily: font.mono,
+                  fontSize: fontSize.md,
+                  textAlign: "right",
+                }}
+              />
+            </label>
+            <span
+              style={{
+                fontSize: fontSize.caption,
+                lineHeight: 1.45,
+                color: color.textDim,
+              }}
+            >
+              Seconds each player has to show or muck. Always on — one locked
+              phone would otherwise hold up the table.
+            </span>
+            {!showdownSecondsDraft.valid ? (
+              <span
+                data-testid="showdown-clock-validation"
+                role="alert"
+                style={{
+                  color: color.accentBright,
+                  fontSize: fontSize.caption,
+                }}
+              >
+                Enter a whole number from {String(MIN_SHOWDOWN_CLOCK_SECONDS)}{" "}
+                to {String(MAX_SHOWDOWN_CLOCK_SECONDS)} seconds.
+              </span>
+            ) : null}
+          </div>
+
+          <div
             style={{
               paddingTop: 20,
               display: "flex",
@@ -607,7 +741,11 @@ export function HouseRulesSheet({
             <PillButton
               data-testid="settings-done"
               aria-busy={saving}
-              disabled={saving || !shotClockSecondsDraft.valid}
+              disabled={
+                saving ||
+                !shotClockSecondsDraft.valid ||
+                !showdownSecondsDraft.valid
+              }
               onClick={() => {
                 void applyHouseRules();
               }}

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -329,6 +329,9 @@ describe("Seats", () => {
   it("tables a shown hand on the seat plate with its rank badge, naming no hand", () => {
     const view: TableView = {
       phase: "showdown",
+      turnEndsAt: null,
+      queue: [],
+      mucked: [],
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -371,6 +374,9 @@ describe("Seats", () => {
   it("keeps a revealed player in-hand when they sit out for the next hand", () => {
     const view: TableView = {
       phase: "showdown",
+      turnEndsAt: null,
+      queue: [],
+      mucked: [],
       button: 0,
       smallBlind: 1,
       bigBlind: 2,
@@ -733,6 +739,9 @@ describe("Seats: position markers", () => {
       {
         ...headsUpPositions,
         phase: "showdown",
+        turnEndsAt: null,
+        queue: [],
+        mucked: [],
         board: [],
         contestants: [0, 1],
         winners: [0],
@@ -862,6 +871,9 @@ describe("Seats: action labels", () => {
 describe("Seats at showdown", () => {
   const board: TableView & { phase: "showdown" } = {
     phase: "showdown",
+    turnEndsAt: null,
+    queue: [],
+    mucked: [],
     button: 0,
     smallBlind: 1,
     bigBlind: 2,
@@ -1196,5 +1208,89 @@ describe("Seats to-act glow", () => {
     expect(html).not.toMatch(
       /data-testid="seat-pod-0-surface"[^>]*class="seat-actor-glow"/,
     );
+  });
+});
+
+describe("Seats through the showing window", () => {
+  const window: TableView & { phase: "showdown" } = {
+    phase: "showdown",
+    turnEndsAt: Date.now() + 2000,
+    queue: [1],
+    mucked: [0],
+    button: 0,
+    smallBlind: 1,
+    bigBlind: 2,
+    dealtSeatCount: 2,
+    board: [],
+    contestants: [0, 1],
+    winners: null,
+    results: [],
+  };
+
+  const twoSeats = [
+    {
+      id: 0,
+      claimed: true,
+      sittingOut: false,
+      sittingOutReason: null,
+      disconnected: false,
+    },
+    {
+      id: 1,
+      claimed: true,
+      sittingOut: false,
+      sittingOutReason: null,
+      disconnected: false,
+    },
+  ] as const;
+
+  it("lays nothing down for a mucked seat, and card backs for one still to act", () => {
+    const html = renderToStaticMarkup(
+      <Seats seats={[...twoSeats]} view={window} />,
+    );
+
+    expect(html).not.toContain('data-testid="seat-pod-0-showdown-card-0"');
+    expect(html).toContain('data-testid="seat-pod-1-showdown-card-0"');
+  });
+
+  it("gives the head of the queue the betting turn's active treatment", () => {
+    const html = renderToStaticMarkup(
+      <Seats seats={[...twoSeats]} view={window} />,
+    );
+
+    expect(html).toMatch(/data-testid="seat-pod-1"[^>]*data-turn="true"/);
+    expect(html).toMatch(/data-testid="seat-pod-0"[^>]*data-turn="false"/);
+    expect(html).toContain('data-testid="seat-pod-1-to-act"');
+  });
+
+  it("holds the seat-plate clock back until the closing seconds", () => {
+    const early = renderToStaticMarkup(
+      <Seats
+        seats={[...twoSeats]}
+        view={{ ...window, turnEndsAt: Date.now() + 25_000 }}
+        showdownClockSeconds={30}
+      />,
+    );
+    expect(early).not.toContain('data-testid="seat-showdown-clock"');
+
+    const closing = renderToStaticMarkup(
+      <Seats
+        seats={[...twoSeats]}
+        view={{ ...window, turnEndsAt: Date.now() + 2000 }}
+        showdownClockSeconds={30}
+      />,
+    );
+    expect(closing).toContain('data-testid="seat-showdown-clock"');
+  });
+
+  it("drops the active treatment once the verdict lands", () => {
+    const html = renderToStaticMarkup(
+      <Seats
+        seats={[...twoSeats]}
+        view={{ ...window, winners: [1], queue: [] }}
+      />,
+    );
+
+    expect(html).toMatch(/data-testid="seat-pod-1"[^>]*data-turn="false"/);
   });
 });

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -24,6 +24,7 @@ export interface SeatsProps {
   readonly seats: readonly SeatView[];
   readonly view: TableView | null;
   readonly shotClockSeconds?: number;
+  readonly showdownClockSeconds?: number;
   readonly onSeatClick?: (seatId: number) => void;
   readonly actionLabels?: SeatActionLabels;
 }
@@ -88,8 +89,13 @@ const FAN_HEIGHT = "5.6em";
  */
 const FAN_TUCK = "8%";
 
+/** The room gets the "clock's running" beat without a permanent timer on screen. */
+const SHOWDOWN_CLOCK_VISIBLE_SECONDS = 5;
+
 interface ShowdownSeat {
   readonly hand: RevealedResult | null;
+  /** Declined, and so laying nothing down: distinct from not shown yet. */
+  readonly mucked: boolean;
   readonly isWinner: boolean;
   readonly splitting: boolean;
 }
@@ -105,6 +111,7 @@ function showdownSeats(view: TableView | null): Map<SeatId, ShowdownSeat> {
   for (const seatId of view.contestants) {
     bySeat.set(seatId, {
       hand: shown.get(seatId) ?? null,
+      mucked: view.mucked.includes(seatId),
       isWinner: winners.includes(seatId) && shown.has(seatId),
       splitting: winners.length > 1,
     });
@@ -189,14 +196,17 @@ function ShowdownBadges({
 function ShowdownHand({
   seatId,
   hand,
+  mucked,
   isWinner,
   isTopRow,
 }: {
   readonly seatId: SeatId;
   readonly hand: RevealedResult | null;
+  readonly mucked: boolean;
   readonly isWinner: boolean;
   readonly isTopRow: boolean;
 }) {
+  if (mucked) return null;
   const faces = hand === null ? [null, null] : [...hand.holeCards];
 
   return (
@@ -307,7 +317,12 @@ function deriveSeat(seat: SeatView, view: TableView | null): SeatVisual {
   return {
     status,
     marker: positionMarkerFor(seat.id, view),
-    isActor: view?.phase === "betting" && view.toAct[0] === seat.id,
+    isActor:
+      view?.phase === "betting"
+        ? view.toAct[0] === seat.id
+        : view?.phase === "showdown" && view.winners === null
+          ? view.queue[0] === seat.id
+          : false,
     isWinner,
     avatarBackground,
     avatarColor,
@@ -318,6 +333,7 @@ export function Seats({
   seats,
   view,
   shotClockSeconds = 90,
+  showdownClockSeconds = 30,
   onSeatClick,
   actionLabels,
 }: SeatsProps) {
@@ -346,6 +362,16 @@ export function Seats({
                 variant="number"
                 testId="seat-shot-clock"
                 numberPosition="bottom-right"
+              />
+            ) : null}
+            {visual.isActor && view?.phase === "showdown" ? (
+              <ShotClock
+                turnEndsAt={view.turnEndsAt}
+                durationSeconds={showdownClockSeconds}
+                variant="number"
+                testId="seat-showdown-clock"
+                numberPosition="bottom-right"
+                showWithinSeconds={SHOWDOWN_CLOCK_VISIBLE_SECONDS}
               />
             ) : null}
             <div
@@ -628,6 +654,7 @@ export function Seats({
                 <ShowdownHand
                   seatId={seat.id}
                   hand={tabledHand}
+                  mucked={seatShowdown.mucked}
                   isWinner={seatShowdown.isWinner}
                   isTopRow={isTopRow}
                 />

--- a/packages/table-client/src/Seats.tsx
+++ b/packages/table-client/src/Seats.tsx
@@ -89,12 +89,10 @@ const FAN_HEIGHT = "5.6em";
  */
 const FAN_TUCK = "8%";
 
-/** The room gets the "clock's running" beat without a permanent timer on screen. */
 const SHOWDOWN_CLOCK_VISIBLE_SECONDS = 5;
 
 interface ShowdownSeat {
   readonly hand: RevealedResult | null;
-  /** Declined, and so laying nothing down: distinct from not shown yet. */
   readonly mucked: boolean;
   readonly isWinner: boolean;
   readonly splitting: boolean;

--- a/packages/table-client/src/TableControls.test.tsx
+++ b/packages/table-client/src/TableControls.test.tsx
@@ -74,7 +74,7 @@ describe("TableControls", () => {
         handComplete
         canDealNextHand
         awaitingShowdown
-        rejectionHint="The hands are still being turned over"
+        dealRejected
         onStartHand={noop}
         onNextHand={noop}
         onEndSession={noop}

--- a/packages/table-client/src/TableControls.test.tsx
+++ b/packages/table-client/src/TableControls.test.tsx
@@ -38,23 +38,22 @@ describe("TableControls", () => {
     expect(html).toContain('data-testid="next-hand-button"');
   });
 
-  it("swaps Next hand for Reveal until the table has revealed", () => {
+  it("withholds Next hand while the showing window is open", () => {
     const awaiting = renderToStaticMarkup(
       <TableControls
         canStartHand={false}
         handComplete
         canDealNextHand
-        awaitingReveal
+        awaitingShowdown
         onStartHand={noop}
         onNextHand={noop}
         onEndSession={noop}
-        onReveal={noop}
       />,
     );
-    expect(awaiting).toContain('data-testid="reveal-button"');
+    expect(awaiting).toContain('data-testid="showdown-in-progress-hint"');
     expect(awaiting).not.toContain('data-testid="next-hand-button"');
 
-    const revealed = renderToStaticMarkup(
+    const closed = renderToStaticMarkup(
       <TableControls
         canStartHand={false}
         handComplete
@@ -62,11 +61,26 @@ describe("TableControls", () => {
         onStartHand={noop}
         onNextHand={noop}
         onEndSession={noop}
-        onReveal={noop}
       />,
     );
-    expect(revealed).not.toContain('data-testid="reveal-button"');
-    expect(revealed).toContain('data-testid="next-hand-button"');
+    expect(closed).not.toContain('data-testid="showdown-in-progress-hint"');
+    expect(closed).toContain('data-testid="next-hand-button"');
+  });
+
+  it("surfaces the engine's reason when the table deals too early", () => {
+    const html = renderToStaticMarkup(
+      <TableControls
+        canStartHand={false}
+        handComplete
+        canDealNextHand
+        awaitingShowdown
+        rejectionHint="The hands are still being turned over"
+        onStartHand={noop}
+        onNextHand={noop}
+        onEndSession={noop}
+      />,
+    );
+    expect(html).toContain("The hands are still being turned over");
   });
 
   it("shows neither deal control mid-hand", () => {

--- a/packages/table-client/src/TableControls.tsx
+++ b/packages/table-client/src/TableControls.tsx
@@ -47,7 +47,8 @@ export interface TableControlsProps {
   readonly onAddBot?: () => void;
   /** The showing window is open: the room, not the table, closes it. */
   readonly awaitingShowdown?: boolean;
-  readonly rejectionHint?: string | null;
+  /** The engine refused a deal while the showing window was still open. */
+  readonly dealRejected?: boolean;
   readonly placement?: TableControlsPlacement;
   readonly onReviewHands?: () => void;
 }
@@ -62,7 +63,7 @@ export function TableControls({
   testMode = false,
   onAddBot,
   awaitingShowdown = false,
-  rejectionHint = null,
+  dealRejected = false,
   placement = "rail",
   onReviewHands,
 }: TableControlsProps) {
@@ -83,7 +84,9 @@ export function TableControls({
       )}
       {awaitingShowdown ? (
         <div data-testid="showdown-in-progress-hint" style={hintStyle}>
-          {rejectionHint ?? "Waiting on the players to show or muck"}
+          {dealRejected
+            ? "The hands are still being turned over"
+            : "Waiting on the players to show or muck"}
         </div>
       ) : (
         handComplete && (

--- a/packages/table-client/src/TableControls.tsx
+++ b/packages/table-client/src/TableControls.tsx
@@ -45,8 +45,9 @@ export interface TableControlsProps {
   readonly onEndSession: () => void;
   readonly testMode?: boolean;
   readonly onAddBot?: () => void;
-  readonly awaitingReveal?: boolean;
-  readonly onReveal?: () => void;
+  /** The showing window is open: the room, not the table, closes it. */
+  readonly awaitingShowdown?: boolean;
+  readonly rejectionHint?: string | null;
   readonly placement?: TableControlsPlacement;
   readonly onReviewHands?: () => void;
 }
@@ -60,8 +61,8 @@ export function TableControls({
   onEndSession,
   testMode = false,
   onAddBot,
-  awaitingReveal = false,
-  onReveal,
+  awaitingShowdown = false,
+  rejectionHint = null,
   placement = "rail",
   onReviewHands,
 }: TableControlsProps) {
@@ -80,14 +81,10 @@ export function TableControls({
           Deal hand
         </PillButton>
       )}
-      {awaitingReveal ? (
-        <PillButton
-          data-testid="reveal-button"
-          onClick={onReveal}
-          style={actionButtonStyle}
-        >
-          Reveal
-        </PillButton>
+      {awaitingShowdown ? (
+        <div data-testid="showdown-in-progress-hint" style={hintStyle}>
+          {rejectionHint ?? "Waiting on the players to show or muck"}
+        </div>
       ) : (
         handComplete && (
           <div style={actionButtonStyle}>

--- a/packages/table-client/src/api/rooms.ts
+++ b/packages/table-client/src/api/rooms.ts
@@ -2,6 +2,7 @@ import type {
   RoomView,
   SeatCountChange,
   ShotClockSettings,
+  ShowdownClockSettings,
   SoundSettings,
 } from "@table-top-poker/protocol";
 
@@ -122,4 +123,21 @@ export async function changeShotClockSettings(
     );
   }
   return (await response.json()) as ShotClockSettings;
+}
+
+export async function changeShowdownClockSettings(
+  code: string,
+  settings: ShowdownClockSettings,
+): Promise<ShowdownClockSettings> {
+  const response = await fetch(`/rooms/${code}/showdown-clock`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(settings),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `failed to change showdown-clock settings: ${String(response.status)}`,
+    );
+  }
+  return (await response.json()) as ShowdownClockSettings;
 }

--- a/packages/table-client/src/replay/HandReview.test.tsx
+++ b/packages/table-client/src/replay/HandReview.test.tsx
@@ -201,7 +201,7 @@ describe("HandReview", () => {
     expect(html).not.toContain(
       `data-testid="replay-tick-${String(events.length + 1)}"`,
     );
-    expect(html.match(/data-street-boundary="true"/g)).toHaveLength(2);
+    expect(html.match(/data-segment-boundary="true"/g)).toHaveLength(2);
   });
 
   it("offers a chapter for each street the hand reached, and no others", () => {

--- a/packages/table-client/src/replay/HandReview.tsx
+++ b/packages/table-client/src/replay/HandReview.tsx
@@ -18,7 +18,7 @@ export interface HandReviewProps {
 /**
  * One recorded hand, scrubbable. The whole hand is already in hand — the
  * server sends every position in one message — so the track can lay out its
- * ticks and street chapters before anything is touched (Phase 2 spec #129 §5).
+ * ticks and chapters before anything is touched (Phase 2 spec #129 §5).
  */
 export function HandReview({ review, seats, onClose }: HandReviewProps) {
   const positions = review.status === "ready" ? review.positions : [];
@@ -112,7 +112,7 @@ export function HandReview({ review, seats, onClose }: HandReviewProps) {
         onSeek={setPosition}
         onScrubbingChange={changeScrubbing}
         onTogglePlay={togglePlay}
-        currentStreet={beatAt(beats, position)?.street ?? null}
+        currentSegment={beatAt(beats, position)?.segment ?? null}
       />
     </>
   );

--- a/packages/table-client/src/replay/ReplayStage.test.tsx
+++ b/packages/table-client/src/replay/ReplayStage.test.tsx
@@ -70,6 +70,9 @@ describe("ReplayStage", () => {
 describe("ReplayStage at showdown", () => {
   const showdown: TableView = {
     phase: "showdown",
+    turnEndsAt: null,
+    queue: [],
+    mucked: [],
     button: 0,
     smallBlind: 1,
     bigBlind: 2,

--- a/packages/table-client/src/replay/ReplayTransport.tsx
+++ b/packages/table-client/src/replay/ReplayTransport.tsx
@@ -12,7 +12,7 @@ export interface ReplayTransportProps {
   readonly onSeek: (position: number) => void;
   readonly onScrubbingChange: (scrubbing: boolean) => void;
   readonly onTogglePlay: () => void;
-  readonly currentStreet: Chapter["street"] | null;
+  readonly currentSegment: Chapter["segment"] | null;
 }
 
 /** Past the ~44px touch-target floor at the table device's root size. */
@@ -36,7 +36,7 @@ export function ReplayTransport({
   onSeek,
   onScrubbingChange,
   onTogglePlay,
-  currentStreet,
+  currentSegment,
 }: ReplayTransportProps) {
   const total = beats.length;
   const trackRef = useRef<HTMLDivElement | null>(null);
@@ -97,10 +97,10 @@ export function ReplayTransport({
         <span style={{ flex: 1 }} />
         {chapters.map((chapter) => (
           <Chip
-            key={chapter.street}
-            active={currentStreet === chapter.street}
+            key={chapter.segment}
+            active={currentSegment === chapter.segment}
             label={`Seek to the ${chapter.label.toLowerCase()}`}
-            testId={`replay-chapter-${chapter.street}`}
+            testId={`replay-chapter-${chapter.segment}`}
             onClick={() => {
               onSeek(chapter.position);
             }}
@@ -150,15 +150,15 @@ export function ReplayTransport({
           <span
             key={beat.position}
             data-testid={`replay-tick-${String(beat.position)}`}
-            data-street-boundary={beat.isStreetBoundary}
+            data-segment-boundary={beat.isSegmentBoundary}
             style={{
               position: "absolute",
               left: `${String((beat.position / total) * 100)}%`,
               transform: "translateX(-50%)",
-              width: beat.isStreetBoundary ? "3px" : "2px",
-              height: beat.isStreetBoundary ? "2.2em" : "1.1em",
+              width: beat.isSegmentBoundary ? "3px" : "2px",
+              height: beat.isSegmentBoundary ? "2.2em" : "1.1em",
               borderRadius: "999px",
-              background: beat.isStreetBoundary
+              background: beat.isSegmentBoundary
                 ? color.textMuted
                 : "rgba(255,255,255,.34)",
             }}

--- a/packages/table-client/src/replay/actionLabels.test.ts
+++ b/packages/table-client/src/replay/actionLabels.test.ts
@@ -89,6 +89,24 @@ describe("actionLabelsAt", () => {
     expect([...labels.entries()]).toEqual([[1, "check"]]);
   });
 
+  it("clears every label once the hand reaches showdown", () => {
+    const positions = positionsFor([
+      ...preflop,
+      { type: "ShowdownReached", contestants: [1, 2] },
+    ]);
+
+    expect(actionLabelsAt(positions, preflop.length + 1).size).toBe(0);
+  });
+
+  it("clears every label once the hand is folded out", () => {
+    const positions = positionsFor([
+      ...preflop,
+      { type: "HandFoldedOut", winner: 2 },
+    ]);
+
+    expect(actionLabelsAt(positions, preflop.length + 1).size).toBe(0);
+  });
+
   it("survives a position past the end of the hand", () => {
     const labels = actionLabelsAt(positionsFor(preflop), 99);
 

--- a/packages/table-client/src/replay/actionLabels.ts
+++ b/packages/table-client/src/replay/actionLabels.ts
@@ -17,6 +17,10 @@ export function actionLabelsAt(
 
   for (const { event } of positions.slice(1, position + 1)) {
     if (event === null) continue;
+    if (event.type === "ShowdownReached" || event.type === "HandFoldedOut") {
+      labels.clear();
+      continue;
+    }
     const next = streetOf(event, street);
     if (next !== street) labels.clear();
     street = next;

--- a/packages/table-client/src/replay/actionLabels.ts
+++ b/packages/table-client/src/replay/actionLabels.ts
@@ -1,11 +1,10 @@
 import type {
   ActionType,
   SeatId,
-  Street,
   TableReplayPosition,
 } from "@table-top-poker/protocol";
 import type { SeatActionLabels } from "../actionWords.js";
-import { streetOf } from "./beats.js";
+import { segmentOf, type Segment } from "./beats.js";
 
 /** The Action labels at one position — see Action label in `CONTEXT.md`. */
 export function actionLabelsAt(
@@ -13,7 +12,7 @@ export function actionLabelsAt(
   position: number,
 ): SeatActionLabels {
   const labels = new Map<SeatId, ActionType>();
-  let street: Street | null = null;
+  let segment: Segment | null = null;
 
   for (const { event } of positions.slice(1, position + 1)) {
     if (event === null) continue;
@@ -21,9 +20,9 @@ export function actionLabelsAt(
       labels.clear();
       continue;
     }
-    const next = streetOf(event, street);
-    if (next !== street) labels.clear();
-    street = next;
+    const next = segmentOf(event, segment);
+    if (next !== segment) labels.clear();
+    segment = next;
     if (event.type === "ActionTaken") labels.set(event.seatId, event.action);
   }
   return labels;

--- a/packages/table-client/src/replay/beats.test.ts
+++ b/packages/table-client/src/replay/beats.test.ts
@@ -55,12 +55,12 @@ describe("toBeats", () => {
     );
   });
 
-  it("marks each street's first beat, which the track draws heavier", () => {
+  it("marks each segment's first beat, which the track draws heavier", () => {
     const beats = toBeats(positionsFor(toTheTurn));
 
     expect(
       beats
-        .filter((beat) => beat.isStreetBoundary)
+        .filter((beat) => beat.isSegmentBoundary)
         .map((beat) => beat.position),
     ).toEqual([3, 6, 10]);
   });
@@ -69,8 +69,8 @@ describe("toBeats", () => {
     const beats = toBeats(positionsFor(toTheTurn));
 
     // ordinal 5 is `StreetClosed preflop`, 6 is the flop's `BoardDealt`.
-    expect(beatAt(beats, 5)?.street).toBe("preflop");
-    expect(beatAt(beats, 6)?.street).toBe("flop");
+    expect(beatAt(beats, 5)?.segment).toBe("preflop");
+    expect(beatAt(beats, 6)?.segment).toBe("flop");
   });
 
   it("holds the beats that change the felt longer than the bookkeeping", () => {
@@ -90,13 +90,13 @@ describe("chaptersOf", () => {
     const chapters = chaptersOf(toBeats(positionsFor(toTheTurn)));
 
     expect(chapters).toEqual([
-      { street: "preflop", label: "Preflop", position: 3 },
-      { street: "flop", label: "Flop", position: 6 },
-      { street: "turn", label: "Turn", position: 10 },
+      { segment: "preflop", label: "Preflop", position: 3 },
+      { segment: "flop", label: "Flop", position: 6 },
+      { segment: "turn", label: "Turn", position: 10 },
     ]);
   });
 
-  it("offers only the streets the hand reached", () => {
+  it("offers only the segments the hand reached", () => {
     const walk: HandEvent[] = [
       { type: "HandStarted", seed: "s", button: 0 },
       { type: "StreetStarted", street: "preflop", actor: 1 },
@@ -106,16 +106,37 @@ describe("chaptersOf", () => {
     ];
 
     expect(chaptersOf(toBeats(positionsFor(walk)))).toEqual([
-      { street: "preflop", label: "Preflop", position: 2 },
+      { segment: "preflop", label: "Preflop", position: 2 },
     ]);
   });
 
-  it("names each street once, however many beats it holds", () => {
+  it("names each segment once, however many beats it holds", () => {
     const chapters = chaptersOf(toBeats(positionsFor(toTheTurn)));
 
-    expect(new Set(chapters.map((chapter) => chapter.street)).size).toBe(
+    expect(new Set(chapters.map((chapter) => chapter.segment)).size).toBe(
       chapters.length,
     );
+  });
+
+  it("chapters the showdown, which is no street but its own place to seek", () => {
+    const toShowdown: HandEvent[] = [
+      ...toTheTurn.slice(0, 5),
+      ...streetCascade("flop"),
+      ...streetCascade("turn"),
+      ...streetCascade("river"),
+      { type: "StreetClosed", street: "river" },
+      { type: "ShowdownReached", contestants: [1, 2] },
+      { type: "HandComplete" },
+    ];
+
+    const chapters = chaptersOf(toBeats(positionsFor(toShowdown)));
+
+    expect(chapters.at(-1)).toEqual({
+      segment: "showdown",
+      label: "Showdown",
+      position:
+        toShowdown.findIndex((event) => event.type === "ShowdownReached") + 1,
+    });
   });
 
   it("seeks each chapter to the beat the track draws heaviest", () => {
@@ -123,7 +144,7 @@ describe("chaptersOf", () => {
 
     expect(chaptersOf(beats).map((chapter) => chapter.position)).toEqual(
       beats
-        .filter((beat) => beat.isStreetBoundary)
+        .filter((beat) => beat.isSegmentBoundary)
         .map((beat) => beat.position),
     );
   });

--- a/packages/table-client/src/replay/beats.ts
+++ b/packages/table-client/src/replay/beats.ts
@@ -4,14 +4,17 @@ import type {
   TableReplayPosition,
 } from "@table-top-poker/protocol";
 
+/** A stretch of a Hand the Scrub can chapter — see Segment in `CONTEXT.md`. */
+export type Segment = Street | "showdown";
+
 /** One Event ordinal, dressed for the transport — see Replay position in `CONTEXT.md`. */
 export interface Beat {
   readonly position: number;
-  readonly street: Street | null;
+  readonly segment: Segment | null;
   /** How long autoplay holds here, in ms. */
   readonly weight: number;
   /** One flag for the heavier tick and the Chapter seek, so the two cannot drift apart. */
-  readonly isStreetBoundary: boolean;
+  readonly isSegmentBoundary: boolean;
 }
 
 export const streetLabel: Record<Street, string> = {
@@ -19,6 +22,11 @@ export const streetLabel: Record<Street, string> = {
   flop: "Flop",
   turn: "Turn",
   river: "River",
+};
+
+export const segmentLabel: Record<Segment, string> = {
+  ...streetLabel,
+  showdown: "Showdown",
 };
 
 /** Autoplay pacing: what changes the felt is held, bookkeeping goes past quickly. */
@@ -37,51 +45,52 @@ const WEIGHTS: Record<HandEvent["type"], number> = {
   HandComplete: 2000,
 };
 
-/** A beat belongs to the street it *shows* — see Chapter in `CONTEXT.md`. */
-export function streetOf(
+/** A beat belongs to the segment it *shows* — see Chapter in `CONTEXT.md`. */
+export function segmentOf(
   event: HandEvent,
-  current: Street | null,
-): Street | null {
+  current: Segment | null,
+): Segment | null {
   if (event.type === "StreetStarted" || event.type === "BoardDealt") {
     return event.street;
   }
+  if (event.type === "ShowdownReached") return "showdown";
   return current;
 }
 
 export function toBeats(
   positions: readonly TableReplayPosition[],
 ): readonly Beat[] {
-  let street: Street | null = null;
+  let segment: Segment | null = null;
   const beats: Beat[] = [];
 
   for (const [index, position] of positions.entries()) {
     const event = position.event;
     if (event === null) continue;
-    const previous = street;
-    street = streetOf(event, street);
+    const previous = segment;
+    segment = segmentOf(event, segment);
     beats.push({
       position: index,
-      street,
+      segment,
       weight: WEIGHTS[event.type],
-      isStreetBoundary: street !== null && street !== previous,
+      isSegmentBoundary: segment !== null && segment !== previous,
     });
   }
   return beats;
 }
 
 export interface Chapter {
-  readonly street: Street;
+  readonly segment: Segment;
   readonly label: string;
   /** The ordinal the chip seeks to. */
   readonly position: number;
 }
 
-/** The Scrub's street landmarks — see Chapter in `CONTEXT.md`. */
+/** The Scrub's landmarks — see Chapter in `CONTEXT.md`. */
 export function chaptersOf(beats: readonly Beat[]): readonly Chapter[] {
   return beats.flatMap((beat) => {
-    const street = beat.street;
-    if (!beat.isStreetBoundary || street === null) return [];
-    return [{ street, label: streetLabel[street], position: beat.position }];
+    const segment = beat.segment;
+    if (!beat.isSegmentBoundary || segment === null) return [];
+    return [{ segment, label: segmentLabel[segment], position: beat.position }];
   });
 }
 

--- a/packages/table-client/src/replay/beats.ts
+++ b/packages/table-client/src/replay/beats.ts
@@ -32,6 +32,7 @@ const WEIGHTS: Record<HandEvent["type"], number> = {
   HandFoldedOut: 2400,
   ShowdownReached: 3200,
   HoleCardsShown: 1600,
+  HoleCardsMucked: 1600,
   WinnersDeclared: 2400,
   HandComplete: 2000,
 };

--- a/packages/table-client/src/replay/caption.test.ts
+++ b/packages/table-client/src/replay/caption.test.ts
@@ -120,3 +120,11 @@ describe("captionFor", () => {
     }
   });
 });
+
+describe("captionFor a muck", () => {
+  it("says only what happened at the table, never why", () => {
+    expect(captionFor({ type: "HoleCardsMucked", seatId: 2 }, [])).toBe(
+      "Seat 3 mucks",
+    );
+  });
+});

--- a/packages/table-client/src/replay/caption.ts
+++ b/packages/table-client/src/replay/caption.ts
@@ -49,6 +49,8 @@ export function captionFor(
       return "Showdown";
     case "HoleCardsShown":
       return `${seatLabel(event.result.seatId, seats)} shows ${event.result.description}`;
+    case "HoleCardsMucked":
+      return `${seatLabel(event.seatId, seats)} mucks`;
     case "WinnersDeclared":
       return winnersCaption(event, seats);
     case "HandComplete":

--- a/packages/table-client/src/replay/track.test.ts
+++ b/packages/table-client/src/replay/track.test.ts
@@ -5,9 +5,9 @@ import { MAX_TICKS, positionAtRatio, ticksFor } from "./track.js";
 function beats(count: number, boundaries: readonly number[] = []): Beat[] {
   return Array.from({ length: count }, (_unused, index) => ({
     position: index + 1,
-    street: "preflop" as const,
+    segment: "preflop" as const,
     weight: 100,
-    isStreetBoundary: boundaries.includes(index + 1),
+    isSegmentBoundary: boundaries.includes(index + 1),
   }));
 }
 
@@ -53,7 +53,7 @@ describe("ticksFor", () => {
     }
     expect(
       drawn
-        .filter((tick) => tick.isStreetBoundary)
+        .filter((tick) => tick.isSegmentBoundary)
         .map((tick) => tick.position),
     ).toEqual(boundaries);
   });

--- a/packages/table-client/src/replay/track.ts
+++ b/packages/table-client/src/replay/track.ts
@@ -11,13 +11,13 @@ export function positionAtRatio(ratio: number, total: number): number {
 
 /**
  * The ticks the track draws. Ticks are a visual affordance and may collapse on
- * a long hand; street boundaries never do, because chapters are the
+ * a long hand; segment boundaries never do, because chapters are the
  * navigation contract (#129 §6).
  */
 export function ticksFor(beats: readonly Beat[]): readonly Beat[] {
   if (beats.length <= MAX_TICKS) return beats;
   const stride = Math.ceil(beats.length / MAX_TICKS);
   return beats.filter(
-    (beat, index) => beat.isStreetBoundary || index % stride === 0,
+    (beat, index) => beat.isSegmentBoundary || index % stride === 0,
   );
 }

--- a/packages/table-client/src/store/handSlice.ts
+++ b/packages/table-client/src/store/handSlice.ts
@@ -1,18 +1,25 @@
-import type { TableView } from "@table-top-poker/protocol";
+import type { RejectionReason, TableView } from "@table-top-poker/protocol";
 import type { StateCreator } from "zustand";
 
 export interface HandSlice {
   readonly handView: TableView | null;
+  /** The last refusal the table itself provoked; cleared by the next update. */
+  readonly commandRejection: RejectionReason | null;
   readonly setHandView: (view: TableView) => void;
+  readonly setCommandRejection: (reason: RejectionReason) => void;
   readonly clearHand: () => void;
 }
 
 export const createHandSlice: StateCreator<HandSlice> = (set) => ({
   handView: null,
+  commandRejection: null,
   setHandView: (view) => {
-    set({ handView: view });
+    set({ handView: view, commandRejection: null });
+  },
+  setCommandRejection: (reason) => {
+    set({ commandRejection: reason });
   },
   clearHand: () => {
-    set({ handView: null });
+    set({ handView: null, commandRejection: null });
   },
 });

--- a/packages/table-client/src/store/roomSlice.ts
+++ b/packages/table-client/src/store/roomSlice.ts
@@ -1,9 +1,11 @@
 import {
   DEFAULT_SHOT_CLOCK,
+  DEFAULT_SHOWDOWN_CLOCK,
   DEFAULT_SOUND_SETTINGS,
   type RoomView,
   type SeatView,
   type ShotClockSettings,
+  type ShowdownClockSettings,
   type SoundSettings,
 } from "@table-top-poker/protocol";
 import type { StateCreator } from "zustand";
@@ -17,6 +19,7 @@ export interface RoomSlice {
   readonly pendingShotClock: ShotClockSettings | null;
   readonly soundSettings: SoundSettings;
   readonly shotClockSettings: ShotClockSettings;
+  readonly showdownClockSettings: ShowdownClockSettings;
   /**
    * Latched true once "Continue without recording" resumes the Room —
    * never cleared while the Room lives, since recording never comes back
@@ -42,6 +45,7 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
   pendingShotClock: null,
   soundSettings: DEFAULT_SOUND_SETTINGS,
   shotClockSettings: DEFAULT_SHOT_CLOCK,
+  showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
   recordingStopped: false,
   setRoomCreated: ({ code, joinUrl, qrCodeDataUrl }) => {
     set({
@@ -60,6 +64,7 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
       pendingShotClock: view.pendingShotClock,
       soundSettings: view.soundSettings,
       shotClockSettings: view.shotClockSettings,
+      showdownClockSettings: view.showdownClockSettings,
     });
   },
   setRecordingStopped: () => {
@@ -75,6 +80,7 @@ export const createRoomSlice: StateCreator<RoomSlice> = (set) => ({
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
       recordingStopped: false,
     });
   },

--- a/packages/table-client/src/store/store.test.ts
+++ b/packages/table-client/src/store/store.test.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_SHOT_CLOCK,
+  DEFAULT_SHOWDOWN_CLOCK,
   DEFAULT_SOUND_SETTINGS,
   type HandSummary,
   type TableReplayPosition,
@@ -67,6 +68,7 @@ describe("useTableStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
       seats: [
         {
           id: 0,
@@ -96,6 +98,7 @@ describe("useTableStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
       seats: [
         {
           id: 0,
@@ -128,6 +131,7 @@ describe("useTableStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
       seats: [],
     });
     expect(useTableStore.getState().recordingStopped).toBe(true);
@@ -140,6 +144,7 @@ describe("useTableStore", () => {
       pendingShotClock: null,
       soundSettings: DEFAULT_SOUND_SETTINGS,
       shotClockSettings: DEFAULT_SHOT_CLOCK,
+      showdownClockSettings: DEFAULT_SHOWDOWN_CLOCK,
       seats: [
         {
           id: 0,

--- a/packages/table-client/src/ws/useWebSocket.ts
+++ b/packages/table-client/src/ws/useWebSocket.ts
@@ -42,6 +42,9 @@ export function useWebSocket(
   const addHandSummary = useTableStore((state) => state.addHandSummary);
   const receiveReplay = useTableStore((state) => state.receiveReplay);
   const failReview = useTableStore((state) => state.failReview);
+  const setCommandRejection = useTableStore(
+    (state) => state.setCommandRejection,
+  );
   const socketRef = useRef<WebSocket | null>(null);
   const optionsRef = useRef(options);
   optionsRef.current = options;
@@ -93,11 +96,11 @@ export function useWebSocket(
           addHandSummary(message.summary);
         } else if (message.type === "hand-replay") {
           receiveReplay(message.handOrdinal, message.positions);
-        } else if (
-          message.type === "command-rejected" &&
-          message.reason === "hand-unavailable"
-        ) {
-          failReview();
+        } else if (message.type === "command-rejected") {
+          if (message.reason === "hand-unavailable") failReview();
+          else if (message.reason === "showdown-unresolved") {
+            setCommandRejection(message.reason);
+          }
         } else if (message.type === "room-ended") {
           optionsRef.current.onRoomEnded?.();
         } else if (message.type === "recording-stopped") {
@@ -124,6 +127,7 @@ export function useWebSocket(
     addHandSummary,
     receiveReplay,
     failReview,
+    setCommandRejection,
   ]);
 
   const send = useCallback((message: ClientCommand | ReplayRequest) => {

--- a/packages/ui-shared/src/ShotClock.tsx
+++ b/packages/ui-shared/src/ShotClock.tsx
@@ -9,6 +9,8 @@ export interface ShotClockProps {
   readonly variant: ShotClockVariant;
   readonly testId: string;
   readonly numberPosition?: "top-right" | "bottom-right";
+  /** Stays hidden until this many seconds remain; absent means always shown. */
+  readonly showWithinSeconds?: number;
 }
 
 export function shotClockColor(fraction: number): string {
@@ -46,12 +48,19 @@ export function ShotClock({
   variant,
   testId,
   numberPosition = "top-right",
+  showWithinSeconds,
 }: ShotClockProps) {
   const now = useNow();
   if (turnEndsAt === null) return null;
 
   const durationMs = Math.max(1, durationSeconds * 1000);
   const remainingMs = Math.max(0, turnEndsAt - now);
+  if (
+    showWithinSeconds !== undefined &&
+    remainingMs > showWithinSeconds * 1000
+  ) {
+    return null;
+  }
   const fraction = Math.max(0, Math.min(1, remainingMs / durationMs));
   const tint = shotClockColor(fraction);
   const seconds = Math.ceil(remainingMs / 1000);

--- a/packages/ui-shared/src/positionMarker.test.ts
+++ b/packages/ui-shared/src/positionMarker.test.ts
@@ -73,6 +73,9 @@ describe("positionMarkerFor", () => {
         "showdown",
         {
           phase: "showdown",
+          turnEndsAt: null,
+          queue: [],
+          mucked: [],
           ...headsUp,
           board: [],
           contestants: [0, 1],

--- a/packages/ui-shared/src/sound/engine.test.ts
+++ b/packages/ui-shared/src/sound/engine.test.ts
@@ -434,3 +434,25 @@ describe("your-turn prompt", () => {
     expect(r.played.filter((c) => c === "yourTurn")).toEqual(["yourTurn"]);
   });
 });
+
+describe("muck", () => {
+  it("reuses the fold cue, on the mucking player's own phone only", () => {
+    const own = rig();
+    own.engine.onHandUpdate({
+      surface: "player",
+      seatId: 1,
+      event: { type: "HoleCardsMucked", seatId: 1 },
+      view: noHandView,
+    });
+    expect(own.played).toEqual(["fold"]);
+
+    const other = rig();
+    other.engine.onHandUpdate({
+      surface: "player",
+      seatId: 2,
+      event: { type: "HoleCardsMucked", seatId: 1 },
+      view: noHandView,
+    });
+    expect(other.played).toEqual([]);
+  });
+});

--- a/packages/ui-shared/src/sound/engine.ts
+++ b/packages/ui-shared/src/sound/engine.ts
@@ -102,6 +102,10 @@ export function createSoundEngine(
         }
         break;
 
+      case "HoleCardsMucked":
+        if (surface === "player" && event.seatId === seatId) playCue("fold");
+        break;
+
       case "StreetStarted":
       case "StreetClosed":
       case "ShowdownReached":


### PR DESCRIPTION
Closes #259.

## What changed

River close opens the showing window by itself. The table-originated `reveal`
command is deleted outright — from the engine's `Command` union, the protocol
schema and the table UI — because both of its jobs belong to the hand's own
progress: river close is the opening, and the queue emptying is the
publication.

All-in contestants are tabled by the engine at that instant; their hands were
decided streets ago. Everyone else enters a queue, ordered aggressor-first,
else first-to-act left of the button, then clockwise. Only the head may act:
a committed peel is the `show`, and the same upward fold-drag that folds during
betting sends the new `muck`. The bend-to-peek stays live for every contestant
throughout.

Compulsion is a property of the window, not of a seat: until some hand is
face-up the head cannot muck, and the first tabled hand discharges it for
everyone left — including a seat holding the winner who has misread the board.
Winners are the best *shown* hand, published only once the queue empties, with
`nextHand` and `startHand` rejected until then in the engine rather than by
greying out a control.

A new per-room house rule bounds each turn — seconds configurable, default 30,
`enabled` fixed true. It reuses the action clock's scheduler, its `turnEndsAt`
broadcast and the shot-clock component. Expiry mucks the head, or shows a
compelled one, as an ordinary command, so the engine keeps no notion of time
and the act replays like any other.

## Notes for review

- `ENGINE_LOG_VERSION` moves 5 → 6; the harness fixture is regenerated.
- ADR-0009 is added, ADR-0008 marked Superseded (its thesis stands, its
  Decision section is replaced), and `CONTEXT.md` gains *Muck*, *Showing
  order* and *Showdown clock*.
- Two review findings are fixed in the second commit: `startHand` was falling
  through to `hand-already-in-progress` so the table's hint never surfaced for
  it, and the player's clock ring always drew against the 30s default because
  the room's value was never passed down.

## Two deliberate choices (confirmed)

Both were raised with @ewanhardingham and confirmed as-is; no change pending.

- The showdown clock applies **immediately**, where the shot clock queues to
  the next hand. The shot clock defers so a mid-hand edit cannot move a live
  deadline; the showdown clock takes effect at once.
- A compelled head who tries to muck is rejected with the generic
  `action-not-legal`, whose player copy is the betting-phase wording. The
  client gates it, so it should not surface.

## Verification

`npx vitest run` — 1397 passed, 120 files. `npx tsc --build` clean.
`npm run lint` (eslint + prettier) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nyg8H7osWtxHAYdJ4ceA1A
