### PR TITLE
fix(sound): bundle live shared audio source

### DIFF
--- a/packages/player-client/src/vite-config.test.ts
+++ b/packages/player-client/src/vite-config.test.ts
@@ -2,21 +2,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { loadConfigFromFile } from "vite";
 
-describe("table-client Vite dev proxy", () => {
-  it("forwards server config discovery to the backend", async () => {
-    const loaded = await loadConfigFromFile(
-      { command: "serve", mode: "test" },
-      fileURLToPath(new URL("../vite.config.ts", import.meta.url)),
-    );
-
-    const proxy = loaded?.config.server?.proxy;
-    expect(proxy).toBeDefined();
-    if (proxy === undefined) return;
-
-    expect(proxy["/rooms"]).toBeDefined();
-    expect(proxy["/config"]).toBe(proxy["/rooms"]);
-  });
-
+describe("player-client Vite workspace aliases", () => {
   it("resolves ui-shared from source so stale workspace dist cannot hide cues", async () => {
     const loaded = await loadConfigFromFile(
       { command: "serve", mode: "test" },

--- a/packages/player-client/vite.config.ts
+++ b/packages/player-client/vite.config.ts
@@ -2,6 +2,8 @@ import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv } from "vite";
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
+const uiSharedSource = new URL("../ui-shared/src/index.ts", import.meta.url)
+  .pathname;
 
 export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, repoRoot, "");
@@ -17,6 +19,11 @@ export default defineConfig(({ command, mode }) => {
 
   return {
     plugins: [react()],
+    resolve: {
+      alias: {
+        "@table-top-poker/ui-shared": uiSharedSource,
+      },
+    },
     base: command === "build" ? "/player/" : "/",
     build: {
       outDir: "build",

--- a/packages/table-client/vite.config.ts
+++ b/packages/table-client/vite.config.ts
@@ -2,6 +2,8 @@ import react from "@vitejs/plugin-react";
 import { defineConfig, loadEnv } from "vite";
 
 const repoRoot = new URL("../..", import.meta.url).pathname;
+const uiSharedSource = new URL("../ui-shared/src/index.ts", import.meta.url)
+  .pathname;
 
 export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, repoRoot, "");
@@ -17,6 +19,11 @@ export default defineConfig(({ command, mode }) => {
 
   return {
     plugins: [react()],
+    resolve: {
+      alias: {
+        "@table-top-poker/ui-shared": uiSharedSource,
+      },
+    },
     base: command === "build" ? "/table/" : "/",
     build: {
       outDir: "build",


### PR DESCRIPTION
## Summary
- resolve `@table-top-poker/ui-shared` from source in both Vite clients
- prevent stale workspace `dist` output from hiding newly added sound cues
- cover both client aliases with Vite config regression tests

## Verification
- `npm test -- --run packages/table-client/src/vite-config.test.ts packages/player-client/src/vite-config.test.ts`
- `npm run -w @table-top-poker/table-client build:app`
- `npm run -w @table-top-poker/player-client build:app`
- `npm run build`
- `npm run lint`
- verified both built bundles contain `burn.wav` and `CardBurned`