### PR TITLE
Fix burn appearing before the street starts

### DIFF
--- a/docs/design/engine.md
+++ b/docs/design/engine.md
@@ -67,9 +67,10 @@ A street *already* open ends the moment nobody left in `toAct` faces a bet
 opponents who cannot answer — while a lone seat that *does* face a shove still
 gets its fold-or-call.
 
-`BoardDealt` advances `hand.street`, so a run-out's intermediate states never
-pair a five-card board with a stale `preflop`, and `StreetStarted` only
-confirms the street the board already moved to.
+`CardBurned` advances `hand.street` before the burn is fanned out, so the
+table never renders a new burn against the prior street (including during an
+all-in run-out). `BoardDealt` then appends that street's board cards, and
+`StreetStarted` only confirms the street the burn and board already moved to.
 
 ## `apply` details
 

--- a/packages/engine/src/apply.ts
+++ b/packages/engine/src/apply.ts
@@ -159,6 +159,12 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
         ...state,
         hand: {
           ...hand,
+          // The burn is the first event for the street it opens.  The server
+          // fans out each event separately, so leaving `street` on the prior
+          // round makes the table briefly render a new burn as preflop (or
+          // as the previous postflop street).  A hand that folds before this
+          // event is emitted therefore never gets a burn on its view.
+          street: event.street,
           burned: [
             ...hand.burned,
             must(event.card, "a burn is only applied with its card"),

--- a/packages/engine/src/burn.test.ts
+++ b/packages/engine/src/burn.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { apply } from "./apply.js";
 import { createInitialState } from "./room.js";
 import { dealFromDeck } from "./table.js";
 import { play, playAll } from "./test-utils.js";
@@ -58,6 +59,39 @@ describe("burning a card before each street", () => {
     ]);
     const burn = must(tail.find((event) => event.type === "CardBurned"));
     expect(burn).toMatchObject({ street: "flop" });
+  });
+
+  it("starts the next street before its burn reaches the table", () => {
+    const preflop = playAll(started("burn-street-state"), [
+      { type: "call", seatId: 0 },
+      { type: "call", seatId: 1 },
+    ]);
+    const outcome = play(preflop, { type: "check", seatId: 2 });
+    if ("rejection" in outcome) throw new Error("unexpected rejection");
+
+    let state = preflop;
+    for (const event of outcome.events) {
+      state = apply(state, event);
+      if (event.type !== "CardBurned") continue;
+
+      if (state.hand?.status !== "betting") {
+        throw new Error("expected a betting hand after a burn");
+      }
+      expect(state.hand.street).toBe(event.street);
+      expect(state.hand.board).toHaveLength(0);
+      break;
+    }
+  });
+
+  it("does not burn a hand that folds out before the flop starts", () => {
+    const state = playAll(started("fold-out-preflop"), [
+      { type: "fold", seatId: 0 },
+      { type: "fold", seatId: 1 },
+    ]);
+
+    const table = tableView(state);
+    expect(table.phase).toBe("folded-out");
+    expect(table.burnedCount).toBe(0);
   });
 
   it("never burns before the preflop deal", () => {
@@ -137,6 +171,27 @@ describe("burning a card before each street", () => {
     const dealt = new Set([...hand.board, ...holeCards].map(key));
     for (const burnt of hand.burned) expect(dealt.has(key(burnt))).toBe(false);
     expect(hand.burned).toHaveLength(3);
+  });
+
+  it("starts each all-in run-out burn on the street it deals", () => {
+    let state = started("run-out-street-state");
+    state = playAll(state, [
+      { type: "allInRaise", seatId: 0 },
+      { type: "allInCall", seatId: 1 },
+    ]);
+    const outcome = play(state, { type: "call", seatId: 2 });
+    if ("rejection" in outcome) throw new Error("unexpected rejection");
+
+    let current = state;
+    for (const event of outcome.events) {
+      current = apply(current, event);
+      if (event.type !== "CardBurned") continue;
+
+      if (current.hand?.status !== "betting") {
+        throw new Error("expected a betting hand after a burn");
+      }
+      expect(current.hand.street).toBe(event.street);
+    }
   });
 });
 

--- a/packages/engine/src/replay.test.ts
+++ b/packages/engine/src/replay.test.ts
@@ -140,6 +140,31 @@ describe("replayHand: the flipbook", () => {
     expect(board).toHaveLength(3);
   });
 
+  it("replays a burn with the street it opens already visible in state", () => {
+    const start: EngineState = { seats: [0, 1, 2], button: 0, hand: null };
+    const { recording } = record(start, [
+      { type: "startHand", seatId: 0, seed: "burn-replay-seed" },
+      { type: "call", seatId: 0 },
+      { type: "call", seatId: 1 },
+      { type: "check", seatId: 2 },
+    ]);
+    const outcome = replayHand(inputFrom(recording));
+
+    expect(outcome.status).toBe("complete");
+    if (outcome.status !== "complete") return;
+    const burn = outcome.positions.find(
+      (position) => position.event?.type === "CardBurned",
+    );
+    if (burn?.event?.type !== "CardBurned") {
+      throw new Error("expected a flop burn");
+    }
+    if (burn.state.hand?.status !== "betting") {
+      throw new Error("expected a betting hand after a burn");
+    }
+    expect(burn.state.hand.street).toBe(burn.event.street);
+    expect(burn.state.hand.board).toHaveLength(0);
+  });
+
   it("is pure — the same input replays to the same flipbook", () => {
     const recording = foldOutHand();
     expect(replayHand(inputFrom(recording))).toEqual(


### PR DESCRIPTION
## Summary

- advance the hand street when its burn event is applied
- prevent a new burn from being rendered against pre-flop or the previous street
- preserve all-in run-out burns and document the updated transition
- add regression coverage for pre-flop fold-outs and replay intermediates

## Validation

- focused engine/replay tests pass
- full test suite passes
- build, ESLint, Prettier, and diff checks pass