### PR TITLE
Keep community cards visible after fold-out

### DIFF
--- a/docs/design/board-card-entry.md
+++ b/docs/design/board-card-entry.md
@@ -25,7 +25,9 @@ The fix, settled on `prototype/replay-transport` (wayfinder #82, ticket #117):
 - Render one shape for every phase that has a hand, so `CommunityCards` keeps
   its position in the tree as the phase changes.
 
-A folded-out hand shows no board at all — nobody paid to see it.
+A folded-out hand keeps whatever community cards were already dealt. The table
+does not replace them with a winner banner: the player devices still show the
+winner in their own hand status.
 
 The remount behaviour is invisible in live play, where the board only ever
 grows one street at a time, and obvious the moment a replay is scrubbed

--- a/docs/design/engine.md
+++ b/docs/design/engine.md
@@ -119,6 +119,9 @@ burnt (`CONTEXT.md`, Burn).
   or set to sit out).
 - A seat's `yourHoleCards` is null once folded; `legalActions` is populated only
   when it is that seat's turn (`toAct[0] === seatId`).
+- A `folded-out` view retains the community `board` already dealt before the
+  last opponent folded. The table keeps those cards in place, while each
+  player view continues to identify the winner in its own hand banner.
 
 ## Replay
 

--- a/packages/engine/src/apply.ts
+++ b/packages/engine/src/apply.ts
@@ -178,6 +178,7 @@ export function apply(state: EngineState, event: HandEvent): EngineState {
           seed: hand.seed,
           button: hand.button,
           ...handPositions(hand),
+          board: hand.board,
           winner: event.winner,
         },
       };

--- a/packages/engine/src/complete-hand-state.test.ts
+++ b/packages/engine/src/complete-hand-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createInitialState } from "./room.js";
 import { playAll } from "./test-utils.js";
+import { view } from "./view.js";
 
 describe("CompleteHandState carries how the hand ended", () => {
   it("tags a fold-out completion with reason 'folded-out' and the winner", () => {
@@ -16,6 +17,30 @@ describe("CompleteHandState carries how the hand ended", () => {
     if (state.hand.reason === "folded-out") {
       expect(state.hand.winner).toBe(2);
     }
+  });
+
+  it("keeps the dealt board on a fold-out completion and its table view", () => {
+    let state = createInitialState([0, 1, 2]);
+    state = playAll(state, [{ type: "startHand", seatId: 0, seed: "foldout" }]);
+    state = playAll(state, [
+      { type: "call", seatId: 0 },
+      { type: "call", seatId: 1 },
+      { type: "check", seatId: 2 },
+      { type: "fold", seatId: 1 },
+      { type: "fold", seatId: 2 },
+    ]);
+
+    if (state.hand?.status !== "complete") throw new Error("expected complete");
+    if (state.hand.reason !== "folded-out") {
+      throw new Error("expected a fold-out completion");
+    }
+    expect(state.hand.board).toHaveLength(3);
+
+    const table = view(state, "table");
+    if (table.phase !== "folded-out") {
+      throw new Error("expected a folded-out table view");
+    }
+    expect(table.board).toEqual(state.hand.board);
   });
 
   it("tags a showdown completion with reason 'showdown' plus results and winners", () => {

--- a/packages/engine/src/replay.test.ts
+++ b/packages/engine/src/replay.test.ts
@@ -115,8 +115,8 @@ describe("replayHand: the flipbook", () => {
     }
   });
 
-  it("reaches state the terminal view cannot express — a folded-out hand's board", () => {
-    // Seat 1 folds on the turn, leaving a board no `FoldedOutView` carries.
+  it("preserves a folded-out hand's board through replay", () => {
+    // Seat 1 folds on the turn, leaving a board the terminal view must carry.
     const start: EngineState = { seats: [0, 1], button: 0, hand: null };
     const { recording } = record(start, [
       { type: "startHand", seatId: 0, seed: "board-seed" },
@@ -138,6 +138,12 @@ describe("replayHand: the flipbook", () => {
         ? boardDealt.state.hand.board
         : [];
     expect(board).toHaveLength(3);
+
+    const terminal = outcome.positions.at(-1)?.state.hand;
+    if (terminal?.status !== "complete" || terminal.reason !== "folded-out") {
+      throw new Error("expected a folded-out terminal state");
+    }
+    expect(terminal.board).toHaveLength(4);
   });
 
   it("is pure — the same input replays to the same flipbook", () => {

--- a/packages/engine/src/replay.ts
+++ b/packages/engine/src/replay.ts
@@ -49,7 +49,7 @@ export interface ReplayInput {
 
 /**
  * See Replay position in `CONTEXT.md`. State is carried whole, never as a
- * view: `FoldedOutView` has no board, so a fold-out's board would be lost.
+ * view, so a fold-out's board remains available for the terminal table view.
  */
 export interface ReplayPosition {
   readonly position: number;

--- a/packages/engine/src/types.ts
+++ b/packages/engine/src/types.ts
@@ -114,6 +114,8 @@ export interface FoldedOutCompleteHandState extends HandPositions {
   readonly status: "complete";
   readonly reason: "folded-out";
   readonly seed: string;
+  /** Community cards dealt before the last opponents folded. */
+  readonly board: readonly Card[];
   readonly winner: SeatId;
 }
 

--- a/packages/engine/src/view.ts
+++ b/packages/engine/src/view.ts
@@ -23,6 +23,7 @@ interface NoHandView {
 
 interface FoldedOutView extends HandPositions {
   readonly phase: "folded-out";
+  readonly board: readonly Card[];
   readonly winner: SeatId;
 }
 
@@ -110,6 +111,7 @@ export function view(
       bigBlind: hand.bigBlind,
       dealtSeatCount: hand.dealtSeatCount,
       burnedCount: hand.burnedCount,
+      board: hand.board,
       winner: hand.winner,
     };
   }

--- a/packages/player-client/src/Hand.test.tsx
+++ b/packages/player-client/src/Hand.test.tsx
@@ -550,6 +550,7 @@ describe("Hand", () => {
         bigBlind: 2,
         dealtSeatCount: 3,
         burnedCount: 0,
+        board: [],
         winner: 0,
       };
       const html = renderToStaticMarkup(<Hand view={view} seatId={0} />);
@@ -569,6 +570,7 @@ describe("Hand", () => {
         bigBlind: 2,
         dealtSeatCount: 3,
         burnedCount: 0,
+        board: [],
         winner: 1,
       };
       const html = renderToStaticMarkup(<Hand view={view} seatId={0} />);
@@ -586,6 +588,7 @@ describe("Hand", () => {
         bigBlind: 2,
         dealtSeatCount: 3,
         burnedCount: 0,
+        board: [],
         winner: 1,
       };
       const html = renderToStaticMarkup(<Hand view={view} seatId={0} />);
@@ -680,6 +683,7 @@ describe("Hand", () => {
           bigBlind: 2,
           dealtSeatCount: 3,
           burnedCount: 0,
+          board: [],
           winner: 1,
         },
       ],

--- a/packages/player-client/src/store/store.test.ts
+++ b/packages/player-client/src/store/store.test.ts
@@ -188,6 +188,7 @@ describe("usePlayerStore", () => {
       bigBlind: 0,
       dealtSeatCount: 1,
       burnedCount: 0,
+      board: [],
       winner: 0,
     });
 
@@ -223,6 +224,7 @@ describe("usePlayerStore", () => {
       bigBlind: 0,
       dealtSeatCount: 1,
       burnedCount: 0,
+      board: [],
       winner: 0,
     });
 

--- a/packages/server/src/app.test.ts
+++ b/packages/server/src/app.test.ts
@@ -3569,9 +3569,10 @@ describe("hand replay over WebSocket", () => {
     await settle();
 
     const replay = table.messages.find((m) => m.type === "hand-replay");
-    // The terminal `folded-out` view carries no board, so the flop is only
-    // reachable from the positions before it.
-    expect(replay?.positions.at(-1)?.view.phase).toBe("folded-out");
+    const terminal = replay?.positions.at(-1)?.view;
+    expect(terminal?.phase).toBe("folded-out");
+    if (terminal?.phase !== "folded-out") throw new Error("expected fold-out");
+    expect(terminal.board).toHaveLength(3);
     const boards = (replay?.positions ?? []).flatMap((position) =>
       "board" in position.view ? [position.view.board.length] : [],
     );

--- a/packages/server/src/hand-replay.test.ts
+++ b/packages/server/src/hand-replay.test.ts
@@ -175,17 +175,15 @@ describe("tableReplayOf", () => {
     );
   });
 
-  it("keeps a fold-out hand's board, which its terminal view cannot express", async () => {
+  it("keeps a fold-out hand's board in its terminal view", async () => {
     const replay = tableReplayOf(await record(foldOutOnTheTurn));
 
     if (replay.status !== "replayed") throw new Error(replay.diagnostic);
-    expect(replay.positions.at(-1)?.view.phase).toBe("folded-out");
-    // The final view has no board at all, so the four cards the table
-    // watched land are only reachable from the positions before it.
-    const boards = replay.positions.flatMap((p) =>
-      "board" in p.view ? [p.view.board.length] : [],
-    );
-    expect(Math.max(...boards)).toBe(4);
+    const terminal = replay.positions.at(-1)?.view;
+    if (terminal?.phase !== "folded-out") {
+      throw new Error("expected a folded-out terminal view");
+    }
+    expect(terminal.board).toHaveLength(4);
   });
 
   it("refuses a hand whose recording could not be read", () => {

--- a/packages/table-client/src/App.review.test.tsx
+++ b/packages/table-client/src/App.review.test.tsx
@@ -67,6 +67,7 @@ const completeHand: TableView = {
   bigBlind: 2,
   dealtSeatCount: 2,
   burnedCount: 0,
+  board: [],
   winner: 0,
 };
 

--- a/packages/table-client/src/App.test.tsx
+++ b/packages/table-client/src/App.test.tsx
@@ -55,6 +55,7 @@ const completeHand: TableView = {
   bigBlind: 2,
   dealtSeatCount: 2,
   burnedCount: 0,
+  board: [],
   winner: 0,
 };
 
@@ -236,11 +237,12 @@ describe("App", () => {
     expect(closed).toContain('data-testid="next-hand-button"');
   });
 
-  it("banners a fold-out ending", () => {
+  it("keeps the table board visible after a fold-out ending", () => {
     enterRoom(2, completeHand);
     const html = renderToStaticMarkup(<App />);
 
-    expect(html).toContain('data-testid="hand-complete-banner"');
+    expect(html).not.toContain('data-testid="hand-complete-banner"');
+    expect(html).toContain('data-testid="community-cards"');
   });
 
   it("moves the controls to the rail and shows the room code once a hand starts", () => {

--- a/packages/table-client/src/Board.test.tsx
+++ b/packages/table-client/src/Board.test.tsx
@@ -39,7 +39,7 @@ describe("Board", () => {
     expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(3);
   });
 
-  it("names the winner in a hand-complete banner after everyone else folds", () => {
+  it("keeps the dealt community cards after everyone else folds", () => {
     const view: TableView = {
       phase: "folded-out",
       button: 0,
@@ -47,6 +47,11 @@ describe("Board", () => {
       bigBlind: 2,
       dealtSeatCount: 3,
       burnedCount: 0,
+      board: [
+        { rank: "A", suit: "spades" },
+        { rank: "K", suit: "hearts" },
+        { rank: "2", suit: "clubs" },
+      ],
       winner: 1,
     };
     const html = renderToStaticMarkup(
@@ -73,9 +78,9 @@ describe("Board", () => {
     );
 
     expect(html).toMatch(/data-testid="board"[^>]*data-phase="folded-out"/);
-    expect(html).toContain('data-testid="hand-complete-banner"');
-    expect(html).toContain("Avery wins — everyone folded");
-    expect(html).not.toContain('data-testid="community-cards"');
+    expect(html).not.toContain('data-testid="hand-complete-banner"');
+    expect(html).toContain('data-testid="community-cards"');
+    expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(3);
   });
 
   it("shows only the community cards at showdown, suppressing the banner the overlay now owns", () => {
@@ -175,13 +180,19 @@ describe("Board", () => {
       bigBlind: 2,
       dealtSeatCount: 3,
       burnedCount: 3,
+      board: [
+        { rank: "A", suit: "spades" },
+        { rank: "K", suit: "hearts" },
+        { rank: "2", suit: "clubs" },
+      ],
       winner: 1,
     };
     const html = renderToStaticMarkup(<Board view={view} />);
 
-    expect(html).toContain('data-testid="hand-complete-banner"');
+    expect(html).not.toContain('data-testid="hand-complete-banner"');
     expect(html).toMatch(/data-testid="burn-pile"[^>]*data-burned="3"/);
     expect((html.match(/data-face-down="true"/g) ?? []).length).toBe(3);
+    expect((html.match(/data-face-down="false"/g) ?? []).length).toBe(3);
   });
 
   it("shows an empty pile before the first burn", () => {

--- a/packages/table-client/src/Board.tsx
+++ b/packages/table-client/src/Board.tsx
@@ -3,7 +3,7 @@ import type {
   SeatView,
   TableView,
 } from "@table-top-poker/protocol";
-import { Card, color, font } from "@table-top-poker/ui-shared";
+import { Card } from "@table-top-poker/ui-shared";
 import { motion, useReducedMotion } from "motion/react";
 import { useEffect, useRef } from "react";
 import { BurnPile } from "./BurnPile.js";
@@ -57,48 +57,6 @@ function CommunityCards({ board }: { readonly board: readonly CardType[] }) {
   );
 }
 
-function HandCompleteBanner({ text }: { readonly text: string }) {
-  return (
-    <div
-      data-testid="hand-complete-banner"
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: "0.5em",
-        padding: "0.45em 1em",
-        borderRadius: "999px",
-        background: color.winBackground,
-        border: `1px solid ${color.winBorder}`,
-        fontSize: "0.9em",
-        whiteSpace: "nowrap",
-      }}
-    >
-      <span
-        style={{
-          width: "0.5em",
-          height: "0.5em",
-          borderRadius: "50%",
-          flex: "none",
-          background: color.winBright,
-          boxShadow: `0 0 0.5em ${color.winBright}`,
-        }}
-      />
-      <span
-        style={{
-          fontFamily: font.mono,
-          fontSize: "0.65em",
-          letterSpacing: "0.16em",
-          textTransform: "uppercase",
-          color: color.winKicker,
-        }}
-      >
-        Hand complete
-      </span>
-      <span style={{ color: color.winText, fontWeight: 600 }}>{text}</span>
-    </div>
-  );
-}
-
 export function Board({ view, seats = [] }: BoardProps) {
   if (view.phase === "no-hand") {
     return (
@@ -137,13 +95,7 @@ export function Board({ view, seats = [] }: BoardProps) {
         >
           <BurnPile count={view.burnedCount} />
         </div>
-        {view.phase === "folded-out" ? (
-          <HandCompleteBanner
-            text={`${seatLabel(view.winner, seats)} wins — everyone folded`}
-          />
-        ) : (
-          <CommunityCards board={view.board} />
-        )}
+        <CommunityCards board={view.board} />
       </div>
     </div>
   );

--- a/packages/table-client/src/Seats.test.tsx
+++ b/packages/table-client/src/Seats.test.tsx
@@ -437,6 +437,7 @@ describe("Seats", () => {
       bigBlind: 2,
       dealtSeatCount: 3,
       burnedCount: 0,
+      board: [],
       winner: 1,
     };
     const sittingOutWinnerSeats = seats.map((seat) =>
@@ -765,6 +766,7 @@ describe("Seats: position markers", () => {
       {
         ...headsUpPositions,
         phase: "folded-out",
+        board: [],
         winner: 0,
       } satisfies TableView,
     ],

--- a/packages/table-client/src/replay/HandReview.test.tsx
+++ b/packages/table-client/src/replay/HandReview.test.tsx
@@ -111,6 +111,7 @@ const foldedOut: TableView = {
   bigBlind: 2,
   dealtSeatCount: 3,
   burnedCount: 0,
+  board: flop,
   winner: 2,
 };
 

--- a/packages/ui-shared/src/positionMarker.test.ts
+++ b/packages/ui-shared/src/positionMarker.test.ts
@@ -85,7 +85,7 @@ describe("positionMarkerFor", () => {
           winners: [0],
         },
       ],
-      ["folded-out", { phase: "folded-out", ...headsUp, winner: 0 }],
+      ["folded-out", { phase: "folded-out", ...headsUp, board: [], winner: 0 }],
     ];
 
     it.each(cases)("marks the button and nothing else (%s)", (_phase, view) => {


### PR DESCRIPTION
## Summary

- preserve dealt community cards in folded-out engine state and views
- keep the community-card layout mounted after everyone else folds
- remove the table winner status bar so the burn pile no longer shifts
- retain existing winner and loss messaging on player devices
- update live and replay regressions plus design documentation

## Validation

- full suite: 1,454 tests passed
- focused review suite: 233 tests passed
- build, ESLint, Prettier, and diff checks pass